### PR TITLE
feat(bot): add auto-registration of slash commands on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,19 @@ docker compose -f docker-compose.prod.yml up -d
 
 This pulls the pre-built images and starts PostgreSQL, the API + bot, and the web UI.
 
-### 4. Access the Web UI
+### 4. Register Slash Commands
+
+Slash commands are automatically registered with Discord on startup. By default, this happens every time the bot starts (configurable via `AUTO_DEPLOY_COMMANDS`).
+
+If you need to manually register or re-register commands (e.g., after adding or modifying commands while the bot is running):
+
+```bash
+docker compose -f docker-compose.prod.yml exec api npm run bot:deploy
+```
+
+> **Note:** Commands are registered as guild commands, which update instantly. You must re-run this after adding, removing, or renaming commands if auto-deploy is disabled.
+
+### 5. Access the Web UI
 
 - **Web UI:** `http://localhost:8080`
 - **API:** `http://localhost:3001`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,6 +60,14 @@ cp packages/bot/.env.example packages/bot/.env
 | `DISCORD_BOT_TOKEN` | Discord bot token (same as API) | `MTAwMC4xMjM0NTY3ODkw...` |
 | `DISCORD_CLIENT_ID` | Discord application client ID (same as API) | `123456789012345678` |
 
+### Optional Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `AUTO_DEPLOY_COMMANDS` | Auto-register slash commands on startup | `true` |
+
+> **Note:** Set `AUTO_DEPLOY_COMMANDS=false` if you want to manually control when slash commands are registered. This is useful for advanced use cases where you want to test command changes before deploying them.
+
 ---
 
 ## Database Configuration

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -186,7 +186,26 @@ docker compose restart api
 # Rebuild a specific service
 docker compose build api
 docker compose up -d api
+
+# Manually register slash commands with Discord
+docker compose exec api npm run bot:deploy
 ```
+
+### Slash Commands Registration
+
+Slash commands must be registered with Discord before the bot will respond to them. By default, commands are auto-registered on startup.
+
+**Automatic Registration (Default):**
+Commands are automatically registered when the bot starts. Set `AUTO_DEPLOY_COMMANDS=false` to disable this behavior.
+
+**Manual Registration:**
+If you add, remove, or rename commands while the bot is running, run this to update Discord:
+
+```bash
+docker compose exec api npm run bot:deploy
+```
+
+> **Note:** Guild commands update instantly (no propagation delay). Without registered commands, slash commands won't appear in Discord.
 
 ---
 
@@ -212,6 +231,9 @@ cp .env.example .env
 
 # 4. Start all services
 docker compose -f docker-compose.prod.yml up -d
+
+# 5. Register slash commands (automatic on startup, but can be run manually)
+docker compose -f docker-compose.prod.yml exec api npm run bot:deploy
 ```
 
 That's it! The stack will pull the pre-built images and start:
@@ -242,6 +264,22 @@ All configuration is handled through a single `.env` file in the project root. C
 | `DISCORD_REDIRECT_URI` | ⚪ | OAuth2 callback URL |
 
 > **Security:** Use a strong, random `JWT_SECRET`. Generate one with: `openssl rand -hex 32`
+
+### Slash Commands Registration
+
+Slash commands must be registered with Discord before the bot will respond to them. By default, commands are auto-registered on startup.
+
+**Automatic Registration (Default):**
+Commands are automatically registered when the bot starts. Set `AUTO_DEPLOY_COMMANDS=false` to disable this behavior.
+
+**Manual Registration:**
+If you add, remove, or rename commands, run this to update Discord:
+
+```bash
+docker compose -f docker-compose.prod.yml exec api npm run bot:deploy
+```
+
+> **Important:** Without registered commands, slash commands won't appear in Discord. Guild commands update instantly (no propagation delay).
 
 ### Reverse Proxy (Optional)
 

--- a/packages/bot/src/index.ts
+++ b/packages/bot/src/index.ts
@@ -1,4 +1,4 @@
-import { Client, GatewayIntentBits, Collection, Interaction, InteractionReplyOptions } from 'discord.js';
+import { Client, GatewayIntentBits, Collection, Interaction, InteractionReplyOptions, REST, Routes } from 'discord.js';
 import { joinCommand } from './commands/join';
 import { leaveCommand } from './commands/leave';
 import { playCommand } from './commands/play';
@@ -11,6 +11,29 @@ import { queueCommand } from './commands/queue';
 import { nowplayingCommand } from './commands/nowplaying';
 import { playlistCommand } from './commands/playlist';
 import type { Command } from './types';
