### PR TITLE
fix: remove -moz-osx-font-smoothing from body rule

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -862,7 +862,6 @@
         color: var(--color-fg);
         font-family: var(--font-body);
         -webkit-font-smoothing: antialiased;
-        -moz-osx-font-smoothing: grayscale;
         text-rendering: optimizeLegibility;
         font-variant-ligatures: common-ligatures;
         transition:


### PR DESCRIPTION
## Summary

- Remove `-moz-osx-font-smoothing: grayscale` from the `body` rule in `packages/web/src/index.css`
- This property is not needed for modern browsers and causes CSS parsing warnings in production

## Test plan

- [x] `bun run check` passes locally
- [x] `bun run --filter @alfira-bot/web build` succeeds
- [x] CSS in `packages/web/dist/index.css` contains no `-moz-osx-font-smoothing`
- [x] Production deployment: page loads without CSS warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)