### PR TITLE
docs: add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Initial public release
+- Discord OAuth2 login with role-based permissions (Admin vs Member)
+- Song library with YouTube URL ingestion via yt-dlp
+- Playlist management (create, rename, delete, add/remove songs)
+- Real-time sync via Socket.io for player state and library changes
+- Web UI player with progress bar and queue view
+- Slash commands: `/join`, `/leave`, `/play`, `/skip`, `/stop`, `/pause`, `/loop`, `/shuffle`, `/queue`, `/nowplaying`, `/playlist`
+- Queue management with loop modes (`off`, `song`, `queue`) and shuffle
+- Audio playback via `yt-dlp` + `ffmpeg` + `@discordjs/voice`
+- Auto-registration of slash commands on bot startup
+- Short-lived JWT tokens with refresh token flow
+- Rate limiting on authentication endpoints
+- Helmet middleware for HTTP security headers
+- Socket.io authentication middleware
+- Input length validation for security
+- Docker production deployment with pre-built images
+- Database migration service for PostgreSQL
+- Architecture diagram in tech stack documentation
+- Contributing guide for contributors
+
+### Security
+- Socket.io authentication middleware to validate connections
+- Helmet middleware for security headers
+- Input length validation on all user inputs
+- Short-lived JWT tokens with refresh token rotation
+- Rate limiting on authentication endpoints to prevent brute force


### PR DESCRIPTION
## What does this PR do?
Adds a `CHANGELOG.md` file following the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format to document project changes.

## Related issue
Closes #59 

## Summary
- Created `CHANGELOG.md` with initial content documenting the unreleased features
- Follows Keep a Changelog format with sections for Added and Security changes
- Documents all major features implemented so far including:
  - Discord OAuth2 login with role-based permissions
  - Song library with YouTube URL ingestion
  - Playlist management
  - Real-time sync via Socket.io
  - Web UI player with queue view
  - Slash commands for Discord bot
  - Security features (JWT tokens, rate limiting, helmet middleware, etc.)

## Testing
- Verified file content follows Keep a Changelog format
- Confirmed file is no longer in `.gitignore` expectations

## Checklist
- [x] TypeScript compiles without errors
- [x] Docker images build successfully
- [x] Documentation updated