### PR TITLE
docs: update skills and fix container name in troubleshooting

### DIFF
--- a/.claude/skills/hoshimi/SKILL.md
+++ b/.claude/skills/hoshimi/SKILL.md
@@ -274,39 +274,72 @@ await player.play({ track, volume: 100 });
 
 ## Seyfert Integration (Alfira)
 
-Alfira uses a **two-phase voice state handling**:
+Alfira uses **two-phase voice state handling** via Seyfert `createEvent`:
 
-### Phase 1: Raw Packet Forwarding
-All raw gateway packets are forwarded to Hoshimi so NodeLink receives Discord's voice server details:
+### Phase 1: `raw` — Forward Packets to Hoshimi
 
 ```typescript
 // packages/bot/src/index.ts
-client.on('raw', (packet) => {
-    hoshimi.updateVoiceState(packet);
+const rawEvent = createEvent({
+  data: { name: 'raw' as const },
+  run(packet, _client) {
+    hoshimi.updateVoiceState(packet as Parameters<typeof hoshimi.updateVoiceState>[0]);
+
+    // Track human users in voice channels for auto-pause.
+    if (packet.t === 'VOICE_STATE_UPDATE') {
+      const d = packet.d as {
+        guild_id: string;
+        user_id: string;
+        channel_id: string | null;
+        member?: { user?: { bot?: boolean } };
+      };
+      // Human tracking: add/remove user from humanVoiceMembers map
+    }
+  },
 });
 ```
 
-### Phase 2: Human-Left Detection
-The `voiceStateUpdate` event detects when all humans leave the bot's channel:
+### Phase 2: `voiceStateUpdate` — Auto-Pause on Human Leave
 
 ```typescript
-client.on('voiceStateUpdate', (oldState, newState) => {
-    // Ignore bot-only voice changes
-    if (newState.member?.user.bot && oldState.member?.user.bot) return;
+// packages/bot/src/index.ts
+const voiceStateUpdateEvent = createEvent({
+  data: { name: 'voiceStateUpdate' as const },
+  run(state, oldState, _client) {
+    // Seyfert passes [state] or [state, oldState]; destructure appropriately.
+    const currentState = Array.isArray(state) ? state[0] : state;
+    const previousState = Array.isArray(state) ? state[1] : oldState;
 
-    const player = manager.players.get(guildId);
+    const oldChannelId = previousState?.channelId;
+    const newChannelId = currentState?.channelId;
+    if (oldChannelId === newChannelId) return;
+
+    const guildId = currentState?.guildId ?? previousState?.guildId;
+    if (!guildId) return;
+
+    const player = hoshimi.players.get(guildId);
     if (!player) return;
 
-    // Only act when someone left the bot's channel
-    if (oldState.channelId !== player.voiceId) return;
-    if (newState.channelId === player.voiceId) return; // joined, not left
+    const botChannelId = player.voiceId;
+    if (!botChannelId) return;
 
-    // Auto-pause when no humans remain
-    const humanCount = voiceChannel.members.filter((m) => !m.user.bot).size;
+    // Only act when someone left the bot's channel.
+    const leftBotChannel = oldChannelId === botChannelId && newChannelId !== botChannelId;
+    if (!leftBotChannel) return;
+
+    // Auto-pause when no humans remain in the bot's channel.
+    const channelMembers = humanVoiceMembers.get(botChannelId);
+    const humanCount = channelMembers?.size ?? 0;
     if (humanCount === 0) {
-        guildPlayer.togglePause();
+      guildPlayer.togglePause();
     }
+  },
 });
+```
+
+Events are registered after `client.start()`:
+```typescript
+client.events.set([readyEvent, rawEvent, voiceStateUpdateEvent] as any);
 ```
 
 ---
@@ -386,8 +419,10 @@ player.destroy(DestroyReasons.Requested);  // Used in GuildPlayer.destroyPlayer(
 ## Search (Hoshimi Built-in)
 
 ```typescript
+import { SearchEngines } from 'hoshimi';
+
 const result = await hoshimi.search('never gonna give you up', {
-    source: 'youtube',
+    source: 'youtube',           // or SearchEngines.Youtube = "ytsearch"
     limit: 10,
 });
 
@@ -395,6 +430,28 @@ if (result.tracks.length > 0) {
     // Use result.tracks[0] with getStreamFormat() then player.play()
 }
 ```
