### PR TITLE
refactor: remove dead exports

### DIFF
--- a/packages/bot/src/utils/format.ts
+++ b/packages/bot/src/utils/format.ts
@@ -2,17 +2,11 @@ import type { LoopMode, QueuedSong } from '@alfira-bot/shared';
 import { formatDuration } from '@alfira-bot/shared';
 import { EmbedBuilder } from 'discord.js';
 
-export function pluralize(count: number, noun: string): string {
-  return `${count} ${noun}${count === 1 ? '' : 's'}`;
-}
-
 const LOOP_MODE_LABELS: Record<LoopMode, string> = {
   off: '⬛ Off',
   song: '🔂 Song',
   queue: '🔁 Queue',
 };
-
-export const EMBED_COLOR = 0x5865f2;
 
 export function formatLoopMode(mode: LoopMode): string {
   return LOOP_MODE_LABELS[mode];
@@ -20,7 +14,7 @@ export function formatLoopMode(mode: LoopMode): string {
 
 export function buildNowPlayingEmbed(song: QueuedSong, loopMode: LoopMode): EmbedBuilder {
   return new EmbedBuilder()
-    .setColor(EMBED_COLOR)
+    .setColor(0x5865f2)
     .setTitle('▶️  Now Playing')
     .setDescription(`**[${song.title}](${song.youtubeUrl})**`)
     .setThumbnail(song.thumbnailUrl)

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -116,10 +116,6 @@ export function deleteSong(id: string): Promise<void> {
   return remove(`/api/songs/${id}`);
 }
 
-export function updateSongNickname(id: string, nickname: string | null): Promise<Song> {
-  return patch(`/api/songs/${id}`, { nickname });
-}
-
 /**
  * Data for updating a song. Only provide fields you want to change.
  */

--- a/packages/web/src/api/api.ts
+++ b/packages/web/src/api/api.ts
@@ -41,5 +41,4 @@ export {
   togglePause,
   togglePlaylistVisibility,
   unshuffleQueue,
-  updateSongNickname,
 } from '@alfira-bot/shared/api';


### PR DESCRIPTION
## Summary
- Remove `pluralize()` and `EMBED_COLOR` from `packages/bot/src/utils/format.ts`
- Remove `updateSongNickname()` from `packages/shared/src/api.ts`
- Remove `updateSongNickname` re-export from `packages/web/src/api/api.ts`

All three exports are confirmed dead code — never imported or called anywhere.

## Test plan
- [x] `bun run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)