### PR TITLE
feat: integrate NodeLink into main alfira container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,10 +69,10 @@ DISCORD_REDIRECT_URI=https://your-domain.com/auth/callback
 # DOCKER_HOST_IP=0.0.0.0
 
 # NodeLink audio server (Lavalink-compatible) for bot audio streaming
-# Must match the password configured in NodeLink (default in NodeLink config: youshallnotpass)
-# This value is read by Docker Compose to configure the NodeLink service
+# Also used as the NodeLink server password (default: nodelink-internal)
+# Generate with: openssl rand -hex 16
 NODELINK_URL=http://localhost:2333
-NODELINK_AUTHORIZATION=
+NODELINK_AUTHORIZATION=nodelink-internal
 
 # Minutes the bot waits before leaving a voice channel when idle (paused or queue empty). Defaults to 5.
 # VOICE_IDLE_TIMEOUT_MINUTES=5

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,14 @@ WORKDIR /app
 # Development stage
 # ---------------------------------------------------------------------------
 FROM build AS dev
+RUN apk add --no-cache git
+WORKDIR /usr/local/nodelink
+ARG NODELINK_VERSION=v3
+RUN git clone --depth 1 --branch ${NODELINK_VERSION} https://github.com/PerformanC/NodeLink.git . && \
+    bun install && \
+    bun run build
+WORKDIR /app
+
 COPY package.json bun.lock ./
 COPY packages ./packages
 
@@ -20,6 +28,9 @@ RUN bun run --filter @alfira-bot/shared build && \
     bun run --filter @alfira-bot/bot build && \
     bun run --filter @alfira-bot/api build && \
     bun run --filter @alfira-bot/web build
+
+# Copy custom NodeLink config into the cloned repo
+COPY nodelink-config/config.js /usr/local/nodelink/config.js
 
 ENV NODE_ENV=development
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -29,37 +29,18 @@ services:
     # expose:
     #   - 5432
 
-  nodelink:
-    image: docker.io/performanc/nodelink:latest
-    restart: unless-stopped
-    environment:
-      HOST: 0.0.0.0
-      PORT: 2333
-      NODELINK_AUTHORIZATION: ${NODELINK_AUTHORIZATION:-}
-      NODELINK_SERVER_USE_BUN_SERVER: "true"
-    ports:
-      - "2333:3000"
-    healthcheck:
-      test: ["CMD-SHELL", "wget --spider -q http://localhost:3000/ || exit 0"]
-      interval: 15s
-      timeout: 10s
-      retries: 10
-      start_period: 30s
-
   alfira:
     image: ghcr.io/ebears/alfira:latest
     restart: unless-stopped
     depends_on:
       db:
         condition: service_healthy
-      nodelink:
-        condition: service_healthy
     environment:
       NODE_ENV: production
       PORT: 3001
       DATABASE_URL: ${DATABASE_URL}
-      NODELINK_URL: http://nodelink:3000
-      NODELINK_AUTHORIZATION: ${NODELINK_AUTHORIZATION:-}
+      NODELINK_URL: http://localhost:2333
+      NODELINK_AUTHORIZATION: ${NODELINK_AUTHORIZATION:-nodelink-internal}
       DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN}
       DISCORD_CLIENT_ID: ${DISCORD_CLIENT_ID}
       DISCORD_CLIENT_SECRET: ${DISCORD_CLIENT_SECRET}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,23 +25,6 @@
 # ---------------------------------------------------------------------------
 
 services:
-  nodelink:
-    image: docker.io/performanc/nodelink:latest
-    restart: unless-stopped
-    environment:
-      HOST: 0.0.0.0
-      PORT: 2333
-      NODELINK_AUTHORIZATION: ${NODELINK_AUTHORIZATION:-}
-      NODELINK_SERVER_USE_BUN_SERVER: "true"
-    ports:
-      - "2333:3000"
-    healthcheck:
-      test: ["CMD-SHELL", "wget --spider -q http://localhost:3000/ || exit 0"]
-      interval: 15s
-      timeout: 10s
-      retries: 10
-      start_period: 30s
-
   db:
     image: postgres:16-alpine
     restart: unless-stopped
