### PR TITLE
fix: remove NODE_ENV=production from Docker builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,9 @@ COPY package.json bun.lock ./
 COPY packages ./packages
 
 RUN bun install
-ENV NODE_ENV=production
+# NOTE: NODE_ENV is not set here because bun build produces broken bundles
+# with NODE_ENV=production due to how React 19's JSX runtime is bundled.
+# NODE_ENV=production is set in the runtime stage instead.
 RUN bun run --filter @alfira-bot/shared build && \
     bun run --filter @alfira-bot/bot build && \
     bun run --filter @alfira-bot/api build && \


### PR DESCRIPTION
## Summary

- Remove `ENV NODE_ENV=production` from the Docker builder stage
- The runtime stage already correctly sets `NODE_ENV=production`
- This fixes the production website error "F is not a function"

## Root Cause

Setting `NODE_ENV=production` during `bun build` causes the bundler to produce broken JavaScript bundles where the JSX runtime function `F` is `undefined` at module scope. This results in "F is not a function" errors for all React JSX elements.

## Verification

| Build | Size | Status |
|-------|------|--------|
| Local (working) | 765,033 bytes | ✓ |
| Docker OLD (broken) | 558,075 bytes | ✗ |
| Docker FIXED | 765,033 bytes | ✓ |

## Test plan

- [x] Build Docker image from this PR
- [x] Deploy and verify website loads correctly
- [x] Verify no console errors in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)