### PR TITLE
feat: auto-join user's voice channel from web UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,8 @@ GUILD_ID=your-guild-id-here
 # Admin role ID(s) - comma-separated for multiple (enable Developer Mode, right-click role, Copy ID)
 ADMIN_ROLE_IDS=your-admin-role-id-here
 
+DEFAULT_TEXT_CHANNEL_ID=
+
 # ===========================================
 # SECURITY (Required)
 # ===========================================

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,6 +34,7 @@ cp packages/bot/.env.example packages/bot/.env
 | `JWT_SECRET` | Secret key for signing JWT tokens | `your-secure-random-string` |
 
 ### Optional Variables
+
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `DATABASE_URL` | PostgreSQL connection string | Set by Docker Compose |
@@ -41,6 +42,7 @@ cp packages/bot/.env.example packages/bot/.env
 | `WEB_UI_ORIGIN` | Public URL of the web UI (for CORS and redirects) | `http://localhost:5173` |
 | `DISCORD_REDIRECT_URI` | OAuth2 callback URL | `http://localhost:3001/auth/callback` |
 | `JWT_EXPIRES_IN` | JWT refresh token expiry duration (supports `d`, `h`, `m`, `s` suffixes) | `7d` |
+| `DEFAULT_TEXT_CHANNEL_ID` | Text channel for "Now playing" embeds when auto-joining via web UI | Guild's system channel |
 
 ### Production-Specific
 

--- a/packages/api/.env.example
+++ b/packages/api/.env.example
@@ -31,6 +31,8 @@ DISCORD_CLIENT_ID=
 # Right-click your server in Discord → Copy Server ID.
 GUILD_ID=
 
+DEFAULT_TEXT_CHANNEL_ID=
+
 # -----------------------------------------------
 # Discord OAuth2
 # -----------------------------------------------

--- a/packages/api/src/routes/player.ts
+++ b/packages/api/src/routes/player.ts
@@ -1,6 +1,9 @@
 import { Router } from 'express';
-import { getVoiceConnection } from '@discordjs/voice';
+import { getVoiceConnection, joinVoiceChannel, VoiceConnectionStatus, entersState } from '@discordjs/voice';
+import { TextChannel } from 'discord.js';
 import prisma from '../lib/prisma';
+import { getClient } from '@discord-music-bot/bot/src/lib/client';
+import { createPlayer } from '@discord-music-bot/bot/src/player/manager';
 import { requireAuth } from '../middleware/requireAuth';
 import { requireAdmin } from '../middleware/requireAdmin';
 import { asyncHandler } from '../middleware/errorHandler';
@@ -76,13 +79,56 @@ router.post(
       startFromSongId?: string;
     };
 
-    const player = getPlayer(GUILD_ID);
-
+    let player = getPlayer(GUILD_ID);
     if (!player) {
-      res.status(409).json({
-        error: 'The bot is not in a voice channel. Use /join in Discord first.',
-      });
-      return;
+      // Auto-join: Find the user's voice channel and join it.
+      const discordClient = getClient();
+      if (!discordClient) {
+        res.status(503).json({ error: 'Discord bot is not ready yet.' });
+        return;
+      }
+
+      try {
+        const guild = await discordClient.guilds.fetch(GUILD_ID);
+        const member = await guild.members.fetch(req.user!.discordId);
+        const voiceChannel = member.voice.channel;
+
+        if (!voiceChannel) {
+          res.status(409).json({
+            error: 'You are not in a voice channel. Join a voice channel in Discord first.',
+          });
+          return;
+        }
+
+        const connection = joinVoiceChannel({
+          channelId: voiceChannel.id,
+          guildId: GUILD_ID,
+          adapterCreator: guild.voiceAdapterCreator,
+        });
+
+        await entersState(connection, VoiceConnectionStatus.Ready, 5_000);
+
+        // Use DEFAULT_TEXT_CHANNEL_ID if set, otherwise fall back to system channel.
+        const textChannelId = process.env.DEFAULT_TEXT_CHANNEL_ID;
+        const textChannel = textChannelId
+          ? (guild.channels.cache.get(textChannelId) as TextChannel | undefined)
+          : (guild.systemChannel as TextChannel | null);
+
+        if (!textChannel) {
+          res.status(503).json({
+            error: 'Could not find a text channel for "Now playing" messages. Set DEFAULT_TEXT_CHANNEL_ID in your environment.',
+          });
+          return;
+        }
+
+        player = createPlayer(GUILD_ID, connection, textChannel);
+      } catch (error) {
+        console.error('Failed to auto-join voice channel:', error);
+        res.status(503).json({
+          error: 'Could not connect to your voice channel. Try using /join in Discord first.',
+        });
+        return;
+      }
     }
 
     // Fetch songs from the database.
@@ -328,12 +374,55 @@ router.post(
       return;
     }
 