+
+### SearchEngines Values
+
+| Engine | Value | Plugin |
+|--------|-------|--------|
+| `SearchEngines.Youtube` | `"ytsearch"` | youtube-source |
+| `SearchEngines.YoutubeMusic` | `"ytmsearch"` | youtube-source |
+| `SearchEngines.Spotify` | `"spsearch"` | lava-src |
+| `SearchEngines.SpotifyRecommendations` | `"sprec"` | lava-src |
+| `SearchEngines.SpotifyArtistMix` | `"sprec:mix:artist"` | lava-src |
+| `SearchEngines.SpotifyAlbumMix` | `"sprec:mix:album"` | lava-src |
+| `SearchEngines.SpotifyTrackMix` | `"sprec:mix:track"` | lava-src |
+| `SearchEngines.SpotifyISRCMix` | `"sprec:mix:isrc"` | lava-src |
+| `SearchEngines.SoundCloud` | `"scsearch"` | lavalink |
+| `SearchEngines.AppleMusic` | `"amsearch"` | lava-src |
+| `SearchEngines.BandCamp` | `"bcsearch"` | lava-src |
+| `SearchEngines.Deezer` | `"dzsearch"` | lava-src |
+| `SearchEngines.DeezerISRC` | `"dzisrc"` | lava-src |
+| `SearchEngines.DeezerRecommendations` | `"dzrec"` | lava-src |
+| `SearchEngines.YandexMusic` | `"ymsearch"` | lava-src |
+
+The `source` parameter in `hoshimi.search()` accepts either a `SearchEngines` value or a `SourceNames` value.
 
 ---
 

--- a/.claude/skills/nodelink/SKILL.md
+++ b/.claude/skills/nodelink/SKILL.md
@@ -31,9 +31,12 @@ nodelink:
     HOST: 0.0.0.0
     PORT: 2333
     NODELINK_AUTHORIZATION: ${NODELINK_AUTHORIZATION:-}
+    NODELINK_SERVER_USE_BUN_SERVER: "true"
   ports:
     - "2333:3000"      # host:container
 ```
+
+> **Note on env var names:** The official NodeLink Docker docs use `NODELINK_SERVER_HOST`, `NODELINK_SERVER_PORT`, and `NODELINK_SERVER_PASSWORD`. This project's `docker-compose.yml` uses `HOST`, `PORT`, and `NODELINK_AUTHORIZATION` instead — these are the actual env vars the image respects in this configuration. The internal port is `3000` (not the documented `2333` default), which appears to be an effect of `NODELINK_SERVER_USE_BUN_SERVER: "true"`.
 
 **Prod compose (`docker-compose.prod.yml`):** Same, but no port exposure (container port only).
 
@@ -44,9 +47,8 @@ nodelink:
 | External port | 2333 |
 | Host binding | 0.0.0.0 |
 | Authorization | `NODELINK_AUTHORIZATION` env var (default: empty = `youshallnotpass` per image default) |
-| Config file | None — all defaults from Docker image |
-
-**Important:** When `NODELINK_AUTHORIZATION` is unset in the environment, NodeLink uses `youshallnotpass` as the default password.
+| Bun server mode | `NODELINK_SERVER_USE_BUN_SERVER: "true"` |
+| Config file | None — all settings via Docker env vars |
 
 ---
 
@@ -228,6 +230,9 @@ Only **YouTube** is used. The codebase passes YouTube URLs directly to `/v4/load
 |----------|-------------|
 | `NODELINK_URL` | Full URL to NodeLink (e.g., `http://nodelink:3000`) |
 | `NODELINK_AUTHORIZATION` | Password for NodeLink (default when unset: `youshallnotpass`) |
+| `HOST` | Listen interface for the NodeLink server (0.0.0.0) |
+| `PORT` | External port mapping (2333) |
+| `NODELINK_SERVER_USE_BUN_SERVER` | Use Bun HTTP server (`"true"`) — internal port becomes 3000 |
 
 ---
 

