### PR TITLE
refactor(player): unify addToQueue and addManyToQueue

### DIFF
--- a/packages/api/src/routes/player.ts
+++ b/packages/api/src/routes/player.ts
@@ -238,12 +238,10 @@ router.post(
 
     // If starting from a specific song, clear the queue and interrupt current playback
     if (startFromSongId) {
-      await player.replaceQueueAndPlay(queuedSongs);
+    await player.replaceQueueAndPlay(queuedSongs);
     } else {
-      // Add songs to existing queue
-      for (const song of queuedSongs) {
-        await player.addToQueue(song);
-      }
+    // Add songs to existing queue
+    await player.addToQueue(queuedSongs);
     }
 
     res.json({ message: `Queued ${queuedSongs.length} song(s).` });

--- a/packages/bot/src/commands/playlist.ts
+++ b/packages/bot/src/commands/playlist.ts
@@ -142,7 +142,7 @@ export const playlistCommand: Command = {
         requestedBy: member.displayName,
       }));
 
-      await player.addManyToQueue(queuedSongs);
+      await player.addToQueue(queuedSongs);
 
       const count = queuedSongs.length;
       await interaction.editReply(

--- a/packages/bot/src/player/GuildPlayer.ts
+++ b/packages/bot/src/player/GuildPlayer.ts
@@ -272,23 +272,9 @@ export class GuildPlayer {
    * If nothing is currently playing, playback starts immediately.
    * Broadcasts the updated state after the queue is modified.
    */
-  async addToQueue(song: QueuedSong): Promise<void> {
-    this.queue.push(song);
-    if (this.currentSong === null) {
-      await this.playNext();
-    } else {
-      // Already playing — just broadcast the new queue length.
-      broadcastQueueUpdate(this.getQueueState());
-    }
-  }
-
-  /**
-   * Add multiple songs to the end of the queue in one operation.
-   * Compared to calling addToQueue() in a loop, this pushes all songs before
-   * starting playback and only broadcasts a single queue-update event.
-   */
-  async addManyToQueue(songs: QueuedSong[]): Promise<void> {
-      this.queue.push(...songs);
+  async addToQueue(songs: QueuedSong | QueuedSong[]): Promise<void> {
+      const arr = Array.isArray(songs) ? songs : [songs];
+      this.queue.push(...arr);
       if (this.currentSong === null) {
         await this.playNext();
       } else {


### PR DESCRIPTION
## Summary

This PR addresses Issue #100 by unifying the `addToQueue` and `addManyToQueue` methods in `GuildPlayer` into a single, more flexible method.

## Changes

- **GuildPlayer.ts**: Updated `addToQueue` to accept `QueuedSong | QueuedSong[]`, removing the need for a separate `addManyToQueue` method
- **playlist.ts**: Changed `addManyToQueue` call to `addToQueue`
- **player.ts**: Replaced loop calling `addToQueue` with a single call passing the array

## Benefits

- Cleaner API with less duplication
- Simpler reasoning when making queue changes
- Single broadcast event when adding multiple songs (more efficient)

## Implementation

```typescript
async addToQueue(songs: QueuedSong | QueuedSong[]): Promise<void> {
  const arr = Array.isArray(songs) ? songs : [songs];
  this.queue.push(...arr);
  if (this.currentSong === null) {
    await this.playNext();
  } else {
    broadcastQueueUpdate(this.getQueueState());
  }
}
```

Closes #100