### PR TITLE
feat: center notification toast

### DIFF
--- a/packages/web/src/components/NotificationToast.tsx
+++ b/packages/web/src/components/NotificationToast.tsx
@@ -7,7 +7,7 @@ interface NotificationToastProps {
 export default function NotificationToast({ notification }: NotificationToastProps) {
   return (
     <div
-      className={`fixed bottom-4 right-4 z-50 px-4 py-3 rounded-lg modal-clay font-mono text-xs animate-fade-up ${
+      className={`fixed bottom-24 left-1/2 -translate-x-1/2 z-50 px-4 py-3 rounded-lg modal-clay font-mono text-xs animate-fade-up ${
         notification.type === 'success'
           ? 'bg-accent/20 border border-accent/40 text-accent'
           : 'bg-danger/20 border border-danger/40 text-danger'


### PR DESCRIPTION
## Summary
- Center the notification toast horizontally and position it above the NowPlayingBar (bottom-24 instead of bottom-4 right-4)

## Test plan
- [x] Trigger a notification and verify it appears centered above the progress bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)