@@ -70,8 +53,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      nodelink:
-        condition: service_healthy
     env_file:
       # Local .env file provides Discord tokens, OAuth secrets, JWT secret, etc.
       # Copy .env.example to .env and fill in real values before first run.
@@ -79,8 +60,8 @@ services:
     environment:
       # Override DATABASE_URL so it resolves to the 'db' service, not localhost.
       DATABASE_URL: postgresql://botuser:botpass@db:5432/musicbot
-      NODELINK_URL: http://nodelink:3000
-      NODELINK_AUTHORIZATION: ${NODELINK_AUTHORIZATION:-}
+      NODELINK_URL: http://localhost:2333
+      NODELINK_AUTHORIZATION: nodelink-internal
       NODE_ENV: development
     ports:
       - "3001:3001"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -150,9 +150,8 @@ This starts:
 
 | Service | URL | Description |
 |---------|-----|-------------|
-| `nodelink` | `localhost:2333` | NodeLink audio server (internal: 3000) |
 | `db` | `localhost:5432` | PostgreSQL 16 |
-| `alfira` | `localhost:3001` | Bun API + Discord bot + Static Web UI |
+| `alfira` | `localhost:3001` | Bun API + Discord bot + Static Web UI + NodeLink audio |
 
 ### Development Workflow
 
@@ -215,9 +214,8 @@ That's it! The stack will pull the pre-built images and start:
 
 | Service | Description |
 |---------|-------------|
-| `nodelink` | NodeLink audio server for bot audio streaming |
 | `db` | PostgreSQL 16 with healthcheck |
-| `alfira` | API + Discord bot + Static Web UI from GHCR image |
+| `alfira` | API + Discord bot + Static Web UI + NodeLink audio from GHCR image |
 
 ### Environment Variables
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -19,9 +19,10 @@ Common issues and solutions for Alfira.
 **Symptoms:** Bot joins but no audio is heard.
 
 **Solutions:**
-1. Ensure the NodeLink service is running and accessible.
-2. Check API logs for NodeLink connection errors.
-3. Try a different video/URL to isolate the issue.
+1. Ensure the NodeLink service is running (it starts automatically inside the alfira container).
+2. Check API logs for NodeLink connection errors: `docker compose logs alfira`
+3. Look for `[NodeLink]` prefix in logs to see NodeLink startup status.
+4. Try a different video/URL to isolate the issue.
 
 ## Authentication Issues
 

