### PR TITLE
feat: require Admin View for admin access to private playlists

### DIFF
--- a/packages/api/src/routes/playlists.ts
+++ b/packages/api/src/routes/playlists.ts
@@ -18,15 +18,18 @@ router.get(
   '/',
   requireAuth,
   asyncHandler(async (req, res) => {
+    const adminView = req.query.adminView === 'true';
     const playlists = await prisma.playlist.findMany({
       orderBy: { createdAt: 'asc' },
       include: { _count: { select: { songs: true } } },
     });
 
-    // Filter private playlists: only visible to creator and admins
+    // Filter private playlists: only visible to creator and admins (in Admin View)
     const filteredPlaylists = playlists.filter((pl) => {
       if (!pl.isPrivate) return true;
-      return pl.createdBy === req.user!.discordId || req.user!.isAdmin;
+      const isCreator = pl.createdBy === req.user!.discordId;
+      const isAdminInAdminView = req.user!.isAdmin && adminView;
+      return isCreator || isAdminInAdminView;
     });
 
     res.json(filteredPlaylists);
@@ -76,6 +79,7 @@ router.get(
   '/:id',
   requireAuth,
   asyncHandler(async (req, res) => {
+    const adminView = req.query.adminView === 'true';
     const playlist = await prisma.playlist.findUnique({
       where: { id: req.params.id as string },
       include: {
@@ -94,8 +98,8 @@ router.get(
     // Check access for private playlists
     if (playlist.isPrivate) {
       const isCreator = playlist.createdBy === req.user!.discordId;
-      const isAdmin = req.user!.isAdmin;
-      if (!isCreator && !isAdmin) {
+      const isAdminInAdminView = req.user!.isAdmin && adminView;
+      if (!isCreator && !isAdminInAdminView) {
         res.status(403).json({ error: 'Access denied. This playlist is private.' });
         return;
       }
@@ -115,8 +119,7 @@ router.patch(
   '/:id/visibility',
   requireAuth,
   asyncHandler(async (req, res) => {
-    const { isPrivate } = req.body as { isPrivate?: boolean };
-
+    const { isPrivate, adminView } = req.body as { isPrivate?: boolean; adminView?: boolean };
     if (typeof isPrivate !== 'boolean') {
       res.status(400).json({ error: 'isPrivate (boolean) is required.' });
       return;
@@ -131,12 +134,11 @@ router.patch(
       return;
     }
 
-    // Check permissions: creator or admin
+    // Check permissions: creator or admin (in Admin View)
     const isCreator = existing.createdBy === req.user!.discordId;
-    const isAdmin = req.user!.isAdmin;
-
-    if (!isCreator && !isAdmin) {
-      res.status(403).json({ error: 'Only the creator or admins can change visibility.' });
+    const isAdminInAdminView = req.user!.isAdmin && adminView;
+    if (!isCreator && !isAdminInAdminView) {
+      res.status(403).json({ error: 'Only the creator or admins (in Admin View) can change visibility.' });
       return;
     }
 

--- a/packages/web/src/api/api.ts
+++ b/packages/web/src/api/api.ts
@@ -18,14 +18,20 @@ export const deleteSong = (id: string) => client.delete(`/api/songs/${id}`);
 // ---------------------------------------------------------------------------
 // Playlists
 // ---------------------------------------------------------------------------
-export const getPlaylists = () => client.get<Playlist[]>('/api/playlists').then((r) => r.data);
+export const getPlaylists = (adminView?: boolean) => {
+  const params = adminView ? '?adminView=true' : '';
+  return client.get<Playlist[]>(`/api/playlists${params}`).then((r) => r.data);
+};
 export const createPlaylist = (name: string) => client.post<Playlist>('/api/playlists', { name }).then((r) => r.data);
-export const getPlaylist = (id: string) => client.get<PlaylistDetail>(`/api/playlists/${id}`).then((r) => r.data);
+export const getPlaylist = (id: string, adminView?: boolean) => {
+  const params = adminView ? '?adminView=true' : '';
+  return client.get<PlaylistDetail>(`/api/playlists/${id}${params}`).then((r) => r.data);
+};
 export const renamePlaylist = (id: string, name: string) => client.patch<Playlist>(`/api/playlists/${id}`, { name }).then((r) => r.data);
 export const deletePlaylist = (id: string) => client.delete(`/api/playlists/${id}`);
 export const addSongToPlaylist = (playlistId: string, songId: string) => client.post(`/api/playlists/${playlistId}/songs`, { songId });
 export const removeSongFromPlaylist = (playlistId: string, songId: string) => client.delete(`/api/playlists/${playlistId}/songs/${songId}`);
-export const togglePlaylistVisibility = (playlistId: string, isPrivate: boolean) => client.patch<Playlist>(`/api/playlists/${playlistId}/visibility`, { isPrivate }).then((r) => r.data);
+export const togglePlaylistVisibility = (playlistId: string, isPrivate: boolean, adminView?: boolean) => client.patch<Playlist>(`/api/playlists/${playlistId}/visibility`, { isPrivate, adminView }).then((r) => r.data);
 
 // ---------------------------------------------------------------------------
 // Player

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -39,7 +39,7 @@ export default function PlaylistDetailPage() {
     if (!id) return;
     setLoading(true);
     try {
-      const pl = await getPlaylist(id);
+      const pl = await getPlaylist(id, isAdminView);
       setPlaylist(pl);
       setNameValue(pl.name);
     } catch {
@@ -47,7 +47,7 @@ export default function PlaylistDetailPage() {
     } finally {
       setLoading(false);
     }
-  }, [id, navigate]);
+  }, [id, navigate, isAdminView]);
 
   useEffect(() => { load(); }, [load]);
 
@@ -119,9 +119,9 @@ export default function PlaylistDetailPage() {
   };
 
   const handleToggleVisibility = async () => {
-    if (!playlist) return;
-    try {
-      const updated = await togglePlaylistVisibility(playlist.id, !playlist.isPrivate);
+  if (!playlist) return;
+  try {
+  const updated = await togglePlaylistVisibility(playlist.id, !playlist.isPrivate, isAdminView);
       setPlaylist((p) => (p ? { ...p, isPrivate: updated.isPrivate } : p));
       setNotification({
         message: updated.isPrivate ? 'Playlist set to private' : 'Playlist set to public',

--- a/packages/web/src/pages/PlaylistsPage.tsx
+++ b/packages/web/src/pages/PlaylistsPage.tsx
@@ -15,13 +15,13 @@ export default function PlaylistsPage() {
   const [deleteTarget, setDeleteTarget] = useState<Playlist | null>(null);
 
   const load = useCallback(async () => {
-    setLoading(true);
-    try {
-      setPlaylists(await getPlaylists());
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+      setLoading(true);
+      try {
+        setPlaylists(await getPlaylists(isAdminView));
+      } finally {
+        setLoading(false);
+      }
+    }, [isAdminView]);
 
   useEffect(() => { load(); }, [load]);
 


### PR DESCRIPTION
## Summary

This PR changes the admin permissions for private playlists so that admins can only see and manage private playlists when they are in **Admin View mode**.

## Changes

### Backend (`packages/api/src/routes/playlists.ts`)
- `GET /api/playlists`: Now checks for `adminView=true` query parameter before allowing admins to see private playlists
- `GET /api/playlists/:id`: Now checks for `adminView=true` query parameter before allowing admins to access private playlist details
- `PATCH /api/playlists/:id/visibility`: Now checks for `adminView: true` in request body before allowing admins to toggle visibility

### Frontend (`packages/web/src/api/api.ts`)
- `getPlaylists(adminView?)`: Added optional `adminView` parameter
- `getPlaylist(id, adminView?)`: Added optional `adminView` parameter
- `togglePlaylistVisibility(playlistId, isPrivate, adminView?)`: Added optional `adminView` parameter

### Frontend Pages
- `PlaylistsPage.tsx`: Passes `isAdminView` to `getPlaylists()`
- `PlaylistDetailPage.tsx`: Passes `isAdminView` to `getPlaylist()` and `togglePlaylistVisibility()`

## Behavior Changes

| Action | Before | After |
|--------|--------|-------|
| Admin sees private playlists in list | Always | Only in Admin View |
| Admin accesses private playlist detail | Always | Only in Admin View |
| Admin toggles private playlist visibility | Always | Only in Admin View |
| Creator sees their private playlists | Always | Always (unchanged) |
| Creator toggles their playlist visibility | Always | Always (unchanged) |

## Testing

- [x] TypeScript compilation passes with no errors
- [x] Backend correctly checks `adminView` parameter
- [x] Frontend passes `isAdminView` to API calls