### PR TITLE
feat: show friendly creator name instead of Discord ID

### DIFF
--- a/packages/api/src/routes/playlists.ts
+++ b/packages/api/src/routes/playlists.ts
@@ -4,10 +4,31 @@ import { requireAuth } from '../middleware/requireAuth';
 import { requireAdmin } from '../middleware/requireAdmin';
 import { asyncHandler } from '../middleware/errorHandler';
 import { emitPlaylistUpdated } from '../lib/socket';
+import { getClient } from '@discord-music-bot/bot/src/lib/client';
 
 const router = Router();
-
 const MAX_NAME_LENGTH = 200;
+
+// ---------------------------------------------------------------------------
+// Helper: Fetch user's display name from Discord
+// Returns nickname if set, otherwise username
+// ---------------------------------------------------------------------------
+async function getUserDisplayName(discordId: string): Promise<string> {
+  const client = getClient();
+  if (!client) return discordId;
+
+  try {
+    // Use the configured guild ID from environment
+    const guildId = process.env.GUILD_ID;
+    if (!guildId) return discordId;
+
+    const guild = await client.guilds.fetch(guildId);
+    const member = await guild.members.fetch(discordId);
+    return member.displayName || member.user.username || discordId;
+  } catch {
+    return discordId;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // GET /api/playlists
@@ -29,7 +50,15 @@ router.get(
       return pl.createdBy === req.user!.discordId || req.user!.isAdmin;
     });
 
-    res.json(filteredPlaylists);
+    // Fetch creator display names for each playlist
+    const playlistsWithCreator = await Promise.all(
+      filteredPlaylists.map(async (pl) => ({
+        ...pl,
+        createdByDisplayName: await getUserDisplayName(pl.createdBy),
+      }))
+    );
+
+    res.json(playlistsWithCreator);
   })
 );
 
@@ -101,9 +130,12 @@ router.get(
       }
     }
 
-    res.json(playlist);
-  })
-);
+    		res.json({
+    			...playlist,
+    			createdByDisplayName: await getUserDisplayName(playlist.createdBy),
+    		});
+    	})
+    );
 
 // ---------------------------------------------------------------------------
 // PATCH /api/playlists/:id/visibility

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -68,6 +68,7 @@ export interface Playlist {
   id: string;
   name: string;
   createdBy: string;
+  createdByDisplayName?: string;
   isPrivate: boolean;
   createdAt: Date;
   songs?: PlaylistSong[];

--- a/packages/web/src/api/types.ts
+++ b/packages/web/src/api/types.ts
@@ -18,6 +18,7 @@ export interface Playlist {
   id: string;
   name: string;
   createdBy: string;
+  createdByDisplayName?: string;
   isPrivate: boolean;
   createdAt: string;
   _count?: { songs: number };

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -235,7 +235,7 @@ export default function PlaylistDetailPage() {
             {' • '}
             {user?.discordId === playlist.createdBy
               ? 'Created by you'
-              : `Created by ${playlist.createdBy}`}
+              : `Created by ${playlist.createdByDisplayName || playlist.createdBy}`}
           </p>
         </div>
 


### PR DESCRIPTION
- Add getUserDisplayName helper to fetch user's display name from Discord
- Update GET /api/playlists to include createdByDisplayName
- Update GET /api/playlists/:id to include createdByDisplayName
- Add createdByDisplayName to Playlist type (web and shared)
- Update PlaylistDetailPage to use display name for creator

The creator name now shows the user's Discord nickname/username instead of their raw Discord ID.