### PR TITLE
refactor: remove dead code and consolidate duplicates

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -150,19 +150,10 @@ const server = Bun.serve({
     }
 
     // Serve built web assets statically (SPA fallback for client-side routing)
-    const ASSET_EXTENSIONS = [
-      '.js',
-      '.css',
-      '.png',
-      '.jpg',
-      '.jpeg',
-      '.svg',
-      '.ico',
-      '.webmanifest',
-      '.woff2',
-    ];
+    const pathname = url.pathname;
+    const ext = pathname.includes('.') ? `.${pathname.split('.').pop()}` : '.html';
     const isAsset =
-      ASSET_EXTENSIONS.some((ext) => url.pathname.endsWith(ext)) ||
+      Object.hasOwn(STATIC_EXTENSIONS, ext) ||
       url.pathname.startsWith('/assets/') ||
       url.pathname === '/sw.js' ||
       url.pathname === '/registerSW.js';

--- a/packages/api/src/lib/socket.ts
+++ b/packages/api/src/lib/socket.ts
@@ -73,10 +73,7 @@ export function emitPlayerUpdate(state: QueueState): void {
  * Emit a newly added song to all connected clients.
  */
 export function emitSongAdded(song: SerializedSong): void {
-  const payload = {
-    ...song,
-    createdAt: song.createdAt instanceof Date ? song.createdAt.toISOString() : song.createdAt,
-  };
+  const payload = formatSong(song);
   const message = serializeMessage('songs:added', payload);
   for (const client of clients) {
     client.send(message);
@@ -97,10 +94,7 @@ export function emitSongDeleted(id: string): void {
  * Emit an updated song to all connected clients.
  */
 export function emitSongUpdated(song: SerializedSong): void {
-  const payload = {
-    ...song,
-    createdAt: song.createdAt instanceof Date ? song.createdAt.toISOString() : song.createdAt,
-  };
+  const payload = formatSong(song);
   const message = serializeMessage('songs:updated', payload);
   for (const client of clients) {
     client.send(message);
@@ -112,12 +106,7 @@ export function emitSongUpdated(song: SerializedSong): void {
  * Covers: create, rename, song added, song removed.
  */
 export function emitPlaylistUpdated(playlist: SerializedPlaylist): void {
-  const payload = {
-    ...playlist,
-    createdAt:
-      playlist.createdAt instanceof Date ? playlist.createdAt.toISOString() : playlist.createdAt,
-  };
-  const message = serializeMessage('playlists:updated', payload);
+  const message = serializeMessage('playlists:updated', playlist);
   for (const client of clients) {
     client.send(message);
   }


### PR DESCRIPTION
## Summary
- Delete empty `requestUser.ts` from shared package
- Simplify `emitSongAdded`/`emitSongUpdated` in socket.ts to use `formatSong` directly instead of duplicating spread + `createdAt` serialization
- Simplify `emitPlaylistUpdated` similarly
- Replace `ASSET_EXTENSIONS` array with `Object.hasOwn(STATIC_EXTENSIONS, ext)` check

## Test plan
- [x] `bun run check` passes (107 files, no errors)
- [x] API server starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)