### PR TITLE
Add Socket.io authentication

### DIFF
--- a/packages/api/src/lib/socket.ts
+++ b/packages/api/src/lib/socket.ts
@@ -1,5 +1,6 @@
 import { Server as SocketIOServer } from 'socket.io';
 import type { Server as HTTPServer } from 'http';
+import jwt from 'jsonwebtoken';
 import type { QueueState, Song, Playlist } from '@discord-music-bot/shared';
 
 // ---------------------------------------------------------------------------
@@ -22,6 +23,29 @@ import type { QueueState, Song, Playlist } from '@discord-music-bot/shared';
 
 let _io: SocketIOServer | null = null;
 
+// ---------------------------------------------------------------------------
+// Cookie parser helper
+//
+// Parses the Cookie header string and returns an object mapping cookie names
+// to values. Returns an empty object if the header is missing or malformed.
+// ---------------------------------------------------------------------------
+function parseCookies(cookieHeader: string | undefined): Record<string, string> {
+  const cookies: Record<string, string> = {};
+  if (!cookieHeader) return cookies;
+
+  for (const part of cookieHeader.split(';')) {
+    const trimmed = part.trim();
+    const separatorIndex = trimmed.indexOf('=');
+    if (separatorIndex === -1) continue;
+
+    const name = trimmed.substring(0, separatorIndex).trim();
+    const value = trimmed.substring(separatorIndex + 1).trim();
+    cookies[name] = value;
+  }
+
+  return cookies;
+}
+
 const WEB_UI_ORIGIN = process.env.WEB_UI_ORIGIN ?? 'http://localhost:5173';
 
 /**
@@ -36,8 +60,52 @@ export function initSocket(httpServer: HTTPServer): SocketIOServer {
     },
   });
 
+  // ---------------------------------------------------------------------------
+  // Socket.io authentication middleware
+  //
+  // Verifies the JWT from the 'session' cookie before allowing a WebSocket
+  // connection. This prevents unauthenticated clients from receiving real-time
+  // events (player:update, songs:added, etc.).
+  //
+  // The session cookie is HttpOnly and set by the OAuth flow in auth.ts.
+  // ---------------------------------------------------------------------------
+  _io.use((socket, next) => {
+    const { JWT_SECRET } = process.env;
+
+    if (!JWT_SECRET) {
+      console.error('JWT_SECRET is not set — cannot verify Socket.io connections.');
+      next(new Error('Server misconfiguration.'));
+      return;
+    }
+
+    const cookieHeader = socket.handshake.headers.cookie;
+    const cookies = parseCookies(cookieHeader);
+    const token = cookies['session'];
+
+    if (!token) {
+      next(new Error('Authentication required. Please log in.'));
+      return;
+    }
+
+    try {
+      const payload = jwt.verify(token, JWT_SECRET) as {
+        discordId: string;
+        username: string;
+        avatar: string | null;
+        isAdmin: boolean;
+      };
+
+      // Attach the decoded user to socket.data for potential future use
+      // (e.g., admin-only socket events, user-specific rooms)
+      socket.data.user = payload;
+      next();
+    } catch {
+      next(new Error('Session expired or invalid. Please log in again.'));
+    }
+  });
+
   _io.on('connection', (socket) => {
-    console.log(`🔌  Socket connected: ${socket.id}`);
+    console.log(`🔌 Socket connected: ${socket.id} (user: ${socket.data.user?.username})`);
 
     socket.on('disconnect', (reason) => {
       console.log(`🔌  Socket disconnected: ${socket.id} (${reason})`);


### PR DESCRIPTION
## Summary

This PR adds authentication middleware to Socket.io to address security issue #20.

Previously, anyone who could reach the API port (3001) could open a WebSocket connection and receive all `player:update`, `songs:added`, etc. events without any authentication check.

## Changes

- Added JWT verification middleware to Socket.io in `packages/api/src/lib/socket.ts`
- Parses the `session` cookie from WebSocket handshake headers
- Verifies the JWT using the existing `JWT_SECRET`
- Attaches the decoded user payload to `socket.data.user` for potential future use
- Rejects unauthenticated connections with appropriate error messages
- Enhanced connection logging to include username

## Testing

- TypeScript compilation passes (`npx tsc --noEmit`)
- No new dependencies added (manual cookie parsing)

Closes #20