### PR TITLE
feat(auth): Add short-lived JWT tokens with refresh flow

### DIFF
--- a/packages/api/prisma/migrations/20260301000000_add_refresh_token/migration.sql
+++ b/packages/api/prisma/migrations/20260301000000_add_refresh_token/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "RefreshToken" (
+    "id" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "discordId" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RefreshToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RefreshToken_tokenHash_key" ON "RefreshToken"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "RefreshToken_discordId_idx" ON "RefreshToken"("discordId");

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -31,15 +31,30 @@ model Playlist {
 }
 
 model PlaylistSong {
-  id         String   @id @default(cuid())
-  playlist   Playlist @relation(fields: [playlistId], references: [id], onDelete: Cascade)
+  id        String   @id @default(cuid())
+  playlist  Playlist @relation(fields: [playlistId], references: [id], onDelete: Cascade)
   playlistId String
-  song       Song     @relation(fields: [songId], references: [id], onDelete: Cascade)
-  songId     String
-  position   Int
+  song      Song     @relation(fields: [songId], references: [id], onDelete: Cascade)
+  songId    String
+  position  Int
 
   // A song can only appear once per playlist.
   @@unique([playlistId, songId])
+
   // Index on (playlistId, position) makes ordered playlist queries fast.
   @@index([playlistId, position])
+}
+
+// Refresh tokens for JWT authentication.
+// Stored as SHA-256 hash for security - the raw token is never stored.
+// This allows tokens to be revoked by deleting them from the database.
+model RefreshToken {
+  id        String   @id @default(cuid())
+  tokenHash String   @unique // SHA-256 hash of the refresh token
+  discordId String   // Discord user ID this token belongs to
+  expiresAt DateTime // When the refresh token expires
+  createdAt DateTime @default(now())
+
+  // Index for quick lookup by discordId (e.g., when revoking all tokens for a user)
+  @@index([discordId])
 }

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1,9 +1,11 @@
 import { Router } from 'express';
 import axios from 'axios';
 import jwt from 'jsonwebtoken';
+import crypto from 'crypto';
 import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import { asyncHandler } from '../middleware/errorHandler';
 import { requireAuth } from '../middleware/requireAuth';
+import prisma from '../lib/prisma';
 
 const router = Router();
 
@@ -25,13 +27,140 @@ const ADMIN_ROLE_ID_SET = new Set(
   (ADMIN_ROLE_IDS ?? '').split(',').map((id) => id.trim()).filter(Boolean)
 );
 
-const JWT_EXPIRES_IN = '7d';
-const COOKIE_NAME = 'session';
+// ---------------------------------------------------------------------------
+// Token configuration
+//
+// Access tokens are short-lived (1 hour) and contain the user's info including
+// isAdmin status. This limits the window where a revoked admin can still
+// access admin features.
+//
+// Refresh tokens are long-lived (7 days) and stored in the database as a
+// SHA-256 hash. They can be revoked by deleting them from the database.
+// When a user refreshes, we re-fetch their roles from Discord to ensure
+// admin status is up-to-date.
+// ---------------------------------------------------------------------------
+const ACCESS_TOKEN_EXPIRES_IN = '1h';
+const REFRESH_TOKEN_EXPIRES_IN = '7d';
+const ACCESS_COOKIE_NAME = 'session';
+const REFRESH_COOKIE_NAME = 'refresh_token';
+
+// ---------------------------------------------------------------------------
+// Helper: Hash a token using SHA-256
+//
+// We store only the hash of refresh tokens in the database.
+// This means even if the database is compromised, the tokens cannot be used.
+// ---------------------------------------------------------------------------
+function hashToken(token: string): string {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
+// ---------------------------------------------------------------------------
+// Helper: Generate access token
+//
+// Contains user info including isAdmin. Short-lived so role changes take
+// effect within 1 hour maximum.
+// ---------------------------------------------------------------------------
+function generateAccessToken(payload: {
+  discordId: string;
+  username: string;
+  avatar: string | null;
+  isAdmin: boolean;
+}): string {
+  return jwt.sign(payload, JWT_SECRET!, {
+    expiresIn: ACCESS_TOKEN_EXPIRES_IN,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helper: Generate refresh token
+//
+// Contains only the discord ID. Long-lived and stored in DB for revocation.
+// ---------------------------------------------------------------------------
+function generateRefreshToken(discordId: string): string {
+  return jwt.sign({ discordId, type: 'refresh' }, JWT_SECRET!, {
+    expiresIn: REFRESH_TOKEN_EXPIRES_IN,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helper: Set auth cookies
+// ---------------------------------------------------------------------------
+function setAuthCookies(
+  res: import('express').Response,
+  accessToken: string,
+  refreshToken: string
+): void {
+  const isProduction = process.env.NODE_ENV === 'production';
+
+  // Access token cookie - short-lived
+  res.cookie(ACCESS_COOKIE_NAME, accessToken, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: isProduction,
+    maxAge: 60 * 60 * 1000, // 1 hour
+  });
+
+  // Refresh token cookie - long-lived
+  res.cookie(REFRESH_COOKIE_NAME, refreshToken, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: isProduction,
+    maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helper: Clear auth cookies
+// ---------------------------------------------------------------------------
+function clearAuthCookies(res: import('express').Response): void {
+  res.clearCookie(ACCESS_COOKIE_NAME, { httpOnly: true, sameSite: 'lax' });
+  res.clearCookie(REFRESH_COOKIE_NAME, { httpOnly: true, sameSite: 'lax' });
+}
+
+// ---------------------------------------------------------------------------
+// Helper: Fetch user's admin status from Discord
+//
+// Returns null if the user is not in the guild or Discord is unreachable.
+// ---------------------------------------------------------------------------
+async function fetchUserAdminStatus(
+  discordId: string
+): Promise<{ isAdmin: boolean; username: string; avatar: string | null } | null> {
+  try {
+    // Fetch user's current username/avatar
+    const userRes = await axios.get(
+      `https://discord.com/api/users/${discordId}`,
+      { headers: { Authorization: `Bot ${DISCORD_BOT_TOKEN}` } }
+    );
+    const { username, avatar } = userRes.data;
+
+    // Fetch member roles to determine admin status
+    const memberRes = await axios.get(
+      `https://discord.com/api/guilds/${GUILD_ID}/members/${discordId}`,
+      { headers: { Authorization: `Bot ${DISCORD_BOT_TOKEN}` } }
+    );
+    const memberRoles: string[] = memberRes.data.roles ?? [];
+    const isAdmin = memberRoles.some((roleId) => ADMIN_ROLE_ID_SET.has(roleId));
+
+    const avatarUrl = avatar
+      ? `https://cdn.discordapp.com/avatars/${discordId}/${avatar}.png`
+      : null;
+
+    return { isAdmin, username, avatar: avatarUrl };
+  } catch (err: any) {
+    // User not in guild
+    if (err?.response?.status === 404) {
+      return null;
+    }
+    // Discord error - log and return null
+    console.error('Failed to fetch user info from Discord:', err?.message);
+    return null;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Rate limiting
 //
-// Applied to /auth/login and /auth/callback.
+// Applied to /auth/login, /auth/callback, and /auth/refresh.
 //
 // Why: without rate limiting, an attacker can hammer the OAuth flow to probe
 // for valid guild members or attempt to enumerate users. The callback is
@@ -69,7 +198,6 @@ router.get('/login', authLimiter, (_req, res) => {
     response_type: 'code',
     scope: 'identify',
   });
-
   res.redirect(`https://discord.com/oauth2/authorize?${params}`);
 });
 
@@ -81,7 +209,6 @@ router.get(
   authLimiter,
   asyncHandler(async (req, res) => {
     const { code } = req.query;
-
     if (!code || typeof code !== 'string') {
       res.status(400).json({ error: 'Missing authorization code.' });
       return;
@@ -122,13 +249,13 @@ router.get(
     // 3. Fetch guild member roles via bot token.
     //
     // Three outcomes:
-    //   - Success (2xx): proceed with the real role list.
-    //   - 404: user is not in the guild — deny login.
-    //   - Anything else (network error, rate limit, 5xx from Discord): fail
-    //     closed. We do not know the user's roles, so we cannot safely issue
-    //     a token. Logging in with an assumed role list would mean a Discord
-    //     outage silently grants or revokes admin access depending on which
-    //     direction we default. Refusing is the only safe option.
+    // - Success (2xx): proceed with the real role list.
+    // - 404: user is not in the guild — deny login.
+    // - Anything else (network error, rate limit, 5xx from Discord): fail
+    //   closed. We do not know the user's roles, so we cannot safely issue
+    //   a token. Logging in with an assumed role list would mean a Discord
+    //   outage silently grants or revokes admin access depending on which
+    //   direction we default. Refusing is the only safe option.
     let memberRoles: string[];
     try {
       const memberRes = await axios.get(
@@ -141,7 +268,6 @@ router.get(
         res.status(403).json({ error: 'You must be a member of the server to use this app.' });
         return;
       }
-
       // Discord is unreachable or returned an unexpected error.
       // Log the detail server-side; return a generic message to the client.
       console.error(
@@ -150,9 +276,9 @@ router.get(
         '— denying login.',
         err?.message
       );
-      res.status(503).json({
-        error: 'Could not verify your server membership. Please try again in a moment.',
-      });
+      res
+        .status(503)
+        .json({ error: 'Could not verify your server membership. Please try again in a moment.' });
       return;
     }
 
@@ -164,25 +290,133 @@ router.get(
       ? `https://cdn.discordapp.com/avatars/${discordUser.id}/${discordUser.avatar}.png`
       : null;
 
-    // 6. Issue JWT.
+    // 6. Generate tokens.
     const payload = {
       discordId: discordUser.id,
       username: discordUser.username,
       avatar: avatarUrl,
       isAdmin,
     };
+    const accessToken = generateAccessToken(payload);
+    const refreshToken = generateRefreshToken(discordUser.id);
 
-    const token = jwt.sign(payload, JWT_SECRET!, { expiresIn: JWT_EXPIRES_IN });
-
-    res.cookie(COOKIE_NAME, token, {
-      httpOnly: true,
-      sameSite: 'lax',
-      secure: process.env.NODE_ENV === 'production',
-      maxAge: 7 * 24 * 60 * 60 * 1000,
+    // 7. Store refresh token hash in database.
+    const refreshTokenHash = hashToken(refreshToken);
+    const refreshTokenExpiry = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // 7 days
+    await prisma.refreshToken.create({
+      data: {
+        tokenHash: refreshTokenHash,
+        discordId: discordUser.id,
+        expiresAt: refreshTokenExpiry,
+      },
     });
 
-    // 7. Redirect to the web UI. The cookie travels with this redirect.
+    // 8. Set cookies and redirect.
+    setAuthCookies(res, accessToken, refreshToken);
     res.redirect(WEB_UI_ORIGIN);
+  })
+);
+
+// ---------------------------------------------------------------------------
+// POST /auth/refresh
+//
+// Exchange a refresh token for a new access token.
+// This also re-fetches the user's admin status from Discord to ensure
+// role changes take effect quickly.
+// ---------------------------------------------------------------------------
+router.post(
+  '/refresh',
+  asyncHandler(async (req, res) => {
+    const refreshToken = req.cookies?.[REFRESH_COOKIE_NAME];
+
+    if (!refreshToken) {
+      res.status(401).json({ error: 'No refresh token provided.' });
+      return;
+    }
+
+    // 1. Verify the refresh token signature and expiration.
+    let decoded: { discordId: string; type: string };
+    try {
+      decoded = jwt.verify(refreshToken, JWT_SECRET!) as { discordId: string; type: string };
+      if (decoded.type !== 'refresh') {
+        res.status(401).json({ error: 'Invalid token type.' });
+        return;
+      }
+    } catch {
+      clearAuthCookies(res);
+      res.status(401).json({ error: 'Invalid or expired refresh token.' });
+      return;
+    }
+
+    // 2. Check if the refresh token exists in the database (not revoked).
+    const tokenHash = hashToken(refreshToken);
+    const storedToken = await prisma.refreshToken.findUnique({
+      where: { tokenHash },
+    });
+
+    if (!storedToken) {
+      clearAuthCookies(res);
+      res.status(401).json({ error: 'Refresh token has been revoked.' });
+      return;
+    }
+
+    // 3. Check if the refresh token has expired.
+    if (storedToken.expiresAt < new Date()) {
+      await prisma.refreshToken.delete({ where: { id: storedToken.id } });
+      clearAuthCookies(res);
+      res.status(401).json({ error: 'Refresh token has expired.' });
+      return;
+    }
+
+    // 4. Delete the used refresh token (single-use for security).
+    await prisma.refreshToken.delete({ where: { id: storedToken.id } });
+
+    // 5. Clean up expired tokens for this user (lazy cleanup).
+    await prisma.refreshToken.deleteMany({
+      where: {
+        discordId: decoded.discordId,
+        expiresAt: { lt: new Date() },
+      },
+    });
+
+    // 6. Re-fetch user info from Discord (including admin status).
+    const userInfo = await fetchUserAdminStatus(decoded.discordId);
+
+    if (!userInfo) {
+      // User is no longer in the guild or Discord is unreachable.
+      // Clear all refresh tokens for this user for security.
+      await prisma.refreshToken.deleteMany({
+        where: { discordId: decoded.discordId },
+      });
+      clearAuthCookies(res);
+      res.status(401).json({ error: 'Unable to verify user membership. Please log in again.' });
+      return;
+    }
+
+    // 7. Generate new tokens.
+    const payload = {
+      discordId: decoded.discordId,
+      username: userInfo.username,
+      avatar: userInfo.avatar,
+      isAdmin: userInfo.isAdmin,
+    };
+    const newAccessToken = generateAccessToken(payload);
+    const newRefreshToken = generateRefreshToken(decoded.discordId);
+
+    // 8. Store new refresh token.
+    const newTokenHash = hashToken(newRefreshToken);
+    const newExpiry = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+    await prisma.refreshToken.create({
+      data: {
+        tokenHash: newTokenHash,
+        discordId: decoded.discordId,
+        expiresAt: newExpiry,
+      },
+    });
+
+    // 9. Set cookies and return user info.
+    setAuthCookies(res, newAccessToken, newRefreshToken);
+    res.json({ user: payload });
   })
 );
 
@@ -200,9 +434,20 @@ router.get(
 // ---------------------------------------------------------------------------
 // POST /auth/logout
 // ---------------------------------------------------------------------------
-router.post('/logout', (_req, res) => {
-  res.clearCookie(COOKIE_NAME, { httpOnly: true, sameSite: 'lax' });
+router.post('/logout', asyncHandler(async (req, res) => {
+  // Try to revoke the refresh token if present.
+  const refreshToken = req.cookies?.[REFRESH_COOKIE_NAME];
+  if (refreshToken) {
+    try {
+      const tokenHash = hashToken(refreshToken);
+      await prisma.refreshToken.deleteMany({ where: { tokenHash } });
+    } catch {
+      // Ignore errors - just clear cookies anyway.
+    }
+  }
+
+  clearAuthCookies(res);
   res.json({ message: 'Logged out.' });
-});
+}));
 
 export default router;

--- a/packages/web/src/api/api.ts
+++ b/packages/web/src/api/api.ts
@@ -4,87 +4,52 @@ import type { Song, Playlist, PlaylistDetail, QueueState, LoopMode, User } from 
 // ---------------------------------------------------------------------------
 // Auth
 // ---------------------------------------------------------------------------
-export const getMe = () =>
-  client.get<{ user: User }>('/auth/me').then((r) => r.data.user);
-
-export const logout = () =>
-  client.post('/auth/logout');
+export const getMe = () => client.get<{ user: User }>('/auth/me').then((r) => r.data.user);
+export const logout = () => client.post('/auth/logout');
+export const refresh = () => client.post<{ user: User }>('/auth/refresh').then((r) => r.data);
 
 // ---------------------------------------------------------------------------
 // Songs
 // ---------------------------------------------------------------------------
-export const getSongs = () =>
-  client.get<Song[]>('/api/songs').then((r) => r.data);
-
-export const addSong = (youtubeUrl: string) =>
-  client.post<Song>('/api/songs', { youtubeUrl }).then((r) => r.data);
-
-export const deleteSong = (id: string) =>
-  client.delete(`/api/songs/${id}`);
+export const getSongs = () => client.get<Song[]>('/api/songs').then((r) => r.data);
+export const addSong = (youtubeUrl: string) => client.post<Song>('/api/songs', { youtubeUrl }).then((r) => r.data);
+export const deleteSong = (id: string) => client.delete(`/api/songs/${id}`);
 
 // ---------------------------------------------------------------------------
 // Playlists
 // ---------------------------------------------------------------------------
-export const getPlaylists = () =>
-  client.get<Playlist[]>('/api/playlists').then((r) => r.data);
-
-export const createPlaylist = (name: string) =>
-  client.post<Playlist>('/api/playlists', { name }).then((r) => r.data);
-
-export const getPlaylist = (id: string) =>
-  client.get<PlaylistDetail>(`/api/playlists/${id}`).then((r) => r.data);
-
-export const renamePlaylist = (id: string, name: string) =>
-  client.patch<Playlist>(`/api/playlists/${id}`, { name }).then((r) => r.data);
-
-export const deletePlaylist = (id: string) =>
-  client.delete(`/api/playlists/${id}`);
-
-export const addSongToPlaylist = (playlistId: string, songId: string) =>
-  client.post(`/api/playlists/${playlistId}/songs`, { songId });
-
-export const removeSongFromPlaylist = (playlistId: string, songId: string) =>
-  client.delete(`/api/playlists/${playlistId}/songs/${songId}`);
+export const getPlaylists = () => client.get<Playlist[]>('/api/playlists').then((r) => r.data);
+export const createPlaylist = (name: string) => client.post<Playlist>('/api/playlists', { name }).then((r) => r.data);
+export const getPlaylist = (id: string) => client.get<PlaylistDetail>(`/api/playlists/${id}`).then((r) => r.data);
+export const renamePlaylist = (id: string, name: string) => client.patch<Playlist>(`/api/playlists/${id}`, { name }).then((r) => r.data);
+export const deletePlaylist = (id: string) => client.delete(`/api/playlists/${id}`);
+export const addSongToPlaylist = (playlistId: string, songId: string) => client.post(`/api/playlists/${playlistId}/songs`, { songId });
+export const removeSongFromPlaylist = (playlistId: string, songId: string) => client.delete(`/api/playlists/${playlistId}/songs/${songId}`);
 
 // ---------------------------------------------------------------------------
 // Player
 // ---------------------------------------------------------------------------
-export const getQueueState = () =>
-  client.get<QueueState>('/api/player/queue').then((r) => r.data);
-
-export const startPlayback = (opts: {
-  playlistId?: string;
-  mode: 'sequential' | 'random';
-  loop: LoopMode;
-  startFromSongId?: string;
-}) => client.post('/api/player/play', opts);
-
+export const getQueueState = () => client.get<QueueState>('/api/player/queue').then((r) => r.data);
+export const startPlayback = (opts: { playlistId?: string; mode: 'sequential' | 'random'; loop: LoopMode; startFromSongId?: string; }) => client.post('/api/player/play', opts);
 export const skipTrack = () => client.post('/api/player/skip');
-
 /**
  * Stop playback, clear the queue, and disconnect the bot from the voice
  * channel. This is the primary "leave" action for the web UI.
  */
 export const leaveVoice = () => client.post('/api/player/leave');
-
 /**
  * Alias for leaveVoice — kept for any call sites that used stopPlayback.
  * Both stop playback AND disconnect the bot.
  */
 export const stopPlayback = leaveVoice;
-
 export const setLoopMode = (mode: LoopMode) => client.post('/api/player/loop', { mode });
 export const shuffleQueue = () => client.post('/api/player/shuffle');
 export const clearQueue = () => client.post('/api/player/clear');
 export const resumePlayback = () => client.post('/api/player/resume');
-
-export const togglePause = () =>
-  client.post<{ isPaused: boolean }>('/api/player/pause-toggle').then((r) => r.data);
-
-export const quickAddToQueue = (youtubeUrl: string) =>
-  client
-    .post<{ message: string; song: { title: string; duration: number; thumbnailUrl: string; requestedBy: string } }>(
-      '/api/player/quick-add',
-      { youtubeUrl }
-    )
-    .then((r) => r.data);
+export const togglePause = () => client.post<{ isPaused: boolean }>('/api/player/pause-toggle').then((r) => r.data);
+export const quickAddToQueue = (youtubeUrl: string) => client
+  .post<{ message: string; song: { title: string; duration: number; thumbnailUrl: string; requestedBy: string } }>(
+    '/api/player/quick-add',
+    { youtubeUrl }
+  )
+  .then((r) => r.data);

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios';
 
 // ---------------------------------------------------------------------------
 // Axios instance
@@ -14,14 +14,115 @@ const client = axios.create({
   withCredentials: true,
 });
 
-// Intercept 401 responses globally — redirect to login without flash.
-client.interceptors.response.use(
-  (res) => res,
-  (err) => {
-    if (err.response?.status === 401 && window.location.pathname !== '/login') {
-      window.location.href = '/login';
+// ---------------------------------------------------------------------------
+// Token refresh state
+//
+// We need to prevent multiple concurrent refresh attempts. If multiple
+// requests fail with 401 at the same time, we want them to all wait for
+// the same refresh promise rather than triggering multiple refresh calls.
+// ---------------------------------------------------------------------------
+let isRefreshing = false;
+let failedQueue: Array<{
+  resolve: (value?: unknown) => void;
+  reject: (error: unknown) => void;
+}> = [];
+
+// ---------------------------------------------------------------------------
+// Process the failed queue
+//
+// After a refresh attempt (success or failure), resolve or reject all
+// queued requests that were waiting for the refresh.
+// ---------------------------------------------------------------------------
+function processQueue(error: AxiosError | null): void {
+  failedQueue.forEach((prom) => {
+    if (error) {
+      prom.reject(error);
+    } else {
+      prom.resolve();
     }
-    return Promise.reject(err);
+  });
+  failedQueue = [];
+}
+
+// ---------------------------------------------------------------------------
+// Response interceptor for automatic token refresh
+//
+// When a request fails with 401:
+// 1. If we're not already refreshing, attempt to refresh the token
+// 2. If refresh succeeds, retry the original request
+// 3. If refresh fails, redirect to login
+//
+// Multiple concurrent 401s will all wait for the same refresh promise,
+// preventing multiple refresh calls.
+// ---------------------------------------------------------------------------
+client.interceptors.response.use(
+  (response) => response,
+  async (error: AxiosError) => {
+    const originalRequest = error.config as InternalAxiosRequestConfig & {
+      _retry?: boolean;
+    };
+
+    // Only handle 401 errors
+    if (error.response?.status !== 401) {
+      return Promise.reject(error);
+    }
+
+    // Don't retry if this is already a retry
+    if (originalRequest._retry) {
+      // Refresh failed, redirect to login
+      if (window.location.pathname !== '/login') {
+        window.location.href = '/login';
+      }
+      return Promise.reject(error);
+    }
+
+    // If this is a refresh request that failed, don't try to refresh again
+    if (originalRequest.url === '/auth/refresh') {
+      if (window.location.pathname !== '/login') {
+        window.location.href = '/login';
+      }
+      return Promise.reject(error);
+    }
+
+    // If we're already refreshing, queue this request
+    if (isRefreshing) {
+      return new Promise((resolve, reject) => {
+        failedQueue.push({ resolve, reject });
+      })
+        .then(() => {
+          // Retry the original request after refresh completes
+          return client(originalRequest);
+        })
+        .catch((err) => {
+          return Promise.reject(err);
+        });
+    }
+
+    // Start refreshing
+    isRefreshing = true;
+    originalRequest._retry = true;
+
+    try {
+      // Attempt to refresh the token
+      await client.post('/auth/refresh');
+
+      // Refresh succeeded, process queued requests
+      processQueue(null);
+
+      // Retry the original request
+      return client(originalRequest);
+    } catch (refreshError) {
+      // Refresh failed, reject queued requests and redirect to login
+      processQueue(refreshError as AxiosError);
+
+      if (window.location.pathname !== '/login') {
+        window.location.href = '/login';
+      }
+
+      return Promise.reject(refreshError);
+    } finally {
+      isRefreshing = false;
+    }
   }
 );
 


### PR DESCRIPTION
## Summary

This PR implements short-lived JWT tokens with a refresh flow to address the security concern raised in Issue #18.

## Problem

Previously, `isAdmin` was encoded into a JWT that was valid for 7 days. If a user's admin role was revoked in Discord, they retained admin access for up to 7 days with no mechanism to invalidate existing tokens.

## Solution

Implemented a dual-token authentication system:

### Access Tokens (Short-lived)
- Valid for **1 hour**
- Contains user info including `isAdmin` status
- Limits the window where a revoked admin can still access admin features

### Refresh Tokens (Long-lived)
- Valid for **7 days**
- Stored in database as SHA-256 hash (can be revoked)
- Single-use (invalidated after each refresh)
- On refresh, re-fetches admin status from Discord

## Changes

### Backend
- **`packages/api/prisma/schema.prisma`**: Added `RefreshToken` model for token storage
- **`packages/api/src/routes/auth.ts`**: 
  - New `/auth/refresh` endpoint
  - Modified `/auth/callback` to issue both tokens
  - Modified `/auth/logout` to revoke refresh tokens
  - Helper functions for token generation and cookie management

### Frontend
- **`packages/web/src/api/client.ts`**: Automatic token refresh on 401 errors with request queue
- **`packages/web/src/api/api.ts`**: Added `refresh()` function

### Database Migration
- Created migration for `RefreshToken` table

## Security Benefits

- ✅ Admin role changes now take effect within **1 hour maximum** (instead of 7 days)
- ✅ Refresh tokens can be revoked by deleting from database
- ✅ Single-use refresh tokens prevent token replay attacks
- ✅ Token hashes stored in database (not raw tokens)

## Testing

To apply the migration:
```bash
cd packages/api
npx prisma migrate deploy
```

Closes #18