### PR TITLE
fix: move postgres to root dependencies for script module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "undici": "6.24.0",
     "lodash": "4.17.23"
   },
+  "dependencies": {
+    "postgres": "^3.4.9"
+  },
   "devDependencies": {
     "@biomejs/biome": "^2.4.9",
     "typescript": "5.9.3"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -19,8 +19,7 @@
   },
   "dependencies": {
     "drizzle-orm": "^0.45.2",
-    "pino": "^10.3.1",
-    "postgres": "^3.4.9"
+    "pino": "^10.3.1"
   },
   "devDependencies": {
     "bun-types": "^1.3.11",


### PR DESCRIPTION
## Summary

The migration script at `/app/scripts/` cannot resolve modules from `/app/packages/shared/node_modules/` — bun's module resolution only walks up the directory tree from the script, not into sibling package directories.

Moving `postgres` from `packages/shared/dependencies` to root `dependencies` ensures it hoists to `/app/node_modules/` where the migration script can find it.

## Changes

- `package.json`: Added `postgres: "^3.4.9"` to dependencies
- `packages/shared/package.json`: Removed `postgres` from dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)