### PR TITLE
fix(bot): trim .env.example to only required variables

### DIFF
--- a/packages/bot/.env.example
+++ b/packages/bot/.env.example
@@ -1,27 +1,13 @@
 # -----------------------------------------------
-# API + Bot Configuration
+# Discord Bot Configuration
 # -----------------------------------------------
-# Copy this file to .env and fill in all values before running.
+# Copy this file to .env and fill in all values.
+#
+# NOTE: The bot runs inside the API process, not standalone.
+# The API loads all environment variables before starting the bot.
+# This file is only needed if you run npm run bot:deploy directly
+# (without Docker) to register slash commands with Discord.
 
-# Port the Express API listens on.
-PORT=3001
-
-# PostgreSQL credentials — used by docker-compose.prod.yml.
-# Change these before deploying. The DATABASE_URL below is constructed
-# from these values inside docker-compose.prod.yml at startup.
-POSTGRES_USER=botuser
-POSTGRES_PASSWORD=CHANGE_ME_STRONG_PASSWORD
-POSTGRES_DB=musicbot
-
-# PostgreSQL connection string.
-# - For local dev (docker-compose.yml): use localhost and the values above.
-# - For containers (docker-compose.prod.yml): this is constructed automatically
-#   from POSTGRES_* vars — you do not need to set it separately there.
-DATABASE_URL=postgresql://botuser:CHANGE_ME_STRONG_PASSWORD@localhost:5432/musicbot
-
-# -----------------------------------------------
-# Discord Bot
-# -----------------------------------------------
 # Found in the Discord Developer Portal → your application → Bot → Token.
 DISCORD_BOT_TOKEN=
 
@@ -30,45 +16,3 @@ DISCORD_CLIENT_ID=
 
 # Right-click your server in Discord → Copy Server ID.
 GUILD_ID=
-
-# -----------------------------------------------
-# Discord OAuth2
-# -----------------------------------------------
-# Found in the Developer Portal → General Information → Client Secret.
-# Click "Reset Secret" if you haven't saved it already.
-DISCORD_CLIENT_SECRET=
-
-# Must exactly match a redirect URI you've added in the Developer Portal
-# under OAuth2 → Redirects.
-# - For local dev:        http://localhost:3001/auth/callback
-# - For dockerised stack: http://localhost:8080/auth/callback
-DISCORD_REDIRECT_URI=http://localhost:3001/auth/callback
-
-# -----------------------------------------------
-# JWT
-# -----------------------------------------------
-# A long random string used to sign JWTs. Generate one with:
-#   node -e "console.log(require('crypto').randomBytes(64).toString('hex'))"
-# Keep this secret. Changing it invalidates all existing sessions.
-JWT_SECRET=CHANGE_ME_GENERATE_WITH_COMMAND_ABOVE
-
-# -----------------------------------------------
-# Role-based access
-# -----------------------------------------------
-# Comma-separated list of Discord role IDs that grant admin access.
-# Right-click a role in Server Settings → Roles → Copy Role ID.
-# Anyone in the server who doesn't have one of these roles is a member.
-ADMIN_ROLE_IDS=
-
-# -----------------------------------------------
-# Web access
-# -----------------------------------------------
-WEB_UI_ORIGIN=http://localhost:5173
-
-# IP of the machine running these Docker containers (your Docker host)
-# Used to bind the port to just the LAN interface
-DOCKER_HOST_IP=192.168.1.x
-
-# IP of the machine running Caddy
-# Used so Express trusts X-Forwarded-For only from Caddy
-TRUSTED_PROXY_IP=192.168.1.x


### PR DESCRIPTION
## Summary

Fixes #32

The `packages/bot/.env.example` was a copy of `packages/api/.env.example` and included many variables the bot never uses at runtime. This PR trims it down to only the three variables the bot actually needs.

## Changes

Removed the following unnecessary variables from `packages/bot/.env.example`:
- `PORT` - API-only
- `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `DATABASE_URL` - API handles DB connection; bot runs in same process
- `DISCORD_CLIENT_SECRET`, `DISCORD_REDIRECT_URI` - OAuth is API-only
- `JWT_SECRET`, `ADMIN_ROLE_IDS` - Auth/authorization is API-only
- `WEB_UI_ORIGIN`, `DOCKER_HOST_IP`, `TRUSTED_PROXY_IP` - Web config, API-only

Kept only:
- `DISCORD_BOT_TOKEN` - Used for bot login
- `DISCORD_CLIENT_ID` - Used for slash command registration
- `GUILD_ID` - Used for slash command registration

Added a clarifying note explaining that the bot runs inside the API process and this file is only needed for running `npm run bot:deploy` directly (without Docker).

## Security Impact

Reduces attack surface by removing unnecessary secrets (`DISCORD_CLIENT_SECRET`, `JWT_SECRET`) from the bot's environment file template.