### PR TITLE
docs: update documentation for Postgres → SQLite migration

### DIFF
--- a/.claude/commands/debug.md
+++ b/.claude/commands/debug.md
@@ -12,7 +12,7 @@ You are a senior debugger specializing in distributed systems. When investigatin
 
 This project is a Discord music bot monorepo with these key subsystems:
 - NodeLink/Hoshimi audio pipeline (Lavalink v4 compatible)
-- Drizzle/PostgreSQL persistence
+- Drizzle/SQLite persistence
 - Bun native WebSocket real-time broadcasts
 - Discord OAuth2 authentication
 - Docker Compose orchestration

--- a/.claude/commands/devops.md
+++ b/.claude/commands/devops.md
@@ -12,4 +12,4 @@ You are a DevOps engineer maintaining this project's infrastructure. Focus on:
 - Service networking, health checks, and restart policies
 - Production vs development configuration drift
 
-Prioritize reproducibility and operational simplicity. Flag anything that could cause silent failures in production. Always consider the interaction between api, bot, web, and postgres services.
+Prioritize reproducibility and operational simplicity. Flag anything that could cause silent failures in production. Always consider the interaction between api, bot, web, and sqlite services.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ The bot and API run in a **single Bun process** started from `packages/api/src/i
 - **Discord:** Seyfert v4
 - **Audio:** NodeLink (Lavalink v4-compatible) via `hoshimi` v0.3
 - **API:** Bun native HTTP + WebSocket
-- **Database:** PostgreSQL 16 + Drizzle ORM
+- **Database:** SQLite + Drizzle ORM
 - **Frontend:** React 19 + Tailwind CSS 4
 - **Linting:** Biome
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <br>
   <a href="https://bun.com/"><img src="https://img.shields.io/badge/Bun%20-F472B6?logo=bun&logoColor=white" alt="Bun"></a>
   <a href="https://www.docker.com/"><img src="https://img.shields.io/badge/Docker-2496ED?logo=docker&logoColor=white" alt="Docker"></a>
-  <a href="https://www.postgresql.org/"><img src="https://img.shields.io/badge/Postgres-4169E1?logo=postgresql&logoColor=white" alt="Postgres"></a>
+  <a href="https://www.sqlite.org/"><img src="https://img.shields.io/badge/SQLite-003B57?logo=sqlite&logoColor=white" alt="SQLite"></a>
   <br>
   <a href="https://react.dev/"><img src="https://img.shields.io/badge/React%20-61DAFB?logo=react&logoColor=black" alt="React"></a>
   <a href="https://tailwindcss.com/"><img src="https://img.shields.io/badge/Tailwind%20-06B6D4?logo=tailwindcss&logoColor=white" alt="Tailwind CSS"></a>
@@ -57,7 +57,7 @@ From that same folder:
 docker compose up -d
 ```
 
-This starts a stack with PostgreSQL, NodeLink, and Alfira.
+This starts NodeLink and Alfira (with SQLite database).
 
 ### 3. Access the Web UI
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,10 +29,7 @@ cp .env.example .env
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `DATABASE_URL` | PostgreSQL connection string | `postgresql://user:pass@host:5432/db` |
-| `POSTGRES_USER` | PostgreSQL database user (used by Docker Compose) | `alfira` |
-| `POSTGRES_PASSWORD` | PostgreSQL user password | `change-this-to-a-secure-password` |
-| `POSTGRES_DB` | PostgreSQL database name | `alfira` |
+| `DATABASE_URL` | SQLite database file path | `/data/alfira.db` |
 
 ---
 
@@ -58,27 +55,25 @@ cp .env.example .env
 
 ## Database Configuration
 
-The `DATABASE_URL` follows the PostgreSQL connection string format:
-
-```
-postgresql://[user]:[password]@[host]:[port]/[database]
-```
+Alfira uses SQLite for data persistence. The database is stored as a file inside the container.
 
 ### Development
 
 In development, Docker Compose sets this automatically. The default is:
 
 ```
-DATABASE_URL=postgresql://botuser:botpass@db:5432/musicbot
+DATABASE_URL=/data/alfira.db
 ```
 
 ### Production
 
-Docker Compose uses `DATABASE_URL` directly from your `.env` file. For an external database, set `DATABASE_URL` directly:
+Docker Compose uses `DATABASE_URL` directly from your `.env` file:
 
 ```env
-DATABASE_URL=postgresql://alfira_user:secure_password@db.example.com:5432/alfira
+DATABASE_URL=/data/alfira.db
 ```
+
+> **Note:** The `/data` directory is a Docker volume mount, so your database persists across container restarts.
 
 ---
 
@@ -133,7 +128,7 @@ DISCORD_BOT_TOKEN=your-bot-token
 GUILD_ID=987654321098765432
 ADMIN_ROLE_IDS=123456789012345678
 JWT_SECRET=a1b2c3d4e5f6...your-secure-64-char-hex-string
