### PR TITLE
fix(shared): add types field and document source-only nature

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,5 +2,7 @@
   "name": "@discord-music-bot/shared",
   "version": "0.1.0",
   "private": true,
-  "main": "src/types.ts"
+  "main": "src/types.ts",
+  "types": "src/types.ts",
+  "_note": "Source-only package. Consumed directly by ts-node (api/bot) and Vite (web). No build step. All imports use 'import type' so types are erased at compile time."
 }


### PR DESCRIPTION
## Summary

This PR addresses Issue #57 by documenting the source-only nature of the `@discord-music-bot/shared` package.

## Changes

- Added `"types": "src/types.ts"` field to explicitly indicate where TypeScript type definitions are located
- Added `"_note"` field explaining that this is a source-only package consumed directly by ts-node (api/bot) and Vite (web)

## Rationale

The `shared` package contains only TypeScript type definitions. All imports from this package use `import type` syntax, which means:

1. Types are completely erased at compile time
2. There's no runtime dependency on the shared package
3. Adding a build step would be unnecessary overhead

This follows **Option B** from the issue, which is the simpler and more appropriate solution given the package's usage pattern.

## Testing

- No functional changes to the codebase
- The package continues to work as before with ts-node and Vite

Closes #57