### PR TITLE
feat: enable Bun native WebSocket in NodeLink

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -36,6 +36,7 @@ services:
       HOST: 0.0.0.0
       PORT: 2333
       NODELINK_AUTHORIZATION: ${NODELINK_AUTHORIZATION:-}
+      NODELINK_SERVER_USE_BUN_SERVER: "true"
     ports:
       - "2333:3000"
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       HOST: 0.0.0.0
       PORT: 2333
       NODELINK_AUTHORIZATION: ${NODELINK_AUTHORIZATION:-}
+      NODELINK_SERVER_USE_BUN_SERVER: "true"
     ports:
       - "2333:3000"
     healthcheck:


### PR DESCRIPTION
## Summary

- Set `NODELINK_SERVER_USE_BUN_SERVER=true` on the NodeLink Docker container in both `docker-compose.yml` and `docker-compose.prod.yml`
- This lets NodeLink use Bun's native WebSocket server implementation, improving connection handling efficiency

## Test plan

- [x] Run `docker compose up --build` and verify NodeLink starts with Bun WebSocket
- [x] Play a track and confirm audio streams correctly (bot connects to voice and plays)
- [x] Check `docker compose logs nodelink` for any errors on startup

## Notes

NodeLink's `useBunServer` is experimental. The hoshimi client still uses the `ws` npm package client-side, which produces a cosmetic `[bun] Warning: ws.WebSocket 'upgrade' event is not implemented in bun` warning in the alfira logs — this does not affect functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)