### PR TITLE
feat: add duration display to NowPlayingBar

### DIFF
--- a/packages/server/src/utils/nodelink.ts
+++ b/packages/server/src/utils/nodelink.ts
@@ -38,7 +38,7 @@ interface LoadTrackResponse {
     info?: {
       title?: string;
       identifier?: string;
-      duration?: number;
+      length?: number; // milliseconds
       isStream?: boolean;
       isSeekable?: boolean;
       position?: number;
@@ -46,7 +46,7 @@ interface LoadTrackResponse {
       artworkUrl?: string;
     };
   };
-  tracks?: { info?: { identifier?: string; title?: string; duration?: number } }[];
+  tracks?: { info?: { identifier?: string; title?: string; length?: number } }[]; // length in milliseconds
   playlistInfo?: { name?: string; selectedTrack?: number };
   exception?: { message?: string };
 }
@@ -95,7 +95,7 @@ export async function getMetadata(youtubeUrl: string): Promise<SongMetadata> {
   return {
     title,
     youtubeId,
-    duration: info.duration ?? 0,
+    duration: (info.length ?? 0) / 1000,
     thumbnailUrl: `https://img.youtube.com/vi/${youtubeId}/hqdefault.jpg`,
   };
 }
@@ -130,7 +130,7 @@ export async function getPlaylistMetadataWithVideos(
     return {
       id,
       title: t.info?.title ?? 'Unknown',
-      duration: t.info?.duration ?? 0,
+      duration: (t.info?.length ?? 0) / 1000,
       thumbnailUrl: `https://img.youtube.com/vi/${id}/hqdefault.jpg`,
     };
   });

