### PR TITLE
feat: Add nickname to songs from Library

### DIFF
--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -18,6 +18,7 @@ model Song {
   duration      Int            // seconds
   thumbnailUrl  String
   addedBy       String         // Discord user ID (or 'system' before Phase 5)
+  nickname String?
   createdAt     DateTime       @default(now())
   playlistSongs PlaylistSong[]
 }

--- a/packages/api/src/routes/songs.ts
+++ b/packages/api/src/routes/songs.ts
@@ -43,7 +43,7 @@ router.post(
   requireAuth,
   requireAdmin,
   asyncHandler(async (req, res) => {
-    const { youtubeUrl } = req.body as { youtubeUrl?: string };
+    const { youtubeUrl, nickname } = req.body as { youtubeUrl?: string; nickname?: string };
 
     if (!youtubeUrl || typeof youtubeUrl !== 'string') {
       res.status(400).json({ error: 'youtubeUrl is required.' });
@@ -94,6 +94,7 @@ router.post(
         duration: metadata.duration,
         thumbnailUrl: metadata.thumbnailUrl,
         addedBy: req.user!.discordId,
+        nickname: nickname?.trim() || null,
       },
     });
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -13,14 +13,15 @@
 // requestedBy — use QueuedSong for that.
 // ---------------------------------------------------------------------------
 export interface Song {
-  id: string;
-  title: string;
-  youtubeUrl: string;
-  youtubeId: string;
-  duration: number;       // seconds
-  thumbnailUrl: string;
-  addedBy: string;        // Discord user ID
-  createdAt: Date;
+ id: string;
+ title: string;
+ youtubeUrl: string;
+ youtubeId: string;
+ duration: number; // seconds
+ thumbnailUrl: string;
+ addedBy: string; // Discord user ID
+ nickname?: string | null; // Custom display name for the song
+ createdAt: Date;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/api/api.ts
+++ b/packages/web/src/api/api.ts
@@ -12,7 +12,8 @@ export const refresh = () => client.post<{ user: User }>('/auth/refresh').then((
 // Songs
 // ---------------------------------------------------------------------------
 export const getSongs = () => client.get<Song[]>('/api/songs').then((r) => r.data);
-export const addSong = (youtubeUrl: string) => client.post<Song>('/api/songs', { youtubeUrl }).then((r) => r.data);
+export const addSong = (youtubeUrl: string, nickname?: string) => client.post<Song>('/api/songs', { youtubeUrl, ...(nickname && { nickname }) }).then((r) => r.data);
+
 export const deleteSong = (id: string) => client.delete(`/api/songs/${id}`);
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/api/types.ts
+++ b/packages/web/src/api/types.ts
@@ -11,6 +11,7 @@ export interface Song {
   duration: number;
   thumbnailUrl: string;
   addedBy: string;
+  nickname?: string | null;
   createdAt: string;
 }
 

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -384,12 +384,15 @@ function SongRow({
       </div>
       <img
         src={song.thumbnailUrl}
-        alt={song.title}
+        alt={song.nickname || song.title}
         className="w-10 h-7 object-cover rounded border border-border shrink-0"
         loading="lazy"
       />
       <div className="flex-1 min-w-0">
-        <p className="font-body text-sm font-medium text-fg truncate">{song.title}</p>
+        <p className="font-body text-sm font-medium text-fg truncate">{song.nickname || song.title}</p>
+                      {song.nickname && (
+                        <p className="font-mono text-[10px] text-muted truncate">{song.title}</p>
+                      )}
       </div>
       <span className="font-mono text-xs text-muted shrink-0">
         {formatDuration(song.duration)}
@@ -488,11 +491,11 @@ function AddSongsModal({
                                                hover:bg-elevated transition-colors duration-100">
                   <img
                     src={song.thumbnailUrl}
-                    alt={song.title}
+                    alt={song.nickname || song.title}
                     className="w-10 h-7 object-cover rounded border border-border shrink-0"
                     loading="lazy"
                   />
-                  <span className="flex-1 font-body text-sm text-fg truncate">{song.title}</span>
+                  <span className="flex-1 font-body text-sm text-fg truncate">{song.nickname || song.title}</span>
                   <span className="font-mono text-xs text-muted">{formatDuration(song.duration)}</span>
                   <button
                     disabled={isAdded || isAdding}

--- a/packages/web/src/pages/QueuePage.tsx
+++ b/packages/web/src/pages/QueuePage.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect } from 'react';
 import { usePlayer } from '../context/PlayerContext';
 import { useAdminView } from '../context/AdminViewContext';
 import { startPlayback, getPlaylists, quickAddToQueue } from '../api/api';
-import type { LoopMode, Playlist } from '../api/types';
+import type { LoopMode, Playlist, QueuedSong } from '../api/types';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -183,12 +183,12 @@ export default function QueuePage() {
                 </span>
                 <img
                   src={song.thumbnailUrl}
-                  alt={song.title}
+                  alt={song.nickname || song.title}
                   className="w-10 h-7 object-cover rounded border border-border shrink-0"
                   loading="lazy"
                 />
                 <div className="flex-1 min-w-0">
-                  <p className="font-body text-sm font-medium text-fg truncate">{song.title}</p>
+                  <p className="font-body text-sm font-medium text-fg truncate">{song.nickname || song.title}</p>
                   <p className="font-mono text-[10px] text-muted">req. {song.requestedBy}</p>
                 </div>
                 <span className="font-mono text-xs text-muted shrink-0">
@@ -242,7 +242,7 @@ function NowPlayingCard({
   elapsed,
   progress,
 }: {
-  song: { title: string; thumbnailUrl: string; duration: number; requestedBy: string };
+  song: QueuedSong;
   isPlaying: boolean;
   elapsed: number;
   progress: number;
@@ -264,7 +264,7 @@ function NowPlayingCard({
           <div className="relative">
             <img
               src={song.thumbnailUrl}
-              alt={song.title}
+              alt={song.nickname || song.title}
               className="h-36 w-auto rounded-lg border border-border shadow-2xl object-cover"
             />
             {/* Playing indicator */}
@@ -281,7 +281,7 @@ function NowPlayingCard({
       {/* Info + progress */}
       <div className="px-5 py-4">
         <p className="font-body font-bold  text-fg truncate leading-tight">
-          {song.title}
+          {song.nickname || song.title}
         </p>
         <p className="font-mono text-[10px] text-muted mt-0.5">
           requested by {song.requestedBy}

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -238,7 +238,7 @@ function SongCard({
       <div className="relative aspect-video bg-elevated overflow-hidden">
         <img
           src={song.thumbnailUrl}
-          alt={song.title}
+          alt={song.nickname || song.title}
           className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
           loading="lazy"
         />
@@ -271,7 +271,7 @@ function SongCard({
       {/* Info */}
       <div className="p-3 flex-1 flex flex-col gap-2">
         <p className="font-body font-semibold text-sm text-fg leading-tight line-clamp-2">
-          {song.title}
+          {song.nickname || song.title}
         </p>
 
         {isAdmin && (
@@ -338,6 +338,7 @@ function AddSongModal({
   onAdded: (song: Song) => void;
 }) {
   const [url, setUrl] = useState('');
+  const [nickname, setNickname] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
@@ -349,7 +350,7 @@ function AddSongModal({
     setLoading(true);
     setError('');
     try {
-      const song = await addSong(url.trim());
+      const song = await addSong(url.trim(), nickname.trim() || undefined);
       onAdded(song);
     } catch (err: unknown) {
       const error = err as { response?: { data?: { error?: string } } };
@@ -378,6 +379,13 @@ function AddSongModal({
           onChange={(e) => { setUrl(e.target.value); setError(''); }}
           onKeyDown={handleKeyDown}
           disabled={loading}
+      />
+      <input
+        className="input mb-3"
+        placeholder="Nickname (optional)"
+        value={nickname}
+        onChange={(e) => setNickname(e.target.value)}
+        disabled={loading}
         />
 
         {error && (
@@ -421,7 +429,7 @@ function ConfirmDeleteModal({
       <div className="bg-surface border border-border rounded-xl p-6 w-full max-w-sm shadow-2xl animate-fade-up">
         <h2 className="font-display text-3xl text-fg tracking-wider mb-1">Delete Song</h2>
         <p className="font-body text-sm text-muted mb-2">
-          Remove <span className="text-fg font-semibold">"{song.title}"</span> from the library?
+          Remove <span className="text-fg font-semibold">"{song.nickname || song.title}"</span> from the library?
         </p>
         <p className="font-mono text-xs text-danger/70 mb-6">
           this will remove it from all playlists too.


### PR DESCRIPTION
## Summary
This PR implements the feature requested in Issue #11: Allow users to add custom nicknames to songs from the Library.

## Changes

### Database
- Added optional `nickname` field to the `Song` model in Prisma schema

### API
- Updated `POST /api/songs` endpoint to accept an optional `nickname` parameter
- Nickname is stored as `null` if not provided

### Types
- Updated `Song` interface in `packages/shared/src/types.ts` to include `nickname?: string | null`
- Updated `Song` interface in `packages/web/src/api/types.ts` to include `nickname?: string | null`

### Web UI
- Added nickname input field in the `AddSongModal` component (below the URL input)
- Updated `SongCard` to display nickname if available, with original title shown as subtitle
- Updated `PlaylistDetailPage` to show nickname in song lists
- Updated `QueuePage` to show nickname in the now playing card and queue list

## Screenshots
When a song has a nickname:
- The nickname is displayed prominently
- The original title is shown as a smaller subtitle below

## Testing
1. Start the application with `docker compose up`
2. Log in to the web UI
3. Navigate to the Library page
4. Click "Add Song" and enter a YouTube URL
5. Optionally enter a nickname in the "Nickname (optional)" field
6. The song will display with the nickname if provided

Closes #11