### PR TITLE
fix(deps): update postcss to 8.5.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4865,9 +4865,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "dev": true,
       "funding": [
         {
@@ -6146,7 +6146,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.4",
         "autoprefixer": "^10.4.20",
-        "postcss": "^8.4.45",
+        "postcss": "^8.5.8",
         "tailwindcss": "^4.2.1",
         "typescript": "^5.5.3",
         "vite": "^7.3.1"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -21,7 +21,7 @@
     "@tailwindcss/postcss": "^4.2.1",
     "@vitejs/plugin-react": "^5.1.4",
     "autoprefixer": "^10.4.20",
-    "postcss": "^8.4.45",
+    "postcss": "^8.5.8",
     "tailwindcss": "^4.2.1",
     "typescript": "^5.5.3",
     "vite": "^7.3.1"


### PR DESCRIPTION
## Summary

This PR correctly updates postcss from 8.5.6 to 8.5.8, fixing an issue with the original dependabot PR #81.

## Problem

The original dependabot PR #81 had an unintended change where `@snazzah/davey` was incorrectly changed from `"^0.1.10"` to `"*"` (wildcard version). Using `*` as a version specifier is bad practice as it allows any version which can lead to instability.

## Solution

- Updated postcss to 8.5.8 using `npm install`
- This ensures the package-lock.json is updated correctly without affecting other dependencies

## Changes

- `packages/web/package.json`: Updated postcss from `^8.4.45` to `^8.5.8`
- `package-lock.json`: Updated postcss version and integrity hash

## Related

- Closes #81 (the problematic dependabot PR)