### PR TITLE
upgrade: migrate to TypeScript 6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.9",
         "@types/node": "^22.0.0",
-        "typescript": "5.9.3",
+        "typescript": "^6.0.0",
       },
     },
     "packages/api": {
@@ -25,7 +25,7 @@
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^25.4.0",
         "bun-types": "^1.3.11",
-        "typescript": "^5.4.5",
+        "typescript": "^6.0.0",
       },
     },
     "packages/bot": {
@@ -39,7 +39,7 @@
       },
       "devDependencies": {
         "@types/node": "^25.4.0",
-        "typescript": "^5.4.5",
+        "typescript": "^6.0.0",
       },
     },
     "packages/shared": {
@@ -52,7 +52,7 @@
       "devDependencies": {
         "bun-types": "^1.3.11",
         "drizzle-kit": "^0.31.10",
-        "typescript": "5.9.3",
+        "typescript": "^6.0.0",
       },
     },
     "packages/web": {
@@ -74,7 +74,7 @@
         "bun-types": "^1.3.11",
         "postcss": "^8.5.8",
         "tailwindcss": "^4.2.2",
-        "typescript": "^5.4.5",
+        "typescript": "^6.0.0",
       },
     },
   },
@@ -430,7 +430,7 @@
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.9",
     "@types/node": "^22.0.0",
-    "typescript": "5.9.3"
+    "typescript": "^6.0.0"
   }
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -22,6 +22,6 @@
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^25.4.0",
     "bun-types": "^1.3.11",
-    "typescript": "^5.4.5"
+    "typescript": "^6.0.0"
   }
 }

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -3,7 +3,9 @@
     "target": "ES2020",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
+    "rootDir": "./src",
     "paths": {
       "@alfira-bot/shared": ["./node_modules/@alfira-bot/shared/dist/"],
       "@alfira-bot/shared/*": ["./node_modules/@alfira-bot/shared/dist/*"],

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "@types/node": "^25.4.0",
-    "typescript": "^5.4.5"
+    "typescript": "^6.0.0"
   }
 }

--- a/packages/bot/tsconfig.json
+++ b/packages/bot/tsconfig.json
@@ -3,7 +3,9 @@
     "target": "ES2020",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
+    "rootDir": "./src",
     "paths": {
       "@alfira-bot/shared": ["./node_modules/@alfira-bot/shared/dist/"],
       "@alfira-bot/shared/*": ["./node_modules/@alfira-bot/shared/dist/*"]

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -24,6 +24,6 @@
   "devDependencies": {
     "bun-types": "^1.3.11",
     "drizzle-kit": "^0.31.10",
-    "typescript": "5.9.3"
+    "typescript": "^6.0.0"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -24,6 +24,6 @@
     "bun-types": "^1.3.11",
     "postcss": "^8.5.8",
     "tailwindcss": "^4.2.2",
-    "typescript": "^5.4.5"
+    "typescript": "^6.0.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["drizzle.config.ts"]
+}


### PR DESCRIPTION
## Summary

- Upgrade TypeScript from 5.x to 6.0 in all packages (root, shared, bot, api, web)
- Add `ignoreDeprecations: "6.0"` to tsconfigs that use `baseUrl` (bot, api)
- Add `rootDir: "./src"` to bot and api tsconfigs (required in TS6 when `baseUrl` is used with `include`)
- Create root `tsconfig.json` with `types: ["node"]` so `drizzle.config.ts` can reference `process.env`

## Test plan

- [x] `bun run check` passes (biome lint/format)
- [x] `bun run build` passes for all packages (shared, bot, api, web)
- [x] `bun run db:generate` runs without TS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)