### PR TITLE
feat(web): make artwork square in grid and list views

### DIFF
--- a/packages/web/src/components/AddSongsModal.tsx
+++ b/packages/web/src/components/AddSongsModal.tsx
@@ -212,7 +212,7 @@ const SongRow = memo(function SongRow({
       <img
         src={song.thumbnailUrl}
         alt={song.nickname || song.title}
-        className="w-12 h-8 md:w-10 md:h-7 object-cover rounded border border-border shrink-0"
+        className="w-10 h-10 md:w-8 md:h-8 object-cover rounded border border-border shrink-0"
         loading="lazy"
         decoding="async"
       />

--- a/packages/web/src/components/LibrarySongRow.tsx
+++ b/packages/web/src/components/LibrarySongRow.tsx
@@ -80,7 +80,7 @@ export const LibrarySongRow = memo(
           <img
             src={song.thumbnailUrl}
             alt={song.nickname || song.title}
-            className="w-24 h-14 md:w-20 md:h-12 object-cover rounded border border-border shrink-0"
+            className="w-14 h-14 md:w-12 md:h-12 object-cover rounded border border-border shrink-0"
             loading="lazy"
             decoding="async"
           />

--- a/packages/web/src/components/QueuePanel.tsx
+++ b/packages/web/src/components/QueuePanel.tsx
@@ -309,7 +309,7 @@ const QueueSongItem = memo(function QueueSongItem({
       <img
         src={song.thumbnailUrl}
         alt={song.nickname || song.title}
-        className="w-10 h-7 object-cover rounded border border-border shrink-0"
+        className="w-8 h-8 object-cover rounded border border-border shrink-0"
         loading="lazy"
         decoding="async"
       />

--- a/packages/web/src/components/SongCard.tsx
+++ b/packages/web/src/components/SongCard.tsx
@@ -61,7 +61,7 @@ const SongCardInner = ({
       onClick={() => isAdmin && setOpenSongId(isOpen ? null : song.id)}
     >
       {/* Thumbnail with play overlay */}
-      <div className="relative aspect-video bg-elevated overflow-hidden rounded-xl clay-flat m-3 mb-0">
+      <div className="relative aspect-square bg-elevated overflow-hidden rounded-xl clay-flat m-3 mb-0">
         <img
           src={song.thumbnailUrl}
           alt={song.nickname || song.title}

--- a/packages/web/src/components/SongRow.tsx
+++ b/packages/web/src/components/SongRow.tsx
@@ -79,7 +79,7 @@ export const SongRow = memo(
           <img
             src={song.thumbnailUrl}
             alt={song.nickname || song.title}
-            className="w-24 h-14 md:w-20 md:h-12 object-cover rounded border border-border shrink-0"
+            className="w-14 h-14 md:w-12 md:h-12 object-cover rounded border border-border shrink-0"
             loading="lazy"
             decoding="async"
           />

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -354,7 +354,7 @@ function SkeletonGrid({ itemsPerPage }: { itemsPerPage: number }) {
       {Array.from({ length: Math.max(4, Math.round(itemsPerPage / 2)) }).map((_, i) => (
         <div key={i} className="flex flex-col bg-elevated rounded-xl clay-resting">
           {/* Thumbnail */}
-          <div className="relative aspect-video bg-elevated overflow-hidden rounded-xl clay-flat m-3 mb-0">
+          <div className="relative aspect-square bg-elevated overflow-hidden rounded-xl clay-flat m-3 mb-0">
             <div className="skeleton w-full h-full" />
             {/* Duration badge placeholder */}
             <div className="absolute bottom-2 right-2 z-20">
@@ -378,7 +378,7 @@ function SkeletonList({ itemsPerPage }: { itemsPerPage: number }) {
           key={i}
           className="flex items-center gap-2 md:gap-4 px-3 md:px-4 py-3 rounded-lg bg-elevated clay-resting"
         >
-          <div className="skeleton w-20 h-12 md:w-16 md:h-10 rounded border border-border shrink-0" />
+          <div className="skeleton w-12 h-12 md:w-10 md:h-10 rounded border border-border shrink-0" />
           <div className="flex-1 min-w-0">
             <div className="skeleton h-3 w-3/4" />
             <div className="skeleton h-2 w-1/2 mt-1" />


### PR DESCRIPTION
## Summary
- Change song thumbnail aspect ratio from 16:9 to square (1:1) across all views
- Updated SongCard grid view, SongRow/LibrarySongRow list views, AddSongsModal, QueueSongItem, and skeleton loading placeholders

## Test Plan
- [x] Verify artwork displays as square in Songs grid view
- [x] Verify artwork is square in library song list
- [x] Verify artwork is square in playlist detail song list
- [x] Verify artwork is square in Add Songs modal
- [x] Verify artwork is square in queue panel items

🤖 Generated with [Claude Code](https://claude.com/claude-code)