### PR TITLE
fix(security): add input length validation

### DIFF
--- a/packages/api/src/routes/player.ts
+++ b/packages/api/src/routes/player.ts
@@ -10,6 +10,8 @@ import type { LoopMode, QueuedSong, Song } from '@discord-music-bot/shared';
 
 const router = Router();
 
+const MAX_URL_LENGTH = 2000;
+
 // ---------------------------------------------------------------------------
 // Resolve the guild ID once at startup.
 // The player is looked up by guild ID on every request. Since this is a
@@ -315,6 +317,11 @@ router.post(
     }
 
     const url = youtubeUrl.trim();
+
+    if (url.length > MAX_URL_LENGTH) {
+      res.status(400).json({ error: `URL must be ${MAX_URL_LENGTH} characters or less.` });
+      return;
+    }
 
     if (!isValidYouTubeUrl(url)) {
       res.status(400).json({ error: 'That does not look like a valid YouTube URL.' });


### PR DESCRIPTION
## Summary

This PR adds input length validation to prevent potential DoS attacks from oversized input strings, as described in Issue #21.

## Changes

### `packages/api/src/routes/playlists.ts`
- Added `MAX_NAME_LENGTH = 200` constant
- Added length validation in `POST /api/playlists` (create playlist)
- Added length validation in `PATCH /api/playlists/:id` (rename playlist)

### `packages/api/src/routes/songs.ts`
- Added `MAX_URL_LENGTH = 2000` constant
- Added URL length validation in `POST /api/songs` (add song)

### `packages/api/src/routes/player.ts`
- Added `MAX_URL_LENGTH = 2000` constant
- Added URL length validation in `POST /api/player/quick-add` (quick add to queue)

## Validation Behavior

All endpoints now return a `400 Bad Request` with a clear error message when input exceeds the maximum length:
- Playlist names: "name must be 200 characters or less."
- YouTube URLs: "URL must be 2000 characters or less."

Closes #21