### PR TITLE
fix: copy NodeLink into runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,8 +84,8 @@ COPY --from=builder --chown=nodejs:nodejs /app/packages/bot/dist ./packages/bot/
 COPY --from=builder --chown=nodejs:nodejs /app/packages/shared/dist ./packages/shared/dist
 COPY --from=builder --chown=nodejs:nodejs /app/packages/web/dist ./packages/web/dist
 
-# Create NodeLink working directory (required for spawn cwd)
-RUN mkdir -p /usr/local/nodelink
+# Copy built NodeLink into the runtime image
+COPY --from=dev /usr/local/nodelink /usr/local/nodelink
 
 # Switch to non-root user
 ENV PATH=/usr/local/bin:$PATH


### PR DESCRIPTION
## Summary

- Replace `RUN mkdir -p /usr/local/nodelink` with `COPY --from=dev /usr/local/nodelink /usr/local/nodelink` in the runtime stage of the Dockerfile
- The dev stage clones, builds, and configures NodeLink at `/usr/local/nodelink`; the runtime stage now copies this instead of creating an empty directory
- Fixes "Module not found src/index.ts" error in production containers where NodeLink source was never copied to the runtime image

## Root Cause

The runtime stage was creating an empty `/usr/local/nodelink` directory. When `startNodeLink()` spawned bun with `cwd: '/usr/local/nodelink'`, the directory existed but contained no files — hence "Module not found".

## Test plan

- [x] Build Docker image with the change
- [x] Start container and verify no "Module not found" error in logs
- [x] Confirm NodeLink connects successfully

🤖 Generated with [Claude Code](https://claude.ai/claude-code)