### PR TITLE
fix: copy web/dist to Docker runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,7 @@ RUN bun install --production
 # bot and shared are workspace:* deps - copy their built output
 COPY --from=builder --chown=nodejs:nodejs /app/packages/bot/dist ./packages/bot/dist
 COPY --from=builder --chown=nodejs:nodejs /app/packages/shared/dist ./packages/shared/dist
+COPY --from=builder --chown=nodejs:nodejs /app/packages/web/dist ./packages/web/dist
 
 # Switch to non-root user
 USER nodejs


### PR DESCRIPTION
## Summary

- Add missing `COPY --from=builder /app/packages/web/dist ./packages/web/dist` to Dockerfile runtime stage
- Without this, `packages/api/src/index.ts:177` serves no web assets (404 or wrong MIME type), causing "F is not a function" in the browser

## Test plan

- [x] Rebuild Docker image
- [x] Browser network tab: `main.js` returns 200 with `application/javascript`
- [x] Browser network tab: `index.css` returns 200 with `text/css`
- [x] "F is not a function" error disappears
- [x] Site loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)