### PR TITLE
feat(queue): redesign queue page with priority queue and override

### DIFF
--- a/packages/api/src/routes/player.ts
+++ b/packages/api/src/routes/player.ts
@@ -36,13 +36,14 @@ router.get(
 
     if (!player) {
       res.json({
-        isPlaying: false,
-        isPaused: false,
-        loopMode: 'off',
-        currentSong: null,
-        queue: [],
-        trackStartedAt: null,
-      });
+            isPlaying: false,
+            isPaused: false,
+            loopMode: 'off',
+            currentSong: null,
+            priorityQueue: [],
+            queue: [],
+            trackStartedAt: null,
+          });
       return;
     }
 
@@ -460,7 +461,7 @@ router.post(
       requestedBy,
     };
 
-    await player.addToQueue(queuedSong);
+    await player.addToPriorityQueue(queuedSong);
 
     res.json({
         message: `Added "${metadata.title}" to the queue.`,
@@ -641,6 +642,207 @@ router.post(
     }
     await player.resume();
     res.json({ message: 'Resumed.' });
+  })
+);
+
+// ---------------------------------------------------------------------------
+// POST /api/player/add-to-priority
+// Member accessible.
+//
+// Adds a song from the library to the priority queue (Up Next).
+//
+// Body:
+// songId — ID of the song from the library
+// ---------------------------------------------------------------------------
+router.post(
+  '/add-to-priority',
+  requireAuth,
+  asyncHandler(async (req, res) => {
+    const { songId } = req.body as { songId?: string };
+
+    if (!songId || typeof songId !== 'string') {
+      res.status(400).json({ error: 'songId is required.' });
+      return;
+    }
+
+    // Fetch the song from the database
+    const song = await prisma.song.findUnique({ where: { id: songId } });
+    if (!song) {
+      res.status(404).json({ error: 'Song not found.' });
+      return;
+    }
+
+    let player = getPlayer(GUILD_ID);
+    if (!player) {
+      // Auto-join: Find the user's voice channel and join it.
+      const discordClient = getClient();
+      if (!discordClient) {
+        res.status(503).json({ error: 'Discord bot is not ready yet.' });
+        return;
+      }
+      try {
+        const guild = await discordClient.guilds.fetch(GUILD_ID);
+        const member = await guild.members.fetch(req.user!.discordId);
+        const voiceChannel = member.voice.channel;
+        if (!voiceChannel) {
+          res.status(409).json({
+            error: 'You are not in a voice channel. Join a voice channel in Discord first.',
+          });
+          return;
+        }
+        const connection = joinVoiceChannel({
+          channelId: voiceChannel.id,
+          guildId: GUILD_ID,
+          adapterCreator: guild.voiceAdapterCreator,
+        });
+        await entersState(connection, VoiceConnectionStatus.Ready, 5_000);
+        const textChannelId = process.env.DEFAULT_TEXT_CHANNEL_ID;
+        const textChannel = textChannelId
+          ? (guild.channels.cache.get(textChannelId) as TextChannel | undefined)
+          : (guild.systemChannel as TextChannel | null);
+        if (!textChannel) {
+          res.status(503).json({
+            error: 'Could not find a text channel for "Now playing" messages. Set DEFAULT_TEXT_CHANNEL_ID in your environment.',
+          });
+          return;
+        }
+        player = createPlayer(GUILD_ID, connection, textChannel);
+      } catch (error) {
+        console.error('Failed to auto-join voice channel:', error);
+        res.status(503).json({ error: 'Could not connect to your voice channel. Try using /join in Discord first.' });
+        return;
+      }
+    }
+
+    // Create a QueuedSong from the database song
+    const requestedBy = req.user!.username;
+    const queuedSong: QueuedSong = {
+      id: song.id,
+      title: song.title,
+      youtubeUrl: song.youtubeUrl,
+      youtubeId: song.youtubeId,
+      duration: song.duration,
+      thumbnailUrl: song.thumbnailUrl,
+      addedBy: song.addedBy,
+      nickname: song.nickname,
+      createdAt: song.createdAt,
+      requestedBy,
+    };
+
+    await player.addToPriorityQueue(queuedSong);
+
+    res.json({
+      message: `Added "${song.nickname || song.title}" to Up Next.`,
+      song: queuedSong,
+    });
+  })
+);
+
+// ---------------------------------------------------------------------------
+// POST /api/player/override
+// Admin only.
+//
+// Immediately stops current song, clears both queues, and plays the
+// requested song. Does NOT save the song to the library.
+//
+// Body:
+// youtubeUrl — YouTube URL to fetch and play immediately
+// ---------------------------------------------------------------------------
+router.post(
+  '/override',
+  requireAuth,
+  requireAdmin,
+  asyncHandler(async (req, res) => {
+    const { youtubeUrl } = req.body as { youtubeUrl?: string };
+
+    if (!youtubeUrl || typeof youtubeUrl !== 'string') {
+      res.status(400).json({ error: 'youtubeUrl is required.' });
+      return;
+    }
+
+    const url = youtubeUrl.trim();
+    if (url.length > MAX_URL_LENGTH) {
+      res.status(400).json({ error: `URL must be ${MAX_URL_LENGTH} characters or less.` });
+      return;
+    }
+
+    if (!isValidYouTubeUrl(url)) {
+      res.status(400).json({ error: 'That does not look like a valid YouTube URL.' });
+      return;
+    }
+
+    let player = getPlayer(GUILD_ID);
+    if (!player) {
+      // Auto-join: Find the user's voice channel and join it.
+      const discordClient = getClient();
+      if (!discordClient) {
+        res.status(503).json({ error: 'Discord bot is not ready yet.' });
+        return;
+      }
+      try {
+        const guild = await discordClient.guilds.fetch(GUILD_ID);
+        const member = await guild.members.fetch(req.user!.discordId);
+        const voiceChannel = member.voice.channel;
+        if (!voiceChannel) {
+          res.status(409).json({
+            error: 'You are not in a voice channel. Join a voice channel in Discord first.',
+          });
+          return;
+        }
+        const connection = joinVoiceChannel({
+          channelId: voiceChannel.id,
+          guildId: GUILD_ID,
+          adapterCreator: guild.voiceAdapterCreator,
+        });
+        await entersState(connection, VoiceConnectionStatus.Ready, 5_000);
+        const textChannelId = process.env.DEFAULT_TEXT_CHANNEL_ID;
+        const textChannel = textChannelId
+          ? (guild.channels.cache.get(textChannelId) as TextChannel | undefined)
+          : (guild.systemChannel as TextChannel | null);
+        if (!textChannel) {
+          res.status(503).json({
+            error: 'Could not find a text channel for "Now playing" messages. Set DEFAULT_TEXT_CHANNEL_ID in your environment.',
+          });
+          return;
+        }
+        player = createPlayer(GUILD_ID, connection, textChannel);
+      } catch (error) {
+        console.error('Failed to auto-join voice channel:', error);
+        res.status(503).json({ error: 'Could not connect to your voice channel. Try using /join in Discord first.' });
+        return;
+      }
+    }
+
+    // Fetch metadata from YouTube
+    let metadata;
+    try {
+      metadata = await getMetadata(url);
+    } catch {
+      res.status(422).json({ error: 'Could not fetch video info. The video may be private, age-restricted, or unavailable.' });
+      return;
+    }
+
+    // Create a QueuedSong without saving to database
+    const requestedBy = req.user!.username;
+    const queuedSong: QueuedSong = {
+      id: `temp-${Date.now()}`,
+      title: metadata.title,
+      youtubeUrl: url,
+      youtubeId: metadata.youtubeId,
+      duration: metadata.duration,
+      thumbnailUrl: metadata.thumbnailUrl,
+      addedBy: req.user!.discordId,
+      createdAt: new Date(),
+      requestedBy,
+    };
+
+    // Clear both queues and play immediately
+    await player.replaceQueueAndPlay([queuedSong]);
+
+    res.json({
+      message: `Now playing "${metadata.title}".`,
+      song: queuedSong,
+    });
   })
 );
 