+
+// ---------------------------------------------------------------------------
+// deployCommands
+//
+// Registers slash commands with Discord. Called automatically on startup when
+// AUTO_DEPLOY_COMMANDS is enabled (default: true in production).
+// ---------------------------------------------------------------------------
+async function deployCommands(clientId: string, guildId: string, token: string, commands: Command[]): Promise<void> {
+  const rest = new REST().setToken(token);
+  const commandData = commands.map((c) => c.data.toJSON());
+
+  try {
+    console.log(`🔄 Auto-registering ${commandData.length} slash command(s)...`);
+    await rest.put(
+      Routes.applicationGuildCommands(clientId, guildId),
+      { body: commandData }
+    );
+    console.log('✅ Slash commands registered successfully.');
+  } catch (error) {
+    console.error('❌ Failed to register commands:', error);
+    // Don't throw - the bot can still function, commands just won't work until deployed
+  }
+}
 
 // ---------------------------------------------------------------------------
 // startBot
@@ -26,10 +49,17 @@ import type { Command } from './types';
 // calling startBot(), so they are already on process.env by the time this runs.
 // ---------------------------------------------------------------------------
 export async function startBot(): Promise<void> {
-  const { DISCORD_BOT_TOKEN } = process.env;
+  const { DISCORD_BOT_TOKEN, DISCORD_CLIENT_ID, GUILD_ID, AUTO_DEPLOY_COMMANDS } = process.env;
 
+  // Validate required environment variables
   if (!DISCORD_BOT_TOKEN) {
     throw new Error('DISCORD_BOT_TOKEN is not set.');
+  }
+  if (!DISCORD_CLIENT_ID) {
+    throw new Error('DISCORD_CLIENT_ID is not set.');
+  }
+  if (!GUILD_ID) {
+    throw new Error('GUILD_ID is not set.');
   }
 
   const client = new Client({
@@ -59,8 +89,17 @@ export async function startBot(): Promise<void> {
     client.commands.set(command.data.name, command);
   }
 
-  client.once('clientReady', (readyClient) => {
-    console.log(`✅  Bot logged in as ${readyClient.user.tag}`);
+  client.once('clientReady', async (readyClient) => {
+    console.log(`✅ Bot logged in as ${readyClient.user.tag}`);
+
+    // Auto-deploy commands if enabled (default: true for convenience)
+    // Set AUTO_DEPLOY_COMMANDS=false to disable (e.g., for advanced use cases)
+    const shouldAutoDeploy = AUTO_DEPLOY_COMMANDS !== 'false';
+    if (shouldAutoDeploy) {
+      await deployCommands(DISCORD_CLIENT_ID!, GUILD_ID!, DISCORD_BOT_TOKEN!, commands);
+    } else {
+      console.log('ℹ️  Auto-deploy disabled (AUTO_DEPLOY_COMMANDS=false). Run `npm run bot:deploy` manually if needed.');
+    }
   });
 
   client.on('interactionCreate', async (interaction: Interaction) => {


### PR DESCRIPTION
## Summary

This PR addresses Issue #37 by implementing both documentation improvements and an auto-registration feature for Discord slash commands.

## Changes

### Auto-Registration Feature
- Added `deployCommands()` function in `packages/bot/src/index.ts` that registers slash commands with Discord
- Modified `startBot()` to automatically register commands on bot startup
- Added `AUTO_DEPLOY_COMMANDS` environment variable (default: `true`) to control this behavior
- Added validation for `DISCORD_CLIENT_ID` and `GUILD_ID` environment variables
- Graceful error handling - if registration fails, the bot continues running but logs the error

### Documentation Updates
- **README.md**: Added step 4 "Register Slash Commands" in Quick Start section
- **docs/installation.md**: 
  - Added `bot:deploy` command to Useful Commands section
  - Added "Slash Commands Registration" subsection in both Development and Production sections
- **docs/configuration.md**: Documented the new `AUTO_DEPLOY_COMMANDS` variable

## Benefits

1. **Better Developer Experience**: Commands are automatically registered, eliminating the "forgot to deploy" issue
2. **Still Flexible**: Users can disable auto-deploy with `AUTO_DEPLOY_COMMANDS=false` for advanced use cases
3. **Clear Documentation**: Users understand what's happening and have a manual fallback
4. **No Breaking Changes**: Existing setups continue to work; the manual `npm run bot:deploy` command still works

## Testing

- TypeScript compilation passes with no errors
- The auto-registration logic mirrors the existing `deploy-commands.ts` script

Closes #37