### PR TITLE
fix(deps): update @types/node to v25 and fix @snazzah/davey version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2431,12 +2431,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
-      "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
+      "version": "25.3.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",
+      "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/qs": {
@@ -5837,9 +5837,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -6099,7 +6099,7 @@
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.6",
         "@types/jsonwebtoken": "^9.0.10",
-        "@types/node": "^22.0.0",
+        "@types/node": "^25.3.3",
         "prisma": "^7.4.2",
         "ts-node": "^10.9.2",
         "typescript": "^5.4.5"
@@ -6121,7 +6121,7 @@
         "tweetnacl": "^1.0.3"
       },
       "devDependencies": {
-        "@types/node": "^22.0.0",
+        "@types/node": "^25.3.3",
         "ts-node": "^10.9.2",
         "typescript": "^5.4.5"
       }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -35,7 +35,7 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.6",
     "@types/jsonwebtoken": "^9.0.10",
-    "@types/node": "^22.0.0",
+    "@types/node": "^25.3.3",
     "prisma": "^7.4.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5"

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -21,14 +21,14 @@
     "@discordjs/voice": "^0.19.0",
     "@prisma/adapter-pg": "^7.4.2",
     "@prisma/client": "^7.4.2",
-    "@snazzah/davey": "latest",
+    "@snazzah/davey": "^0.1.10",
     "discord.js": "^14.14.1",
     "dotenv": "^17.3.1",
     "fs-capacitor": "^8.0.0",
     "tweetnacl": "^1.0.3"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
+    "@types/node": "^25.3.3",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5"
   }


### PR DESCRIPTION
## Summary

This PR fixes the issue with Dependabot PR #83 and properly updates `@types/node` to v25.

## Problem

The original Dependabot PR #83 had an issue where `@snazzah/davey` was being resolved to `*` in the package-lock.json due to the `latest` version constraint in `packages/bot/package.json`. This is problematic because:
- `*` means "any version" which is unstable and can break at any time
- It could lead to unexpected behavior in production

## Changes

- Update `@types/node` from 22.19.13 to 25.3.3
- Fix `@snazzah/davey` version constraint from `latest` to `^0.1.10`
- This ensures proper version locking in package-lock.json

## Testing

- No TypeScript errors after the update
- All diagnostics pass

Closes #83