### PR TITLE
feat: add YouTube playlist import support

### DIFF
--- a/packages/api/src/routes/player.ts
+++ b/packages/api/src/routes/player.ts
@@ -8,7 +8,7 @@ import { requireAuth } from '../middleware/requireAuth';
 import { requireAdmin } from '../middleware/requireAdmin';
 import { asyncHandler } from '../middleware/errorHandler';
 import { getPlayer, removePlayer } from '@discord-music-bot/bot/src/player/manager';
-import { isValidYouTubeUrl, getMetadata } from '@discord-music-bot/bot/src/utils/ytdlp';
+import { isValidYouTubeUrl, getMetadata, isYouTubePlaylistUrl, getPlaylistMetadataWithVideos } from '@discord-music-bot/bot/src/utils/ytdlp';
 import type { LoopMode, QueuedSong, Song } from '@discord-music-bot/shared';
 
 const router = Router();
@@ -463,16 +463,133 @@ router.post(
     await player.addToQueue(queuedSong);
 
     res.json({
-      message: `Added "${metadata.title}" to the queue.`,
-      song: queuedSong,
-    });
-  })
-);
+        message: `Added "${metadata.title}" to the queue.`,
+        song: queuedSong,
+      });
+    })
+    );
 
-// ---------------------------------------------------------------------------
-// POST /api/player/pause-toggle
-// Member accessible.
-// ---------------------------------------------------------------------------
+    // ---------------------------------------------------------------------------
+    // POST /api/player/quick-add-playlist
+    //
+    // Adds all songs from a YouTube playlist to the queue without saving to library.
+    // Member accessible.
+    //
+    // Body:
+    // youtubeUrl — YouTube playlist URL to fetch and queue
+    // maxVideos — Optional limit on number of videos to queue
+    // ---------------------------------------------------------------------------
+    router.post(
+      '/quick-add-playlist',
+      requireAuth,
+      asyncHandler(async (req, res) => {
+        const { youtubeUrl, maxVideos } = req.body as { youtubeUrl?: string; maxVideos?: number };
+
+        if (!youtubeUrl || typeof youtubeUrl !== 'string') {
+          res.status(400).json({ error: 'youtubeUrl is required.' });
+          return;
+        }
+
+        const url = youtubeUrl.trim();
+
+        if (url.length > MAX_URL_LENGTH) {
+          res.status(400).json({ error: `URL must be ${MAX_URL_LENGTH} characters or less.` });
+          return;
+        }
+
+        if (!isYouTubePlaylistUrl(url)) {
+          res.status(400).json({ error: 'That does not look like a valid YouTube playlist URL. It should contain a "list" parameter.' });
+          return;
+        }
+
+        let player = getPlayer(GUILD_ID);
+        if (!player) {
+          // Auto-join: Find the user's voice channel and join it.
+          const discordClient = getClient();
+          if (!discordClient) {
+            res.status(503).json({ error: 'Discord bot is not ready yet.' });
+            return;
+          }
+          try {
+            const guild = await discordClient.guilds.fetch(GUILD_ID);
+            const member = await guild.members.fetch(req.user!.discordId);
+            const voiceChannel = member.voice.channel;
+            if (!voiceChannel) {
+              res.status(409).json({
+                error: 'You are not in a voice channel. Join a voice channel in Discord first.',
+              });
+              return;
+            }
+            const connection = joinVoiceChannel({
+              channelId: voiceChannel.id,
+              guildId: GUILD_ID,
+              adapterCreator: guild.voiceAdapterCreator,
+            });
+            await entersState(connection, VoiceConnectionStatus.Ready, 5_000);
+
+            const textChannelId = process.env.DEFAULT_TEXT_CHANNEL_ID;
+            const textChannel = textChannelId
+              ? (guild.channels.cache.get(textChannelId) as TextChannel | undefined)
+              : (guild.systemChannel as TextChannel | null);
+            if (!textChannel) {
+              res.status(503).json({
+                error: 'Could not find a text channel for "Now playing" messages. Set DEFAULT_TEXT_CHANNEL_ID in your environment.',
+              });
+              return;
+            }
+            player = createPlayer(GUILD_ID, connection, textChannel);
+          } catch (error) {
+            console.error('Failed to auto-join voice channel:', error);
+            res.status(503).json({
+              error: 'Could not connect to your voice channel. Try using /join in Discord first.',
+            });
+            return;
+          }
+        }
+
+        // Fetch playlist metadata with videos
+            let playlistMetadata;
+            try {
+              playlistMetadata = await getPlaylistMetadataWithVideos(url, maxVideos);
+            } catch {
+          res.status(422).json({ error: 'Could not fetch playlist info. The playlist may be private or unavailable.' });
+          return;
+        }
+
+        // Queue all songs from the playlist
+        const requestedBy = req.user!.username;
+        const queuedSongs: QueuedSong[] = [];
+
+        for (const video of playlistMetadata.videos) {
+          const queuedSong: QueuedSong = {
+            id: `temp-${Date.now()}-${video.id}`,
+            title: video.title,
+            youtubeUrl: `https://www.youtube.com/watch?v=${video.id}`,
+            youtubeId: video.id,
+            duration: video.duration,
+            thumbnailUrl: video.thumbnailUrl,
+            addedBy: req.user!.discordId,
+            createdAt: new Date(),
+            requestedBy,
+          };
+          await player.addToQueue(queuedSong);
+          queuedSongs.push(queuedSong);
+        }
+
+        res.json({
+          message: `Added ${queuedSongs.length} song(s) from "${playlistMetadata.title}" to the queue.`,
+          playlistTitle: playlistMetadata.title,
+          totalVideos: playlistMetadata.videoCount,
+          queuedCount: queuedSongs.length,
+          songs: queuedSongs,
+        });
+      })
+    );
+
+    // ---------------------------------------------------------------------------
+    // POST /api/player/pause-toggle
+    // Member accessible.
+    // ---------------------------------------------------------------------------
 router.post(
   '/pause-toggle',
   requireAuth,

--- a/packages/api/src/routes/songs.ts
+++ b/packages/api/src/routes/songs.ts
@@ -3,7 +3,7 @@ import prisma from '../lib/prisma';
 import { requireAuth } from '../middleware/requireAuth';
 import { requireAdmin } from '../middleware/requireAdmin';
 import { asyncHandler } from '../middleware/errorHandler';
-import { isValidYouTubeUrl, getMetadata } from '@discord-music-bot/bot/src/utils/ytdlp';
+import { isValidYouTubeUrl, getMetadata, isYouTubePlaylistUrl, getPlaylistMetadataWithVideos } from '@discord-music-bot/bot/src/utils/ytdlp';
 import { emitSongAdded, emitSongDeleted } from '../lib/socket';
 
 const router = Router();
@@ -102,6 +102,120 @@ router.post(
     emitSongAdded(song);
 
     res.status(201).json(song);
+  })
+);
+
+// ---------------------------------------------------------------------------
+// POST /api/songs/import-playlist
+//
+// Imports all songs from a YouTube playlist into the library. Admin only.
+//
+// Flow:
+// 1. Validate the URL is a YouTube playlist URL.
+// 2. Fetch playlist metadata via yt-dlp (title, videos).
+// 3. For each video, check for duplicates by youtubeId AND youtubeUrl.
+// 4. Create songs in the database (batch insert).
+// 5. Emit songs:added for each new song.
+// ---------------------------------------------------------------------------
+router.post(
+  '/import-playlist',
+  requireAuth,
+  requireAdmin,
+  asyncHandler(async (req, res) => {
+    const { youtubeUrl, maxVideos } = req.body as { youtubeUrl?: string; maxVideos?: number };
+
+    if (!youtubeUrl || typeof youtubeUrl !== 'string') {
+      res.status(400).json({ error: 'youtubeUrl is required.' });
+      return;
+    }
+
+    const url = youtubeUrl.trim();
+
+    if (url.length > MAX_URL_LENGTH) {
+      res.status(400).json({ error: `URL must be ${MAX_URL_LENGTH} characters or less.` });
+      return;
+    }
+
+    if (!isYouTubePlaylistUrl(url)) {
+      res.status(400).json({ error: 'That does not look like a valid YouTube playlist URL. It should contain a "list" parameter.' });
+      return;
+    }
+
+    	// Fetch playlist metadata with videos
+    	let playlistMetadata;
+    	try {
+    		playlistMetadata = await getPlaylistMetadataWithVideos(url, maxVideos);
+    	} catch {
+    		res.status(422).json({ error: 'Could not fetch playlist info. The playlist may be private or unavailable.' });
+    		return;
+    	}
+
+    // Build the canonical URL format for each video
+    const videosWithUrls = playlistMetadata.videos.map((v) => ({
+      ...v,
+      canonicalUrl: `https://www.youtube.com/watch?v=${v.id}`,
+    }));
+
+    // Get existing songs that match either by youtubeId OR youtubeUrl
+    const existingSongs = await prisma.song.findMany({
+      where: {
+        OR: [
+          { youtubeId: { in: videosWithUrls.map((v) => v.id) } },
+          { youtubeUrl: { in: videosWithUrls.map((v) => v.canonicalUrl) } },
+        ],
+      },
+      select: { youtubeId: true, youtubeUrl: true },
+    });
+
+    // Create sets for quick lookup
+    const existingYoutubeIds = new Set(existingSongs.map((s) => s.youtubeId));
+    const existingYoutubeUrls = new Set(existingSongs.map((s) => s.youtubeUrl));
+
+    // Filter out duplicates (check both youtubeId and youtubeUrl)
+    const newVideos = videosWithUrls.filter(
+      (v) => !existingYoutubeIds.has(v.id) && !existingYoutubeUrls.has(v.canonicalUrl)
+    );
+
+    if (newVideos.length === 0) {
+      res.status(200).json({
+        message: 'All songs from this playlist are already in your library.',
+        playlistTitle: playlistMetadata.title,
+        totalVideos: playlistMetadata.videoCount,
+        importedCount: 0,
+        skippedCount: playlistMetadata.videos.length,
+      });
+      return;
+    }
+
+    // Create songs
+    const createdSongs = await prisma.$transaction(
+      newVideos.map((video) =>
+        prisma.song.create({
+          data: {
+            title: video.title,
+            youtubeUrl: video.canonicalUrl,
+            youtubeId: video.id,
+            duration: video.duration,
+            thumbnailUrl: video.thumbnailUrl,
+            addedBy: req.user!.discordId,
+          },
+        })
+      )
+    );
+
+    // Emit socket events for each new song
+    for (const song of createdSongs) {
+      emitSongAdded(song);
+    }
+
+    res.status(201).json({
+      message: `Successfully imported ${createdSongs.length} song(s) from "${playlistMetadata.title}".`,
+      playlistTitle: playlistMetadata.title,
+      totalVideos: playlistMetadata.videoCount,
+      importedCount: createdSongs.length,
+      skippedCount: playlistMetadata.videos.length - newVideos.length,
+      songs: createdSongs,
+    });
   })
 );
 

