### PR TITLE
refactor: remove dead code and simplify serialization

### DIFF
--- a/packages/api/src/lib/serialization.ts
+++ b/packages/api/src/lib/serialization.ts
@@ -1,0 +1,20 @@
+import type { Song } from '@alfira-bot/shared';
+
+// Accept both Date and string createdAt — Drizzle uses Date at the DB level,
+// but we serialize to ISO string for JSON serialization.
+type SerializedSong = Omit<Song, 'createdAt'> & { createdAt: string | Date };
+
+// ---------------------------------------------------------------------------
+// Serialization helpers
+// ---------------------------------------------------------------------------
+
+export function formatSong(s: {
+  createdAt: Date | string;
+  tags?: string[] | null;
+}): SerializedSong {
+  return {
+    ...s,
+    createdAt: s.createdAt instanceof Date ? s.createdAt.toISOString() : s.createdAt,
+    tags: s.tags ?? [],
+  } as SerializedSong;
+}

--- a/packages/api/src/lib/socket.ts
+++ b/packages/api/src/lib/socket.ts
@@ -1,25 +1,12 @@
 import type { Playlist, QueueState, Song, User } from '@alfira-bot/shared';
 import { logger } from './config';
 
+import { formatSong } from './serialization';
+
 // Accept both Date and string createdAt — Drizzle uses Date at the DB level,
 // but we serialize to ISO string for JSON serialization.
-export type SerializedSong = Omit<Song, 'createdAt'> & { createdAt: string | Date };
+type SerializedSong = Omit<Song, 'createdAt'> & { createdAt: string | Date };
 type SerializedPlaylist = Omit<Playlist, 'createdAt'> & { createdAt: string | Date };
-
-// ---------------------------------------------------------------------------
-// Serialization helpers
-// ---------------------------------------------------------------------------
-
-export function formatSong(s: {
-  createdAt: Date | string;
-  tags?: string[] | null;
-}): SerializedSong {
-  return {
-    ...s,
-    createdAt: s.createdAt instanceof Date ? s.createdAt.toISOString() : s.createdAt,
-    tags: s.tags ?? [],
-  } as SerializedSong;
-}
 
 // ---------------------------------------------------------------------------
 // WebSocket client registry

--- a/packages/api/src/routes/player.ts
+++ b/packages/api/src/routes/player.ts
@@ -22,27 +22,6 @@ import { requireUserInVoice, resolveOrAutoJoinPlayer } from '../lib/voice';
 
 const { song: songTable } = tables;
 
-type YouTubeMetadata = { title: string; youtubeId: string; duration: number; thumbnailUrl: string };
-
-function buildQueuedSong(
-  url: string,
-  metadata: YouTubeMetadata,
-  addedBy: string,
-  requestedBy: string
-) {
-  return {
-    id: `temp-${Date.now()}`,
-    title: metadata.title,
-    youtubeUrl: url,
-    youtubeId: metadata.youtubeId,
-    duration: metadata.duration,
-    thumbnailUrl: metadata.thumbnailUrl,
-    addedBy,
-    createdAt: new Date().toISOString(),
-    requestedBy,
-  };
-}
-
 // ---------------------------------------------------------------------------
 // GET /api/player/queue — returns current queue state
 // ---------------------------------------------------------------------------
@@ -308,7 +287,17 @@ async function handleQuickAdd(ctx: RouteContext, request: Request): Promise<Resp
 
   const requestedBy = ctx.user.username;
   const addedBy = ctx.user.discordId ?? '';
-  const queuedSong = buildQueuedSong(url, metadata, addedBy, requestedBy);
+  const queuedSong = {
+    id: `temp-${Date.now()}`,
+    title: metadata.title,
+    youtubeUrl: url,
+    youtubeId: metadata.youtubeId,
+    duration: metadata.duration,
+    thumbnailUrl: metadata.thumbnailUrl,
+    addedBy,
+    createdAt: new Date().toISOString(),
+    requestedBy,
+  };
 
   await player.addToPriorityQueue(queuedSong);
 
@@ -502,7 +491,17 @@ async function handleOverride(ctx: RouteContext, request: Request): Promise<Resp
 
   const requestedBy = ctx.user.username;
   const addedBy = ctx.user.discordId ?? '';
-  const queuedSong = buildQueuedSong(url, metadata, addedBy, requestedBy);
+  const queuedSong = {
+    id: `temp-${Date.now()}`,
+    title: metadata.title,
+    youtubeUrl: url,
+    youtubeId: metadata.youtubeId,
+    duration: metadata.duration,
+    thumbnailUrl: metadata.thumbnailUrl,
+    addedBy,
+    createdAt: new Date().toISOString(),
+    requestedBy,
+  };
 
   await player.replaceQueueAndPlay([queuedSong]);
 

--- a/packages/api/src/routes/songs.ts
+++ b/packages/api/src/routes/songs.ts
@@ -5,7 +5,8 @@ import { db } from '../lib/db';
 import { getUserDisplayName } from '../lib/displayName';
 import { json } from '../lib/json';
 
-import { emitSongAdded, emitSongDeleted, emitSongUpdated, formatSong } from '../lib/socket';
+import { emitSongAdded, emitSongDeleted, emitSongUpdated } from '../lib/socket';
+import { formatSong } from '../lib/serialization';
 import {
   clampMaxVideos,
   fetchPlaylistMetadata,

--- a/packages/bot/src/index.ts
+++ b/packages/bot/src/index.ts
@@ -6,7 +6,6 @@ import { getPlayer } from './player/manager';
 export type { DestroyReasons } from 'hoshimi';
 export { broadcastQueueUpdate, setBroadcastQueueUpdate } from './lib/broadcast';
 export { getClient, getHoshimi } from './lib/client';
-export { VOICE_CONNECTION_TIMEOUT_MS } from './lib/constants';
 export type { GuildPlayer } from './player/GuildPlayer';
 export { createPlayer, destroyAllPlayers, getPlayer } from './player/manager';
 export {

--- a/packages/bot/src/lib/constants.ts
+++ b/packages/bot/src/lib/constants.ts
@@ -1,2 +1,0 @@
-/** Timeout (ms) when waiting for voice connection to be ready */
-export const VOICE_CONNECTION_TIMEOUT_MS = 5_000;


### PR DESCRIPTION
## Summary
- Remove unused `VOICE_CONNECTION_TIMEOUT_MS` constant and its re-export
- Remove unnecessary `export` from `SerializedSong` (internal type)
- Inline `buildQueuedSong` into its two call sites in `player.ts`
- Move `formatSong` from `socket.ts` to new `serialization.ts` module

## Test plan
- [x] `bun run lint` passes
- [x] `VOICE_CONNECTION_TIMEOUT_MS` no longer appears in codebase
- [x] `formatSong` imports resolve correctly after move

🤖 Generated with [Claude Code](https://claude.com/claude-code)