### PR TITLE
feat(web): add member view sidebar styling with blue accent

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,11 @@
+{
+  "languages": {
+    "CSS": {
+      "language_servers": [
+        "tailwindcss-intellisense-css",
+        "!vscode-css-language-server",
+        "..."
+      ]
+    }
+  }
+}

--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -27,11 +27,11 @@ export default function Layout() {
       {/* Sidebar                                                             */}
       {/* ------------------------------------------------------------------ */}
       <aside
-        className={`${
-          collapsed ? 'w-16' : 'w-56'
-        } flex-shrink-0 flex flex-col border-r border-border bg-surface transition-[width] duration-200 overflow-hidden${
-          isAdminView ? ' border-t-2 border-t-accent' : ''
-        }`}
+      className={`${
+      collapsed ? 'w-16' : 'w-56'
+      } shrink-0 flex flex-col border-r border-border bg-surface transition-[width] duration-200 overflow-hidden border-t-2 ${
+      isAdminView ? 'border-t-accent' : 'border-t-member'
+      }`}
       >
         {/* Wordmark + collapse toggle */}
         <div
@@ -42,26 +42,26 @@ export default function Layout() {
           }`}
         >
           {!collapsed && (
-            <div className="flex items-center gap-2 min-w-0">
-              <span className="font-display text-3xl text-accent tracking-wider">alfira</span>
-              {isAdminView && (
-                <span className="text-[10px] font-mono bg-accent/10 text-accent border border-accent/20 px-1.5 py-0.5 rounded uppercase tracking-widest">
-                  admin
-                </span>
-              )}
-            </div>
+          <div className="flex items-center gap-2 min-w-0">
+          <span className="font-display text-3xl text-accent tracking-wider">alfira</span>
+          {isAdminView && (
+          <span className="text-[10px] font-mono bg-accent/10 text-accent border border-accent/20 px-1.5 py-0.5 rounded uppercase tracking-widest">
+          admin
+          </span>
           )}
-          {collapsed && isAdminView && (
-            <div
-              className="w-7 h-7 flex items-center justify-center text-accent"
-              title="Admin mode"
-            >
-              <IconShield size={18} />
-            </div>
+          </div>
+          )}
+          {collapsed && (
+          <div
+          className={`w-7 h-7 flex items-center justify-center ${isAdminView ? 'text-accent' : 'text-member'}`}
+          title={isAdminView ? 'Admin mode' : 'Member mode'}
+          >
+          {isAdminView ? <IconShield size={18} /> : <IconMusic size={18} />}
+          </div>
           )}
           <button
             onClick={() => setCollapsed(c => !c)}
-            className="w-7 h-7 flex-shrink-0 flex items-center justify-center rounded text-muted
+            className="w-7 h-7 shrink-0 flex items-center justify-center rounded text-muted
                        hover:text-fg hover:bg-elevated transition-colors duration-150"
             title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
           >
@@ -235,7 +235,7 @@ function NowPlayingBar() {
   };
 
   return (
-    <div className="flex-shrink-0 border-t border-border bg-surface">
+    <div className="shrink-0 border-t border-border bg-surface">
       {/* Progress bar — sits flush at the very top of the bar */}
       <div className="h-px w-full bg-elevated relative overflow-hidden">
         <div
@@ -247,7 +247,7 @@ function NowPlayingBar() {
       <div className="h-16 flex items-center px-6 gap-4">
         {/* Thumbnail + song info */}
         <div className="flex items-center gap-3 flex-1 min-w-0">
-          <div className="w-9 h-9 rounded bg-elevated border border-border flex-shrink-0 overflow-hidden">
+          <div className="w-9 h-9 rounded bg-elevated border border-border shrink-0 overflow-hidden">
             {currentSong ? (
               <img
                 src={currentSong.thumbnailUrl}
@@ -284,7 +284,7 @@ function NowPlayingBar() {
 
         {/* Playback controls */}
         {currentSong && (
-          <div className="flex items-center gap-2 flex-shrink-0">
+          <div className="flex items-center gap-2 shrink-0">
             <BarButton
               onClick={handlePauseResume}
               busy={pauseBusy}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -15,8 +15,10 @@
   --color-surface: #111111;
   --color-elevated: #191919;
   --color-border: #252525;
-  --color-accent: #c8f135;
-  --color-accent-muted: #8aaa22;
+  	--color-accent: #c8f135;
+  	--color-accent-muted: #8aaa22;
+  	--color-member: #3b82f6;
+  	--color-member-muted: #1d4ed8;
   --color-fg: #f0f0f0;
   --color-muted: #7a7a7a;
   --color-faint: #333333;

--- a/packages/web/tailwind.config.js
+++ b/packages/web/tailwind.config.js
@@ -2,39 +2,7 @@
 export default {
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   theme: {
-    extend: {
-      colors: {
-        base:     '#080808',
-        surface:  '#111111',
-        elevated: '#191919',
-        border:   '#252525',
-        accent:   '#c8f135',
-        'accent-muted': '#8aaa22',
-        fg:       '#f0f0f0',
-        muted:    '#7a7a7a',
-        faint:    '#333333',
-        danger:   '#ff4444',
-      },
-      fontFamily: {
-        display: ['"Bebas Neue"', 'cursive'],
-        body:    ['Karla', 'sans-serif'],
-        mono:    ['"JetBrains Mono"', 'monospace'],
-      },
-      keyframes: {
-        fadeUp: {
-          '0%':   { opacity: '0', transform: 'translateY(12px)' },
-          '100%': { opacity: '1', transform: 'translateY(0)' },
-        },
-        shimmer: {
-          '0%':   { backgroundPosition: '-400px 0' },
-          '100%': { backgroundPosition: '400px 0' },
-        },
-      },
-      animation: {
-        'fade-up':  'fadeUp 0.3s ease forwards',
-        'shimmer':  'shimmer 1.4s infinite linear',
-      },
-    },
+    extend: {},
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- Add thin color bar at top of sidebar for member view (blue)
- Add icon when sidebar is collapsed for member view
- Define member colors in Tailwind v4 `@theme` directive
- Clean up unused theme config from `tailwind.config.js`
- Add Zed editor settings for Tailwind CSS v4 support

## Changes
1. **Sidebar styling**: Member view now shows a blue color bar at the top and a music icon when collapsed
2. **Tailwind v4 colors**: Added `--color-member` and `--color-member-muted` to the `@theme` block in `index.css`
3. **Config cleanup**: Removed redundant theme configuration from `tailwind.config.js` (now handled in CSS)
4. **Zed settings**: Added `.zed/settings.json` to enable Tailwind CSS IntelliSense for CSS files

## Visual Changes
| View | Expanded Sidebar | Collapsed Sidebar |
|------|------------------|-------------------|
| Admin | Green top border + "admin" badge | Shield icon (green) |
| Member | Blue top border | Music icon (blue) |