--- a/.claude/skills/seyfert/SKILL.md
+++ b/.claude/skills/seyfert/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: seyfert
+description: Use when working with Seyfert v4 Discord framework — client initialization, createEvent API, gateway, intents, command registration, or voice integration.
+---
+
+# Seyfert v4 Expert Reference
+
+Seyfert is a TypeScript Discord framework. Alfira uses Seyfert v4 with Hoshimi for audio.
+
+## Docs
+- **GitHub:** https://github.com/Zyumiy0/Seyfert
+- **npm:** https://www.npmjs.com/package/seyfert
+
+---
+
+## Client Initialization
+
+```typescript
+import { Client } from 'seyfert';
+
+const client = new Client({
+  getRC: async () => ({
+    token: process.env.DISCORD_BOT_TOKEN,
+    locations: { base: '' },   // empty when using programmatic event registration
+    intents,                  // GatewayIntentBits value
+    debug: false,
+  }),
+});
+```
+
+No `seyfert.config.mjs` required. All config is passed via `getRC`.
+
+---
+
+## Starting the Client
+
+```typescript
+await client.start();
+// Events are loaded automatically from the file-system location or registered programmatically.
+```
+
+`client.start()` returns `Promise<void>`. After start, register events programmatically:
+
+```typescript
+await client.start();
+client.events.set([readyEvent, rawEvent] as any);
+```
+
+---
+
+## `createEvent` — Event Definition API
+
+The correct v4 API for defining events:
+
+```typescript
+import { createEvent } from 'seyfert';
+
+const readyEvent = createEvent({
+  data: { name: 'ready' as const, once: true },
+  run(user, _client) {
+    // user is the bot's User object
+    logger.info(`Bot logged in as ${user.username}`);
+  },
+});
+```
+
+```typescript
+const rawEvent = createEvent({
+  data: { name: 'raw' as const },
+  run(packet, _client) {
+    // packet is the raw GatewayDispatchPayload
+    hoshimi.updateVoiceState(packet as Parameters<typeof hoshimi.updateVoiceState>[0]);
+  },
+});
+```
+
+```typescript
+const voiceStateUpdateEvent = createEvent({
+  data: { name: 'voiceStateUpdate' as const },
+  run(state, oldState, _client) {
+    // Seyfert passes [state] or [state, oldState]; destructure appropriately.
+    const currentState = Array.isArray(state) ? state[0] : state;
+    const previousState = Array.isArray(state) ? state[1] : oldState;
+    // ...
+  },
+});
+```
+
+### Event `data` Options
+| Property | Type | Description |
+|----------|------|-------------|
+| `name` | `string` | Event name — e.g. `'ready'`, `'raw'`, `'voiceStateUpdate'` |
+| `once` | `boolean?` | If `true`, the event is removed after first fire |
+
+### Event `run` Signature
+`run(payload, client)` — payload shape depends on the event name.
+
+---
+
+## Event Registration (Programmatic)
+
+After `client.start()`, register events via `client.events.set()`:
+
+```typescript
+client.events.set([readyEvent, rawEvent, voiceStateUpdateEvent] as any);
+```
+
+The `as any` is needed because `createEvent` return has `once?: boolean` but `ClientEvent` requires `once: boolean` — values are correct at runtime.
+
+---
+
+## Gateway
+
+### Sending Payloads
+```typescript
+client.gateway.send(shardId, payload);
+
+// Calculate shard for a guild
+const shardId = client.gateway.calculateShardId(guildId);
+```
+
+### Latency
+```typescript
+client.gateway.latency; // number (ms)
+```
+
+---
+
+## Intent Bits
+
+```typescript
+import { GatewayIntentBits } from 'seyfert';
+
+// Or bitwise OR directly
+const intents = GatewayIntentBits.Guilds | GatewayIntentBits.GuildVoiceStates;
+// 1 | 128
+```
+
+| Intent | Bit | Value |
+|--------|-----|-------|
+| `Guilds` | `1` | `1` |
+| `GuildVoiceStates` | `128` | `128` |
+
+---
+
+## `ready` vs `botReady`
+
+- **`ready`** — fires per-shard when that shard is ready. Use with `once: true` for single-fire behavior.
+- **`botReady`** — fires once when **all shards** are ready.
+
+Alfira uses `ready` with `once: true`:
+
+```typescript
+const readyEvent = createEvent({
+  data: { name: 'ready' as const, once: true },
+  run(user, _client) {
+    hoshimi.init({ id: user.id, username: user.username });
+    logger.info(`Bot logged in as ${user.username}`);
+  },
+});
+```
+
+---
+
+## Uploading Slash Commands
+
+```typescript
+await client.uploadCommands({ cachePath });
+```
+
+---
+
+## Client Logger
+
+```typescript
+client.logger.info('message');
+client.logger.error('message');
+// etc.
+```
+
+Seyfert exposes its built-in logger via `client.logger`.
+
+---
+
+## Two-Phase Voice Handling (Alfira)
+
+Alfira uses **two separate Seyfert events** for voice integration:
+
+### Phase 1: `raw` — Forward Packets to Hoshimi
+
+```typescript
+const rawEvent = createEvent({
+  data: { name: 'raw' as const },
+  run(packet, _client) {
+    hoshimi.updateVoiceState(packet as Parameters<typeof hoshimi.updateVoiceState>[0]);
+
+    // Also track human voice membership for auto-pause.
+    if (packet.t === 'VOICE_STATE_UPDATE') {
+      const d = packet.d as { guild_id: string; user_id: string; channel_id: string | null; member?: { user?: { bot?: boolean } } };
+      // ... human tracking logic
+    }
+  },
+});
+```
+
+### Phase 2: `voiceStateUpdate` — Auto-Pause on Human Leave
+
+```typescript
+const voiceStateUpdateEvent = createEvent({
+  data: { name: 'voiceStateUpdate' as const },
+  run(state, oldState, _client) {
+    const currentState = Array.isArray(state) ? state[0] : state;
+    const previousState = Array.isArray(state) ? state[1] : oldState;
+    // ... detect if human left bot's channel, auto-pause if no humans remain
+  },
+});
+```
+
+---
+
+## Links
+
+| Resource | URL |
+|----------|-----|
+| Seyfert GitHub | https://github.com/Zyumiy0/Seyfert |
+| Seyfert npm | https://www.npmjs.com/package/seyfert |

