### PR TITLE
refactor: simplify codebase

### DIFF
--- a/packages/api/src/lib/socket.ts
+++ b/packages/api/src/lib/socket.ts
@@ -55,15 +55,11 @@ export function unregisterClient(
 // Broadcast helpers
 // ---------------------------------------------------------------------------
 
-function serializeMessage(event: string, data: unknown): string {
-  return JSON.stringify({ event, data });
-}
-
 /**
  * Emit the full queue state to all connected clients.
  */
 export function emitPlayerUpdate(state: QueueState): void {
-  const message = serializeMessage('player:update', state);
+  const message = JSON.stringify({ event: 'player:update', data: state });
   for (const client of clients) {
     client.send(message);
   }
@@ -74,7 +70,7 @@ export function emitPlayerUpdate(state: QueueState): void {
  */
 export function emitSongAdded(song: SerializedSong): void {
   const payload = formatSong(song);
-  const message = serializeMessage('songs:added', payload);
+  const message = JSON.stringify({ event: 'songs:added', data: payload });
   for (const client of clients) {
     client.send(message);
   }
@@ -84,7 +80,7 @@ export function emitSongAdded(song: SerializedSong): void {
  * Emit the deleted song's ID to all connected clients.
  */
 export function emitSongDeleted(id: string): void {
-  const message = serializeMessage('songs:deleted', id);
+  const message = JSON.stringify({ event: 'songs:deleted', data: id });
   for (const client of clients) {
     client.send(message);
   }
@@ -95,7 +91,7 @@ export function emitSongDeleted(id: string): void {
  */
 export function emitSongUpdated(song: SerializedSong): void {
   const payload = formatSong(song);
-  const message = serializeMessage('songs:updated', payload);
+  const message = JSON.stringify({ event: 'songs:updated', data: payload });
   for (const client of clients) {
     client.send(message);
   }
@@ -106,7 +102,7 @@ export function emitSongUpdated(song: SerializedSong): void {
  * Covers: create, rename, song added, song removed.
  */
 export function emitPlaylistUpdated(playlist: SerializedPlaylist): void {
-  const message = serializeMessage('playlists:updated', playlist);
+  const message = JSON.stringify({ event: 'playlists:updated', data: playlist });
   for (const client of clients) {
     client.send(message);
   }

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -263,190 +263,201 @@ export async function handleAuth(ctx: RouteContext, request: Request): Promise<R
   const url = new URL(request.url);
   const pathname = url.pathname;
 
-  // GET /auth/login
   if (request.method === 'GET' && pathname === '/auth/login') {
-    const ip = getClientIp(request);
-    if (!authRateLimit(ip)) {
-      return json(
-        { error: 'Too many authentication attempts. Please try again in 15 minutes.' },
-        429
-      );
-    }
-    const params = new URLSearchParams({
-      client_id: DISCORD_CLIENT_ID,
-      redirect_uri: DISCORD_REDIRECT_URI,
-      response_type: 'code',
-      scope: 'identify',
-    });
-    return Response.redirect(`https://discord.com/oauth2/authorize?${params}`, 302);
+    return handleLogin(request);
   }
-
-  // GET /auth/callback
   if (request.method === 'GET' && pathname === '/auth/callback') {
-    const ip = getClientIp(request);
-    if (!authRateLimit(ip)) {
-      return json(
-        { error: 'Too many authentication attempts. Please try again in 15 minutes.' },
-        429
-      );
-    }
-    const code = url.searchParams.get('code');
-    if (!code) {
-      return json({ error: 'Missing authorization code.' }, 400);
-    }
-
-    // 1. Exchange code for Discord access token.
-    const discordToken = await exchangeAuthorizationCode(code);
-    if (!discordToken) {
-      return json({ error: 'Failed to exchange authorization code with Discord.' }, 502);
-    }
-
-    // 2. Fetch Discord identity.
-    const discordUser = await fetchDiscordIdentity(discordToken);
-    if (!discordUser) {
-      return json({ error: 'Failed to fetch Discord user info.' }, 502);
-    }
-
-    // 3. Verify guild membership and get member roles.
-    const rolesResult = await fetchGuildMemberRoles(discordUser.id);
-    if (rolesResult === null || rolesResult === 'not-in-guild') {
-      return json({ error: 'You must be a member of the server to use this app.' }, 403);
-    }
-    const memberRoles = rolesResult;
-
-    // 4. Determine admin status.
-    const isAdmin = isAdminUser(memberRoles);
-
-    // 5. Generate and store tokens.
-    const { accessToken, refreshToken } = await generateAndStoreTokens(discordUser, isAdmin);
-
-    // 6. Set cookies and redirect.
-    const headers = new Headers();
-    headers.append(
-      'Set-Cookie',
-      buildCookieHeader(ACCESS_COOKIE_NAME, accessToken, { maxAge: 60 * 60 * 1000 })
-    );
-    headers.append(
-      'Set-Cookie',
-      buildCookieHeader(REFRESH_COOKIE_NAME, refreshToken, { maxAge: REFRESH_TOKEN_MAX_AGE })
-    );
-    headers.append('Location', WEB_UI_ORIGIN);
-    return new Response(null, { status: 302, headers });
+    return await handleCallback(request, url);
   }
-
-  // POST /auth/refresh
   if (request.method === 'POST' && pathname === '/auth/refresh') {
-    const refreshToken = ctx.cookies[REFRESH_COOKIE_NAME];
-    if (!refreshToken) {
-      return json({ error: 'No refresh token provided.' }, 401);
-    }
-
-    // 1. Verify the refresh token signature and expiration.
-    let decoded: { discordId: string; type: string };
-    try {
-      decoded = jwt.verify(refreshToken, JWT_SECRET) as { discordId: string; type: string };
-      if (decoded.type !== 'refresh') {
-        return json({ error: 'Invalid token type.' }, 401);
-      }
-    } catch {
-      return json({ error: 'Invalid or expired refresh token.' }, 401);
-    }
-
-    // 2. Check if the refresh token exists in the database (not revoked).
-    const tokenHash = hashToken(refreshToken);
-    const [storedToken] = await db
-      .select()
-      .from(refreshTokenTable)
-      .where(eq(refreshTokenTable.tokenHash, tokenHash))
-      .limit(1);
-    if (!storedToken) {
-      return json({ error: 'Refresh token has been revoked.' }, 401);
-    }
-
-    // 3. Check if the refresh token has expired.
-    if (storedToken.expiresAt < new Date()) {
-      await db.delete(refreshTokenTable).where(eq(refreshTokenTable.id, storedToken.id));
-      return json({ error: 'Refresh token has expired.' }, 401);
-    }
-
-    // 4. Delete the used refresh token (single-use for security).
-    await db.delete(refreshTokenTable).where(eq(refreshTokenTable.id, storedToken.id));
-
-    // 5. Clean up expired tokens for this user (lazy cleanup).
-    await db
-      .delete(refreshTokenTable)
-      .where(
-        and(
-          eq(refreshTokenTable.discordId, decoded.discordId),
-          lt(refreshTokenTable.expiresAt, new Date())
-        )
-      );
-
-    // 6. Re-fetch user info from Discord (including admin status).
-    const userInfo = await fetchUserAdminStatus(decoded.discordId);
-    if (!userInfo) {
-      await db.delete(refreshTokenTable).where(eq(refreshTokenTable.discordId, decoded.discordId));
-      return json({ error: 'Unable to verify user membership. Please log in again.' }, 401);
-    }
-
-    // 7. Generate new tokens.
-    const payload = {
-      discordId: decoded.discordId,
-      username: userInfo.username,
-      avatar: userInfo.avatar,
-      isAdmin: userInfo.isAdmin,
-    };
-    const newAccessToken = generateAccessToken(payload);
-    const newRefreshToken = generateRefreshToken(decoded.discordId);
-
-    // 8. Store new refresh token.
-    const newTokenHash = hashToken(newRefreshToken);
-    const newExpiry = new Date(Date.now() + REFRESH_TOKEN_MAX_AGE);
-    await db.insert(refreshTokenTable).values({
-      tokenHash: newTokenHash,
-      discordId: decoded.discordId,
-      expiresAt: newExpiry,
-    });
-
-    // 9. Set cookies and return user info.
-    const headers = new Headers();
-    headers.append(
-      'Set-Cookie',
-      buildCookieHeader(ACCESS_COOKIE_NAME, newAccessToken, { maxAge: 60 * 60 * 1000 })
-    );
-    headers.append(
-      'Set-Cookie',
-      buildCookieHeader(REFRESH_COOKIE_NAME, newRefreshToken, { maxAge: REFRESH_TOKEN_MAX_AGE })
-    );
-    headers.set('Content-Type', 'application/json');
-    return new Response(JSON.stringify({ user: payload }), { status: 200, headers });
+    return await handleRefresh(ctx);
   }
-
-  // GET /auth/me
   if (request.method === 'GET' && pathname === '/auth/me') {
-    if (!ctx.user) {
-      return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-    }
-    return json({ user: ctx.user });
+    return handleMe(ctx);
   }
-
-  // POST /auth/logout
   if (request.method === 'POST' && pathname === '/auth/logout') {
-    const refreshToken = ctx.cookies[REFRESH_COOKIE_NAME];
-    if (refreshToken) {
-      try {
-        const tokenHash = hashToken(refreshToken);
-        await db.delete(refreshTokenTable).where(eq(refreshTokenTable.tokenHash, tokenHash));
-      } catch {
-        logger.warn('Failed to revoke refresh token on logout');
-      }
-    }
-    const headers = new Headers();
-    headers.append('Set-Cookie', buildClearCookieHeader(ACCESS_COOKIE_NAME));
-    headers.append('Set-Cookie', buildClearCookieHeader(REFRESH_COOKIE_NAME));
-    headers.set('Content-Type', 'application/json');
-    return new Response(JSON.stringify({ message: 'Logged out.' }), { status: 200, headers });
+    return await handleLogout(ctx);
   }
 
   return json({ error: 'Not Found' }, 404);
+}
+
+function handleLogin(request: Request): Response {
+  const ip = getClientIp(request);
+  if (!authRateLimit(ip)) {
+    return json(
+      { error: 'Too many authentication attempts. Please try again in 15 minutes.' },
+      429
+    );
+  }
+  const params = new URLSearchParams({
+    client_id: DISCORD_CLIENT_ID,
+    redirect_uri: DISCORD_REDIRECT_URI,
+    response_type: 'code',
+    scope: 'identify',
+  });
+  return Response.redirect(`https://discord.com/oauth2/authorize?${params}`, 302);
+}
+
+async function handleCallback(request: Request, url: URL): Promise<Response> {
+  const ip = getClientIp(request);
+  if (!authRateLimit(ip)) {
+    return json(
+      { error: 'Too many authentication attempts. Please try again in 15 minutes.' },
+      429
+    );
+  }
+  const code = url.searchParams.get('code');
+  if (!code) {
+    return json({ error: 'Missing authorization code.' }, 400);
+  }
+
+  // 1. Exchange code for Discord access token.
+  const discordToken = await exchangeAuthorizationCode(code);
+  if (!discordToken) {
+    return json({ error: 'Failed to exchange authorization code with Discord.' }, 502);
+  }
+
+  // 2. Fetch Discord identity.
+  const discordUser = await fetchDiscordIdentity(discordToken);
+  if (!discordUser) {
+    return json({ error: 'Failed to fetch Discord user info.' }, 502);
+  }
+
+  // 3. Verify guild membership and get member roles.
+  const rolesResult = await fetchGuildMemberRoles(discordUser.id);
+  if (rolesResult === null || rolesResult === 'not-in-guild') {
+    return json({ error: 'You must be a member of the server to use this app.' }, 403);
+  }
+  const memberRoles = rolesResult;
+
+  // 4. Determine admin status.
+  const isAdmin = isAdminUser(memberRoles);
+
+  // 5. Generate and store tokens.
+  const { accessToken, refreshToken } = await generateAndStoreTokens(discordUser, isAdmin);
+
+  // 6. Set cookies and redirect.
+  const headers = new Headers();
+  headers.append(
+    'Set-Cookie',
+    buildCookieHeader(ACCESS_COOKIE_NAME, accessToken, { maxAge: 60 * 60 * 1000 })
+  );
+  headers.append(
+    'Set-Cookie',
+    buildCookieHeader(REFRESH_COOKIE_NAME, refreshToken, { maxAge: REFRESH_TOKEN_MAX_AGE })
+  );
+  headers.append('Location', WEB_UI_ORIGIN);
+  return new Response(null, { status: 302, headers });
+}
+
+async function handleRefresh(ctx: RouteContext): Promise<Response> {
+  const refreshToken = ctx.cookies[REFRESH_COOKIE_NAME];
+  if (!refreshToken) {
+    return json({ error: 'No refresh token provided.' }, 401);
+  }
+
+  // 1. Verify the refresh token signature and expiration.
+  let decoded: { discordId: string; type: string };
+  try {
+    decoded = jwt.verify(refreshToken, JWT_SECRET) as { discordId: string; type: string };
+    if (decoded.type !== 'refresh') {
+      return json({ error: 'Invalid token type.' }, 401);
+    }
+  } catch {
+    return json({ error: 'Invalid or expired refresh token.' }, 401);
+  }
+
+  // 2. Check if the refresh token exists in the database (not revoked).
+  const tokenHash = hashToken(refreshToken);
+  const [storedToken] = await db
+    .select()
+    .from(refreshTokenTable)
+    .where(eq(refreshTokenTable.tokenHash, tokenHash))
+    .limit(1);
+  if (!storedToken) {
+    return json({ error: 'Refresh token has been revoked.' }, 401);
+  }
+
+  // 3. Check if the refresh token has expired.
+  if (storedToken.expiresAt < new Date()) {
+    await db.delete(refreshTokenTable).where(eq(refreshTokenTable.id, storedToken.id));
+    return json({ error: 'Refresh token has expired.' }, 401);
+  }
+
+  // 4. Delete the used refresh token (single-use for security).
+  await db.delete(refreshTokenTable).where(eq(refreshTokenTable.id, storedToken.id));
+
+  // 5. Clean up expired tokens for this user (lazy cleanup).
+  await db
+    .delete(refreshTokenTable)
+    .where(
+      and(
+        eq(refreshTokenTable.discordId, decoded.discordId),
+        lt(refreshTokenTable.expiresAt, new Date())
+      )
+    );
+
+  // 6. Re-fetch user info from Discord (including admin status).
+  const userInfo = await fetchUserAdminStatus(decoded.discordId);
+  if (!userInfo) {
+    await db.delete(refreshTokenTable).where(eq(refreshTokenTable.discordId, decoded.discordId));
+    return json({ error: 'Unable to verify user membership. Please log in again.' }, 401);
+  }
+
+  // 7. Generate new tokens.
+  const payload = {
+    discordId: decoded.discordId,
+    username: userInfo.username,
+    avatar: userInfo.avatar,
+    isAdmin: userInfo.isAdmin,
+  };
+  const newAccessToken = generateAccessToken(payload);
+  const newRefreshToken = generateRefreshToken(decoded.discordId);
+
+  // 8. Store new refresh token.
+  const newTokenHash = hashToken(newRefreshToken);
+  const newExpiry = new Date(Date.now() + REFRESH_TOKEN_MAX_AGE);
+  await db.insert(refreshTokenTable).values({
+    tokenHash: newTokenHash,
+    discordId: decoded.discordId,
+    expiresAt: newExpiry,
+  });
+
+  // 9. Set cookies and return user info.
+  const headers = new Headers();
+  headers.append(
+    'Set-Cookie',
+    buildCookieHeader(ACCESS_COOKIE_NAME, newAccessToken, { maxAge: 60 * 60 * 1000 })
+  );
+  headers.append(
+    'Set-Cookie',
+    buildCookieHeader(REFRESH_COOKIE_NAME, newRefreshToken, { maxAge: REFRESH_TOKEN_MAX_AGE })
+  );
+  headers.set('Content-Type', 'application/json');
+  return new Response(JSON.stringify({ user: payload }), { status: 200, headers });
+}
+
+function handleMe(ctx: RouteContext): Response {
+  if (!ctx.user) {
+    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
+  }
+  return json({ user: ctx.user });
+}
+
+async function handleLogout(ctx: RouteContext): Promise<Response> {
+  const refreshToken = ctx.cookies[REFRESH_COOKIE_NAME];
+  if (refreshToken) {
+    try {
+      const tokenHash = hashToken(refreshToken);
+      await db.delete(refreshTokenTable).where(eq(refreshTokenTable.tokenHash, tokenHash));
+    } catch {
+      logger.warn('Failed to revoke refresh token on logout');
+    }
+  }
+  const headers = new Headers();
+  headers.append('Set-Cookie', buildClearCookieHeader(ACCESS_COOKIE_NAME));
+  headers.append('Set-Cookie', buildClearCookieHeader(REFRESH_COOKIE_NAME));
+  headers.set('Content-Type', 'application/json');
+  return new Response(JSON.stringify({ message: 'Logged out.' }), { status: 200, headers });
 }

--- a/packages/api/src/routes/player.ts
+++ b/packages/api/src/routes/player.ts
@@ -22,6 +22,27 @@ import { requireUserInVoice, resolveOrAutoJoinPlayer } from '../lib/voice';
 
 const { song: songTable } = tables;
 
+type YouTubeMetadata = { title: string; youtubeId: string; duration: number; thumbnailUrl: string };
+
+function buildQueuedSong(
+  url: string,
+  metadata: YouTubeMetadata,
+  addedBy: string,
+  requestedBy: string
+) {
+  return {
+    id: `temp-${Date.now()}`,
+    title: metadata.title,
+    youtubeUrl: url,
+    youtubeId: metadata.youtubeId,
+    duration: metadata.duration,
+    thumbnailUrl: metadata.thumbnailUrl,
+    addedBy,
+    createdAt: new Date().toISOString(),
+    requestedBy,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // GET /api/player/queue — returns current queue state
 // ---------------------------------------------------------------------------
@@ -287,17 +308,7 @@ async function handleQuickAdd(ctx: RouteContext, request: Request): Promise<Resp
 
   const requestedBy = ctx.user.username;
   const addedBy = ctx.user.discordId ?? '';
-  const queuedSong = {
-    id: `temp-${Date.now()}`,
-    title: metadata.title,
-    youtubeUrl: url,
-    youtubeId: metadata.youtubeId,
-    duration: metadata.duration,
-    thumbnailUrl: metadata.thumbnailUrl,
-    addedBy,
-    createdAt: new Date().toISOString(),
-    requestedBy,
-  };
+  const queuedSong = buildQueuedSong(url, metadata, addedBy, requestedBy);
 
   await player.addToPriorityQueue(queuedSong);
 
@@ -491,17 +502,7 @@ async function handleOverride(ctx: RouteContext, request: Request): Promise<Resp
 
   const requestedBy = ctx.user.username;
   const addedBy = ctx.user.discordId ?? '';
-  const queuedSong = {
-    id: `temp-${Date.now()}`,
-    title: metadata.title,
-    youtubeUrl: url,
-    youtubeId: metadata.youtubeId,
-    duration: metadata.duration,
-    thumbnailUrl: metadata.thumbnailUrl,
-    addedBy,
-    createdAt: new Date().toISOString(),
-    requestedBy,
-  };
+  const queuedSong = buildQueuedSong(url, metadata, addedBy, requestedBy);
 
   await player.replaceQueueAndPlay([queuedSong]);
 

--- a/packages/api/src/routes/playlists.ts
+++ b/packages/api/src/routes/playlists.ts
@@ -10,6 +10,14 @@ import { validatePlaylistName } from '../lib/validation';
 
 const { playlist: playlistTable, playlistSong: playlistSongTable } = tables;
 
+async function getPlaylistSongCount(playlistId: string): Promise<number> {
+  const [{ value }] = await db
+    .select({ value: count() })
+    .from(playlistSongTable)
+    .where(eq(playlistSongTable.playlistId, playlistId));
+  return value;
+}
+
 type PlaylistRow = {
   id: string;
   name: string;
@@ -33,10 +41,7 @@ async function findPlaylistOr404(id: string, withCount = false): Promise<Playlis
     .limit(1);
   if (!row) return null;
   if (withCount) {
-    const [{ value }] = await db
-      .select({ value: count() })
-      .from(playlistSongTable)
-      .where(eq(playlistSongTable.playlistId, id));
+    const value = await getPlaylistSongCount(id);
     return { ...row, _count: { songs: value } };
   }
   return row;
@@ -85,10 +90,7 @@ async function handleGetPlaylists(ctx: RouteContext, request: Request): Promise<
   // Fetch song counts for each playlist
   const playlistsWithCounts = await Promise.all(
     playlists.map(async (pl) => {
-      const [{ value }] = await db
-        .select({ value: count() })
-        .from(playlistSongTable)
-        .where(eq(playlistSongTable.playlistId, pl.id));
+      const value = await getPlaylistSongCount(pl.id);
       return formatPlaylist(pl, value);
     })
   );
@@ -265,10 +267,7 @@ async function handlePatchVisibility(
     .where(eq(playlistTable.id, id))
     .returning();
 
-  const [{ value }] = await db
-    .select({ value: count() })
-    .from(playlistSongTable)
-    .where(eq(playlistSongTable.playlistId, updatedPlaylist.id));
+  const value = await getPlaylistSongCount(updatedPlaylist.id);
 
   emitPlaylistUpdated(formatPlaylist(updatedPlaylist, value));
   return json(updatedPlaylist);
@@ -313,10 +312,7 @@ async function handlePatchPlaylist(
     .where(eq(playlistTable.id, id))
     .returning();
 
-  const [{ value }] = await db
-    .select({ value: count() })
-    .from(playlistSongTable)
-    .where(eq(playlistSongTable.playlistId, updatedPlaylist.id));
+  const value = await getPlaylistSongCount(updatedPlaylist.id);
 
   emitPlaylistUpdated(formatPlaylist(updatedPlaylist, value));
   return json(updatedPlaylist);
@@ -423,12 +419,9 @@ async function handleAddSong(ctx: RouteContext, request: Request, id: string): P
     .returning();
 
   const songData = { ...song, createdAt: song.createdAt.toISOString(), tags: song.tags ?? [] };
-  const [countRow] = await db
-    .select({ value: count() })
-    .from(playlistSongTable)
-    .where(eq(playlistSongTable.playlistId, playlist.id));
+  const value = await getPlaylistSongCount(playlist.id);
 
-  emitPlaylistUpdated(formatPlaylist(playlist, countRow.value));
+  emitPlaylistUpdated(formatPlaylist(playlist, value));
 
   return json(
     {
@@ -494,10 +487,7 @@ async function handleRemoveSong(
     );
   });
 
-  const [{ value }] = await db
-    .select({ value: count() })
-    .from(playlistSongTable)
-    .where(eq(playlistSongTable.playlistId, playlistId));
+  const value = await getPlaylistSongCount(playlistId);
 
   const updatedPlaylist = formatPlaylist(playlist, value);
   emitPlaylistUpdated(updatedPlaylist);

--- a/packages/bot/src/index.ts
+++ b/packages/bot/src/index.ts
@@ -20,15 +20,6 @@ export {
 const NODELINK_URL = process.env.NODELINK_URL ?? 'http://localhost:2333';
 const NODELINK_AUTH = process.env.NODELINK_AUTHORIZATION ?? '';
 
-function parseNodeLinkUrl(url: string): { host: string; port: number; secure: boolean } {
-  const parsed = new URL(url);
-  return {
-    host: parsed.hostname,
-    port: Number(parsed.port) || (parsed.protocol === 'https:' ? 443 : 2333),
-    secure: parsed.protocol === 'https:',
-  };
-}
-
 // Voice channel membership tracking for auto-pause.
 // Maps voiceChannelId -> Set of human userIds currently in that channel.
 const humanVoiceMembers = new Map<string, Set<string>>();
@@ -174,7 +165,7 @@ export async function startBot(): Promise<void> {
 
   // Initialize Hoshimi manager for audio.
   const { Hoshimi } = await import('hoshimi');
-  const nodeConfig = parseNodeLinkUrl(NODELINK_URL);
+  const nodelinkParsed = new URL(NODELINK_URL);
 
   const hoshimi = new Hoshimi({
     sendPayload: (guildId: string, payload: unknown) => {
@@ -184,10 +175,10 @@ export async function startBot(): Promise<void> {
     },
     nodes: [
       {
-        host: nodeConfig.host,
-        port: nodeConfig.port,
+        host: nodelinkParsed.hostname,
+        port: Number(nodelinkParsed.port) || (nodelinkParsed.protocol === 'https:' ? 443 : 2333),
         password: NODELINK_AUTH,
-        secure: nodeConfig.secure,
+        secure: nodelinkParsed.protocol === 'https:',
       },
     ],
     client: {

--- a/packages/bot/src/lib/client.ts
+++ b/packages/bot/src/lib/client.ts
@@ -47,8 +47,3 @@ export function setHoshimi(hoshimi: Hoshimi): void {
 export function getHoshimi(): Hoshimi | null {
   return _hoshimi;
 }
-
-/** @deprecated Use getHoshimi() instead. */
-export function getNodeManager(): Hoshimi | null {
-  return _hoshimi;
-}

--- a/packages/bot/src/player/GuildPlayer.ts
+++ b/packages/bot/src/player/GuildPlayer.ts
@@ -352,25 +352,13 @@ export class GuildPlayer {
       return;
     }
 
-    let lastError: unknown;
-    let trackData: { track: string; isWebmOpus: boolean } | undefined;
+    let trackData: { track: string; isWebmOpus: boolean };
 
-    for (let attempt = 0; attempt < GuildPlayer.STREAM_RETRY_ATTEMPTS; attempt++) {
-      try {
-        const { getStreamFormat } = await import('../utils/nodelink');
-        trackData = await getStreamFormat(next.youtubeUrl);
-        break;
-      } catch (error) {
-        lastError = error;
-        if (attempt < GuildPlayer.STREAM_RETRY_ATTEMPTS - 1) {
-          await new Promise((resolve) => setTimeout(resolve, GuildPlayer.STREAM_RETRY_DELAY_MS));
-        }
-      }
-    }
-
-    if (!trackData) {
+    try {
+      trackData = await this.fetchStreamWithRetry(next.youtubeUrl);
+    } catch (error) {
       logger.error(
-        { guildId: this.guildId, track: next.title, error: lastError },
+        { guildId: this.guildId, track: next.title, error },
         `Failed to get stream URL after ${GuildPlayer.STREAM_RETRY_ATTEMPTS} attempts`
       );
       await this.handlePlaybackFailure('could not load the track from NodeLink');
@@ -428,6 +416,24 @@ export class GuildPlayer {
     this.trackStartedAt = Date.now();
     this.pausedAt = null;
     this.broadcast();
+  }
+
+  private async fetchStreamWithRetry(
+    youtubeUrl: string
+  ): Promise<{ track: string; isWebmOpus: boolean }> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < GuildPlayer.STREAM_RETRY_ATTEMPTS; attempt++) {
+      try {
+        const { getStreamFormat } = await import('../utils/nodelink');
+        return await getStreamFormat(youtubeUrl);
+      } catch (error) {
+        lastError = error;
+        if (attempt < GuildPlayer.STREAM_RETRY_ATTEMPTS - 1) {
+          await new Promise((resolve) => setTimeout(resolve, GuildPlayer.STREAM_RETRY_DELAY_MS));
+        }
+      }
+    }
+    throw lastError;
   }
 
   private async handlePlaybackFailure(skipMessage: string): Promise<void> {

--- a/packages/bot/src/utils/nodelink.ts
+++ b/packages/bot/src/utils/nodelink.ts
@@ -59,10 +59,6 @@ interface LoadTrackResponse {
   exception?: { message?: string };
 }
 
-function youtubeThumbnail(videoId: string): string {
-  return `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
-}
-
 const YOUTUBE_HOSTS = ['youtube.com', 'www.youtube.com', 'youtu.be', 'music.youtube.com'];
 
 export function isValidYouTubeUrl(url: string): boolean {
@@ -106,7 +102,7 @@ export async function getMetadata(youtubeUrl: string): Promise<SongMetadata> {
     title,
     youtubeId,
     duration: info.duration ?? 0,
-    thumbnailUrl: youtubeThumbnail(youtubeId),
+    thumbnailUrl: `https://img.youtube.com/vi/${youtubeId}/hqdefault.jpg`,
   };
 }
 
@@ -157,7 +153,7 @@ export async function getPlaylistMetadataWithVideos(
       id,
       title: t.info?.title ?? 'Unknown',
       duration: t.info?.duration ?? 0,
-      thumbnailUrl: youtubeThumbnail(id),
+      thumbnailUrl: `https://img.youtube.com/vi/${id}/hqdefault.jpg`,
     };
   });
 

--- a/packages/web/src/utils/api.ts
+++ b/packages/web/src/utils/api.ts
@@ -1,5 +1,4 @@
-/** Extract error message from an Axios-style API error, with a fallback. */
+/** Extract error message from a Fetch-based API error, with a fallback. */
 export function apiErrorMessage(err: unknown, fallback: string): string {
-  const e = err as { response?: { data?: { error?: string } } };
-  return e?.response?.data?.error ?? fallback;
+  return err instanceof Error ? err.message : fallback;
 }


### PR DESCRIPTION
## Summary
- `apiErrorMessage`: use native `Error` instead of Axios-style `err.response.data.error` (web)
- Remove deprecated `getNodeManager` function (bot/lib/client)
- Inline `serializeMessage` into socket emit helpers (api)
- Inline `youtubeThumbnail` and `parseNodeLinkUrl` (bot)
- Extract `buildQueuedSong` helper for quick-add/override (api/player)
- Extract `getPlaylistSongCount` helper (api/playlists)
- Extract auth route handlers: `handleLogin`, `handleCallback`, `handleRefresh`, `handleMe`, `handleLogout` (api/auth)
- Extract `fetchStreamWithRetry` from `playSong` (bot/GuildPlayer)

## Test plan
- [x] `bun run check` passes
- [x] `docker compose up --build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)