--- a/packages/web/src/components/NowPlayingBar.tsx
+++ b/packages/web/src/components/NowPlayingBar.tsx
@@ -277,7 +277,8 @@ const AlbumArt = memo(function AlbumArt({ currentSong, isPlaying, isPaused }: Al
  * --------------------------------------------------------------------------- */
 
 export function NowPlayingBar() {
-  const { state, elapsed, registerProgress, skip, leave, pause, setLoop, shuffle, unshuffle } = usePlayer();
+  const { state, elapsed, registerProgress, skip, leave, pause, setLoop, shuffle, unshuffle } =
+    usePlayer();
   const { currentSong, isPlaying, isPaused, isConnectedToVoice, loopMode, isShuffled } = state;
   const isStopped = !!currentSong && !isPlaying && !isPaused;
 
@@ -348,7 +349,12 @@ export function NowPlayingBar() {
   return (
     <div className="shrink-0 w-full bg-base fixed bottom-0 left-0 right-0 z-10">
       {/* Mobile: progress bar on top */}
-      <ProgressBar currentSong={currentSong} registerProgress={registerProgress} elapsed={elapsed} variant="mobile" />
+      <ProgressBar
+        currentSong={currentSong}
+        registerProgress={registerProgress}
+        elapsed={elapsed}
+        variant="mobile"
+      />
 
       <div
         className={`h-22 md:h-20 flex flex-row items-center px-3 md:px-5 gap-1 md:gap-1.5 ${!currentSong ? 'justify-end md:justify-start' : ''}`}

--- a/packages/web/src/components/NowPlayingBar.tsx
+++ b/packages/web/src/components/NowPlayingBar.tsx
@@ -99,7 +99,7 @@ interface TimingDisplayProps {
 
 const TimingDisplay = memo(function TimingDisplay({ elapsed, duration }: TimingDisplayProps) {
   return (
-    <p className="font-mono text-xs text-muted self-start">
+    <p className="font-mono text-xs text-muted">
       {formatDuration(elapsed)} / {formatDuration(duration)}
     </p>
   );
@@ -216,7 +216,7 @@ const ProgressBar = memo(function ProgressBar({
   const artist = currentSong?.artist || null;
 
   return (
-    <div className="hidden md:flex flex-col flex-1 items-center xl:items-end self-stretch px-4 min-h-0 gap-1">
+    <div className="hidden md:flex flex-col flex-1 items-center xl:items-end self-stretch px-4 min-h-0 gap-1 relative">
       {currentSong ? (
         <div className="text-center w-full truncate xl:text-right h-12 flex flex-col justify-center min-h-12">
           <p className="font-body text-sm font-semibold text-fg truncate">{displayName}</p>
@@ -227,7 +227,9 @@ const ProgressBar = memo(function ProgressBar({
           <p className="font-body text-sm text-muted">Nothing playing</p>
         </div>
       )}
-      <TimingDisplay elapsed={elapsed} duration={currentSong?.duration ?? 0} />
+      <div className="absolute top-0 left-0">
+        <TimingDisplay elapsed={elapsed} duration={currentSong?.duration ?? 0} />
+      </div>
       <div className="w-full h-2 clay-inset rounded-full relative overflow-hidden">
         <div
           ref={currentSong != null ? registerProgress : null}

--- a/packages/web/src/components/NowPlayingBar.tsx
+++ b/packages/web/src/components/NowPlayingBar.tsx
@@ -1,4 +1,5 @@
 import type { QueuedSong } from '@alfira-bot/server/shared';
+import { formatDuration } from '@alfira-bot/server/shared';
 import {
   CircleNotchIcon,
   DoorOpenIcon,
@@ -91,6 +92,19 @@ const PlaybackControls = memo(function PlaybackControls({
   );
 });
 
+interface TimingDisplayProps {
+  elapsed: number;
+  duration: number;
+}
+
+const TimingDisplay = memo(function TimingDisplay({ elapsed, duration }: TimingDisplayProps) {
+  return (
+    <p className="font-mono text-xs text-muted self-start">
+      {formatDuration(elapsed)} / {formatDuration(duration)}
+    </p>
+  );
+});
+
 interface LoopShuffleControlsProps {
   currentSong: QueuedSong | null;
   loopMode: 'off' | 'queue' | 'song';
@@ -171,12 +185,14 @@ const LoopShuffleControls = memo(function LoopShuffleControls({
 
 interface ProgressBarProps {
   currentSong: QueuedSong | null;
+  elapsed: number;
   registerProgress: (ref: HTMLDivElement | null) => void;
   variant: 'mobile' | 'desktop';
 }
 
 const ProgressBar = memo(function ProgressBar({
   currentSong,
+  elapsed,
   registerProgress,
   variant,
 }: ProgressBarProps) {
@@ -211,6 +227,7 @@ const ProgressBar = memo(function ProgressBar({
           <p className="font-body text-sm text-muted">Nothing playing</p>
         </div>
       )}
+      <TimingDisplay elapsed={elapsed} duration={currentSong?.duration ?? 0} />
       <div className="w-full h-2 clay-inset rounded-full relative overflow-hidden">
         <div
           ref={currentSong != null ? registerProgress : null}
@@ -258,7 +275,7 @@ const AlbumArt = memo(function AlbumArt({ currentSong, isPlaying, isPaused }: Al
  * --------------------------------------------------------------------------- */
 
 export function NowPlayingBar() {
-  const { state, registerProgress, skip, leave, pause, setLoop, shuffle, unshuffle } = usePlayer();
+  const { state, elapsed, registerProgress, skip, leave, pause, setLoop, shuffle, unshuffle } = usePlayer();
   const { currentSong, isPlaying, isPaused, isConnectedToVoice, loopMode, isShuffled } = state;
   const isStopped = !!currentSong && !isPlaying && !isPaused;
 
@@ -329,7 +346,7 @@ export function NowPlayingBar() {
   return (
     <div className="shrink-0 w-full bg-base fixed bottom-0 left-0 right-0 z-10">
       {/* Mobile: progress bar on top */}
-      <ProgressBar currentSong={currentSong} registerProgress={registerProgress} variant="mobile" />
+      <ProgressBar currentSong={currentSong} registerProgress={registerProgress} elapsed={elapsed} variant="mobile" />
 
       <div
         className={`h-22 md:h-20 flex flex-row items-center px-3 md:px-5 gap-1 md:gap-1.5 ${!currentSong ? 'justify-end md:justify-start' : ''}`}
@@ -352,6 +369,7 @@ export function NowPlayingBar() {
         <ProgressBar
           currentSong={currentSong}
           registerProgress={registerProgress}
+          elapsed={elapsed}
           variant="desktop"
         />
 

--- a/packages/web/src/components/NowPlayingBar.tsx
+++ b/packages/web/src/components/NowPlayingBar.tsx
@@ -227,7 +227,7 @@ const ProgressBar = memo(function ProgressBar({
           <p className="font-body text-sm text-muted">Nothing playing</p>
         </div>
       )}
-      <div className="absolute top-0 left-0">
+      <div className="absolute top-0 left-4">
         <TimingDisplay elapsed={elapsed} duration={currentSong?.duration ?? 0} />
       </div>
       <div className="w-full h-2 clay-inset rounded-full relative overflow-hidden">

--- a/packages/web/src/components/NowPlayingBar.tsx
+++ b/packages/web/src/components/NowPlayingBar.tsx
@@ -227,7 +227,7 @@ const ProgressBar = memo(function ProgressBar({
           <p className="font-body text-sm text-muted">Nothing playing</p>
         </div>
       )}
-      <div className="absolute top-0 left-4">
+      <div className="absolute top-1/2 -translate-y-1/2 left-4">
         <TimingDisplay elapsed={elapsed} duration={currentSong?.duration ?? 0} />
       </div>
       <div className="w-full h-2 clay-inset rounded-full relative overflow-hidden">


### PR DESCRIPTION
## Summary

- **Bug fix:** NodeLink `duration` field was non-existent — NodeLink v3 returns `length` (milliseconds) not `duration`. All songs were being saved with duration=0.
- **Feature:** Add elapsed/total duration display (e.g. "1:23 / 4:56") to the NowPlayingBar desktop variant, absolutely positioned in the top-left of the progress area, vertically centered with song metadata.

## Test plan

- [x] Add a new song via the UI and verify it shows the correct duration
- [x] Play a song and verify the elapsed time updates correctly
- [x] Verify the progress bar and timing display look correct on desktop
- [x] Verify mobile layout is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)