### PR TITLE
fix(player): allow skipping while paused

### DIFF
--- a/packages/api/src/routes/player.ts
+++ b/packages/api/src/routes/player.ts
@@ -259,7 +259,7 @@ router.post(
   asyncHandler(async (_req, res) => {
     const player = getPlayer(GUILD_ID);
 
-    if (!player || !player.isPlaying()) {
+    if (!player || !player.getCurrentSong()) {
       res.status(409).json({ error: 'Nothing is currently playing.' });
       return;
     }

--- a/packages/bot/src/commands/skip.ts
+++ b/packages/bot/src/commands/skip.ts
@@ -15,7 +15,7 @@ export const skipCommand: Command = {
 
     const player = getPlayer(interaction.guild.id);
 
-    if (!player || !player.isPlaying()) {
+    if (!player || !player.getCurrentSong()) {
       await interaction.reply({ content: 'Nothing is currently playing.', flags: 'Ephemeral' });
       return;
     }

--- a/packages/bot/src/player/GuildPlayer.ts
+++ b/packages/bot/src/player/GuildPlayer.ts
@@ -336,14 +336,25 @@ export class GuildPlayer {
    * Works regardless of loop mode.
    */
   async skip(): Promise<void> {
-    if (this.currentSong === null) return;
-    this.skipping = true;
-    // Stopping the AudioPlayer triggers AudioPlayerStatus.Idle,
-    // which calls onTrackEnd(). The skipping flag tells it to advance.
-    // The old FFmpeg process will be killed at the top of the next playNext()
-    // call. broadcastQueueUpdate will be called inside playNext() / onTrackEnd().
-    this.audioPlayer.stop();
-  }
+      if (this.currentSong === null) return;
+
+      this.skipping = true;
+
+      // If paused, unpause first so that .stop() triggers the Idle event correctly.
+      // Calling .stop() on a paused AudioPlayer does not trigger the Idle event,
+      // which would prevent onTrackEnd() from being called and the queue wouldn't advance.
+      if (this.paused) {
+        this.audioPlayer.unpause();
+        this.paused = false;
+        this.pausedAt = null;
+      }
+
+      // Stopping the AudioPlayer triggers AudioPlayerStatus.Idle,
+      // which calls onTrackEnd(). The skipping flag tells it to advance.
+      // The old FFmpeg process will be killed at the top of the next playNext()
+      // call. broadcastQueueUpdate will be called inside playNext() / onTrackEnd().
+      this.audioPlayer.stop();
+    }
 
   /**
    * Resume playback (after stopping, NOT pausing).


### PR DESCRIPTION
## Summary

This PR fixes the issue where users couldn't skip a song when the player was paused.

## Root Cause

1. **`GuildPlayer.skip()`** — When the player is paused, the `AudioPlayer` is in the `Paused` state. Calling `.stop()` on a paused player does **not** trigger the `Idle` event, which is what drives `onTrackEnd()` and queue advancement. So the skip silently did nothing when paused.

2. **`skip` command & API route** — Both guarded with `player.isPlaying()`, which returns `false` when paused, so the skip was rejected before it even reached `GuildPlayer.skip()`.

## Changes

### `packages/bot/src/player/GuildPlayer.ts`
- Modified `skip()` to unpause the player first (if paused) before calling `.stop()`
- This ensures the `Idle` event fires correctly, triggering `onTrackEnd()` and queue advancement

### `packages/bot/src/commands/skip.ts`
- Changed the guard from `!player.isPlaying()` to `!player.getCurrentSong()`
- This allows skip when paused (as long as there's a current song)

### `packages/api/src/routes/player.ts`
- Same guard fix in the `/skip` route — check `getCurrentSong()` instead of `isPlaying()`

## Testing

- No TypeScript errors or warnings
- The logic follows the existing `togglePause()` pattern for unpausing