### PR TITLE
feat(web): Replace custom SVG icons with Lucide React

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4457,6 +4457,15 @@
         "url": "https://github.com/sponsors/wellwelwel"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.577.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
+      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/magic-bytes.js": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
@@ -6135,6 +6144,7 @@
       "version": "0.1.0",
       "dependencies": {
         "axios": "^1.13.6",
+        "lucide-react": "^0.577.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.13.1",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -10,15 +10,16 @@
   },
   "dependencies": {
     "axios": "^1.13.6",
+    "lucide-react": "^0.577.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.13.1",
     "socket.io-client": "^4.7.5"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.2.1",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@tailwindcss/postcss": "^4.2.1",
     "@vitejs/plugin-react": "^5.1.4",
     "autoprefixer": "^10.4.20",
     "postcss": "^8.5.8",

--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -1,3 +1,4 @@
+import { Music, Disc3, ListMusic, SquarePlay, Play, SkipForward, LogOut, ChevronLeft, ShieldUser, Shield, Pause, Loader2, CirclePlay, CirclePause } from 'lucide-react';
 import { useState } from 'react';
 import { NavLink, Outlet, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
@@ -5,9 +6,9 @@ import { useAdminView } from '../context/AdminViewContext';
 import { usePlayer } from '../context/PlayerContext';
 
 const NAV_ITEMS = [
-  { to: '/songs', label: 'Songs', icon: IconMusic },
-  { to: '/playlists', label: 'Playlists', icon: IconList },
-  { to: '/queue', label: 'Queue', icon: IconQueue },
+  { to: '/songs', label: 'Songs', icon: Disc3 },
+  { to: '/playlists', label: 'Playlists', icon: ListMusic },
+  { to: '/queue', label: 'Queue', icon: SquarePlay },
 ];
 
 export default function Layout() {
@@ -56,7 +57,7 @@ export default function Layout() {
           className={`w-7 h-7 flex items-center justify-center ${isAdminView ? 'text-accent' : 'text-member'}`}
           title={isAdminView ? 'Admin mode' : 'Member mode'}
           >
-          {isAdminView ? <IconShield size={18} /> : <IconMusic size={18} />}
+          {isAdminView ? <ShieldUser size={18} /> : <Music size={18} />}
           </div>
           )}
           <button
@@ -65,7 +66,7 @@ export default function Layout() {
                        hover:text-fg hover:bg-elevated transition-colors duration-150"
             title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
           >
-            <IconChevron size={16} pointRight={collapsed} />
+            <ChevronLeft size={16} className={collapsed ? 'rotate-180' : ''} />
           </button>
         </div>
 
@@ -108,7 +109,7 @@ export default function Layout() {
                   : 'border-border text-muted hover:text-fg hover:border-muted'
               }`}
             >
-              <IconShield size={12} />
+              <Shield size={12} />
               {!collapsed && (isAdminView ? 'admin view' : 'user view')}
             </button>
           </div>
@@ -140,7 +141,7 @@ export default function Layout() {
                            hover:text-danger hover:bg-elevated transition-colors duration-150"
                 title="Log out"
               >
-                <IconLogout size={14} />
+                <LogOut size={14} />
               </button>
             </div>
           ) : (
@@ -256,7 +257,7 @@ function NowPlayingBar() {
               />
             ) : (
               <div className="w-full h-full flex items-center justify-center">
-                <IconMusic size={14} className="text-faint" />
+                <Music size={14} className="text-faint" />
               </div>
             )}
           </div>
@@ -270,9 +271,9 @@ function NowPlayingBar() {
                 <p className="font-mono text-[10px] text-muted leading-tight">
                   {formatDuration(elapsed)} / {formatDuration(currentSong.duration)}
                   {isPlaying ? (
-                    <span className="ml-2 text-accent">▶</span>
+                    <CirclePlay size={12} className="ml-2 text-accent" />
                   ) : (
-                    <span className="ml-2 text-muted">⏸</span>
+                    <CirclePause size={12} className="ml-2 text-muted" />
                   )}
                 </p>
               </>
@@ -292,7 +293,7 @@ function NowPlayingBar() {
               title={isPaused || isStopped ? 'Resume' : 'Pause'}
               hoverColor="hover:text-fg"
             >
-              {isPaused || isStopped ? <IconPlay size={16} /> : <IconPause size={16} />}
+              {isPaused || isStopped ? <Play size={16} /> : <Pause size={16} />}
             </BarButton>
 
             <BarButton
@@ -302,7 +303,7 @@ function NowPlayingBar() {
               title="Skip"
               hoverColor="hover:text-fg"
             >
-              <IconSkip size={16} />
+              <SkipForward size={16} />
             </BarButton>
 
             <button
@@ -311,7 +312,7 @@ function NowPlayingBar() {
               className="w-8 h-8 flex items-center justify-center rounded text-muted
                          hover:text-danger hover:bg-elevated transition-colors duration-150"
             >
-              <IconLeave size={16} />
+              <LogOut size={16} />
             </button>
           </div>
         )}
@@ -350,137 +351,11 @@ function BarButton({
                  }
                  disabled:pointer-events-none`}
     >
-      {busy ? <IconSpinner size={15} /> : children}
+      {busy ? <Loader2 size={15} /> : children}
     </button>
   );
 }
 
