### PR TITLE
fix: add bun to PATH for non-root user in production container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,7 @@ COPY --from=builder --chown=nodejs:nodejs /app/packages/shared/dist ./packages/s
 COPY --from=builder --chown=nodejs:nodejs /app/packages/web/dist ./packages/web/dist
 
 # Switch to non-root user
+ENV PATH=/usr/local/bin:$PATH
 USER nodejs
 
 ENV NODE_ENV=production

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -29,9 +29,9 @@ services:
       ADMIN_ROLE_IDS: ${ADMIN_ROLE_IDS}
       WEB_UI_ORIGIN: ${WEB_UI_ORIGIN:-http://localhost:3001}
     ports:
-      - "${DOCKER_HOST_IP:-0.0.0.0}:3001:3001"
+      - "${DOCKER_HOST_IP:-0.0.0.0}:8180:3001"
     volumes:
-      - alfira-data:/data
+      - ./data:/data
     healthcheck:
       test:
         [
@@ -45,5 +45,7 @@ services:
       retries: 3
       start_period: 40s
 
-volumes:
-  alfira-data:
+networks:
+  default:
+    external: true
+    name: alfira_default


### PR DESCRIPTION
## Summary

- Add `ENV PATH=/usr/local/bin:$PATH` before `USER nodejs` in Dockerfile runtime stage so the non-root `nodejs` user can find `bun` when `spawn('bun')` is called in `startNodeLink()`
- Also includes unrelated docker-compose.prod.yml changes that were staged

## Test plan

- [x] Build image and start container
- [x] Confirm no ENOENT errors in logs
- [x] Confirm NodeLink connects successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)