### PR TITLE
Add SECURITY.md for vulnerability disclosure

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please do not open a public GitHub issue for security vulnerabilities.
+
+Instead, report them by emailing the maintainer or opening a [GitHub private security advisory](https://github.com/ebears/alfira-bot/security/advisories/new).
+
+Include:
+- A description of the vulnerability
+- Steps to reproduce
+- Potential impact
+
+You will receive a response within 72 hours.
+
+## Supported Versions
+
+Security updates are applied to the latest release only.


### PR DESCRIPTION
## What does this PR do?

Adds a `SECURITY.md` file at the repository root that documents the process for reporting security vulnerabilities.

## Related issue

Closes #54

## Summary of changes

- Created `SECURITY.md` with:
  - Instructions to not open public GitHub issues for security vulnerabilities
  - Guidance to report via email or GitHub private security advisory
  - Required information to include (description, steps to reproduce, potential impact)
  - Response time commitment (72 hours)
  - Supported versions section

## Why this is important

This project handles Discord OAuth tokens and JWT secrets. As a self-hosted application that users may run on public-facing servers, having a documented security policy is essential for responsible disclosure.

## Checklist

- [x] Documentation updated