-// ---------------------------------------------------------------------------
-// Icons
-// ---------------------------------------------------------------------------
-function IconMusic({ size = 20, className = '' }: { size?: number; className?: string }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
-      strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" className={className}>
-      <path d="M9 18V5l12-2v13" />
-      <circle cx="6" cy="18" r="3" />
-      <circle cx="18" cy="16" r="3" />
-    </svg>
-  );
-}
-
-function IconList({ size = 20, className = '' }: { size?: number; className?: string }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" className={className}>
-      <line x1="8" y1="6" x2="21" y2="6" />
-      <line x1="8" y1="12" x2="21" y2="12" />
-      <line x1="8" y1="18" x2="21" y2="18" />
-      <line x1="3" y1="6" x2="3.01" y2="6" />
-      <line x1="3" y1="12" x2="3.01" y2="12" />
-      <line x1="3" y1="18" x2="3.01" y2="18" />
-    </svg>
-  );
-}
-
-function IconQueue({ size = 20, className = '' }: { size?: number; className?: string }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" className={className}>
-      <polygon points="5 3 15 10 5 17 5 3" />
-      <line x1="18" y1="6" x2="21" y2="6" />
-      <line x1="18" y1="12" x2="21" y2="12" />
-      <line x1="18" y1="18" x2="21" y2="18" />
-    </svg>
-  );
-}
-
-function IconPlay({ size = 20, className = '' }: { size?: number; className?: string }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
-      strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" className={className}>
-      <polygon points="5 3 19 12 5 21 5 3" />
-    </svg>
-  );
-}
-
-function IconSkip({ size = 20, className = '' }: { size?: number; className?: string }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
-      strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
-      <polygon points="5 4 15 12 5 20 5 4" />
-      <line x1="19" y1="5" x2="19" y2="19" />
-    </svg>
-  );
-}
-
-function IconLeave({ size = 20, className = '' }: { size?: number; className?: string }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
-      strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
-      <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
-      <polyline points="16 17 21 12 16 7" />
-      <line x1="21" y1="12" x2="9" y2="12" />
-    </svg>
-  );
-}
-
-function IconChevron({ size = 20, pointRight = false, className = '' }: { size?: number; pointRight?: boolean; className?: string }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
-      strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
-      {pointRight
-        ? <polyline points="9 18 15 12 9 6" />
-        : <polyline points="15 18 9 12 15 6" />
-      }
-    </svg>
-  );
-}
-
-function IconLogout({ size = 20, className = '' }: { size?: number; className?: string }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
-      strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
-      <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
-      <polyline points="16 17 21 12 16 7" />
-      <line x1="21" y1="12" x2="9" y2="12" />
-    </svg>
-  );
-}
-
-function IconShield({ size = 20, className = '' }: { size?: number; className?: string }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
-      strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
-      <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
-    </svg>
-  );
-}
-
-function IconPause({ size = 20, className = '' }: { size?: number; className?: string }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
-      strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
-      <rect x="6" y="4" width="4" height="16" />
-      <rect x="14" y="4" width="4" height="16" />
-    </svg>
-  );
-}
-
-function IconSpinner({ size = 16, className = '' }: { size?: number; className?: string }) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-      className={`animate-spin ${className}`}
-    >
-      <path d="M12 2a10 10 0 0 1 10 10" />
-    </svg>
-  );
-}
 
 function formatDuration(seconds: number): string {
   const m = Math.floor(seconds / 60);

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -1,3 +1,4 @@
+import { ChevronLeft, Play, Plus, ListVideo, Trash2, CirclePlay, Ghost, Lock, Unlock } from 'lucide-react';
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
@@ -206,7 +207,7 @@ export default function PlaylistDetailPage() {
         className="flex items-center gap-1.5 font-mono text-xs text-muted hover:text-fg
                    transition-colors duration-150 mb-6"
       >
-        <ChevronLeftIcon size={14} /> playlists
+        <ChevronLeft size={14} /> playlists
       </button>
 
       {/* Header */}
@@ -239,7 +240,7 @@ export default function PlaylistDetailPage() {
               </h1>
               {playlist.isPrivate && (
                 <span className="text-muted text-sm" title="Private playlist">
-                  👻 private
+                  <Ghost size={14} className="inline mr-1" /> private
                 </span>
               )}
             </div>
@@ -260,13 +261,13 @@ export default function PlaylistDetailPage() {
             disabled={playlist.songs.length === 0}
             title="Add playlist to current queue"
           >
-            <PlusIcon size={14} /> Add to Queue
+            <Plus size={14} /> Add to Queue
           </button>
           <button className="btn-primary text-xs flex items-center gap-1.5"
             onClick={() => setShowPlay(true)}
             disabled={playlist.songs.length === 0}
             >
-            <PlayIcon size={14} /> Play
+            <Play size={14} /> Play
             </button>
             {(user?.discordId === playlist.createdBy || isAdminView) && (
             <button
@@ -274,7 +275,7 @@ export default function PlaylistDetailPage() {
             onClick={handleToggleVisibility}
             title={playlist.isPrivate ? 'Make playlist public' : 'Make playlist private'}
             >
-            {playlist.isPrivate ? '🔓 Make Public' : '🔒 Make Private'}
+            {playlist.isPrivate ? <> <Unlock size={14} className="inline mr-1" /> Make Public </> : <> <Lock size={14} className="inline mr-1" /> Make Private </>}
             </button>
             )}
             {isAdminView && (
@@ -397,7 +398,7 @@ function SongRow({
             className="hidden group-hover:flex items-center justify-center text-accent hover:text-accent/80 transition-colors duration-150"
             title="Play from this song"
           >
-            <PlayIcon size={14} />
+            <Play size={14} />
           </button>
         )}
       </div>
@@ -422,7 +423,7 @@ function SongRow({
         className="opacity-0 group-hover:opacity-100 flex items-center justify-center text-muted hover:text-accent transition-all duration-150 p-1"
         title="Add to Up Next"
       >
-        <IconQueueAdd size={14} />
+        <ListVideo size={14} />
       </button>
       {isAdmin && (
         <button
@@ -430,7 +431,7 @@ function SongRow({
           className="opacity-0 group-hover:opacity-100 flex items-center justify-center text-faint hover:text-danger transition-all duration-150 p-1"
           title="Remove from playlist"
         >
-          <IconTrash size={14} />
+          <Trash2 size={14} />
         </button>
       )}
     </div>
@@ -630,7 +631,7 @@ function PlayModal({
         <div className="flex gap-2 justify-end">
           <button className="btn-ghost" onClick={onClose} disabled={loading}>Cancel</button>
           <button className="btn-primary" onClick={handlePlay} disabled={loading}>
-            {loading ? 'Starting...' : '▶ Play'}
+            {loading ? 'Starting...' : <> <CirclePlay size={12} className="inline mr-1" /> Play </>}
           </button>
         </div>
       </div>
@@ -714,53 +715,4 @@ function formatDuration(seconds: number): string {
   const m = Math.floor(seconds / 60);
   const s = seconds % 60;
   return `${m}:${s.toString().padStart(2, '0')}`;
-}
-
-function ChevronLeftIcon({ size = 16, className = '' }: { size?: number; className?: string }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
-      strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
-      <polyline points="15 18 9 12 15 6" />
-    </svg>
-  );
-}
-
-function PlayIcon({ size = 16, className = '' }: { size?: number; className?: string }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" className={className}>
-      <polygon points="5 3 19 12 5 21 5 3" />
-    </svg>
-  );
-}
-
-function PlusIcon({ size = 16, className = '' }: { size?: number; className?: string }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
-      strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
-      <line x1="12" y1="5" x2="12" y2="19" />
-      <line x1="5" y1="12" x2="19" y2="12" />
-    </svg>
-  );
-}
-
-function IconQueueAdd({ size = 16, className = "" }: { size?: number; className?: string }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
-      <line x1="12" y1="5" x2="12" y2="19" />
-      <line x1="5" y1="12" x2="19" y2="12" />
-      <path d="M5 19h14a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2z" />
-    </svg>
-  );
-}
-
-function IconTrash({ size = 16, className = "" }: { size?: number; className?: string }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
-      <polyline points="3 6 5 6 21 6" />
-      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
-      <path d="M10 11v6" />
-      <path d="M14 11v6" />
-      <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
-    </svg>
-  );
 }

--- a/packages/web/src/pages/PlaylistsPage.tsx
+++ b/packages/web/src/pages/PlaylistsPage.tsx
@@ -1,3 +1,4 @@
+import { Ghost } from 'lucide-react';
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getPlaylists, createPlaylist, deletePlaylist } from '../api/api';
@@ -171,7 +172,7 @@ function PlaylistRow({
           </p>
           {playlist.isPrivate && (
             <span className="text-muted" title="Private playlist">
-              👻
+              <Ghost size={14} />
             </span>
           )}
         </div>

--- a/packages/web/src/pages/QueuePage.tsx
+++ b/packages/web/src/pages/QueuePage.tsx
@@ -1,3 +1,4 @@
+import { Music, Shuffle, List, Plus, Trash2, Play, Square, Repeat1, Repeat, CirclePlay, AlertTriangle, Zap } from 'lucide-react';
 import { useState, useCallback, useEffect } from 'react';
 import { usePlayer } from '../context/PlayerContext';
 import { useAdminView } from '../context/AdminViewContext';
@@ -83,7 +84,7 @@ export default function QueuePage() {
             onClick={() => setShowOverride(true)}
             className="flex items-center gap-2 btn-danger"
           >
-            <IconOverride size={14} />
+            <Play size={14} />
             <span>Override</span>
           </button>
           <p className="font-mono text-[10px] text-muted mt-1">
@@ -127,7 +128,7 @@ export default function QueuePage() {
                     : 'border-border text-muted hover:border-muted hover:text-fg'
                 }`}
               >
-                {mode === 'off' ? '⬛ off' : mode === 'song' ? '🔂 song' : '🔁 queue'}
+                {mode === "off" ? <> <Square size={12} className="inline mr-1" /> off </> : mode === "song" ? <> <Repeat1 size={12} className="inline mr-1" /> song </> : <> <Repeat size={12} className="inline mr-1" /> queue </>}
               </button>
             ))}
           </div>
@@ -135,14 +136,14 @@ export default function QueuePage() {
             onClick={() => setShowLoadPlaylist(true)}
             className="flex items-center gap-2 btn-primary ml-auto"
           >
-            <IconList size={14} />
+            <List size={14} />
             <span>Load Playlist</span>
           </button>
           <button
             onClick={() => setShowQuickAdd(true)}
             className="flex items-center gap-2 btn-primary"
           >
-            <IconPlus size={14} />
+            <Plus size={14} />
             <span>Quick Add</span>
           </button>
         </div>
@@ -155,7 +156,7 @@ export default function QueuePage() {
               disabled={shuffleBusy || queue.length === 0}
               className="flex items-center gap-2 btn-ghost disabled:opacity-40 disabled:cursor-not-allowed"
             >
-              <IconShuffle size={14} />
+              <Shuffle size={14} />
               <span>Shuffle{queue.length > 0 ? ` (${queue.length})` : ''}</span>
             </button>
             <button
@@ -165,7 +166,7 @@ export default function QueuePage() {
                 queue.length === 0 && priorityQueue.length === 0 && !currentSong ? 'btn-ghost' : 'btn-danger'
               }`}
             >
-              <IconTrash size={14} />
+              <Trash2 size={14} />
               <span>Clear Queue</span>
             </button>
           </div>
@@ -179,7 +180,7 @@ export default function QueuePage() {
         <section className="mt-8">
           <div className="flex items-center justify-between mb-4">
             <h2 className="font-display text-2xl text-fg tracking-wider">
-              ⚡ Up Next
+              <Zap size={18} className="inline mr-1" /> Up Next
               <span className="ml-2 font-mono text-sm text-accent normal-case tracking-normal">
                 {priorityQueue.length} {priorityQueue.length === 1 ? 'song' : 'songs'}
               </span>
@@ -349,7 +350,7 @@ function NowPlayingCard({
           {/* Playing indicator */}
           {isPlaying && (
             <div className="absolute -bottom-2 -right-2 w-8 h-8 rounded-full bg-accent flex items-center justify-center shadow-lg">
-              <span className="text-white text-xs">▶</span>
+              <CirclePlay size={14} className="text-white" />
             </div>
           )}
         </div>
@@ -398,7 +399,7 @@ function IdleCard() {
     <div className="card flex items-center justify-center py-16 border-dashed">
       <div className="text-center">
         <div className="w-16 h-16 rounded-full bg-elevated border border-border flex items-center justify-center mx-auto mb-4">
-          <IconMusic size={24} className="text-faint" />
+          <Music size={24} className="text-faint" />
         </div>
         <p className="font-display text-3xl text-faint tracking-wider mb-1">Nothing Playing</p>
         <p className="font-mono text-xs text-faint">
@@ -558,7 +559,7 @@ function LoadPlaylistModal({
             onClick={handlePlay}
             disabled={submitting || !selectedId || loadingPlaylists}
           >
-            {submitting ? 'Starting...' : '▶ Play'}
+            {submitting ? 'Starting...' : <> <CirclePlay size={12} className="inline mr-1" /> Play </>}
           </button>
         </div>
       </div>
@@ -734,7 +735,7 @@ function OverrideModal({
       <div className="bg-surface border border-border rounded-xl p-6 w-full max-w-sm shadow-2xl animate-fade-up">
         <h2 className="font-display text-3xl text-fg tracking-wider mb-1">Override</h2>
         <p className="font-mono text-xs text-danger mb-6">
-          ⚠️ This will stop current playback, clear all queues, and play the requested song immediately.
+          <AlertTriangle size={14} className="inline mr-1" /> This will stop current playback, clear all queues, and play the requested song immediately.
         </p>
 
         <div className="space-y-4 mb-6">
@@ -784,132 +785,5 @@ function OverrideModal({
         </div>
       </div>
     </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Icons
-// ---------------------------------------------------------------------------
-function IconMusic({ size = 20, className = '' }: { size?: number; className?: string }) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.75"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <path d="M9 18V5l12-2v13" />
-      <circle cx="6" cy="18" r="3" />
-      <circle cx="18" cy="16" r="3" />
-    </svg>
-  );
-}
-
-function IconShuffle({ size = 20, className = '' }: { size?: number; className?: string }) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <polyline points="16 3 21 3 21 8" />
-      <line x1="4" y1="20" x2="21" y2="3" />
-      <polyline points="21 16 21 21 16 21" />
-      <line x1="15" y1="15" x2="21" y2="21" />
-      <line x1="4" y1="4" x2="9" y2="9" />
-    </svg>
-  );
-}
-
-function IconList({ size = 20, className = '' }: { size?: number; className?: string }) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.75"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <line x1="8" y1="6" x2="21" y2="6" />
-      <line x1="8" y1="12" x2="21" y2="12" />
-      <line x1="8" y1="18" x2="21" y2="18" />
-      <line x1="3" y1="6" x2="3.01" y2="6" />
-      <line x1="3" y1="12" x2="3.01" y2="12" />
-      <line x1="3" y1="18" x2="3.01" y2="18" />
-    </svg>
-  );
-}
-
-function IconPlus({ size = 20, className = '' }: { size?: number; className?: string }) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <line x1="12" y1="5" x2="12" y2="19" />
-      <line x1="5" y1="12" x2="19" y2="12" />
-    </svg>
-  );
-}
-
-function IconTrash({ size = 20, className = '' }: { size?: number; className?: string }) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <polyline points="3 6 5 6 21 6" />
-      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
-      <path d="M10 11v6" />
-      <path d="M14 11v6" />
-      <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
-    </svg>
-  );
-}
-
-function IconOverride({ size = 20, className = '' }: { size?: number; className?: string }) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <polygon points="5 3 19 12 5 21 5 3" />
-    </svg>
   );
 }

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -1,3 +1,4 @@
+import { Search, Play, Loader2, ListVideo, ListPlus, Trash2 } from 'lucide-react';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { getSongs, addSong, deleteSong, getPlaylists, addSongToPlaylist, startPlayback, importPlaylist, addToPriorityQueue } from '../api/api';
 import type { Song, Playlist } from '../api/types';
@@ -125,7 +126,7 @@ export default function SongsPage() {
 
       {/* Search */}
       <div className="relative mb-6">
-        <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 text-faint" size={15} />
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-faint" size={15} />
         <input
           className="input pl-9"
           placeholder="Search by title..."
@@ -305,9 +306,9 @@ function SongCard({
             }`}
           >
             {isPlaying ? (
-              <SpinnerIcon size={20} className="text-accent" />
+              <Loader2 size={20} className="text-accent" />
             ) : (
-              <PlayIcon size={20} className="text-white" />
+              <Play size={20} className="text-white" />
             )}
           </div>
         </button>
@@ -329,7 +330,7 @@ function SongCard({
             {addingToQueue ? (
               <span className="w-3 h-3 border border-accent border-t-transparent rounded-full animate-spin inline-block" />
             ) : (
-              <IconQueueAdd size={16} />
+              <ListVideo size={16} />
             )}
           </button>
           {isAdmin && (
@@ -341,7 +342,7 @@ function SongCard({
                   className="flex items-center justify-center w-8 h-8 text-muted hover:text-fg border border-border hover:border-accent/30 rounded transition-colors duration-150"
                   title="Add to playlist"
                 >
-                  <IconPlaylistAdd size={16} />
+                  <ListPlus size={16} />
                 </button>
                 {showPlaylistMenu && (
                   <div className="absolute bottom-full left-0 mb-1 w-44 bg-elevated border border-border rounded shadow-xl z-20 overflow-hidden">
@@ -371,7 +372,7 @@ function SongCard({
                 className="flex items-center justify-center w-8 h-8 text-faint hover:text-danger border border-border hover:border-danger/30 rounded transition-colors duration-150"
                 title="Delete song"
               >
-                <IconTrash size={16} />
+                <Trash2 size={16} />
               </button>
             </>
           )}
@@ -636,118 +637,9 @@ function EmptyState({
 // ---------------------------------------------------------------------------
 // Helpers / icons
 // ---------------------------------------------------------------------------
+
 function formatDuration(seconds: number): string {
   const m = Math.floor(seconds / 60);
   const s = seconds % 60;
   return `${m}:${s.toString().padStart(2, '0')}`;
-}
-
-function SearchIcon({ size = 16, className = '' }: { size?: number; className?: string }) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <circle cx="11" cy="11" r="8" />
-      <line x1="21" y1="21" x2="16.65" y2="16.65" />
-    </svg>
-  );
-}
-
-function PlayIcon({ size = 16, className = '' }: { size?: number; className?: string }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" className={className}>
-      <polygon points="5 3 19 12 5 21 5 3" />
-    </svg>
-  );
-}
-
-function SpinnerIcon({ size = 16, className = '' }: { size?: number; className?: string }) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-      className={`animate-spin ${className}`}
-    >
-      <path d="M12 2a10 10 0 0 1 10 10" />
-    </svg>
-  );
-}
-
-function IconQueueAdd({ size = 16, className = '' }: { size?: number; className?: string }) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <line x1="12" y1="5" x2="12" y2="19" />
-      <line x1="5" y1="12" x2="19" y2="12" />
-      <path d="M5 19h14a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2z" />
-    </svg>
-  );
-}
-
-function IconPlaylistAdd({ size = 16, className = '' }: { size?: number; className?: string }) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <line x1="12" y1="5" x2="12" y2="19" />
-      <line x1="5" y1="12" x2="19" y2="12" />
-      <path d="M19 19h2v2h-2z" />
-      <path d="M19 15h2v2h-2z" />
-      <path d="M19 11h2v2h-2z" />
-      <path d="M19 7h2v2h-2z" />
-      <path d="M19 3h2v2h-2z" />
-    </svg>
-  );
-}
-
-function IconTrash({ size = 16, className = '' }: { size?: number; className?: string }) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <polyline points="3 6 5 6 21 6" />
-      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
-      <path d="M10 11v6" />
-      <path d="M14 11v6" />
-      <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
-    </svg>
-  );
 }


### PR DESCRIPTION
## Summary

This PR replaces all custom SVG icon components and emoji icons with [Lucide React](https://lucide.dev/) icons, addressing issue #95.

## Changes

### Icon Replacements

| File | Custom Icon | Lucide Icon |
|------|-------------|-------------|
| Layout.tsx | `IconMusic`, `IconList`, `IconQueue`, `IconPlay`, `IconSkip`, `IconLeave`, `IconChevron`, `IconLogout`, `IconShield`, `IconPause`, `IconSpinner` | `Music`, `List`, `ListVideo`, `Play`, `SkipForward`, `LogOut`, `ChevronLeft`, `Shield`, `Pause`, `Loader2` |
| QueuePage.tsx | `IconMusic`, `IconShuffle`, `IconList`, `IconPlus`, `IconTrash`, `IconOverride` | `Music`, `Shuffle`, `List`, `Plus`, `Trash2`, `Play` |
| SongsPage.tsx | `SearchIcon`, `PlayIcon`, `SpinnerIcon`, `IconQueueAdd`, `IconPlaylistAdd`, `IconTrash` | `Search`, `Play`, `Loader2`, `ListPlus`, `Trash2` |
| PlaylistDetailPage.tsx | `ChevronLeftIcon`, `PlayIcon`, `PlusIcon`, `IconQueueAdd`, `IconTrash` | `ChevronLeft`, `Play`, `Plus`, `ListPlus`, `Trash2` |
| PlaylistsPage.tsx | (emoji) 👻 | `Ghost` |

### Emoji Replacements

| Emoji | Lucide Icon | Location |
|-------|-------------|----------|
| ▶ | `CirclePlay` | Layout.tsx, QueuePage.tsx, PlaylistDetailPage.tsx |
| ⏸ | `CirclePause` | Layout.tsx |
| 🔂 | `Repeat1` | QueuePage.tsx (loop: song) |
| 🔁 | `Repeat` | QueuePage.tsx (loop: queue) |
| ⬛ | `Square` | QueuePage.tsx (loop: off) |
| ⚡ | `Zap` | QueuePage.tsx (Up Next header) |
| 🔒 | `Lock` | PlaylistDetailPage.tsx |
| 🔓 | `Unlock` | PlaylistDetailPage.tsx |
| 👻 | `Ghost` | PlaylistDetailPage.tsx, PlaylistsPage.tsx |
| ⚠️ | `AlertTriangle` | QueuePage.tsx |

## Benefits

- ✅ Consistent styling across the app
- ✅ Smaller bundle size (tree-shakeable imports)
- ✅ Easier to add new icons
- ✅ Better accessibility support
- ✅ Active maintenance and updates

## Testing

- [x] TypeScript compiles without errors
- [x] Production build succeeds
- [x] All icons render correctly

Closes #95