### PR TITLE
fix(docs): correct ADMIN_ROLE_ID to ADMIN_ROLE_IDS

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,7 +30,7 @@ cp packages/bot/.env.example packages/bot/.env
 | `DISCORD_CLIENT_SECRET` | Discord application client secret | `abc123def456...` |
 | `DISCORD_BOT_TOKEN` | Discord bot token | `MTAwMC4xMjM0NTY3ODkw...` |
 | `GUILD_ID` | Discord server ID where the bot operates | `987654321098765432` |
-| `ADMIN_ROLE_ID` | Discord role ID for admin users | `123456789012345678` |
+| `ADMIN_ROLE_IDS` | Discord role ID(s) for admin users (comma-separated) | `123456789012345678` |
 | `JWT_SECRET` | Secret key for signing JWT tokens | `your-secure-random-string` |
 
 ### Optional Variables
@@ -136,7 +136,7 @@ DISCORD_CLIENT_ID=123456789012345678
 DISCORD_CLIENT_SECRET=your-client-secret
 DISCORD_BOT_TOKEN=your-bot-token
 GUILD_ID=987654321098765432
-ADMIN_ROLE_ID=123456789012345678
+ADMIN_ROLE_IDS=123456789012345678
 JWT_SECRET=dev-secret-change-in-production
 # DATABASE_URL is set by Docker Compose
 ```
@@ -157,7 +157,7 @@ DISCORD_CLIENT_ID=123456789012345678
 DISCORD_CLIENT_SECRET=your-client-secret
 DISCORD_BOT_TOKEN=your-bot-token
 GUILD_ID=987654321098765432
-ADMIN_ROLE_ID=123456789012345678
+ADMIN_ROLE_IDS=123456789012345678
 JWT_SECRET=a1b2c3d4e5f6...your-secure-64-char-hex-string
 WEB_UI_ORIGIN=https://alfira.example.com
 DISCORD_REDIRECT_URI=https://alfira.example.com/auth/callback

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -83,7 +83,7 @@ No local Node.js, ffmpeg, or yt-dlp installation needed — Docker handles every
 
 1. Enable **Developer Mode** in Discord: Settings → Advanced → Developer Mode.
 2. Right-click your server icon and select **"Copy Server ID"** — this is your `GUILD_ID`.
-3. Right-click the admin role and select **"Copy Role ID"** — this is your `ADMIN_ROLE_ID`.
+3. Right-click the admin role and select **"Copy Role ID"** — this is your `ADMIN_ROLE_IDS`.
 
 ---
 
@@ -107,7 +107,7 @@ cp packages/bot/.env.example packages/bot/.env
 | `DISCORD_BOT_TOKEN` | Discord bot token | `MTAwMC4...` |
 | `GUILD_ID` | Discord server ID | `987654321098765432` |
 | `JWT_SECRET` | Secret for signing JWT tokens | `your-secure-random-string` |
-| `ADMIN_ROLE_ID` | Discord role ID for admin permissions | `123456789012345678` |
+| `ADMIN_ROLE_IDS` | Discord role ID(s) for admin permissions (comma-separated) | `123456789012345678` |
 
 #### Required (Bot)
 


### PR DESCRIPTION
## What does this PR do?

Fixes a documentation inconsistency where `ADMIN_ROLE_ID` (singular) was referenced in the docs, but the actual implementation uses `ADMIN_ROLE_IDS` (plural, comma-separated).

## Related issue

Closes #60

## Changes

- Updated `docs/configuration.md`:
  - Changed `ADMIN_ROLE_ID` → `ADMIN_ROLE_IDS` in the Required Variables table
  - Updated description to indicate comma-separated values
  - Fixed example configurations in both development and production sections

- Updated `docs/installation.md`:
  - Changed `ADMIN_ROLE_ID` → `ADMIN_ROLE_IDS` in the "Get Your Guild and Role IDs" section
  - Updated the Required (API) variables table with correct name and description

## Impact

Users following the documentation will now set the correct environment variable name, ensuring admin access works as expected.

## Checklist

- [x] Documentation updated