### PR TITLE
Give playlist owners full control over their playlists

### DIFF
--- a/packages/api/src/routes/playlists.ts
+++ b/packages/api/src/routes/playlists.ts
@@ -68,12 +68,11 @@ router.get(
 // ---------------------------------------------------------------------------
 // POST /api/playlists
 //
-// Creates a new empty playlist. Admin only.
+// Creates a new empty playlist. All authenticated users can create playlists.
 // ---------------------------------------------------------------------------
 router.post(
   '/',
   requireAuth,
-  requireAdmin,
   asyncHandler(async (req, res) => {
     const { name } = req.body as { name?: string };
 
@@ -188,12 +187,11 @@ router.patch(
 // ---------------------------------------------------------------------------
 // PATCH /api/playlists/:id
 //
-// Renames a playlist. Admin only.
+// Renames a playlist. Playlist owner or admin.
 // ---------------------------------------------------------------------------
 router.patch(
   '/:id',
   requireAuth,
-  requireAdmin,
   asyncHandler(async (req, res) => {
     const { name } = req.body as { name?: string };
 
@@ -216,6 +214,14 @@ router.patch(
       return;
     }
 
+    // Check permissions: playlist owner or admin
+    const isOwner = existing.createdBy === req.user!.discordId;
+    const isAdmin = req.user!.isAdmin;
+    if (!isOwner && !isAdmin) {
+      res.status(403).json({ error: 'Only the playlist owner or admins can rename this playlist.' });
+      return;
+    }
+
     const playlist = await prisma.playlist.update({
       where: { id: req.params.id as string },
       data: { name: name.trim() },
@@ -231,12 +237,11 @@ router.patch(
 // DELETE /api/playlists/:id
 //
 // Deletes a playlist. Songs in the library are NOT deleted — only the
-// PlaylistSong associations are removed (via cascade). Admin only.
+// PlaylistSong associations are removed (via cascade). Playlist owner or admin.
 // ---------------------------------------------------------------------------
 router.delete(
   '/:id',
   requireAuth,
-  requireAdmin,
   asyncHandler(async (req, res) => {
     const existing = await prisma.playlist.findUnique({
       where: { id: req.params.id as string }
@@ -244,6 +249,16 @@ router.delete(
 
     if (!existing) {
       res.status(404).json({ error: 'Playlist not found.' });
+      return;
+    }
+
+    // Check permissions: playlist owner or admin
+    const isOwner = existing.createdBy === req.user!.discordId;
+
+    const isAdmin = req.user!.isAdmin;
+
+    if (!isOwner && !isAdmin) {
+      res.status(403).json({ error: 'Only the playlist owner or admins can delete this playlist.' });
       return;
     }
 
@@ -262,12 +277,11 @@ router.delete(
 // POST /api/playlists/:id/songs
 //
 // Adds a song to a playlist. The song must already exist in the library.
-// It is appended at the end (highest existing position + 1). Admin only.
+// It is appended at the end (highest existing position + 1). Playlist owner or admin.
 // ---------------------------------------------------------------------------
 router.post(
   '/:id/songs',
   requireAuth,
-  requireAdmin,
   asyncHandler(async (req, res) => {
     const { songId } = req.body as { songId?: string };
 
@@ -288,6 +302,14 @@ router.post(
 
     if (!song) {
       res.status(404).json({ error: 'Song not found.' });
+      return;
+    }
+
+    // Check permissions: playlist owner or admin
+    const isOwner = playlist.createdBy === req.user!.discordId;
+    const isAdmin = req.user!.isAdmin;
+    if (!isOwner && !isAdmin) {
+      res.status(403).json({ error: 'Only the playlist owner or admins can add songs to this playlist.' });
       return;
     }
 

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -33,8 +33,9 @@ export default function PlaylistDetailPage() {
 
   // Allow editing when:
   // - User is admin AND edit mode is enabled, OR
-  // - User is the playlist owner (can remove songs from their own playlists)
-  const canEdit = (isAdminView && isEditMode) || (user?.discordId === playlist?.createdBy);
+  // - User is the playlist owner AND edit mode is enabled
+  const isOwner = user?.discordId === playlist?.createdBy;
+  const canEdit = (isAdminView || isOwner) && isEditMode;
   const nameInputRef = useRef<HTMLInputElement>(null);
 
   const { state: queueState } = usePlayer();
@@ -280,29 +281,27 @@ export default function PlaylistDetailPage() {
             {playlist.isPrivate ? <> <Unlock size={14} className="inline mr-1" /> Make Public </> : <> <Lock size={14} className="inline mr-1" /> Make Private </>}
             </button>
             )}
-            {isAdminView && (
-            <>
-              {isEditMode && (
-                <>
-                  <button className="btn-ghost text-xs" onClick={() => setShowAddSongs(true)}>
-                    + Add Songs
-                  </button>
-                  <button
-                    className="btn-danger text-xs"
-                    onClick={handleDeletePlaylist}
-                  >
-                    Delete
-                  </button>
-                </>
-              )}
-              <button
-                className={`btn-ghost text-xs ${isEditMode ? 'text-accent' : ''}`}
-                onClick={toggleEditMode}
-              >
-                {isEditMode ? '✎ Editing' : '✎ Edit'}
-              </button>
-            </>
-          )}
+            {(isAdminView || isOwner) && (
+                    <>
+                      {isEditMode && (
+                        <>
+                          <button className="btn-ghost text-xs" onClick={() => setShowAddSongs(true)}>
+                            + Add Songs
+                          </button>
+                          <button className="btn-danger text-xs" onClick={handleDeletePlaylist}
+                          >
+                            Delete
+                          </button>
+                        </>
+                      )}
+                      <button
+                        className={`btn-ghost text-xs ${isEditMode ? 'text-accent' : ''}`}
+                        onClick={toggleEditMode}
+                      >
+                        {isEditMode ? '✎ Editing' : '✎ Edit'}
+                      </button>
+                    </>
+                  )}
         </div>
       </div>
 

--- a/packages/web/src/pages/PlaylistsPage.tsx
+++ b/packages/web/src/pages/PlaylistsPage.tsx
@@ -4,10 +4,12 @@ import { useNavigate } from 'react-router-dom';
 import { getPlaylists, createPlaylist, deletePlaylist } from '../api/api';
 import type { Playlist } from '../api/types';
 import { useAdminView } from '../context/AdminViewContext';
+import { useAuth } from '../context/AuthContext';
 import { useSocket } from '../hooks/useSocket';
 
 export default function PlaylistsPage() {
   const { isAdminView } = useAdminView();
+  const { user } = useAuth();
   const navigate = useNavigate();
   const socket = useSocket();
   const [playlists, setPlaylists] = useState<Playlist[]>([]);
@@ -88,11 +90,9 @@ export default function PlaylistsPage() {
             {loading ? '—' : `${playlists.length} playlist${playlists.length !== 1 ? 's' : ''}`}
           </p>
         </div>
-        {isAdminView && (
-          <button className="btn-primary" onClick={() => setShowCreate(true)}>
-            + New Playlist
-          </button>
-        )}
+        <button className="btn-primary" onClick={() => setShowCreate(true)}>
+          + New Playlist
+        </button>
       </div>
 
       {/* List */}
@@ -107,6 +107,7 @@ export default function PlaylistsPage() {
               key={pl.id}
               playlist={pl}
               isAdmin={isAdminView}
+ isOwner={user?.discordId === pl.createdBy}
               style={{ animationDelay: `${Math.min(i * 40, 400)}ms` }}
               onClick={() => navigate(`/playlists/${pl.id}`)}
               onDelete={(e) => { e.stopPropagation(); setDeleteTarget(pl); }}
@@ -135,19 +136,14 @@ export default function PlaylistsPage() {
 // ---------------------------------------------------------------------------
 // Playlist row
 // ---------------------------------------------------------------------------
-function PlaylistRow({
-  playlist,
-  isAdmin,
-  style,
-  onClick,
-  onDelete,
-}: {
-  playlist: Playlist;
-  isAdmin: boolean;
-  style?: React.CSSProperties;
-  onClick: () => void;
-  onDelete: (e: React.MouseEvent) => void;
-}) {
+  function PlaylistRow({ playlist, isAdmin, isOwner, style, onClick, onDelete }: {
+    playlist: Playlist;
+    isAdmin: boolean;
+    isOwner: boolean;
+    style?: React.CSSProperties;
+    onClick: () => void;
+    onDelete: (e: React.MouseEvent) => void;
+  }) {
   const count = playlist._count?.songs ?? 0;
 
   return (
@@ -181,12 +177,12 @@ function PlaylistRow({
         </p>
       </div>
 
-      {/* Admin actions */}
-      {isAdmin && (
+      {/* Admin/Owner actions */}
+      {(isAdmin || isOwner) && (
         <button
           onClick={onDelete}
           className="opacity-0 group-hover:opacity-100 font-mono text-xs text-faint
-                     hover:text-danger transition-all duration-150 px-2 py-1"
+            hover:text-danger transition-all duration-150 px-2 py-1"
           title="Delete playlist"
         >
           del


### PR DESCRIPTION
## Summary

This PR gives playlist owners full control over their own playlists, including the ability to enter Edit Mode, without requiring admin privileges.

## Changes

### Backend (`packages/api/src/routes/playlists.ts`)

| Endpoint | Before | After |
|----------|--------|-------|
| `POST /api/playlists` | Admin only | All authenticated users |
| `PATCH /api/playlists/:id` | Admin only | Owner or admin |
| `DELETE /api/playlists/:id` | Admin only | Owner or admin |
| `POST /api/playlists/:id/songs` | Admin only | Owner or admin |
| `DELETE /api/playlists/:id/songs/:songId` | Admin only | Owner or admin |

### Frontend

**`PlaylistDetailPage.tsx`:**
- Show Edit Mode toggle for playlist owners (not just admins)
- Show Add Songs button for owners in edit mode
- Show Delete Playlist button for owners in edit mode
- Updated `canEdit` logic: `(isAdminView || isOwner) && isEditMode`

**`PlaylistsPage.tsx`:**
- Show Create Playlist button for all users
- Show delete button for playlist owners on their own playlists
- Added `useAuth` hook to access user context

## Behavior

| Action | Admin | Playlist Owner | Other Users |
|--------|-------|----------------|-------------|
| Create playlist | ✅ | ✅ | ✅ |
| Rename own playlist | ✅ | ✅ | ❌ |
| Delete own playlist | ✅ | ✅ | ❌ |
| Add songs to own playlist | ✅ | ✅ | ❌ |
| Remove songs from own playlist | ✅ | ✅ | ❌ |
| Manage others' playlists | ✅ | ❌ | ❌ |

## Testing

1. As a non-admin user, create a new playlist
2. Enter Edit Mode on your playlist
3. Add songs from the Songs/Library page
4. Remove songs from the playlist
5. Rename the playlist
6. Delete the playlist
7. Verify non-owners cannot manage others' playlists