--- a/nodelink-config/config.js
+++ b/nodelink-config/config.js
@@ -1,0 +1,212 @@
+export default {
+  server: {
+    host: '0.0.0.0',
+    port: 2333,
+    password: 'nodelink-internal',
+    useBunServer: true,
+  },
+  cluster: {
+    enabled: false,
+  },
+  logging: {
+    level: 'info',
+    file: {
+      enabled: false,
+      path: 'logs',
+      rotation: 'daily',
+      ttlDays: 7,
+    },
+    debug: {
+      all: false,
+      request: false,
+      session: false,
+      player: false,
+      filters: false,
+      sources: false,
+      lyrics: false,
+      youtube: false,
+      'youtube-cipher': false,
+    },
+  },
+  maxSearchResults: 10,
+  maxAlbumPlaylistLength: 100,
+  playerUpdateInterval: 2000,
+  statsUpdateInterval: 30000,
+  trackStuckThresholdMs: 10000,
+  eventTimeoutMs: 15000,
+  zombieThresholdMs: 60000,
+  enableHoloTracks: false,
+  enableTrackStreamEndpoint: false,
+  enableLoadStreamEndpoint: false,
+  resolveExternalLinks: false,
+  fetchChannelInfo: false,
+  audio: {
+    quality: 'high',
+    encryption: 'aead_aes256_gcm_rtpsize',
+    resamplingQuality: 'best',
+    loudnessNormalizer: false,
+    lookaheadMs: 5,
+    gateThresholdLUFS: -60,
+  },
+  sources: {
+    youtube: {
+      enabled: true,
+      allowItag: [], // additional itags for audio streams, e.g., [140, 141]
+      targetItag: null, // force a specific itag for audio streams, overriding the quality option
+      getOAuthToken: false,
+      hl: 'en',
+      gl: 'US',
+      clients: {
+        search: ['Android'], // Clients used for searching tracks
+        playback: ['AndroidVR', 'TV', 'TVCast', 'WebEmbedded', 'WebParentTools', 'Web', 'IOS'], // Clients used for playback/streaming
+        resolve: ['AndroidVR', 'TV', 'TVCast', 'WebEmbedded', 'WebParentTools', 'IOS', 'Web'], // Clients used for resolving detailed track information (channel, external links, etc.)
+        settings: {
+          TV: {
+            refreshToken: [''], // You can use a string "token" or an array ["token1", "token2"] for rotation/fallback
+          },
+        },
+      },
+      cipher: {
+        url: 'https://cipher.kikkia.dev/api',
+        token: null,
+      },
+    },
+    soundcloud: {
+      enabled: false,
+    },
+    spotify: {
+      enabled: false,
+    },
+    applemusic: {
+      enabled: false,
+    },
+    deezer: {
+      enabled: false,
+    },
+    bandcamp: {
+      enabled: false,
+    },
+    local: {
+      enabled: false,
+    },
+    http: {
+      enabled: false,
+    },
+    vkmusic: {
+      enabled: false,
+    },
+    amazonmusic: {
+      enabled: false,
+    },
+    bluesky: {
+      enabled: false,
+    },
+    anghami: {
+      enabled: false,
+    },
+    rss: {
+      enabled: false,
+    },
+    songlink: {
+      enabled: false,
+    },
+    mixcloud: {
+      enabled: false,
+    },
+    audiomack: {
+      enabled: false,
+    },
+    eternalbox: {
+      enabled: false,
+    },
+    vimeo: {
+      enabled: false,
+    },
+    iheartradio: {
+      enabled: false,
+    },
+    telegram: {
+      enabled: false,
+    },
+    shazam: {
+      enabled: false,
+    },
+    bilibili: {
+      enabled: false,
+    },
+    genius: {
+      enabled: false,
+    },
+    pinterest: {
+      enabled: false,
+    },
+    flowery: {
+      enabled: false,
+    },
+    lazypytts: {
+      enabled: false,
+    },
+    jiosaavn: {
+      enabled: false,
+    },
+    gaana: {
+      enabled: false,
+    },
+    'google-tts': {
+      enabled: false,
+    },
+    pipertts: {
+      enabled: false,
+    },
+    instagram: {
+      enabled: false,
+    },
+    kwai: {
+      enabled: false,
+    },
+    twitch: {
+      enabled: false,
+    },
+    audius: {
+      enabled: false,
+    },
+    tidal: {
+      enabled: false,
+    },
+    pandora: {
+      enabled: false,
+    },
+    nicovideo: {
+      enabled: false,
+    },
+    reddit: {
+      enabled: false,
+    },
+    tumblr: {
+      enabled: false,
+    },
+    twitter: {
+      enabled: false,
+    },
+    qobuz: {
+      enabled: false,
+    },
+    lastfm: {
+      enabled: false,
+    },
+    netease: {
+      enabled: false,
+    },
+    letrasmus: {
+      enabled: false,
+    },
+    yandexmusic: {
+      enabled: false,
+    },
+    monochrome: {
+      enabled: false,
+    },
+  },
+  defaultSearchSource: ['youtube'],
+  unifiedSearchSources: ['youtube'],
+};

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,3 +1,4 @@
+import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -266,6 +267,44 @@ async function runMigrations(): Promise<void> {
   }
 }
 
