### PR TITLE
fix: stop button requires two clicks and cannot rejoin voice after leave

### DIFF
--- a/packages/api/src/lib/voice.ts
+++ b/packages/api/src/lib/voice.ts
@@ -44,7 +44,11 @@ export async function resolveOrAutoJoinPlayer(
 > {
   const existingPlayer = getPlayer(GUILD_ID);
   if (existingPlayer) {
-    return { ok: true, player: existingPlayer };
+    const hoshimi = getHoshimi();
+    const hoshimiPlayer = hoshimi?.players.get(GUILD_ID);
+    if (hoshimiPlayer?.connected) {
+      return { ok: true, player: existingPlayer };
+    }
   }
 
   const discordClient = getClient();

--- a/packages/api/src/routes/player.ts
+++ b/packages/api/src/routes/player.ts
@@ -172,7 +172,6 @@ async function handleLeave(ctx: RouteContext): Promise<Response> {
   }
 
   if (player) player.stop();
-  if (hoshimi) hoshimi.deletePlayer(GUILD_ID);
 
   return json({ message: 'Left the voice channel.' });
 }

--- a/packages/bot/src/player/GuildPlayer.ts
+++ b/packages/bot/src/player/GuildPlayer.ts
@@ -98,6 +98,10 @@ export class GuildPlayer {
         );
         void track;
       });
+      hoshimi.on('playerDestroy', (player: Player) => {
+        if (player.guildId !== this.guildId) return;
+        this.broadcast();
+      });
     }
   }
 
@@ -182,12 +186,9 @@ export class GuildPlayer {
     this.priorityQueue = [];
     this.paused = false;
     this.trackStartedAt = null;
-    this.broadcast();
 
-    const player = this.hoshimiPlayer();
-    if (player) {
-      player.stop(true);
-    }
+    this.destroyPlayer();
+    // Don't call broadcast() here — let playerDestroy event handler do it
   }
 
   clearQueue(): void {


### PR DESCRIPTION
## Summary

- Fixed stop button staying enabled after single click by deferring broadcast to `playerDestroy` event instead of calling it immediately after `destroyPlayer()`
- Fixed bot unable to rejoin voice channel after Leave button by checking `hoshimiPlayer?.connected` before returning existing `GuildPlayer` in `resolveOrAutoJoinPlayer`
- Removed redundant `hoshimi.deletePlayer(GUILD_ID)` in `handleLeave` (already destroyed via `player.stop()`)

## Test plan

- [x] Play a song, click Stop — button should immediately become non-clickable
- [x] Click Leave, join different channel, click Play — bot should join new channel (not old one)
- [x] Repeat above multiple times to confirm consistent behavior