### PR TITLE
fix: handle Discord permission errors when sending messages

### DIFF
--- a/packages/bot/src/player/GuildPlayer.ts
+++ b/packages/bot/src/player/GuildPlayer.ts
@@ -507,9 +507,13 @@ export class GuildPlayer {
         `[GuildPlayer:${this.guildId}] Failed to get stream URL for "${next.title}" after 3 attempts:`,
         error,
       );
-      await this.textChannel.send(
-        `⚠️ Skipping **${next.title}** — could not resolve the audio stream.`,
-      );
+      try {
+        await this.textChannel.send(
+          `⚠️ Skipping **${next.title}** — could not resolve the audio stream.`,
+        );
+      } catch (e) {
+        console.error(`[GuildPlayer:${this.guildId}] Failed to send message to text channel:`, e);
+      }
       // Try the next song instead.
       await this.playNext();
       return;
@@ -538,9 +542,13 @@ export class GuildPlayer {
       console.error(
         `[GuildPlayer:${this.guildId}] AudioPlayer failed to enter Playing state for "${next.title}"`,
       );
-      await this.textChannel.send(
-        `⚠️ Skipping **${next.title}** — audio failed to start.`,
-      );
+      try {
+        await this.textChannel.send(
+          `⚠️ Skipping **${next.title}** — audio failed to start.`,
+        );
+      } catch (e) {
+        console.error(`[GuildPlayer:${this.guildId}] Failed to send message to text channel:`, e);
+      }
       await this.playNext();
       return;
     }
@@ -552,7 +560,11 @@ export class GuildPlayer {
     // Broadcast after confirming playback has actually started.
     broadcastQueueUpdate(this.getQueueState());
 
-    await this.textChannel.send({ embeds: [this.buildNowPlayingEmbed(next)] });
+    try {
+      await this.textChannel.send({ embeds: [this.buildNowPlayingEmbed(next)] });
+    } catch (e) {
+      console.error(`[GuildPlayer:${this.guildId}] Failed to send "Now Playing" embed:`, e);
+    }
   }
 
   /**


### PR DESCRIPTION
## Problem

When playing a song from the UI, users were seeing a "Missing Access" error message even though the song was playing successfully. This was happening in production.

## Root Cause

The `GuildPlayer` class sends "Now Playing" embed messages to a text channel after playback starts. If the bot doesn't have the "Send Messages" permission in the configured `DEFAULT_TEXT_CHANNEL_ID` channel, Discord returns a "Missing Access" error.

Since the `textChannel.send()` calls were not wrapped in try-catch blocks, this error would propagate up and cause the UI to show an error, even though the audio playback was working correctly.

## Solution

Wrap all `textChannel.send()` calls in try-catch blocks:
- When sending "Now Playing" embeds
- When sending error messages about skipped songs

The error is now logged to the console but doesn't interrupt playback or cause UI errors.

## Testing

- [x] TypeScript compilation passes
- [x] Error handling covers all `textChannel.send()` calls

## Note

This fix ensures that even if the bot lacks permissions to send messages, playback will continue uninterrupted. The "Missing Access" error will be logged server-side for debugging.