+// ---------------------------------------------------------------------------
+// NodeLink subprocess
+// ---------------------------------------------------------------------------
+function startNodeLink(): Promise<void> {
+  return new Promise((resolve) => {
+    nodelinkProcess = spawn('bun', ['src/index.ts'], {
+      cwd: '/usr/local/nodelink',
+      stdio: 'pipe',
+      env: { ...process.env, NODELINK_AUTHORIZATION: 'nodelink-internal' },
+    });
+
+    nodelinkProcess.stdout?.on('data', (data: Buffer) => {
+      console.log('[NodeLink]', data.toString().trimEnd());
+    });
+
+    nodelinkProcess.stderr?.on('data', (data: Buffer) => {
+      console.error('[NodeLink]', data.toString().trimEnd());
+    });
+
+    const checkReady = async () => {
+      try {
+        const res = await fetch('http://localhost:2333/v4/info', {
+          headers: { Authorization: 'nodelink-internal' },
+        });
+        if (res.ok) {
+          logger.info('NodeLink is ready');
+          resolve();
+          return;
+        }
+      } catch {
+        /* retry */
+      }
+      setTimeout(checkReady, 500);
+    };
+    checkReady();
+  });
+}
+
 async function main(): Promise<void> {
   // 1. Run migrations.
   try {
@@ -285,10 +324,17 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  // 2. Inject the broadcast function into the bot package.
+  // 3. Start NodeLink in-process.
+  try {
+    await startNodeLink();
+  } catch (error) {
+    logger.error(error, 'Failed to start NodeLink');
+  }
+
+  // 4. Inject the broadcast function into the bot package.
   setBroadcastQueueUpdate(emitPlayerUpdate);
 
-  // 3. Start the Discord bot.
+  // 5. Start the Discord bot.
   try {
     await startBot();
   } catch (error) {
@@ -305,6 +351,7 @@ main().catch((err) => {
 // Graceful shutdown
 // ---------------------------------------------------------------------------
 let shuttingDown = false;
+let nodelinkProcess: ReturnType<typeof spawn> | undefined;
 
 async function shutdown(signal: string): Promise<void> {
   if (shuttingDown) return;
@@ -312,16 +359,20 @@ async function shutdown(signal: string): Promise<void> {
 
   logger.info({ signal }, 'Starting graceful shutdown');
 
-  // 1. Stop accepting connections and close all WebSocket clients.
+  // 1. Stop the NodeLink subprocess.
+  nodelinkProcess?.kill();
+  logger.info('NodeLink stopped');
+
+  // 2. Stop accepting connections and close all WebSocket clients.
   server.stop();
   closeAllClients();
   logger.info('Server stopped');
 
-  // 2. Destroy all players (FFmpeg + voice connections).
+  // 3. Destroy all players (FFmpeg + voice connections).
   destroyAllPlayers();
   logger.info('All players destroyed');
 
-  // 3. Close database connection.
+  // 4. Close database connection.
   await $client.end();
   logger.info('Database disconnected');
 


### PR DESCRIPTION
## Summary

Consolidates NodeLink (Lavalink-compatible audio server) into the alfira container instead of running it as a separate Docker service.

- Clone and build NodeLink v3 during Docker image build
- Add custom `nodelink-config/config.js` with Bun HTTP server, single-process mode, YouTube-only sources
- Spawn NodeLink as subprocess from `packages/api/src/index.ts` with log forwarding
- Remove `nodelink` service from both compose files; update `NODELINK_URL` to `localhost:2333`
- Add `NODELINK_AUTHORIZATION` env var with hardcoded default
- Update docs to reflect integrated architecture

## Verification

1. `bun run check` — linting passes
2. `docker compose build alfira && docker compose up -d`
3. `docker compose logs alfira` — shows NodeLink startup with `[NodeLink]` prefix and `Alfira connected` (bot logged in)
4. No "Invalid password" errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)