### PR TITLE
fix(db): add missing migration for Song.nickname field

### DIFF
--- a/packages/api/prisma/migrations/20260304000000_add_nickname_to_song/migration.sql
+++ b/packages/api/prisma/migrations/20260304000000_add_nickname_to_song/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Song" ADD COLUMN "nickname" TEXT;


### PR DESCRIPTION
## Problem

Production is experiencing a `PrismaClientKnownRequestError: P2022` error when querying songs:
```
The column `(not available)` does not exist in the current database.
```

## Root Cause

In commit 79fa9ba (PR #91), a `nickname` field was added to the Song model in `schema.prisma`, but **no database migration was created**. This caused a schema drift where:
- The Prisma schema expects a `nickname` column
- The production database doesn't have this column
- Queries fail with P2022 error

## Solution

This PR adds the missing migration file that should have been created with the original feature:
- Creates `20260304000000_add_nickname_to_song/migration.sql`
- Adds `nickname TEXT` column to the Song table (nullable, matching the schema)

## Deployment

After merging:
1. The migration service will automatically apply this migration in production
2. The `nickname` column will be added to the Song table
3. The P2022 error will be resolved

## Testing

- Migration SQL is straightforward: `ALTER TABLE "Song" ADD COLUMN "nickname" TEXT;`
- Matches the schema definition: `nickname String?`
- No data loss (nullable column)