--- a/README.md
+++ b/README.md
@@ -8,12 +8,11 @@
   <br>
   <a href="https://bun.com/"><img src="https://img.shields.io/badge/Bun%20-F472B6?logo=bun&logoColor=white" alt="Bun"></a>
   <a href="https://www.docker.com/"><img src="https://img.shields.io/badge/Docker-2496ED?logo=docker&logoColor=white" alt="Docker"></a>
-  <br>
-  <a href="https://github.com/drizzle-team/drizzle-orm"><img src="https://img.shields.io/badge/Drizzle-C5F74F?logo=drizzle&logoColor=black" alt="Drizzle"></a>
   <a href="https://www.postgresql.org/"><img src="https://img.shields.io/badge/Postgres-4169E1?logo=postgresql&logoColor=white" alt="Postgres"></a>
   <br>
   <a href="https://react.dev/"><img src="https://img.shields.io/badge/React%20-61DAFB?logo=react&logoColor=black" alt="React"></a>
   <a href="https://tailwindcss.com/"><img src="https://img.shields.io/badge/Tailwind%20-06B6D4?logo=tailwindcss&logoColor=white" alt="Tailwind CSS"></a>
+  <a href="https://github.com/drizzle-team/drizzle-orm"><img src="https://img.shields.io/badge/Drizzle-C5F74F?logo=drizzle&logoColor=black" alt="Drizzle"></a>
   <br>
   <a href="https://github.com/tiramisulabs/seyfert"><img src="https://img.shields.io/badge/Seyfert%20-2D7553?logo=discord&logoColor=white" alt="Seyfert"></a>
   <a href="https://github.com/PerformanC/NodeLink"><img src="https://img.shields.io/badge/NodeLink%20-63B64C?logo=apple%20music&logoColor=white" alt="NodeLink"></a>

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -12,7 +12,7 @@ Common issues and solutions for Alfira.
 1. Ensure the bot has the required permissions (Connect, Speak).
 2. Check that the voice channel allows bot access.
 3. Verify `DISCORD_BOT_TOKEN` is correct.
-4. Check API logs: `docker compose logs api`
+4. Check API logs: `docker compose logs alfira`
 
 ### Audio not playing
 
@@ -62,7 +62,7 @@ docker compose up --build
 
 ## Getting Help
 
-1. Check the logs: `docker compose logs -f api`
+1. Check the logs: `docker compose logs -f alfira`
 2. Search existing [GitHub Issues](https://github.com/ebears/alfira/issues).
 3. Open a new issue with:
    - Docker version


### PR DESCRIPTION
## Summary

- **hoshimi**: document `SearchEngines` values and clarify two-phase voice handling with `createEvent`
- **nodelink**: add `HOST`/`PORT` env vars and note about Bun server mode
- **seyfert**: new skill documenting client init, `createEvent` API, and voice integration
- **troubleshooting**: fix container name from `api` to `alfira` in log commands

## Test plan

- [x] Verify skills load correctly in Claude Code
- [x] Confirm troubleshooting log commands match current docker compose service name

🤖 Generated with [Claude Code](https://claude.com/claude-code)