-DATABASE_URL=postgresql://alfira_user:secure_password@db.example.com:5432/alfira
+DATABASE_URL=/data/alfira.db
 WEB_UI_ORIGIN=https://alfira.example.com
 DISCORD_REDIRECT_URI=https://alfira.example.com/auth/callback
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -118,7 +118,7 @@ cp .env.example .env
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `DATABASE_URL` | PostgreSQL connection string | Set by Docker Compose |
+| `DATABASE_URL` | SQLite database path | `/data/alfira.db` |
 | `WEB_UI_ORIGIN` | Public URL of the web UI | `http://localhost:3001` |
 | `DISCORD_REDIRECT_URI` | OAuth2 redirect URI | `http://localhost:3001/auth/callback` |
 | `PORT` | API server port | `3001` |
@@ -150,8 +150,7 @@ This starts:
 
 | Service | URL | Description |
 |---------|-----|-------------|
-| `db` | `localhost:5432` | PostgreSQL 16 |
-| `alfira` | `localhost:3001` | Bun API + Discord bot + Static Web UI + NodeLink audio |
+| `alfira` | `localhost:3001` | Bun API + Discord bot + Static Web UI + NodeLink audio (includes SQLite) |
 
 ### Development Workflow
 
@@ -214,8 +213,7 @@ That's it! The stack will pull the pre-built images and start:
 
 | Service | Description |
 |---------|-------------|
-| `db` | PostgreSQL 16 with healthcheck |
-| `alfira` | API + Discord bot + Static Web UI + NodeLink audio from GHCR image |
+| `alfira` | API + Discord bot + Static Web UI + NodeLink audio from GHCR image (SQLite database included) |
 
 ### Environment Variables
 
@@ -229,9 +227,6 @@ All configuration is handled through a single `.env` file in the project root. C
 | `GUILD_ID` | ✅ | Your Discord server ID |
 | `ADMIN_ROLE_IDS` | ✅ | Admin role ID(s), comma-separated |
 | `JWT_SECRET` | ✅ | Secret for signing JWT tokens |
-| `POSTGRES_USER` | ✅ | PostgreSQL database user |
-| `POSTGRES_PASSWORD` | ✅ | PostgreSQL user password |
-| `POSTGRES_DB` | ✅ | PostgreSQL database name |
 | `WEB_UI_ORIGIN` | ⚪ | Public URL of the web UI |
 | `DISCORD_REDIRECT_URI` | ⚪ | OAuth2 callback URL |
 | `NODELINK_URL` | ⚪ | NodeLink server URL (default: `http://nodelink:3000` in Docker) |

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -9,7 +9,7 @@
 | **Discord** | `Seyfert` v4 |
 | **Audio** | NodeLink (Lavalink v4) via `hoshimi` |
 | **API** | Bun native HTTP + WebSocket |
-| **Database** | PostgreSQL + Drizzle ORM |
+| **Database** | SQLite + Drizzle ORM |
 | **Frontend** | React + Bun + Tailwind |
 | **Logging** | Pino |
 
@@ -33,7 +33,7 @@ flowchart TB
 
     subgraph Data["Data Layer"]
         DRIZZLE[Drizzle ORM]
-        PG[(PostgreSQL)]
+        DB[(SQLite)]
     end
 
     %% User interactions
@@ -50,7 +50,7 @@ flowchart TB
     BOT <-->|Player Control| NL
 
     %% Database
-    DRIZZLE --> PG
+    DRIZZLE --> DB
 ```
 
 The bot and API run in a **single Bun process**, sharing the same memory for the player state. This allows real-time updates to be broadcast directly from the bot's playback events without any additional infrastructure.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -41,13 +41,13 @@ Common issues and solutions for Alfira.
 
 ### Connection errors
 
-**Symptoms:** API crashes with "Connection refused" or "database not found".
+**Symptoms:** API crashes with "database not found" or permission errors.
 
 **Solutions:**
-1. Ensure PostgreSQL is running: `docker compose ps`
-2. Check database logs: `docker compose logs db`
-3. Wait for the healthcheck to pass before starting API.
-4. Verify `DATABASE_URL` format: `postgresql://user:pass@host:5432/dbname`
+1. Ensure the alfira container is running: `docker compose ps`
+2. Check API logs: `docker compose logs alfira`
+3. Verify the `/data` volume is properly mounted and writable.
+4. For fresh database, delete the volume: `docker compose down -v` then `docker compose up --build`
 
 ## Resetting Everything
 


### PR DESCRIPTION
## Summary

- Remove all Postgres references from documentation following the codebase migration to SQLite
- Update `DATABASE_URL` format from `postgresql://...` to SQLite file path (`/data/alfira.db`)
- Remove `db` service from Docker Compose service tables
- Remove `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB` environment variables
- Update tech stack table and architecture diagram to show SQLite instead of PostgreSQL
- Update troubleshooting guide for SQLite-specific issues

## Files changed

- `docs/installation.md` — Remove db service, update DATABASE_URL description
- `docs/configuration.md` — Remove Postgres env vars, update connection string format
- `docs/troubleshooting.md` — Update database troubleshooting section
- `docs/tech-stack.md` — Update stack table and architecture diagram
- `README.md` — Remove Postgres badge, update description
- `CLAUDE.md` — Update tech stack line
- `.claude/commands/debug.md` — Update Drizzle reference
- `.claude/commands/devops.md` — Update services mention

## Test plan

- [x] `bun run check` passes with no errors
- [x] No remaining Postgres references (except transitive dep in bun.lock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)