-    const player = getPlayer(GUILD_ID);
+    let player = getPlayer(GUILD_ID);
     if (!player) {
-      res.status(409).json({
-        error: 'The bot is not in a voice channel. Use /join in Discord first.',
-      });
-      return;
+      // Auto-join: Find the user's voice channel and join it.
+      const discordClient = getClient();
+      if (!discordClient) {
+        res.status(503).json({ error: 'Discord bot is not ready yet.' });
+        return;
+      }
+
+      try {
+        const guild = await discordClient.guilds.fetch(GUILD_ID);
+        const member = await guild.members.fetch(req.user!.discordId);
+        const voiceChannel = member.voice.channel;
+
+        if (!voiceChannel) {
+          res.status(409).json({
+            error: 'You are not in a voice channel. Join a voice channel in Discord first.',
+          });
+          return;
+        }
+
+        const connection = joinVoiceChannel({
+          channelId: voiceChannel.id,
+          guildId: GUILD_ID,
+          adapterCreator: guild.voiceAdapterCreator,
+        });
+
+        await entersState(connection, VoiceConnectionStatus.Ready, 5_000);
+
+        const textChannelId = process.env.DEFAULT_TEXT_CHANNEL_ID;
+        const textChannel = textChannelId
+          ? (guild.channels.cache.get(textChannelId) as TextChannel | undefined)
+          : (guild.systemChannel as TextChannel | null);
+
+        if (!textChannel) {
+          res.status(503).json({
+            error: 'Could not find a text channel for "Now playing" messages. Set DEFAULT_TEXT_CHANNEL_ID in your environment.',
+          });
+          return;
+        }
+
+        player = createPlayer(GUILD_ID, connection, textChannel);
+      } catch (error) {
+        console.error('Failed to auto-join voice channel:', error);
+        res.status(503).json({
+          error: 'Could not connect to your voice channel. Try using /join in Discord first.',
+        });
+        return;
+      }
     }
 
     // Fetch metadata from YouTube

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -8,7 +8,8 @@
     ".": "./dist/bot/src/index.js",
     "./src/utils/ytdlp": "./dist/bot/src/utils/ytdlp.js",
     "./src/player/manager": "./dist/bot/src/player/manager.js",
-    "./src/lib/broadcast": "./dist/bot/src/lib/broadcast.js"
+    "./src/lib/broadcast": "./dist/bot/src/lib/broadcast.js",
+    "./src/lib/client": "./dist/bot/src/lib/client.js"
   },
   "scripts": {
     "deploy": "ts-node src/deploy-commands.ts",

--- a/packages/bot/src/index.ts
+++ b/packages/bot/src/index.ts
@@ -1,4 +1,5 @@
 import { Client, GatewayIntentBits, Collection, Interaction, InteractionReplyOptions, REST, Routes } from 'discord.js';
+import { setClient } from './lib/client';
 import { joinCommand } from './commands/join';
 import { leaveCommand } from './commands/leave';
 import { playCommand } from './commands/play';
@@ -62,12 +63,15 @@ export async function startBot(): Promise<void> {
     throw new Error('GUILD_ID is not set.');
   }
 
-  const client = new Client({
-    intents: [
-      GatewayIntentBits.Guilds,
-      GatewayIntentBits.GuildVoiceStates,
-    ],
-  });
+  	const client = new Client({
+  		intents: [
+  			GatewayIntentBits.Guilds,
+  			GatewayIntentBits.GuildVoiceStates,
+  		],
+  	});
+
+  	// Expose the client so the API can access it for auto-join functionality.
+  	setClient(client);
 
   client.commands = new Collection<string, Command>();
 

--- a/packages/bot/src/lib/client.ts
+++ b/packages/bot/src/lib/client.ts
@@ -1,0 +1,31 @@
+import { Client } from 'discord.js';
+
+// ---------------------------------------------------------------------------
+// Client Singleton
+//
+// The API's player route needs access to the Discord Client instance to fetch
+// channels and guild info for the auto-join feature. This module provides a
+// simple getter/setter so the client created in startBot() can be accessed
+// from the API package.
+//
+// The client is set once during bot startup and remains available for the
+// lifetime of the process.
+// ---------------------------------------------------------------------------
+
+let _client: Client | null = null;
+
+/**
+ * Store the Discord client reference.
+ * Called once during bot startup in packages/bot/src/index.ts.
+ */
+export function setClient(client: Client): void {
+  _client = client;
+}
+
+/**
+ * Retrieve the Discord client instance.
+ * Returns null if the bot hasn't started yet.
+ */
+export function getClient(): Client | null {
+  return _client;
+}


### PR DESCRIPTION
## Summary

This PR implements auto-join functionality for the web UI, allowing users to start playback directly from the web interface without first running `/join` in Discord.

## Changes

### Issue #64: Export Discord client singleton
- Created `packages/bot/src/lib/client.ts` with `setClient()` and `getClient()` functions
- Modified `packages/bot/src/index.ts` to call `setClient(client)` after creating the Discord client
- Added export to `packages/bot/package.json` for the new client module

### Issue #65: Auto-join voice channel from web UI
- Modified `packages/api/src/routes/player.ts` to auto-join the requesting user's voice channel
- When no player exists, the API now:
  1. Fetches the Discord client
  2. Looks up the user's voice state using their Discord ID
  3. Joins the voice channel they're currently in
  4. Creates a player for playback
- Added `DEFAULT_TEXT_CHANNEL_ID` environment variable for "Now playing" embeds
- Updated `.env.example` files and `docs/configuration.md`

## Behavior

- **User in a voice channel**: Bot automatically joins their channel and starts playback
- **User not in a voice channel**: Returns 409 error asking them to join a voice channel first
- **Bot not ready**: Returns 503 service unavailable error

## Environment Variables

| Variable | Description | Default |
|----------|-------------|---------|
| `DEFAULT_TEXT_CHANNEL_ID` | Text channel for "Now playing" embeds when auto-joining via web UI | Guild's system channel |

Closes #64, Closes #65