### PR TITLE
Revert: set NODE_ENV=production during web bundle build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,9 +44,11 @@ COPY package.json bun.lock ./
 COPY packages ./packages
 
 RUN bun install
+# NOTE: NODE_ENV is not set here because bun build produces broken bundles
+# with NODE_ENV=production due to how React 19's JSX runtime is bundled.
 # NODE_ENV=production is set in the runtime stage instead.
 RUN bun run --filter @alfira-bot/server build && \
-    NODE_ENV=production bun run --filter @alfira-bot/web build
+    bun run --filter @alfira-bot/web build
 
 COPY packages/server/src/shared/db/migrations packages/server/dist/shared/db/migrations
 


### PR DESCRIPTION
## Summary
Reverts #430. The `NODE_ENV=production` flag during the web bundle build step breaks the production bundle with React 19's JSX runtime, causing a white page in production.

Root cause: `bun build --minify` with `NODE_ENV=production` produces broken/minified bundles for React 19, as documented in the original Dockerfile comment. The DevTools warning is a known trade-off — it only appears in development builds and is partially sourced from the React DevTools browser extension itself.

## Test plan
- [x] Verify production deployment loads correctly (white page issue resolved)
- [x] Note: DevTools message will remain in production builds until bun/build tooling for React 19 matures

🤖 Generated with [Claude Code](https://claude.com/claude-code)