### PR TITLE
fix: include postgres in production Docker image

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.9",
-    "postgres": "^3.4.9",
     "typescript": "5.9.3"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -19,7 +19,8 @@
   },
   "dependencies": {
     "drizzle-orm": "^0.45.2",
-    "pino": "^10.3.1"
+    "pino": "^10.3.1",
+    "postgres": "^3.4.9"
   },
   "devDependencies": {
     "bun-types": "^1.3.11",


### PR DESCRIPTION
## Summary

Adds `postgres` to `packages/shared/dependencies` so it's installed in the production Docker image. The migration script (`scripts/migrate-postgres-to-sqlite.ts`) runs inside the container and needs the `postgres` package to connect to the old PostgreSQL database.

## Changes

- `packages/shared/package.json`: Added `postgres: "^3.4.9"` to dependencies
- `package.json`: Removed `postgres` from devDependencies (no longer needed at root level)

## Why this fix is needed

The Docker runtime stage runs `bun install --production` which skips devDependencies. With `postgres` in `packages/shared/dependencies`, it gets installed and is available when the migration script runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)