### PR TITLE
fix: create /usr/local/nodelink directory in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,9 @@ COPY --from=builder --chown=nodejs:nodejs /app/packages/bot/dist ./packages/bot/
 COPY --from=builder --chown=nodejs:nodejs /app/packages/shared/dist ./packages/shared/dist
 COPY --from=builder --chown=nodejs:nodejs /app/packages/web/dist ./packages/web/dist
 
+# Create NodeLink working directory (required for spawn cwd)
+RUN mkdir -p /usr/local/nodelink
+
 # Switch to non-root user
 ENV PATH=/usr/local/bin:$PATH
 USER nodejs


### PR DESCRIPTION
## Summary

The `spawn('bun', ...)` call uses `cwd: '/usr/local/nodelink'`. This directory must exist at spawn time — when it doesn't, `posix_spawn` fails with `ENOENT` even though `bun` is correctly in PATH.

## Root cause

Node.js's `posix_spawn` (and Bun's equivalent) resolves the binary path **using the cwd's directory listing**. If the cwd doesn't exist, resolution fails before even looking at PATH.

## Fix

Add `RUN mkdir -p /usr/local/nodelink` in the runtime stage before the `USER nodejs` directive.

## Test plan

- [x] Rebuild image from this branch
- [x] Confirm no ENOENT errors in logs  
- [x] Confirm NodeLink connects successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)