### PR TITLE
Allow playlist owners to delete songs from their playlists

### DIFF
--- a/packages/api/src/routes/playlists.ts
+++ b/packages/api/src/routes/playlists.ts
@@ -335,21 +335,39 @@ router.post(
 // DELETE /api/playlists/:id/songs/:songId
 //
 // Removes a song from a playlist. Does not delete the song from the library.
-// Admin only.
+// Playlist owner or admin.
 // ---------------------------------------------------------------------------
 router.delete(
   '/:id/songs/:songId',
   requireAuth,
-  requireAdmin,
   asyncHandler(async (req, res) => {
     const { id: playlistId, songId } = req.params;
+
+    // Fetch the playlist to check ownership
+    const playlist = await prisma.playlist.findUnique({
+      where: { id: playlistId as string },
+    });
+
+    if (!playlist) {
+      res.status(404).json({ error: 'Playlist not found.' });
+      return;
+    }
+
+    // Check permissions: playlist owner or admin
+    const isOwner = playlist.createdBy === req.user!.discordId;
+    const isAdmin = req.user!.isAdmin;
+
+    if (!isOwner && !isAdmin) {
+      res.status(403).json({ error: 'Only the playlist owner or admins can remove songs.' });
+      return;
+    }
 
     const entry = await prisma.playlistSong.findUnique({
       where: {
         playlistId_songId: {
           playlistId: playlistId as string,
-          songId: songId as string
-        }
+          songId: songId as string,
+        },
       },
     });
 
@@ -362,8 +380,8 @@ router.delete(
       where: {
         playlistId_songId: {
           playlistId: playlistId as string,
-          songId: songId as string
-        }
+          songId: songId as string,
+        },
       },
     });
 

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -31,8 +31,10 @@ export default function PlaylistDetailPage() {
   const [playingSongId, setPlayingSongId] = useState<string | null>(null);
   const [notification, setNotification] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
 
-  // Only allow editing when user is admin AND edit mode is enabled
-  const canEdit = isAdminView && isEditMode;
+  // Allow editing when:
+  // - User is admin AND edit mode is enabled, OR
+  // - User is the playlist owner (can remove songs from their own playlists)
+  const canEdit = (isAdminView && isEditMode) || (user?.discordId === playlist?.createdBy);
   const nameInputRef = useRef<HTMLInputElement>(null);
 
   const { state: queueState } = usePlayer();


### PR DESCRIPTION
## Summary

This PR allows playlist owners to delete songs from their own playlists, even if they are not admins.

## Changes

### Backend (`packages/api/src/routes/playlists.ts`)
- Modified `DELETE /api/playlists/:id/songs/:songId` endpoint to check for playlist ownership in addition to admin role
- Removed `requireAdmin` middleware and added custom permission check
- Returns 403 if user is neither the playlist owner nor an admin

### Frontend (`packages/web/src/pages/PlaylistDetailPage.tsx`)
- Updated `canEdit` logic to include playlist owners
- Playlist owners can now see and use the remove button on their own playlists

## Behavior

| User Type | Can Remove Songs |
|-----------|------------------|
| Admin (in edit mode) | ✅ From any playlist |
| Playlist Owner | ✅ From their own playlist |
| Other Users | ❌ No |

## Testing

1. Create a playlist as a non-admin user
2. Add songs to the playlist (as admin)
3. As the playlist owner, verify the remove button is visible and functional
4. Verify non-owners cannot see or use the remove button on others' playlists