--- a/packages/bot/src/player/GuildPlayer.ts
+++ b/packages/bot/src/player/GuildPlayer.ts
@@ -49,6 +49,7 @@ export class GuildPlayer {
   // State
   // ---------------------------------------------------------------------------
   private queue: QueuedSong[] = [];
+  private priorityQueue: QueuedSong[] = []; // Songs added via Quick Add or "Add to Queue" - play before regular queue
   private currentSong: QueuedSong | null = null;
   private loopMode: LoopMode = 'off';
   private paused = false;
@@ -287,13 +288,36 @@ export class GuildPlayer {
    * starting playback and only broadcasts a single queue-update event.
    */
   async addManyToQueue(songs: QueuedSong[]): Promise<void> {
-    this.queue.push(...songs);
-    if (this.currentSong === null) {
-      await this.playNext();
-    } else {
+      this.queue.push(...songs);
+      if (this.currentSong === null) {
+        await this.playNext();
+      } else {
+        broadcastQueueUpdate(this.getQueueState());
+      }
+    }
+
+    /**
+     * Add a song to the priority queue (Up Next).
+     * Priority queue songs play before regular queue songs.
+     * If nothing is currently playing, playback starts immediately.
+     */
+    async addToPriorityQueue(song: QueuedSong): Promise<void> {
+      this.priorityQueue.push(song);
+      if (this.currentSong === null) {
+        await this.playNext();
+      } else {
+        broadcastQueueUpdate(this.getQueueState());
+      }
+    }
+
+    /**
+     * Clear both priority queue and regular queue.
+     */
+    clearAllQueues(): void {
+      this.priorityQueue = [];
+      this.queue = [];
       broadcastQueueUpdate(this.getQueueState());
     }
-  }
 
   /**
    * Replace the entire queue with new songs and immediately start playback.
@@ -445,16 +469,17 @@ export class GuildPlayer {
   // Returns a QueueState snapshot. Used by GET /api/player/queue and as the
   // payload for the Socket.io player:update event.
   // ---------------------------------------------------------------------------
-  getQueueState(): QueueState {
-    return {
-      isPlaying: this.isPlaying(),
-      isPaused: this.paused,
-      loopMode: this.loopMode,
-      currentSong: this.currentSong,
-      queue: [...this.queue],
-      trackStartedAt: this.trackStartedAt,
-    };
-  }
+  	getQueueState(): QueueState {
+  		return {
+  			isPlaying: this.isPlaying(),
+  			isPaused: this.paused,
+  			loopMode: this.loopMode,
+  			currentSong: this.currentSong,
+  			priorityQueue: [...this.priorityQueue],
+  			queue: [...this.queue],
+  			trackStartedAt: this.trackStartedAt,
+  		};
+  	}
 
   // ---------------------------------------------------------------------------
   // Private methods
@@ -480,15 +505,16 @@ export class GuildPlayer {
       return;
     }
 
-    const next = this.queue.shift();
 
+
+    // Check priority queue first, then regular queue
+    const next = this.priorityQueue.shift() || this.queue.shift();
     if (!next) {
       this.currentSong = null;
       // Queue exhausted — broadcast the idle state.
       broadcastQueueUpdate(this.getQueueState());
       return;
     }
-
     this.currentSong = next;
     this.paused = false;
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -55,6 +55,7 @@ export interface QueueState {
   isPaused: boolean;
   loopMode: LoopMode;
   currentSong: QueuedSong | null;
+  priorityQueue: QueuedSong[]; // Songs added via Quick Add or "Add to Queue" - play before regular queue
   queue: QueuedSong[];
   trackStartedAt: number | null; // Unix ms timestamp, null when not playing
 }

--- a/packages/web/src/api/api.ts
+++ b/packages/web/src/api/api.ts
@@ -113,3 +113,19 @@ export const quickAddPlaylistToQueue = (youtubeUrl: string, maxVideos?: number) 
       ...(maxVideos && { maxVideos }),
     })
     .then((r) => r.data);
+
+export const addToPriorityQueue = (songId: string) =>
+  client
+    .post<{ message: string; song: { title: string; duration: number; thumbnailUrl: string; requestedBy: string } }>(
+      '/api/player/add-to-priority',
+      { songId }
+    )
+    .then((r) => r.data);
+
+export const overridePlay = (youtubeUrl: string) =>
+  client
+    .post<{ message: string; song: { title: string; duration: number; thumbnailUrl: string; requestedBy: string } }>(
+      '/api/player/override',
+      { youtubeUrl }
+    )
+    .then((r) => r.data);

--- a/packages/web/src/api/types.ts
+++ b/packages/web/src/api/types.ts
@@ -48,6 +48,7 @@ export interface QueueState {
   isPaused: boolean;
   loopMode: LoopMode;
   currentSong: QueuedSong | null;
+  priorityQueue: QueuedSong[]; // Songs added via Quick Add or "Add to Queue" - play before regular queue
   queue: QueuedSong[];
   trackStartedAt: number | null;
 }

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -4,6 +4,7 @@ import {
   getPlaylist, renamePlaylist, removeSongFromPlaylist,
   addSongToPlaylist, getSongs, startPlayback, deletePlaylist,
   togglePlaylistVisibility,
+  addToPriorityQueue,
 } from '../api/api';
 import type { PlaylistDetail, Song, LoopMode, Playlist } from '../api/types';
 import { useAdminView } from '../context/AdminViewContext';
@@ -163,20 +164,33 @@ export default function PlaylistDetailPage() {
     }
   };
 
-  const handleAddPlaylistToQueue = async (mode: 'sequential' | 'random' = 'sequential') => {
-    if (!playlist) return;
-    try {
-      await startPlayback({
-        playlistId: playlist.id,
-        mode,
-        loop: queueState.loopMode,
-      });
-      setNotification({ message: `Added "${playlist.name}" to queue`, type: 'success' });
-      setTimeout(() => setNotification(null), 3000);
-    } catch (err: unknown) {
-      const e = err as { response?: { data?: { error?: string } } };
-      const errorMsg = e?.response?.data?.error ?? 'Could not add to queue.';
-      setNotification({ message: errorMsg, type: 'error' });
+  const handleAddToQueue = async (songId: string) => {
+      try {
+        await addToPriorityQueue(songId);
+        setNotification({ message: 'Added to Up Next', type: 'success' });
+        setTimeout(() => setNotification(null), 3000);
+      } catch (err: unknown) {
+        const e = err as { response?: { data?: { error?: string } } };
+        const errorMsg = e?.response?.data?.error ?? 'Could not add to queue. Is the bot in a voice channel?';
+        setNotification({ message: errorMsg, type: 'error' });
+        setTimeout(() => setNotification(null), 5000);
+      }
+    };
+
+    const handleAddPlaylistToQueue = async (mode: 'sequential' | 'random' = 'sequential') => {
+      if (!playlist) return;
+      try {
+        await startPlayback({
+          playlistId: playlist.id,
+          mode,
+          loop: queueState.loopMode,
+        });
+        setNotification({ message: `Added "${playlist.name}" to queue`, type: 'success' });
+        setTimeout(() => setNotification(null), 3000);
+      } catch (err: unknown) {
+        const e = err as { response?: { data?: { error?: string } } };
+        const errorMsg = e?.response?.data?.error ?? 'Could not add to queue.';
+        setNotification({ message: errorMsg, type: 'error' });
       setTimeout(() => setNotification(null), 5000);
     }
   };
@@ -303,6 +317,7 @@ export default function PlaylistDetailPage() {
               onRemove={() => setRemoveId(ps.songId)}
               onPlay={() => handlePlayFromSong(ps.songId)}
               isPlaying={playingSongId === ps.songId}
+              onAddToQueue={() => handleAddToQueue(ps.songId)}
             />
           ))}
         </div>
@@ -352,6 +367,7 @@ function SongRow({
   onRemove,
   onPlay,
   isPlaying,
+  onAddToQueue,
 }: {
   position: number;
   song: Song;
@@ -359,12 +375,16 @@ function SongRow({
   onRemove: () => void;
   onPlay: () => void;
   isPlaying?: boolean;
+  onAddToQueue: () => void;
 }) {
   return (
-    <div className="flex items-center gap-4 px-4 py-3 rounded-lg group
-                    hover:bg-elevated transition-colors duration-100">
+    <div className="flex items-center gap-4 px-4 py-3 rounded-lg group hover:bg-elevated transition-colors duration-100">
       <div className="w-6 shrink-0 flex justify-end">
-        <span className={`font-mono text-xs text-faint text-right ${isPlaying ? 'hidden' : 'group-hover:hidden'}`}>
+        <span
+          className={`font-mono text-xs text-faint text-right ${
+            isPlaying ? 'hidden' : 'group-hover:hidden'
+          }`}
+        >
           {position}
         </span>
         {isPlaying ? (
@@ -374,8 +394,7 @@ function SongRow({
         ) : (
           <button
             onClick={onPlay}
-            className="hidden group-hover:flex items-center justify-center
-                       text-accent hover:text-accent/80 transition-colors duration-150"
+            className="hidden group-hover:flex items-center justify-center text-accent hover:text-accent/80 transition-colors duration-150"
             title="Play from this song"
           >
             <PlayIcon size={14} />
@@ -390,21 +409,28 @@ function SongRow({
       />
       <div className="flex-1 min-w-0">
         <p className="font-body text-sm font-medium text-fg truncate">{song.nickname || song.title}</p>
-                      {song.nickname && (
-                        <p className="font-mono text-[10px] text-muted truncate">{song.title}</p>
-                      )}
+        {song.nickname && (
+          <p className="font-mono text-[10px] text-muted truncate">{song.title}</p>
+        )}
       </div>
       <span className="font-mono text-xs text-muted shrink-0">
         {formatDuration(song.duration)}
       </span>
+      {/* Add to Queue - available to all members */}
+      <button
+        onClick={onAddToQueue}
+        className="opacity-0 group-hover:opacity-100 flex items-center justify-center text-muted hover:text-accent transition-all duration-150 p-1"
+        title="Add to Up Next"
+      >
+        <IconQueueAdd size={14} />
+      </button>
       {isAdmin && (
         <button
           onClick={onRemove}
-          className="opacity-0 group-hover:opacity-100 font-mono text-xs text-faint
-                     hover:text-danger transition-all duration-150 px-2 py-1"
+          className="opacity-0 group-hover:opacity-100 flex items-center justify-center text-faint hover:text-danger transition-all duration-150 p-1"
           title="Remove from playlist"
         >
-          rem
+          <IconTrash size={14} />
         </button>
       )}
     </div>
@@ -713,6 +739,28 @@ function PlusIcon({ size = 16, className = '' }: { size?: number; className?: st
       strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
       <line x1="12" y1="5" x2="12" y2="19" />
       <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  );
+}
+
+function IconQueueAdd({ size = 16, className = "" }: { size?: number; className?: string }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
+      <path d="M5 19h14a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2z" />
+    </svg>
+  );
+}
+
+function IconTrash({ size = 16, className = "" }: { size?: number; className?: string }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+      <polyline points="3 6 5 6 21 6" />
+      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+      <path d="M10 11v6" />
+      <path d="M14 11v6" />
+      <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
     </svg>
   );
 }

