### PR TITLE
Add typecheck CI workflow for PR validation

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -15,14 +15,17 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '25'
-          cache: 'npm'
+          node-version: "25"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
 
       - name: Generate Prisma client
         run: DATABASE_URL="postgresql://dummy:dummy@localhost:5432/dummy" npm run db:generate
+
+      - name: Build bot package
+        run: npm run -w packages/bot build
 
       - name: Typecheck API
         run: npx tsc --noEmit -p packages/api/tsconfig.json


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow to run TypeScript type checking on pull requests and pushes to main.

Closes #53

## Changes
- Added `.github/workflows/typecheck.yml` with the following:
  - Runs on push to `main` and on all pull requests
  - Uses Node.js 25 (matching the project's Dockerfile)
  - Installs dependencies with `npm ci`
  - Generates Prisma client with a dummy `DATABASE_URL`
  - Runs `tsc --noEmit` for each package:
    - `packages/api`
    - `packages/bot`
    - `packages/web`

## Notes
- The `shared` package has no `tsconfig.json` and is source-only, so it's typechecked transitively when the other packages are checked.
- No lint step was added as the project doesn't have an ESLint configuration.