### PR TITLE
fix(web): silent token refresh before showing login page

### DIFF
--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -63,6 +63,30 @@ async function refreshToken(): Promise<boolean> {
   }
 }
 
+/**
+ * Attempts to refresh the access token. Returns true if refresh succeeded.
+ * This is exported so AuthContext can attempt refresh before showing login.
+ */
+export async function trySilentRefresh(): Promise<boolean> {
+  // If a refresh is already in progress, don't start another one
+  // The pending refresh will either succeed or fail - caller will handle
+  if (isRefreshing) {
+    return false;
+  }
+
+  isRefreshing = true;
+  const ok = await refreshToken();
+  isRefreshing = false;
+
+  if (ok) {
+    processQueue(null);
+  } else {
+    processQueue(new Error('Token refresh failed'));
+  }
+
+  return ok;
+}
+
 async function wrappedFetch(url: string, options: RequestInit = {}): Promise<unknown> {
   const makeRequest = async (): Promise<Response> =>
     fetchWithTimeout(url, { ...options, credentials: 'include' });

--- a/packages/web/src/context/AuthContext.tsx
+++ b/packages/web/src/context/AuthContext.tsx
@@ -2,6 +2,7 @@ import type { User } from '@alfira-bot/server/shared';
 import type React from 'react';
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { getMe, logout as logoutApi } from '../api/api';
+import { trySilentRefresh } from '../api/client';
 
 interface AuthContextValue {
   user: User | null;
@@ -21,6 +22,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       const me = await getMe();
       setUser(me);
     } catch {
+      // Token might be expired - try a silent refresh once before giving up
+      const refreshed = await trySilentRefresh();
+      if (refreshed) {
+        // Refresh succeeded, retry getting user info
+        const me = await getMe();
+        setUser(me);
+        setLoading(false);
+        return;
+      }
       setUser(null);
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Summary
- When the access token expires (~1 hour), attempt a silent token refresh before redirecting to login
- This prevents the brief login page flash that was occurring when navigating to the site after the access token expired

## Test plan
- [x] Navigate to site after access token has expired (or wait ~1 hour)
- [x] Verify no login page flash occurs
- [x] Verify user remains authenticated seamlessly

🤖 Generated with [Claude Code](https://claude.com/claude-code)