--- a/packages/bot/src/utils/ytdlp.ts
+++ b/packages/bot/src/utils/ytdlp.ts
@@ -14,6 +14,21 @@ export interface SongMetadata {
 }
 
 // ---------------------------------------------------------------------------
+// Metadata returned from yt-dlp for a YouTube playlist.
+// ---------------------------------------------------------------------------
+export interface PlaylistMetadata {
+  title: string;
+  playlistId: string;
+  videoCount: number;
+  videos: {
+    id: string;
+    title: string;
+    duration: number;
+    thumbnailUrl: string;
+  }[];
+}
+
+// ---------------------------------------------------------------------------
 // getMetadata
 //
 // Fetches title, duration, and id for a YouTube URL by running:
@@ -242,6 +257,160 @@ export function isValidYouTubeUrl(url: string): boolean {
   } catch {
     return false;
   }
+}
+
+// ---------------------------------------------------------------------------
+// isYouTubePlaylistUrl
+//
+// Detects if a URL is a YouTube playlist URL. Supports:
+// - youtube.com/playlist?list=PLAYLIST_ID
+// - youtube.com/watch?v=VIDEO_ID&list=PLAYLIST_ID
+// - youtu.be/VIDEO_ID?list=PLAYLIST_ID
+// ---------------------------------------------------------------------------
+export function isYouTubePlaylistUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const validHosts = ['youtube.com', 'www.youtube.com', 'youtu.be', 'music.youtube.com'];
+    if (!validHosts.includes(parsed.hostname)) {
+      return false;
+    }
+    // Check for 'list' query parameter
+    return parsed.searchParams.has('list');
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// getPlaylistId
+//
+// Extracts the playlist ID from a YouTube playlist URL.
+// Returns null if not a playlist URL or no playlist ID found.
+// ---------------------------------------------------------------------------
+export function getPlaylistId(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    return parsed.searchParams.get('list');
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// getPlaylistMetadata
+//
+// Fetches metadata for a YouTube playlist using yt-dlp.
+// Uses --flat-playlist to avoid fetching info for each video individually
+// (much faster for large playlists).
+//
+// Output format:
+// - Line 0: playlist title
+// - Line 1: playlist id
+// - Line 2: number of entries
+// - Remaining lines: video_id, title, duration (one per line, separated by \t)
+// ---------------------------------------------------------------------------
+export function getPlaylistMetadata(playlistUrl: string, maxVideos?: number): Promise<PlaylistMetadata> {
+  return new Promise((resolve, reject) => {
+    const args = [
+      '--flat-playlist',
+      '-I', `1:${maxVideos || 'inf'}`,
+      '--print', '%(playlist_title)s',
+      '--print', '%(playlist_id)s',
+      '--print', '%(playlist_count)s',
+      playlistUrl,
+    ];
+
+    execFile(
+      'yt-dlp',
+      args,
+      (error, stdout) => {
+        if (error) {
+          return reject(
+            new Error(`yt-dlp playlist metadata fetch failed: ${error.message}`)
+          );
+        }
+
+        const lines = stdout.trimEnd().split('\n');
+        if (lines.length < 3) {
+        return reject(new Error('yt-dlp returned unexpected output for playlist'));
+        }
+
+        const title = lines[0].trim();
+        const playlistId = lines[1].trim();
+        const videoCount = parseInt(lines[2].trim(), 10) || 0;
+
+        resolve({
+          title,
+          playlistId,
+          videoCount,
+          videos: [], // Will be fetched separately
+        });
+      }
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// getPlaylistVideos
+//
+// Fetches the list of videos in a YouTube playlist using yt-dlp.
+// Uses --flat-playlist with --dump-json for reliable parsing.
+// ---------------------------------------------------------------------------
+export function getPlaylistVideos(playlistUrl: string, maxVideos?: number): Promise<PlaylistMetadata['videos']> {
+  return new Promise((resolve, reject) => {
+    const args = [
+      '--flat-playlist',
+      '--dump-json',
+      '-I', `1:${maxVideos || 'inf'}`,
+      playlistUrl,
+    ];
+
+    execFile(
+      'yt-dlp',
+      args,
+      (error, stdout) => {
+        if (error) {
+          return reject(
+            new Error(`yt-dlp playlist videos fetch failed: ${error.message}`)
+          );
+        }
+
+        const lines = stdout.trimEnd().split('\n');
+        const videos = lines.map((line) => {
+          try {
+            const data = JSON.parse(line);
+            return {
+              id: data.id || '',
+              title: data.title || 'Unknown',
+              duration: Math.round(data.duration) || 0,
+              thumbnailUrl: `https://img.youtube.com/vi/${data.id}/hqdefault.jpg`,
+            };
+          } catch {
+            return null;
+          }
+        }).filter((v): v is NonNullable<typeof v> => v !== null);
+
+        resolve(videos);
+      }
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// getPlaylistMetadataWithVideos
+//
+// Convenience function that fetches both playlist metadata and videos.
+// ---------------------------------------------------------------------------
+export async function getPlaylistMetadataWithVideos(playlistUrl: string, maxVideos?: number): Promise<PlaylistMetadata> {
+  const [metadata, videos] = await Promise.all([
+    getPlaylistMetadata(playlistUrl, maxVideos),
+    getPlaylistVideos(playlistUrl, maxVideos),
+  ]);
+
+  return {
+    ...metadata,
+    videos,
+  };
 }
 
 export function getStreamFormat(youtubeUrl: string): Promise<{ url: string; isWebmOpus: boolean }> {

--- a/packages/web/src/api/api.ts
+++ b/packages/web/src/api/api.ts
@@ -12,9 +12,28 @@ export const refresh = () => client.post<{ user: User }>('/auth/refresh').then((
 // Songs
 // ---------------------------------------------------------------------------
 export const getSongs = () => client.get<Song[]>('/api/songs').then((r) => r.data);
-export const addSong = (youtubeUrl: string, nickname?: string) => client.post<Song>('/api/songs', { youtubeUrl, ...(nickname && { nickname }) }).then((r) => r.data);
-
+export const addSong = (youtubeUrl: string, nickname?: string) =>
+  client
+    .post<Song>('/api/songs', { youtubeUrl, ...(nickname && { nickname }) })
+    .then((r) => r.data);
 export const deleteSong = (id: string) => client.delete(`/api/songs/${id}`);
+
+export interface ImportPlaylistResult {
+  message: string;
+  playlistTitle: string;
+  totalVideos: number;
+  importedCount: number;
+  skippedCount: number;
+  songs: Song[];
+}
+
+export const importPlaylist = (youtubeUrl: string, maxVideos?: number) =>
+  client
+    .post<ImportPlaylistResult>('/api/songs/import-playlist', {
+      youtubeUrl,
+      ...(maxVideos && { maxVideos }),
+    })
+    .then((r) => r.data);
 
 // ---------------------------------------------------------------------------
 // Playlists
@@ -23,22 +42,35 @@ export const getPlaylists = (adminView?: boolean) => {
   const params = adminView ? '?adminView=true' : '';
   return client.get<Playlist[]>(`/api/playlists${params}`).then((r) => r.data);
 };
-export const createPlaylist = (name: string) => client.post<Playlist>('/api/playlists', { name }).then((r) => r.data);
+export const createPlaylist = (name: string) =>
+  client.post<Playlist>('/api/playlists', { name }).then((r) => r.data);
 export const getPlaylist = (id: string, adminView?: boolean) => {
   const params = adminView ? '?adminView=true' : '';
   return client.get<PlaylistDetail>(`/api/playlists/${id}${params}`).then((r) => r.data);
 };
-export const renamePlaylist = (id: string, name: string) => client.patch<Playlist>(`/api/playlists/${id}`, { name }).then((r) => r.data);
+export const renamePlaylist = (id: string, name: string) =>
+  client.patch<Playlist>(`/api/playlists/${id}`, { name }).then((r) => r.data);
 export const deletePlaylist = (id: string) => client.delete(`/api/playlists/${id}`);
-export const addSongToPlaylist = (playlistId: string, songId: string) => client.post(`/api/playlists/${playlistId}/songs`, { songId });
-export const removeSongFromPlaylist = (playlistId: string, songId: string) => client.delete(`/api/playlists/${playlistId}/songs/${songId}`);
-export const togglePlaylistVisibility = (playlistId: string, isPrivate: boolean, adminView?: boolean) => client.patch<Playlist>(`/api/playlists/${playlistId}/visibility`, { isPrivate, adminView }).then((r) => r.data);
+export const addSongToPlaylist = (playlistId: string, songId: string) =>
+  client.post(`/api/playlists/${playlistId}/songs`, { songId });
+export const removeSongFromPlaylist = (playlistId: string, songId: string) =>
+  client.delete(`/api/playlists/${playlistId}/songs/${songId}`);
+export const togglePlaylistVisibility = (playlistId: string, isPrivate: boolean, adminView?: boolean) =>
+  client
+    .patch<Playlist>(`/api/playlists/${playlistId}/visibility`, { isPrivate, adminView })
+    .then((r) => r.data);
 
 // ---------------------------------------------------------------------------
 // Player
 // ---------------------------------------------------------------------------
-export const getQueueState = () => client.get<QueueState>('/api/player/queue').then((r) => r.data);
-export const startPlayback = (opts: { playlistId?: string; mode: 'sequential' | 'random'; loop: LoopMode; startFromSongId?: string; }) => client.post('/api/player/play', opts);
+export const getQueueState = () =>
+  client.get<QueueState>('/api/player/queue').then((r) => r.data);
+export const startPlayback = (opts: {
+  playlistId?: string;
+  mode: 'sequential' | 'random';
+  loop: LoopMode;
+  startFromSongId?: string;
+}) => client.post('/api/player/play', opts);
 export const skipTrack = () => client.post('/api/player/skip');
 /**
  * Stop playback, clear the queue, and disconnect the bot from the voice
@@ -50,14 +82,34 @@ export const leaveVoice = () => client.post('/api/player/leave');
  * Both stop playback AND disconnect the bot.
  */
 export const stopPlayback = leaveVoice;
-export const setLoopMode = (mode: LoopMode) => client.post('/api/player/loop', { mode });
+export const setLoopMode = (mode: LoopMode) =>
+  client.post('/api/player/loop', { mode });
 export const shuffleQueue = () => client.post('/api/player/shuffle');
 export const clearQueue = () => client.post('/api/player/clear');
 export const resumePlayback = () => client.post('/api/player/resume');
-export const togglePause = () => client.post<{ isPaused: boolean }>('/api/player/pause-toggle').then((r) => r.data);
-export const quickAddToQueue = (youtubeUrl: string) => client
-  .post<{ message: string; song: { title: string; duration: number; thumbnailUrl: string; requestedBy: string } }>(
-    '/api/player/quick-add',
-    { youtubeUrl }
-  )
-  .then((r) => r.data);
+export const togglePause = () =>
+  client.post<{ isPaused: boolean }>('/api/player/pause-toggle').then((r) => r.data);
+
+export const quickAddToQueue = (youtubeUrl: string) =>
+  client
+    .post<{ message: string; song: { title: string; duration: number; thumbnailUrl: string; requestedBy: string } }>(
+      '/api/player/quick-add',
+      { youtubeUrl }
+    )
+    .then((r) => r.data);
+
+export interface QuickAddPlaylistResult {
+  message: string;
+  playlistTitle: string;
+  totalVideos: number;
+  queuedCount: number;
+  songs: { title: string; duration: number; thumbnailUrl: string; requestedBy: string }[];
+}
+
+export const quickAddPlaylistToQueue = (youtubeUrl: string, maxVideos?: number) =>
+  client
+    .post<QuickAddPlaylistResult>('/api/player/quick-add-playlist', {
+      youtubeUrl,
+      ...(maxVideos && { maxVideos }),
+    })
+    .then((r) => r.data);

--- a/packages/web/src/pages/QueuePage.tsx
+++ b/packages/web/src/pages/QueuePage.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect } from 'react';
 import { usePlayer } from '../context/PlayerContext';
 import { useAdminView } from '../context/AdminViewContext';
-import { startPlayback, getPlaylists, quickAddToQueue } from '../api/api';
+import { startPlayback, getPlaylists, quickAddToQueue, quickAddPlaylistToQueue } from '../api/api';
 import type { LoopMode, Playlist, QueuedSong } from '../api/types';
 
 // ---------------------------------------------------------------------------
@@ -19,7 +19,6 @@ function formatDuration(seconds: number): string {
 export default function QueuePage() {
   const { state, loading, elapsed, setLoop, shuffle, refetch, clear } = usePlayer();
   const { isAdminView } = useAdminView();
-
   const [showLoadPlaylist, setShowLoadPlaylist] = useState(false);
   const [showQuickAdd, setShowQuickAdd] = useState(false);
   const [loopBusy, setLoopBusy] = useState(false);
@@ -28,24 +27,34 @@ export default function QueuePage() {
 
   const { currentSong, queue, isPlaying, loopMode } = state;
 
-  const progress = currentSong
-    ? Math.min((elapsed / currentSong.duration) * 100, 100)
-    : 0;
+  const progress = currentSong ? Math.min((elapsed / currentSong.duration) * 100, 100) : 0;
 
   const handleLoop = async (mode: LoopMode) => {
     if (mode === loopMode) return;
     setLoopBusy(true);
-    try { await setLoop(mode); } finally { setLoopBusy(false); }
+    try {
+      await setLoop(mode);
+    } finally {
+      setLoopBusy(false);
+    }
   };
 
   const handleShuffle = async () => {
     setShuffleBusy(true);
-    try { await shuffle(); } finally { setShuffleBusy(false); }
+    try {
+      await shuffle();
+    } finally {
+      setShuffleBusy(false);
+    }
   };
 
   const handleClear = async () => {
     setClearBusy(true);
-    try { await clear(); } finally { setClearBusy(false); }
+    try {
+      await clear();
+    } finally {
+      setClearBusy(false);
+    }
   };
 
   // Loading skeleton
@@ -66,7 +75,7 @@ export default function QueuePage() {
       <h1 className="font-display text-5xl text-fg tracking-wider mb-8">Queue</h1>
 
       {/* ------------------------------------------------------------------ */}
-      {/* Now Playing card                                                    */}
+      {/* Now Playing card */}
       {/* ------------------------------------------------------------------ */}
       {currentSong ? (
         <NowPlayingCard
@@ -83,70 +92,73 @@ export default function QueuePage() {
       {/* Controls */}
       {/* ------------------------------------------------------------------ */}
       <section className="mt-6 space-y-4">
-      {/* First row: Loop (left) and Load Playlist/Quick Add (right) */}
-      <div className="flex items-center gap-3 flex-wrap">
-      <div className="flex items-center gap-2">
-      <span className="font-mono text-xs text-muted uppercase tracking-widest mr-1">
-      Loop
-      </span>
-      {(['off', 'song', 'queue'] as const).map((mode) => (
-      <button
-      key={mode}
-      disabled={loopBusy}
-      onClick={() => handleLoop(mode)}
-      className={`px-3 py-1.5 text-xs font-mono rounded border transition-colors duration-150 disabled:opacity-50 ${
-      loopMode === mode
-      ? 'bg-accent/10 border-accent/40 text-accent'
-      : 'border-border text-muted hover:border-muted hover:text-fg'
-      }`}
-      >
-      {mode === 'off' ? '⬛ off' : mode === 'song' ? '🔂 song' : '🔁 queue'}
-      </button>
-      ))}
-      </div>
-      <button
-      onClick={() => setShowLoadPlaylist(true)}
-      className="flex items-center gap-2 btn-primary ml-auto"
-      >
-      <IconList size={14} />
-      <span>Load Playlist</span>
-      </button>
-      <button
-      onClick={() => setShowQuickAdd(true)}
-      className="flex items-center gap-2 btn-primary"
-      >
-      <IconPlus size={14} />
-      <span>Quick Add</span>
-      </button>
-      </div>
+        {/* First row: Loop (left) and Load Playlist/Quick Add (right) */}
+        <div className="flex items-center gap-3 flex-wrap">
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-xs text-muted uppercase tracking-widest mr-1">
+              Loop
+            </span>
+            {(['off', 'song', 'queue'] as const).map((mode) => (
+              <button
+                key={mode}
+                disabled={loopBusy}
+                onClick={() => handleLoop(mode)}
+                className={`px-3 py-1.5 text-xs font-mono rounded border transition-colors duration-150 disabled:opacity-50 ${
+                  loopMode === mode
+                    ? 'bg-accent/10 border-accent/40 text-accent'
+                    : 'border-border text-muted hover:border-muted hover:text-fg'
+                }`}
+              >
+                {mode === 'off' ? '⬛ off' : mode === 'song' ? '🔂 song' : '🔁 queue'}
+              </button>
+            ))}
+          </div>
 
-      {/* Second row: Admin-only controls (Shuffle and Clear Queue) */}
-      {isAdminView && (
-      <div className="flex items-center gap-3 flex-wrap">
-      <button
-      onClick={handleShuffle}
-      disabled={shuffleBusy || queue.length === 0}
-      className="flex items-center gap-2 btn-ghost disabled:opacity-40 disabled:cursor-not-allowed"
-      >
-      <IconShuffle size={14} />
-      <span>Shuffle{queue.length > 0 ? ` (${queue.length})` : ''}</span>
-      </button>
-      			<button
-      				onClick={handleClear}
-      				disabled={clearBusy || (queue.length === 0 && !currentSong)}
-      				className={`flex items-center gap-2 disabled:opacity-40 disabled:cursor-not-allowed ${
-      					queue.length === 0 && !currentSong ? 'btn-ghost' : 'btn-danger'
-      				}`}
-      			>
-      				<IconTrash size={14} />
-      				<span>Clear Queue</span>
-      			</button>
-      </div>
-      )}
+          <button
+            onClick={() => setShowLoadPlaylist(true)}
+            className="flex items-center gap-2 btn-primary ml-auto"
+          >
+            <IconList size={14} />
+            <span>Load Playlist</span>
+          </button>
+
+          <button
+            onClick={() => setShowQuickAdd(true)}
+            className="flex items-center gap-2 btn-primary"
+          >
+            <IconPlus size={14} />
+            <span>Quick Add</span>
+          </button>
+        </div>
+
+        {/* Second row: Admin-only controls (Shuffle and Clear Queue) */}
+        {isAdminView && (
+          <div className="flex items-center gap-3 flex-wrap">
+            <button
+              onClick={handleShuffle}
+              disabled={shuffleBusy || queue.length === 0}
+              className="flex items-center gap-2 btn-ghost disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              <IconShuffle size={14} />
+              <span>Shuffle{queue.length > 0 ? ` (${queue.length})` : ''}</span>
+            </button>
+
+            <button
+              onClick={handleClear}
+              disabled={clearBusy || (queue.length === 0 && !currentSong)}
+              className={`flex items-center gap-2 disabled:opacity-40 disabled:cursor-not-allowed ${
+                queue.length === 0 && !currentSong ? 'btn-ghost' : 'btn-danger'
+              }`}
+            >
+              <IconTrash size={14} />
+              <span>Clear Queue</span>
+            </button>
+          </div>
+        )}
       </section>
 
       {/* ------------------------------------------------------------------ */}
-      {/* Queue                                                               */}
+      {/* Queue */}
       {/* ------------------------------------------------------------------ */}
       <section className="mt-8">
         <div className="flex items-center justify-between mb-4">
@@ -175,8 +187,7 @@ export default function QueuePage() {
             {queue.map((song, i) => (
               <div
                 key={`${song.id}-${i}`}
-                className="flex items-center gap-4 px-4 py-3 rounded-lg hover:bg-elevated
-                           transition-colors duration-100 group"
+                className="flex items-center gap-4 px-4 py-3 rounded-lg hover:bg-elevated transition-colors duration-100 group"
               >
                 <span className="font-mono text-xs text-faint w-5 text-right shrink-0">
                   {i + 1}
@@ -269,8 +280,7 @@ function NowPlayingCard({
             />
             {/* Playing indicator */}
             {isPlaying && (
-              <div className="absolute -bottom-2 -right-2 w-6 h-6 rounded-full bg-accent
-                              flex items-center justify-center shadow-lg">
+              <div className="absolute -bottom-2 -right-2 w-6 h-6 rounded-full bg-accent flex items-center justify-center shadow-lg">
                 <span className="text-base text-[8px]">▶</span>
               </div>
             )}
@@ -280,7 +290,7 @@ function NowPlayingCard({
 
       {/* Info + progress */}
       <div className="px-5 py-4">
-        <p className="font-body font-bold  text-fg truncate leading-tight">
+        <p className="font-body font-bold text-fg truncate leading-tight">
           {song.nickname || song.title}
         </p>
         <p className="font-mono text-[10px] text-muted mt-0.5">
@@ -312,8 +322,7 @@ function IdleCard() {
   return (
     <div className="card flex items-center justify-center py-16 border-dashed">
       <div className="text-center">
-        <div className="w-16 h-16 rounded-full bg-elevated border border-border flex items-center
-                        justify-center mx-auto mb-4">
+        <div className="w-16 h-16 rounded-full bg-elevated border border-border flex items-center justify-center mx-auto mb-4">
           <IconMusic size={24} className="text-faint" />
         </div>
         <p className="font-display text-3xl text-faint tracking-wider mb-1">Nothing Playing</p>
@@ -354,20 +363,25 @@ function LoadPlaylistModal({
     }
   }, []);
 
-  useEffect(() => { loadPlaylists(); }, [loadPlaylists]);
+  useEffect(() => {
+    loadPlaylists();
+  }, [loadPlaylists]);
 
   const handlePlay = async () => {
     if (!selectedId) return;
     setSubmitting(true);
     setError('');
     try {
-      await startPlayback({ playlistId: selectedId, mode, loop });
+      await startPlayback({
+        playlistId: selectedId,
+        mode,
+        loop,
+      });
       onLoaded();
     } catch (err: unknown) {
       const e = err as { response?: { data?: { error?: string } } };
       setError(
-        e?.response?.data?.error ??
-          'Could not start playback. Is the bot in a voice channel?'
+        e?.response?.data?.error ?? 'Could not start playback. Is the bot in a voice channel?'
       );
       setSubmitting(false);
     }
@@ -376,7 +390,9 @@ function LoadPlaylistModal({
   return (
     <div
       className="fixed inset-0 z-50 bg-black/70 backdrop-blur-sm flex items-center justify-center p-4"
-      onMouseDown={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
     >
       <div className="bg-surface border border-border rounded-xl p-6 w-full max-w-sm shadow-2xl animate-fade-up">
         <h2 className="font-display text-3xl text-fg tracking-wider mb-1">Load Playlist</h2>
@@ -404,8 +420,7 @@ function LoadPlaylistModal({
               >
                 {playlists.map((pl) => (
                   <option key={pl.id} value={pl.id}>
-                    {pl.name}
-                    {pl._count ? ` (${pl._count.songs} songs)` : ''}
+                    {pl.name} {pl._count ? ` (${pl._count.songs} songs)` : ''}
                   </option>
                 ))}
               </select>
@@ -489,21 +504,38 @@ function QuickAddModal({
   const [youtubeUrl, setYoutubeUrl] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
+  const [successMsg, setSuccessMsg] = useState('');
+  const [isPlaylist, setIsPlaylist] = useState(false);
+  const [importFullPlaylist, setImportFullPlaylist] = useState(false);
+
+  // Detect playlist URLs
+  useEffect(() => {
+    const hasListParam = youtubeUrl.includes('list=');
+    setIsPlaylist(hasListParam);
+    if (!hasListParam) {
+      setImportFullPlaylist(false);
+    }
+  }, [youtubeUrl]);
 
   const handleSubmit = async () => {
     if (!youtubeUrl.trim()) return;
-
     setSubmitting(true);
     setError('');
+    setSuccessMsg('');
     try {
-      await quickAddToQueue(youtubeUrl.trim());
-      onAdded();
+      if (importFullPlaylist) {
+        const result = await quickAddPlaylistToQueue(youtubeUrl.trim());
+        setSuccessMsg(result.message);
+        setTimeout(() => {
+          onAdded();
+        }, 1500);
+      } else {
+        await quickAddToQueue(youtubeUrl.trim());
+        onAdded();
+      }
     } catch (err: unknown) {
       const e = err as { response?: { data?: { error?: string } } };
-      setError(
-        e?.response?.data?.error ??
-          'Could not add song to queue. Is the bot in a voice channel?'
-      );
+      setError(e?.response?.data?.error ?? 'Could not add song to queue. Is the bot in a voice channel?');
       setSubmitting(false);
     }
   };
@@ -529,7 +561,11 @@ function QuickAddModal({
             <input
               type="text"
               value={youtubeUrl}
-              onChange={(e) => setYoutubeUrl(e.target.value)}
+              onChange={(e) => {
+                setYoutubeUrl(e.target.value);
+                setError('');
+                setSuccessMsg('');
+              }}
               placeholder="https://youtube.com/watch?v=..."
               className="input font-body w-full"
               disabled={submitting}
@@ -539,10 +575,30 @@ function QuickAddModal({
                 }
               }}
             />
+            {isPlaylist && (
+              <label className="flex items-center gap-2 cursor-pointer mt-2">
+                <input
+                  type="checkbox"
+                  checked={importFullPlaylist}
+                  onChange={(e) => setImportFullPlaylist(e.target.checked)}
+                  disabled={submitting}
+                  className="w-4 h-4 rounded border-border bg-surface accent-accent"
+                />
+                <span className="font-mono text-xs text-fg">Add all songs from playlist</span>
+              </label>
+            )}
           </div>
         </div>
 
+        {successMsg && <p className="font-mono text-xs text-success mb-4">{successMsg}</p>}
         {error && <p className="font-mono text-xs text-danger mb-4">{error}</p>}
+
+        {submitting && (
+          <p className="font-mono text-xs text-muted mb-4 flex items-center gap-2">
+            <span className="w-3 h-3 border border-accent border-t-transparent rounded-full animate-spin inline-block" />
+            {importFullPlaylist ? 'Adding playlist...' : 'Adding...'}
+          </p>
+        )}
 
         <div className="flex gap-2 justify-end">
           <button className="btn-ghost" onClick={onClose} disabled={submitting}>
@@ -553,7 +609,7 @@ function QuickAddModal({
             onClick={handleSubmit}
             disabled={submitting || !youtubeUrl.trim()}
           >
-            {submitting ? 'Adding...' : 'Add to Queue'}
+            {submitting ? 'Adding...' : importFullPlaylist ? 'Add Playlist' : 'Add to Queue'}
           </button>
         </div>
       </div>
@@ -566,8 +622,17 @@ function QuickAddModal({
 // ---------------------------------------------------------------------------
 function IconMusic({ size = 20, className = '' }: { size?: number; className?: string }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
-      strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" className={className}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
       <path d="M9 18V5l12-2v13" />
       <circle cx="6" cy="18" r="3" />
       <circle cx="18" cy="16" r="3" />
@@ -577,8 +642,17 @@ function IconMusic({ size = 20, className = '' }: { size?: number; className?: s
 
 function IconShuffle({ size = 20, className = '' }: { size?: number; className?: string }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
-      strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
       <polyline points="16 3 21 3 21 8" />
       <line x1="4" y1="20" x2="21" y2="3" />
       <polyline points="21 16 21 21 16 21" />
@@ -590,7 +664,17 @@ function IconShuffle({ size = 20, className = '' }: { size?: number; className?:
 
 function IconList({ size = 20, className = '' }: { size?: number; className?: string }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" className={className}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
       <line x1="8" y1="6" x2="21" y2="6" />
       <line x1="8" y1="12" x2="21" y2="12" />
       <line x1="8" y1="18" x2="21" y2="18" />
@@ -603,7 +687,17 @@ function IconList({ size = 20, className = '' }: { size?: number; className?: st
 
 function IconPlus({ size = 20, className = '' }: { size?: number; className?: string }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
       <line x1="12" y1="5" x2="12" y2="19" />
       <line x1="5" y1="12" x2="19" y2="12" />
     </svg>
@@ -612,8 +706,17 @@ function IconPlus({ size = 20, className = '' }: { size?: number; className?: st
 
 function IconTrash({ size = 20, className = '' }: { size?: number; className?: string }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
-      strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
       <polyline points="3 6 5 6 21 6" />
       <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
       <path d="M10 11v6" />

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { getSongs, addSong, deleteSong, getPlaylists, addSongToPlaylist, startPlayback } from '../api/api';
+import { getSongs, addSong, deleteSong, getPlaylists, addSongToPlaylist, startPlayback, importPlaylist } from '../api/api';
 import type { Song, Playlist } from '../api/types';
 import { useAdminView } from '../context/AdminViewContext';
 import { useSocket } from '../hooks/useSocket';
@@ -9,6 +9,7 @@ export default function SongsPage() {
   const { isAdminView } = useAdminView();
   const socket = useSocket();
   const { state: queueState } = usePlayer();
+
   const [songs, setSongs] = useState<Song[]>([]);
   const [playlists, setPlaylists] = useState<Playlist[]>([]);
   const [loading, setLoading] = useState(true);
@@ -29,7 +30,9 @@ export default function SongsPage() {
     }
   }, []);
 
-  useEffect(() => { load(); }, [load]);
+  useEffect(() => {
+    load();
+  }, [load]);
 
   useEffect(() => {
     const handleSongAdded = (song: Song) => {
@@ -52,15 +55,17 @@ export default function SongsPage() {
     };
   }, [socket]);
 
-  const filtered = songs.filter((s) =>
+  const handleDelete = async (id: string) => {
+  		await deleteSong(id);
+  		setDeleteId(null);
+  		// Socket event will update the songs list
+  	};
+
+  	const filtered = songs.filter((s) =>
     s.title.toLowerCase().includes(search.toLowerCase())
   );
 
-  const handleDelete = async (id: string) => {
-    await deleteSong(id);
-    setSongs((prev) => prev.filter((s) => s.id !== id));
-    setDeleteId(null);
-  };
+
 
   // ---------------------------------------------------------------------------
   // Play from song — replaces the queue with the full library starting from
@@ -79,7 +84,8 @@ export default function SongsPage() {
       setTimeout(() => setNotification(null), 3000);
     } catch (err: unknown) {
       const e = err as { response?: { data?: { error?: string } } };
-      const errorMsg = e?.response?.data?.error ?? 'Could not start playback. Is the bot in a voice channel?';
+      const errorMsg =
+        e?.response?.data?.error ?? 'Could not start playback. Is the bot in a voice channel?';
       setNotification({ message: errorMsg, type: 'error' });
       setTimeout(() => setNotification(null), 5000);
     } finally {
@@ -119,7 +125,11 @@ export default function SongsPage() {
       {loading ? (
         <SkeletonGrid />
       ) : filtered.length === 0 ? (
-        <EmptyState search={search} isAdmin={isAdminView} onAdd={() => setShowAddModal(true)} />
+        <EmptyState
+          search={search}
+          isAdmin={isAdminView}
+          onAdd={() => setShowAddModal(true)}
+        />
       ) : (
         <div className="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-4">
           {filtered.map((song, i) => (
@@ -151,21 +161,29 @@ export default function SongsPage() {
           }}
         />
       )}
-      {deleteId && (
-        <ConfirmDeleteModal
-          song={songs.find((s) => s.id === deleteId)!}
-          onConfirm={() => handleDelete(deleteId)}
-          onCancel={() => setDeleteId(null)}
-        />
-      )}
+
+
+
+      {deleteId && (() => {
+      const songToDelete = songs.find((s) => s.id === deleteId);
+      return songToDelete ? (
+      <ConfirmDeleteModal
+      song={songToDelete}
+      onConfirm={() => handleDelete(deleteId)}
+      onCancel={() => setDeleteId(null)}
+      />
+      ) : null;
+      })()}
 
       {/* Notification Toast */}
       {notification && (
-        <div className={`fixed bottom-4 right-4 z-50 px-4 py-3 rounded-lg shadow-lg font-mono text-xs animate-fade-up ${
-          notification.type === 'success'
-            ? 'bg-accent/20 border border-accent/40 text-accent'
-            : 'bg-danger/20 border border-danger/40 text-danger'
-        }`}>
+        <div
+          className={`fixed bottom-4 right-4 z-50 px-4 py-3 rounded-lg shadow-lg font-mono text-xs animate-fade-up ${
+            notification.type === 'success'
+              ? 'bg-accent/20 border border-accent/40 text-accent'
+              : 'bg-danger/20 border border-danger/40 text-danger'
+          }`}
+        >
           {notification.message}
         </div>
       )}
@@ -230,8 +248,7 @@ function SongCard({
 
   return (
     <div
-      className="card group animate-fade-up opacity-0 flex flex-col hover:border-border/80
-                 hover:bg-elevated transition-colors duration-150"
+      className="card group animate-fade-up opacity-0 flex flex-col hover:border-border/80 hover:bg-elevated transition-colors duration-150"
       style={style}
     >
       {/* Thumbnail with play overlay */}
@@ -251,19 +268,21 @@ function SongCard({
         <button
           onClick={onPlay}
           disabled={isPlaying}
-          className={`absolute inset-0 flex items-center justify-center transition-opacity duration-200
-                     ${isPlaying ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}
-                     disabled:cursor-default`}
+          className={`absolute inset-0 flex items-center justify-center transition-opacity duration-200 ${
+            isPlaying ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+          } disabled:cursor-default`}
           title="Play from this song"
         >
-          <div className={`w-12 h-12 rounded-full bg-black/60 border border-white/20 backdrop-blur-sm
-                          flex items-center justify-center shadow-xl
-                          transition-transform duration-150
-                          ${isPlaying ? 'scale-100' : 'scale-90 group-hover:scale-100'}`}>
-            {isPlaying
-              ? <SpinnerIcon size={20} className="text-accent" />
-              : <PlayIcon size={20} className="text-white" />
-            }
+          <div
+            className={`w-12 h-12 rounded-full bg-black/60 border border-white/20 backdrop-blur-sm flex items-center justify-center shadow-xl transition-transform duration-150 ${
+              isPlaying ? 'scale-100' : 'scale-90 group-hover:scale-100'
+            }`}
+          >
+            {isPlaying ? (
+              <SpinnerIcon size={20} className="text-accent" />
+            ) : (
+              <PlayIcon size={20} className="text-white" />
+            )}
           </div>
         </button>
       </div>
@@ -280,14 +299,13 @@ function SongCard({
             <div className="relative flex-1" ref={menuRef}>
               <button
                 onClick={() => setShowPlaylistMenu((p) => !p)}
-                className="w-full text-xs font-mono text-muted hover:text-fg border border-border
-                           hover:border-accent/30 rounded px-2 py-1 transition-colors duration-150"
+                className="w-full text-xs font-mono text-muted hover:text-fg border border-border hover:border-accent/30 rounded px-2 py-1 transition-colors duration-150"
               >
                 + playlist
               </button>
+
               {showPlaylistMenu && (
-                <div className="absolute bottom-full left-0 mb-1 w-44 bg-elevated border border-border
-                                rounded shadow-xl z-20 overflow-hidden">
+                <div className="absolute bottom-full left-0 mb-1 w-44 bg-elevated border border-border rounded shadow-xl z-20 overflow-hidden">
                   {playlists.length === 0 ? (
                     <p className="px-3 py-2 text-xs font-mono text-muted">no playlists yet</p>
                   ) : (
@@ -296,9 +314,7 @@ function SongCard({
                         key={pl.id}
                         disabled={addingToPlaylist === pl.id || addedTo.has(pl.id)}
                         onClick={() => handleAddToPlaylist(pl.id)}
-                        className="w-full text-left px-3 py-2 text-xs font-body text-fg
-                                   hover:bg-border/50 transition-colors duration-100
-                                   disabled:opacity-50 flex items-center justify-between"
+                        className="w-full text-left px-3 py-2 text-xs font-body text-fg hover:bg-border/50 transition-colors duration-100 disabled:opacity-50 flex items-center justify-between"
                       >
                         <span className="truncate">{pl.name}</span>
                         {addedTo.has(pl.id) && (
@@ -314,8 +330,7 @@ function SongCard({
             {/* Delete */}
             <button
               onClick={onDelete}
-              className="text-xs font-mono text-faint hover:text-danger border border-border
-                         hover:border-danger/30 rounded px-2 py-1 transition-colors duration-150"
+              className="text-xs font-mono text-faint hover:text-danger border border-border hover:border-danger/30 rounded px-2 py-1 transition-colors duration-150"
               title="Delete song"
             >
               del
@@ -341,17 +356,45 @@ function AddSongModal({
   const [nickname, setNickname] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [successMsg, setSuccessMsg] = useState('');
+  const [isPlaylist, setIsPlaylist] = useState(false);
+  const [importFullPlaylist, setImportFullPlaylist] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => { inputRef.current?.focus(); }, []);
+  // Detect playlist URLs
+  useEffect(() => {
+    const hasListParam = url.includes('list=');
+    setIsPlaylist(hasListParam);
+    if (!hasListParam) {
+      setImportFullPlaylist(false);
+    }
+  }, [url]);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
 
   const handleSubmit = async () => {
     if (!url.trim()) return;
     setLoading(true);
     setError('');
+    setSuccessMsg('');
+
     try {
+      if (importFullPlaylist) {
+      // Import playlist
+      const result = await importPlaylist(url.trim());
+      setSuccessMsg(result.message);
+      // Close modal after a short delay to show success message
+      // The socket events will update the song list automatically
+      setTimeout(() => {
+      onClose();
+      }, 1500);
+      } else {
+      // Add single song
       const song = await addSong(url.trim(), nickname.trim() || undefined);
       onAdded(song);
+      }
     } catch (err: unknown) {
       const error = err as { response?: { data?: { error?: string } } };
       setError(error?.response?.data?.error ?? 'Something went wrong. Try again.');
@@ -376,26 +419,46 @@ function AddSongModal({
           className="input mb-3"
           placeholder="https://youtube.com/watch?v=..."
           value={url}
-          onChange={(e) => { setUrl(e.target.value); setError(''); }}
+          onChange={(e) => {
+            setUrl(e.target.value);
+            setError('');
+            setSuccessMsg('');
+          }}
           onKeyDown={handleKeyDown}
           disabled={loading}
-      />
-      <input
-        className="input mb-3"
-        placeholder="Nickname (optional)"
-        value={nickname}
-        onChange={(e) => setNickname(e.target.value)}
-        disabled={loading}
         />
 
-        {error && (
-          <p className="font-mono text-xs text-danger mb-3">{error}</p>
+        {isPlaylist && (
+          <label className="flex items-center gap-2 mb-3 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={importFullPlaylist}
+              onChange={(e) => setImportFullPlaylist(e.target.checked)}
+              disabled={loading}
+              className="w-4 h-4 rounded border-border bg-surface accent-accent"
+            />
+            <span className="font-mono text-xs text-fg">Import full playlist</span>
+          </label>
         )}
+
+        {!importFullPlaylist && (
+          <input
+            className="input mb-3"
+            placeholder="Nickname (optional)"
+            value={nickname}
+            onChange={(e) => setNickname(e.target.value)}
+            disabled={loading}
+          />
+        )}
+
+        {error && <p className="font-mono text-xs text-danger mb-3">{error}</p>}
+
+        {successMsg && <p className="font-mono text-xs text-success mb-3">{successMsg}</p>}
 
         {loading && (
           <p className="font-mono text-xs text-muted mb-3 flex items-center gap-2">
             <span className="w-3 h-3 border border-accent border-t-transparent rounded-full animate-spin inline-block" />
-            fetching metadata...
+            {importFullPlaylist ? 'importing playlist...' : 'fetching metadata...'}
           </p>
         )}
 
@@ -403,8 +466,12 @@ function AddSongModal({
           <button className="btn-ghost" onClick={onClose} disabled={loading}>
             Cancel
           </button>
-          <button className="btn-primary" onClick={handleSubmit} disabled={loading || !url.trim()}>
-            Add
+          <button
+            className="btn-primary"
+            onClick={handleSubmit}
+            disabled={loading || !url.trim()}
+          >
+            {importFullPlaylist ? 'Import' : 'Add'}
           </button>
         </div>
       </div>
@@ -429,14 +496,19 @@ function ConfirmDeleteModal({
       <div className="bg-surface border border-border rounded-xl p-6 w-full max-w-sm shadow-2xl animate-fade-up">
         <h2 className="font-display text-3xl text-fg tracking-wider mb-1">Delete Song</h2>
         <p className="font-body text-sm text-muted mb-2">
-          Remove <span className="text-fg font-semibold">"{song.nickname || song.title}"</span> from the library?
+          Remove <span className="text-fg font-semibold">"{song.nickname || song.title}"</span> from
+          the library?
         </p>
         <p className="font-mono text-xs text-danger/70 mb-6">
           this will remove it from all playlists too.
         </p>
         <div className="flex gap-2 justify-end">
-          <button className="btn-ghost" onClick={onCancel}>Cancel</button>
-          <button className="btn-danger border-danger/50" onClick={onConfirm}>Delete</button>
+          <button className="btn-ghost" onClick={onCancel}>
+            Cancel
+          </button>
+          <button className="btn-danger border-danger/50" onClick={onConfirm}>
+            Delete
+          </button>
         </div>
       </div>
     </Backdrop>
@@ -446,11 +518,19 @@ function ConfirmDeleteModal({
 // ---------------------------------------------------------------------------
 // Shared backdrop
 // ---------------------------------------------------------------------------
-function Backdrop({ children, onClose }: { children: React.ReactNode; onClose: () => void }) {
+function Backdrop({
+  children,
+  onClose,
+}: {
+  children: React.ReactNode;
+  onClose: () => void;
+}) {
   return (
     <div
       className="fixed inset-0 z-50 bg-black/70 backdrop-blur-sm flex items-center justify-center p-4"
-      onMouseDown={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
     >
       {children}
     </div>
@@ -496,6 +576,7 @@ function EmptyState({
       </div>
     );
   }
+
   return (
     <div className="text-center py-24">
       <p className="font-display text-4xl text-faint tracking-wider mb-2">Empty Library</p>
@@ -524,8 +605,17 @@ function formatDuration(seconds: number): string {
 
 function SearchIcon({ size = 16, className = '' }: { size?: number; className?: string }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
-      strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
       <circle cx="11" cy="11" r="8" />
       <line x1="21" y1="21" x2="16.65" y2="16.65" />
     </svg>


### PR DESCRIPTION
## Summary

This PR adds support for importing YouTube playlists via the Library page and Quick Add functionality, addressing Issue #73.

## Changes

### Backend
- Added playlist detection and metadata fetching functions in `ytdlp.ts`:
  - `isYouTubePlaylistUrl()` - detects playlist URLs
  - `getPlaylistId()` - extracts playlist ID from URL
  - `getPlaylistMetadata()` - fetches playlist info
  - `getPlaylistVideos()` - fetches video list using `--dump-json`
  - `getPlaylistMetadataWithVideos()` - combined convenience function

- Added new API endpoints:
  - `POST /api/songs/import-playlist` - imports all songs from a playlist to the library
  - `POST /api/player/quick-add-playlist` - adds all songs from a playlist to the queue

- Fixed duplicate detection to check both `youtubeId` and `youtubeUrl` to prevent unique constraint violations

### Frontend
- Updated `AddSongModal` to:
  - Detect playlist URLs (containing `list=` parameter)
  - Show "Import full playlist" checkbox when a playlist is detected
  - Import all songs when checkbox is checked

- Updated `QuickAddModal` with the same playlist detection and import functionality

- Added API functions: `importPlaylist()`, `quickAddPlaylistToQueue()`

- Fixed race condition when deleting songs (socket event vs modal state)

## Testing
- Tested importing playlists from the Library page
- Tested adding playlists to queue via Quick Add
- Tested deleting songs (no more blank page issue)
- Verified socket events properly update the UI

## Screenshot
When a playlist URL is detected, a checkbox appears:
- [x] Import full playlist

Closes #73