--- a/packages/web/src/pages/QueuePage.tsx
+++ b/packages/web/src/pages/QueuePage.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect } from 'react';
 import { usePlayer } from '../context/PlayerContext';
 import { useAdminView } from '../context/AdminViewContext';
-import { startPlayback, getPlaylists, quickAddToQueue, quickAddPlaylistToQueue } from '../api/api';
+import { startPlayback, getPlaylists, quickAddToQueue, quickAddPlaylistToQueue, overridePlay } from '../api/api';
 import type { LoopMode, Playlist, QueuedSong } from '../api/types';
 
 // ---------------------------------------------------------------------------
@@ -21,12 +21,12 @@ export default function QueuePage() {
   const { isAdminView } = useAdminView();
   const [showLoadPlaylist, setShowLoadPlaylist] = useState(false);
   const [showQuickAdd, setShowQuickAdd] = useState(false);
+  const [showOverride, setShowOverride] = useState(false);
   const [loopBusy, setLoopBusy] = useState(false);
   const [shuffleBusy, setShuffleBusy] = useState(false);
   const [clearBusy, setClearBusy] = useState(false);
 
-  const { currentSong, queue, isPlaying, loopMode } = state;
-
+  const { currentSong, queue, priorityQueue, isPlaying, loopMode } = state;
   const progress = currentSong ? Math.min((elapsed / currentSong.duration) * 100, 100) : 0;
 
   const handleLoop = async (mode: LoopMode) => {
@@ -75,6 +75,24 @@ export default function QueuePage() {
       <h1 className="font-display text-5xl text-fg tracking-wider mb-8">Queue</h1>
 
       {/* ------------------------------------------------------------------ */}
+      {/* Admin Override Button */}
+      {/* ------------------------------------------------------------------ */}
+      {isAdminView && (
+        <section className="mb-6">
+          <button
+            onClick={() => setShowOverride(true)}
+            className="flex items-center gap-2 btn-danger"
+          >
+            <IconOverride size={14} />
+            <span>Override</span>
+          </button>
+          <p className="font-mono text-[10px] text-muted mt-1">
+            Immediately play a song, clearing all queues
+          </p>
+        </section>
+      )}
+
+      {/* ------------------------------------------------------------------ */}
       {/* Now Playing card */}
       {/* ------------------------------------------------------------------ */}
       {currentSong ? (
@@ -113,7 +131,6 @@ export default function QueuePage() {
               </button>
             ))}
           </div>
-
           <button
             onClick={() => setShowLoadPlaylist(true)}
             className="flex items-center gap-2 btn-primary ml-auto"
@@ -121,7 +138,6 @@ export default function QueuePage() {
             <IconList size={14} />
             <span>Load Playlist</span>
           </button>
-
           <button
             onClick={() => setShowQuickAdd(true)}
             className="flex items-center gap-2 btn-primary"
@@ -142,12 +158,11 @@ export default function QueuePage() {
               <IconShuffle size={14} />
               <span>Shuffle{queue.length > 0 ? ` (${queue.length})` : ''}</span>
             </button>
-
             <button
               onClick={handleClear}
-              disabled={clearBusy || (queue.length === 0 && !currentSong)}
+              disabled={clearBusy || (queue.length === 0 && priorityQueue.length === 0 && !currentSong)}
               className={`flex items-center gap-2 disabled:opacity-40 disabled:cursor-not-allowed ${
-                queue.length === 0 && !currentSong ? 'btn-ghost' : 'btn-danger'
+                queue.length === 0 && priorityQueue.length === 0 && !currentSong ? 'btn-ghost' : 'btn-danger'
               }`}
             >
               <IconTrash size={14} />
@@ -158,12 +173,58 @@ export default function QueuePage() {
       </section>
 
       {/* ------------------------------------------------------------------ */}
+      {/* Up Next (Priority Queue) */}
+      {/* ------------------------------------------------------------------ */}
+      {priorityQueue.length > 0 && (
+        <section className="mt-8">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="font-display text-2xl text-fg tracking-wider">
+              ⚡ Up Next
+              <span className="ml-2 font-mono text-sm text-accent normal-case tracking-normal">
+                {priorityQueue.length} {priorityQueue.length === 1 ? 'song' : 'songs'}
+              </span>
+            </h2>
+            <span className="font-mono text-[10px] text-muted uppercase tracking-widest">
+              Priority Queue
+            </span>
+          </div>
+          <div className="space-y-1 border-l-2 border-accent/40 pl-3">
+            {priorityQueue.map((song, i) => (
+              <div
+                key={`priority-${song.id}-${i}`}
+                className="flex items-center gap-4 px-4 py-3 rounded-lg hover:bg-elevated transition-colors duration-100 group"
+              >
+                <span className="font-mono text-xs text-accent w-5 text-right shrink-0">
+                  {i + 1}
+                </span>
+                <img
+                  src={song.thumbnailUrl}
+                  alt={song.nickname || song.title}
+                  className="w-10 h-7 object-cover rounded border border-border shrink-0"
+                  loading="lazy"
+                />
+                <div className="flex-1 min-w-0">
+                  <p className="font-body text-sm font-medium text-fg truncate">
+                    {song.nickname || song.title}
+                  </p>
+                  <p className="font-mono text-[10px] text-muted">req. {song.requestedBy}</p>
+                </div>
+                <span className="font-mono text-xs text-muted shrink-0">
+                  {formatDuration(song.duration)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* ------------------------------------------------------------------ */}
       {/* Queue */}
       {/* ------------------------------------------------------------------ */}
       <section className="mt-8">
         <div className="flex items-center justify-between mb-4">
           <h2 className="font-display text-2xl text-fg tracking-wider">
-            Up Next
+            Queue
             {queue.length > 0 && (
               <span className="ml-2 font-mono text-sm text-muted normal-case tracking-normal">
                 {queue.length} {queue.length === 1 ? 'song' : 'songs'}
@@ -171,16 +232,17 @@ export default function QueuePage() {
             )}
           </h2>
         </div>
-
         {queue.length === 0 ? (
           <div className="py-12 text-center border border-dashed border-border rounded-xl">
             <p className="font-mono text-xs text-faint">queue is empty</p>
-            <button
-              onClick={() => setShowLoadPlaylist(true)}
-              className="mt-3 font-mono text-xs text-accent hover:underline"
-            >
-              load a playlist to get started
-            </button>
+            {priorityQueue.length === 0 && (
+              <button
+                onClick={() => setShowLoadPlaylist(true)}
+                className="mt-3 font-mono text-xs text-accent hover:underline"
+              >
+                load a playlist to get started
+              </button>
+            )}
           </div>
         ) : (
           <div className="space-y-1">
@@ -199,7 +261,9 @@ export default function QueuePage() {
                   loading="lazy"
                 />
                 <div className="flex-1 min-w-0">
-                  <p className="font-body text-sm font-medium text-fg truncate">{song.nickname || song.title}</p>
+                  <p className="font-body text-sm font-medium text-fg truncate">
+                    {song.nickname || song.title}
+                  </p>
                   <p className="font-mono text-[10px] text-muted">req. {song.requestedBy}</p>
                 </div>
                 <span className="font-mono text-xs text-muted shrink-0">
@@ -240,12 +304,26 @@ export default function QueuePage() {
           }}
         />
       )}
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Override modal */}
+      {/* ------------------------------------------------------------------ */}
+      {showOverride && (
+        <OverrideModal
+          onClose={() => setShowOverride(false)}
+          onOverride={async () => {
+            setShowOverride(false);
+            await new Promise((r) => setTimeout(r, 600));
+            await refetch();
+          }}
+        />
+      )}
     </div>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Now Playing card
+// Now Playing card - Redesigned
 // ---------------------------------------------------------------------------
 function NowPlayingCard({
   song,
@@ -260,54 +338,51 @@ function NowPlayingCard({
 }) {
   return (
     <div className="card overflow-hidden">
-      {/* Blurred thumbnail banner */}
-      <div className="relative h-48 overflow-hidden">
-        <img
-          src={song.thumbnailUrl}
-          alt=""
-          className="absolute inset-0 w-full h-full object-cover scale-110 blur-xl opacity-30"
-          aria-hidden="true"
-        />
-        <div className="absolute inset-0 bg-linear-to-b from-transparent to-surface/90" />
-
-        {/* Centred thumbnail */}
-        <div className="relative h-full flex items-center justify-center">
-          <div className="relative">
-            <img
-              src={song.thumbnailUrl}
-              alt={song.nickname || song.title}
-              className="h-36 w-auto rounded-lg border border-border shadow-2xl object-cover"
-            />
-            {/* Playing indicator */}
-            {isPlaying && (
-              <div className="absolute -bottom-2 -right-2 w-6 h-6 rounded-full bg-accent flex items-center justify-center shadow-lg">
-                <span className="text-base text-[8px]">▶</span>
-              </div>
-            )}
-          </div>
+      <div className="flex flex-col sm:flex-row gap-4 p-5">
+        {/* Large square album art */}
+        <div className="relative shrink-0">
+          <img
+            src={song.thumbnailUrl}
+            alt={song.nickname || song.title}
+            className="w-40 h-40 rounded-lg border border-border shadow-lg object-cover"
+          />
+          {/* Playing indicator */}
+          {isPlaying && (
+            <div className="absolute -bottom-2 -right-2 w-8 h-8 rounded-full bg-accent flex items-center justify-center shadow-lg">
+              <span className="text-white text-xs">▶</span>
+            </div>
+          )}
         </div>
-      </div>
 
-      {/* Info + progress */}
-      <div className="px-5 py-4">
-        <p className="font-body font-bold text-fg truncate leading-tight">
-          {song.nickname || song.title}
-        </p>
-        <p className="font-mono text-[10px] text-muted mt-0.5">
-          requested by {song.requestedBy}
-        </p>
+        {/* Info */}
+        <div className="flex-1 flex flex-col justify-center">
+          {/* Song title as YouTube link */}
+          <a
+            href={song.youtubeUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-body font-bold text-lg text-fg hover:text-accent transition-colors duration-150 line-clamp-2"
+          >
+            {song.nickname || song.title}
+          </a>
 
-        {/* Progress bar */}
-        <div className="mt-4">
-          <div className="relative h-1 w-full bg-elevated rounded-full overflow-hidden">
-            <div
-              className="absolute inset-y-0 left-0 bg-accent rounded-full transition-all duration-1000 ease-linear"
-              style={{ width: `${progress}%` }}
-            />
-          </div>
-          <div className="flex justify-between mt-1.5">
-            <span className="font-mono text-[10px] text-muted">{formatDuration(elapsed)}</span>
-            <span className="font-mono text-[10px] text-muted">{formatDuration(song.duration)}</span>
+          {/* Requester */}
+          <p className="font-mono text-xs text-muted mt-1">
+            requested by {song.requestedBy}
+          </p>
+
+          {/* Progress bar */}
+          <div className="mt-4">
+            <div className="relative h-2 w-full bg-elevated rounded-full overflow-hidden">
+              <div
+                className="absolute inset-y-0 left-0 bg-accent rounded-full transition-all duration-1000 ease-linear"
+                style={{ width: `${progress}%` }}
+              />
+            </div>
+            <div className="flex justify-between mt-1.5">
+              <span className="font-mono text-xs text-muted">{formatDuration(elapsed)}</span>
+              <span className="font-mono text-xs text-muted">{formatDuration(song.duration)}</span>
+            </div>
           </div>
         </div>
       </div>
@@ -550,7 +625,7 @@ function QuickAddModal({
       <div className="bg-surface border border-border rounded-xl p-6 w-full max-w-sm shadow-2xl animate-fade-up">
         <h2 className="font-display text-3xl text-fg tracking-wider mb-1">Quick Add</h2>
         <p className="font-mono text-xs text-muted mb-6">
-          add a song to the queue without saving to library
+          add a song to Up Next without saving to library
         </p>
 
         <div className="space-y-4 mb-6">
@@ -609,7 +684,102 @@ function QuickAddModal({
             onClick={handleSubmit}
             disabled={submitting || !youtubeUrl.trim()}
           >
-            {submitting ? 'Adding...' : importFullPlaylist ? 'Add Playlist' : 'Add to Queue'}
+            {submitting
+              ? 'Adding...'
+              : importFullPlaylist
+              ? 'Add Playlist'
+              : 'Add to Up Next'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Override Modal (Admin only)
+// ---------------------------------------------------------------------------
+function OverrideModal({
+  onClose,
+  onOverride,
+}: {
+  onClose: () => void;
+  onOverride: () => void;
+}) {
+  const [youtubeUrl, setYoutubeUrl] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async () => {
+    if (!youtubeUrl.trim()) return;
+    setSubmitting(true);
+    setError('');
+    try {
+      await overridePlay(youtubeUrl.trim());
+      onOverride();
+    } catch (err: unknown) {
+      const e = err as { response?: { data?: { error?: string } } };
+      setError(e?.response?.data?.error ?? 'Could not override playback. Is the bot in a voice channel?');
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/70 backdrop-blur-sm flex items-center justify-center p-4"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="bg-surface border border-border rounded-xl p-6 w-full max-w-sm shadow-2xl animate-fade-up">
+        <h2 className="font-display text-3xl text-fg tracking-wider mb-1">Override</h2>
+        <p className="font-mono text-xs text-danger mb-6">
+          ⚠️ This will stop current playback, clear all queues, and play the requested song immediately.
+        </p>
+
+        <div className="space-y-4 mb-6">
+          <div>
+            <p className="font-mono text-xs text-muted mb-2 uppercase tracking-widest">
+              YouTube URL
+            </p>
+            <input
+              type="text"
+              value={youtubeUrl}
+              onChange={(e) => {
+                setYoutubeUrl(e.target.value);
+                setError('');
+              }}
+              placeholder="https://youtube.com/watch?v=..."
+              className="input font-body w-full"
+              disabled={submitting}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && youtubeUrl.trim()) {
+                  handleSubmit();
+                }
+              }}
+            />
+          </div>
+        </div>
+
+        {error && <p className="font-mono text-xs text-danger mb-4">{error}</p>}
+
+        {submitting && (
+          <p className="font-mono text-xs text-muted mb-4 flex items-center gap-2">
+            <span className="w-3 h-3 border border-accent border-t-transparent rounded-full animate-spin inline-block" />
+            Overriding...
+          </p>
+        )}
+
+        <div className="flex gap-2 justify-end">
+          <button className="btn-ghost" onClick={onClose} disabled={submitting}>
+            Cancel
+          </button>
+          <button
+            className="btn-danger"
+            onClick={handleSubmit}
+            disabled={submitting || !youtubeUrl.trim()}
+          >
+            {submitting ? 'Overriding...' : 'Override & Play'}
           </button>
         </div>
       </div>
@@ -722,6 +892,24 @@ function IconTrash({ size = 20, className = '' }: { size?: number; className?: s
       <path d="M10 11v6" />
       <path d="M14 11v6" />
       <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+    </svg>
+  );
+}
+
+function IconOverride({ size = 20, className = '' }: { size?: number; className?: string }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <polygon points="5 3 19 12 5 21 5 3" />
     </svg>
   );
 }

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { getSongs, addSong, deleteSong, getPlaylists, addSongToPlaylist, startPlayback, importPlaylist } from '../api/api';
+import { getSongs, addSong, deleteSong, getPlaylists, addSongToPlaylist, startPlayback, importPlaylist, addToPriorityQueue } from '../api/api';
 import type { Song, Playlist } from '../api/types';
 import { useAdminView } from '../context/AdminViewContext';
 import { useSocket } from '../hooks/useSocket';
@@ -71,11 +71,12 @@ export default function SongsPage() {
   // Play from song — replaces the queue with the full library starting from
   // the clicked song, then continues sequentially through the rest.
   // ---------------------------------------------------------------------------
+
+
   const handlePlayFromSong = async (songId: string) => {
     setPlayingId(songId);
     try {
       await startPlayback({
-        // No playlistId = whole library
         mode: 'sequential',
         loop: queueState.loopMode,
         startFromSongId: songId,
@@ -84,12 +85,24 @@ export default function SongsPage() {
       setTimeout(() => setNotification(null), 3000);
     } catch (err: unknown) {
       const e = err as { response?: { data?: { error?: string } } };
-      const errorMsg =
-        e?.response?.data?.error ?? 'Could not start playback. Is the bot in a voice channel?';
+      const errorMsg = e?.response?.data?.error ?? 'Could not start playback. Is the bot in a voice channel?';
       setNotification({ message: errorMsg, type: 'error' });
       setTimeout(() => setNotification(null), 5000);
     } finally {
       setPlayingId(null);
+    }
+  };
+
+  const handleAddToQueue = async (songId: string) => {
+    try {
+      await addToPriorityQueue(songId);
+      setNotification({ message: 'Added to Up Next', type: 'success' });
+      setTimeout(() => setNotification(null), 3000);
+    } catch (err: unknown) {
+      const e = err as { response?: { data?: { error?: string } } };
+      const errorMsg = e?.response?.data?.error ?? 'Could not add to queue. Is the bot in a voice channel?';
+      setNotification({ message: errorMsg, type: 'error' });
+      setTimeout(() => setNotification(null), 5000);
     }
   };
 
@@ -134,15 +147,16 @@ export default function SongsPage() {
         <div className="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-4">
           {filtered.map((song, i) => (
             <SongCard
-              key={song.id}
-              song={song}
-              isAdmin={isAdminView}
-              playlists={playlists}
-              style={{ animationDelay: `${Math.min(i * 30, 300)}ms` }}
-              onDelete={() => setDeleteId(song.id)}
-              onAddedToPlaylist={() => {/* optimistic — no refresh needed */}}
-              onPlay={() => handlePlayFromSong(song.id)}
-              isPlaying={playingId === song.id}
+            key={song.id}
+            song={song}
+            isAdmin={isAdminView}
+            playlists={playlists}
+            style={{ animationDelay: `${Math.min(i * 30, 300)}ms` }}
+            onDelete={() => setDeleteId(song.id)}
+            onAddedToPlaylist={() => {/* optimistic — no refresh needed */}}
+            onPlay={() => handlePlayFromSong(song.id)}
+            isPlaying={playingId === song.id}
+            onAddToQueue={() => handleAddToQueue(song.id)}
             />
           ))}
         </div>
@@ -203,6 +217,7 @@ function SongCard({
   onAddedToPlaylist,
   onPlay,
   isPlaying,
+  onAddToQueue,
 }: {
   song: Song;
   isAdmin: boolean;
@@ -212,10 +227,12 @@ function SongCard({
   onAddedToPlaylist: () => void;
   onPlay: () => void;
   isPlaying: boolean;
+  onAddToQueue: () => void;
 }) {
   const [showPlaylistMenu, setShowPlaylistMenu] = useState(false);
   const [addingToPlaylist, setAddingToPlaylist] = useState<string | null>(null);
   const [addedTo, setAddedTo] = useState<Set<string>>(new Set());
+  const [addingToQueue, setAddingToQueue] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
   // Close playlist menu when clicking outside
@@ -243,6 +260,15 @@ function SongCard({
       }
     } finally {
       setAddingToPlaylist(null);
+    }
+  };
+
+  const handleAddToQueue = async () => {
+    setAddingToQueue(true);
+    try {
+      await onAddToQueue();
+    } finally {
+      setAddingToQueue(false);
     }
   };
 
@@ -292,51 +318,64 @@ function SongCard({
         <p className="font-body font-semibold text-sm text-fg leading-tight line-clamp-2">
           {song.nickname || song.title}
         </p>
-
-        {isAdmin && (
-          <div className="flex gap-1.5 mt-auto pt-1">
-            {/* Add to playlist */}
-            <div className="relative flex-1" ref={menuRef}>
+        <div className="flex gap-1.5 mt-auto pt-1">
+          {/* Add to Queue - available to all members */}
+          <button
+            onClick={handleAddToQueue}
+            disabled={addingToQueue}
+            className="flex items-center justify-center w-8 h-8 text-muted hover:text-accent border border-border hover:border-accent/30 rounded transition-colors duration-150 disabled:opacity-50"
+            title="Add to Up Next"
+          >
+            {addingToQueue ? (
+              <span className="w-3 h-3 border border-accent border-t-transparent rounded-full animate-spin inline-block" />
+            ) : (
+              <IconQueueAdd size={16} />
+            )}
+          </button>
+          {isAdmin && (
+            <>
+              {/* Add to playlist */}
+              <div className="relative" ref={menuRef}>
+                <button
+                  onClick={() => setShowPlaylistMenu((p) => !p)}
+                  className="flex items-center justify-center w-8 h-8 text-muted hover:text-fg border border-border hover:border-accent/30 rounded transition-colors duration-150"
+                  title="Add to playlist"
+                >
+                  <IconPlaylistAdd size={16} />
+                </button>
+                {showPlaylistMenu && (
+                  <div className="absolute bottom-full left-0 mb-1 w-44 bg-elevated border border-border rounded shadow-xl z-20 overflow-hidden">
+                    {playlists.length === 0 ? (
+                      <p className="px-3 py-2 text-xs font-mono text-muted">no playlists yet</p>
+                    ) : (
+                      playlists.map((pl) => (
+                        <button
+                          key={pl.id}
+                          disabled={addingToPlaylist === pl.id || addedTo.has(pl.id)}
+                          onClick={() => handleAddToPlaylist(pl.id)}
+                          className="w-full text-left px-3 py-2 text-xs font-body text-fg hover:bg-border/50 transition-colors duration-100 disabled:opacity-50 flex items-center justify-between"
+                        >
+                          <span className="truncate">{pl.name}</span>
+                          {addedTo.has(pl.id) && (
+                            <span className="text-accent text-[10px] ml-1">✓</span>
+                          )}
+                        </button>
+                      ))
+                    )}
+                  </div>
+                )}
+              </div>
+              {/* Delete */}
               <button
-                onClick={() => setShowPlaylistMenu((p) => !p)}
-                className="w-full text-xs font-mono text-muted hover:text-fg border border-border hover:border-accent/30 rounded px-2 py-1 transition-colors duration-150"
+                onClick={onDelete}
+                className="flex items-center justify-center w-8 h-8 text-faint hover:text-danger border border-border hover:border-danger/30 rounded transition-colors duration-150"
+                title="Delete song"
               >
-                + playlist
+                <IconTrash size={16} />
               </button>
-
-              {showPlaylistMenu && (
-                <div className="absolute bottom-full left-0 mb-1 w-44 bg-elevated border border-border rounded shadow-xl z-20 overflow-hidden">
-                  {playlists.length === 0 ? (
-                    <p className="px-3 py-2 text-xs font-mono text-muted">no playlists yet</p>
-                  ) : (
-                    playlists.map((pl) => (
-                      <button
-                        key={pl.id}
-                        disabled={addingToPlaylist === pl.id || addedTo.has(pl.id)}
-                        onClick={() => handleAddToPlaylist(pl.id)}
-                        className="w-full text-left px-3 py-2 text-xs font-body text-fg hover:bg-border/50 transition-colors duration-100 disabled:opacity-50 flex items-center justify-between"
-                      >
-                        <span className="truncate">{pl.name}</span>
-                        {addedTo.has(pl.id) && (
-                          <span className="text-accent text-[10px] ml-1">✓</span>
-                        )}
-                      </button>
-                    ))
-                  )}
-                </div>
-              )}
-            </div>
-
-            {/* Delete */}
-            <button
-              onClick={onDelete}
-              className="text-xs font-mono text-faint hover:text-danger border border-border hover:border-danger/30 rounded px-2 py-1 transition-colors duration-150"
-              title="Delete song"
-            >
-              del
-            </button>
-          </div>
-        )}
+            </>
+          )}
+        </div>
       </div>
     </div>
   );
@@ -643,6 +682,72 @@ function SpinnerIcon({ size = 16, className = '' }: { size?: number; className?:
       className={`animate-spin ${className}`}
     >
       <path d="M12 2a10 10 0 0 1 10 10" />
+    </svg>
+  );
+}
+
+function IconQueueAdd({ size = 16, className = '' }: { size?: number; className?: string }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
+      <path d="M5 19h14a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2z" />
+    </svg>
+  );
+}
+
+function IconPlaylistAdd({ size = 16, className = '' }: { size?: number; className?: string }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
+      <path d="M19 19h2v2h-2z" />
+      <path d="M19 15h2v2h-2z" />
+      <path d="M19 11h2v2h-2z" />
+      <path d="M19 7h2v2h-2z" />
+      <path d="M19 3h2v2h-2z" />
+    </svg>
+  );
+}
+
+function IconTrash({ size = 16, className = '' }: { size?: number; className?: string }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <polyline points="3 6 5 6 21 6" />
+      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+      <path d="M10 11v6" />
+      <path d="M14 11v6" />
+      <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
     </svg>
   );
 }


### PR DESCRIPTION
## Summary

This PR implements Issues #66 and #67, redesigning the Queue page and adding icon-based action buttons.

### Issue #66 - Queue Page Redesign

- **Priority Queue (Up Next)**: Added a new priority queue that plays before the regular queue. Songs added via Quick Add or "Add to Queue" go here first.
- **Now Playing Redesign**: Large square album art on the left, song title as a YouTube link, requester info, and progress bar.
- **Admin Override Button**: Admin-only button that immediately stops current playback, clears all queues, and plays the requested song (without saving to library).
- **Admin-Only Controls**: Override, Shuffle, and Clear Queue buttons only display in Admin View mode.

### Issue #67 - Add to Queue Button & Icon Conversion

- **Add to Queue Button**: New icon button on each song card in Library and Playlist Detail pages. Available to all members.
- **Icon Conversion**: All song card action buttons now use icons with accessible `title` tooltips:
  - Add to Queue → queue/add icon
  - Add to Playlist → playlist-add icon
  - Delete/Remove → trash icon

## Changes

### Backend
- Added `priorityQueue` to `QueueState` type
- Added `addToPriorityQueue()` and `clearAllQueues()` methods to `GuildPlayer`
- Updated `playNext()` to check priority queue first
- Added `/api/player/add-to-priority` endpoint for adding songs from library
- Added `/api/player/override` endpoint for admin override

### Frontend
- Redesigned `QueuePage` with priority queue section and override modal
- Updated `SongsPage` and `PlaylistDetailPage` with icon-based action buttons
- Added `addToPriorityQueue` and `overridePlay` API functions

Closes #66
Closes #67