### PR TITLE
Add GitHub Issue and Pull Request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Something isn't working
+labels: bug
+---
+
+## Describe the bug
+A clear description of what the bug is.
+
+## Steps to reproduce
+1. ...
+2. ...
+3. ...
+
+## Expected behaviour
+What you expected to happen.
+
+## Actual behaviour
+What actually happened.
+
+## Environment
+- Deployment: [ ] Docker production [ ] Docker development
+- OS:
+- Docker version:
+- Browser (if web UI issue):
+
+## Relevant logs
+Please paste any relevant log output (from `docker compose logs -f api` or `docker compose logs -f web`):
+
+```
+Paste logs here
+```
+
+## Screenshots
+If applicable, add screenshots to help explain the problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an improvement
+labels: enhancement
+---
+
+## Summary
+A brief description of the feature.
+
+## Motivation
+Why would this be useful? What problem does it solve?
+
+## Proposed solution
+How you think it could be implemented (optional).
+
+## Alternatives considered
+Any alternative solutions or features you've considered (optional).
+
+## Additional context
+Add any other context or screenshots about the feature request here (optional).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## What does this PR do?
+A brief description of the changes introduced by this PR.
+
+## Related issue
+Closes #
+
+## Type of change
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+- [ ] CI/CD improvement
+
+## Testing
+How was this tested? Describe the steps you took to verify the changes.
+
+## Checklist
+- [ ] TypeScript compiles without errors (`npm run typecheck` or `tsc --noEmit`)
+- [ ] Docker images build successfully (`docker compose build`)
+- [ ] Documentation updated if needed
+- [ ] Changes follow the project's code style
+
+## Screenshots (if applicable)
+Add screenshots to help explain your changes.
+
+## Additional notes
+Any other information that reviewers should know about.


### PR DESCRIPTION
## What does this PR do?
Adds GitHub Issue and Pull Request templates to help contributors provide the necessary information when submitting bug reports, feature requests, and pull requests.

## Related issue
Closes #51

## Changes Made
- Added `.github/ISSUE_TEMPLATE/bug_report.md` - Template for bug reports with sections for description, reproduction steps, environment details, logs, and screenshots
- Added `.github/ISSUE_TEMPLATE/feature_request.md` - Template for feature requests with sections for summary, motivation, proposed solution, and alternatives
- Added `.github/PULL_REQUEST_TEMPLATE.md` - Template for pull requests with checklist for type of change, testing steps, and verification checklist

## Testing
- Verified templates are in the correct location for GitHub to recognize them
- Templates follow GitHub's issue/PR template format with YAML frontmatter for labels

## Checklist
- [x] Documentation updated if needed (N/A - these are documentation files)
- [x] Changes follow the project's code style