### PR TITLE
ci: add PR validation for Docker builds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,17 +1,51 @@
 name: Build Docker images
-
 on:
   push:
     branches: main
     paths-ignore:
       - "docs/**"
       - "README.md"
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "README.md"
   workflow_dispatch:
 
 jobs:
-  build-images:
+  build:
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build API + bot image (validate only)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.api
+          push: false
+
+      - name: Build web image (validate only)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.web
+          push: false
+
+      - name: Build migrate image (validate only)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.migrate
+          push: false
+
+  publish:
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -26,7 +60,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build API + bot image
+      - name: Build and push API + bot image
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -36,7 +70,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/alfira-bot-api:latest
             ghcr.io/${{ github.repository_owner }}/alfira-bot-api:${{ github.sha }}
 
-      - name: Build web image
+      - name: Build and push web image
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -46,7 +80,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/alfira-bot-web:latest
             ghcr.io/${{ github.repository_owner }}/alfira-bot-web:${{ github.sha }}
 
-      - name: Build migrate image
+      - name: Build and push migrate image
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
## Summary

This PR addresses Issue #58 by splitting the `docker-build.yml` workflow into two jobs:

1. **`build` job**: Validates Dockerfiles by building all three images without pushing. Runs on both `push` to main and `pull_request` events.

2. **`publish` job**: Pushes images to GHCR. Only runs on `push` to main branch (after `build` succeeds).

## Changes

- Added `pull_request` trigger to the workflow
- Split the single `build-images` job into:
  - `build`: Builds images with `push: false` for validation
  - `publish`: Depends on `build`, only runs on `refs/heads/main`
- Updated step names to clarify "validate only" vs "build and push"

## Benefits

- Prevents broken Dockerfiles from being merged to main
- CI validation runs on every PR before merge
- No changes to the actual publish behavior on main

Closes #58