### PR TITLE
fix: chown NodeLink directory to nodejs user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,8 +85,9 @@ COPY --from=builder --chown=nodejs:nodejs /app/packages/bot/dist ./packages/bot/
 COPY --from=builder --chown=nodejs:nodejs /app/packages/shared/dist ./packages/shared/dist
 COPY --from=builder --chown=nodejs:nodejs /app/packages/web/dist ./packages/web/dist
 
-# Copy built NodeLink into the runtime image
+# Copy built NodeLink into the runtime image and make it writable by nodejs user
 COPY --from=dev /usr/local/nodelink /usr/local/nodelink
+RUN chown -R nodejs:nodejs /usr/local/nodelink
 
 # Switch to non-root user
 ENV PATH=/usr/local/bin:$PATH


### PR DESCRIPTION
## Summary

The previous PR #406 missed the `chown` fix because the commit was force-pushed after the merge. The current GHCR image still has `/usr/local/nodelink` owned by `root`, causing `EACCES: permission denied` when NodeLink's CredentialManager tries to write `.cache/`.

This adds the missing `chown -R nodejs:nodejs /usr/local/nodelink` to the runtime Dockerfile.

## Test plan

- [x] Verify image build succeeds and `/usr/local/nodelink` is `nodejs:nodejs` owned
- [x] Confirm no EACCES error in NodeLink logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)