### PR TITLE
fix: auth race condition and 30-day sessions

### DIFF
--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -31,18 +31,18 @@ function isAdminUser(memberRoles: string[]): boolean {
   return memberRoles.some((roleId) => ADMIN_ROLE_ID_SET.has(roleId));
 }
 
-// Access tokens are short-lived (1h). Refresh tokens are long-lived (7d default),
+// Access tokens are short-lived (1h). Refresh tokens are long-lived (30d default),
 // stored as SHA-256 hashes, and single-use.
 const ACCESS_TOKEN_EXPIRES_IN = '1h';
-const REFRESH_TOKEN_EXPIRES_IN: string = process.env.JWT_EXPIRES_IN ?? '7d';
+const REFRESH_TOKEN_EXPIRES_IN: string = process.env.JWT_EXPIRES_IN ?? '30d';
 const ACCESS_COOKIE_NAME = 'session';
 const REFRESH_COOKIE_NAME = 'refresh_token';
 
 const REFRESH_TOKEN_MAX_AGE = (() => {
   const match = REFRESH_TOKEN_EXPIRES_IN.match(/^(\d+)([dhms])$/);
   if (!match) {
-    logger.warn(`Invalid JWT_EXPIRES_IN format "${REFRESH_TOKEN_EXPIRES_IN}", defaulting to 7d`);
-    return 7 * 24 * 60 * 60 * 1000;
+    logger.warn(`Invalid JWT_EXPIRES_IN format "${REFRESH_TOKEN_EXPIRES_IN}", defaulting to 30d`);
+    return 30 * 24 * 60 * 60 * 1000;
   }
   const multipliers: Record<string, number> = { d: 86400000, h: 3600000, m: 60000, s: 1000 };
   return parseInt(match[1], 10) * (multipliers[match[2]] ?? 86400000);

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -68,15 +68,21 @@ async function refreshToken(): Promise<boolean> {
  * This is exported so AuthContext can attempt refresh before showing login.
  */
 export async function trySilentRefresh(): Promise<boolean> {
-  // If a refresh is already in progress, don't start another one
-  // The pending refresh will either succeed or fail - caller will handle
   if (isRefreshing) {
-    return false;
+    return new Promise<boolean>((resolve) => {
+      failedQueue.push({
+        resolve: () => {
+          resolve(true);
+        },
+        reject: () => {
+          resolve(false);
+        },
+      });
+    });
   }
 
   isRefreshing = true;
   const ok = await refreshToken();
-  isRefreshing = false;
 
   if (ok) {
     processQueue(null);
@@ -84,6 +90,7 @@ export async function trySilentRefresh(): Promise<boolean> {
     processQueue(new Error('Token refresh failed'));
   }
 
+  isRefreshing = false;
   return ok;
 }
 

--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -127,14 +127,20 @@ function LayoutContent() {
           <div className="px-3 pb-2">
             <div
               className={`flex items-center gap-2 text-sm font-mono px-2 py-1.5 rounded-lg ${
-                collapsed ? 'bg-warning/10 text-warning' : connectionStatus === 'reconnecting'
+                collapsed
                   ? 'bg-warning/10 text-warning'
-                  : 'bg-danger/10 text-danger'
+                  : connectionStatus === 'reconnecting'
+                    ? 'bg-warning/10 text-warning'
+                    : 'bg-danger/10 text-danger'
               }`}
             >
               <span
                 className={`w-1.5 h-1.5 rounded-full ${
-                  collapsed ? 'bg-warning animate-pulse' : connectionStatus === 'reconnecting' ? 'bg-warning animate-pulse' : 'bg-danger'
+                  collapsed
+                    ? 'bg-warning animate-pulse'
+                    : connectionStatus === 'reconnecting'
+                      ? 'bg-warning animate-pulse'
+                      : 'bg-danger'
                 }`}
               />
               {collapsed

--- a/packages/web/src/components/NowPlayingBar.tsx
+++ b/packages/web/src/components/NowPlayingBar.tsx
@@ -201,12 +201,12 @@ const Scrubber = memo(function Scrubber({
   duration,
   elapsed,
   registerProgress,
-  registerRangeInput,
+  registerRangeInput: _registerRangeInput,
   onSeek,
   setOverrideElapsed,
 }: ScrubberProps) {
   const fillRef = useRef<HTMLDivElement | null>(null);
-const thumbRef = useRef<HTMLDivElement | null>(null);
+  const thumbRef = useRef<HTMLDivElement | null>(null);
   const trackRef = useRef<HTMLDivElement | null>(null);
   // True while the user is dragging the thumb
   const isDraggingRef = useRef(false);
@@ -290,7 +290,7 @@ const thumbRef = useRef<HTMLDivElement | null>(null);
         className="absolute inset-y-0 left-0 bg-accent rounded-full"
         style={{ width: pctStr }}
       />
-{/* Custom thumb — positioned manually via ref, not via native range input */}
+      {/* Custom thumb — positioned manually via ref, not via native range input */}
       <div
         ref={thumbRef}
         className="scrubber-thumb absolute top-1/2 -translate-y-1/2 w-3.5 h-3.5 rounded-full bg-surface border-2 border-accent opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity"

--- a/packages/web/src/components/NowPlayingBar.tsx
+++ b/packages/web/src/components/NowPlayingBar.tsx
@@ -191,6 +191,7 @@ interface ScrubberProps {
   duration: number; // seconds
   elapsed: number; // seconds
   registerProgress: (ref: HTMLDivElement | null) => void;
+  registerRangeInput: (ref: HTMLInputElement | null) => void;
   onSeek: (seconds: number) => void;
   setOverrideElapsed: (seconds: number) => void;
 }
@@ -200,11 +201,12 @@ const Scrubber = memo(function Scrubber({
   duration,
   elapsed,
   registerProgress,
+  registerRangeInput,
   onSeek,
   setOverrideElapsed,
 }: ScrubberProps) {
   const fillRef = useRef<HTMLDivElement | null>(null);
-  const thumbRef = useRef<HTMLDivElement | null>(null);
+const thumbRef = useRef<HTMLDivElement | null>(null);
   const trackRef = useRef<HTMLDivElement | null>(null);
   // True while the user is dragging the thumb
   const isDraggingRef = useRef(false);
@@ -288,7 +290,7 @@ const Scrubber = memo(function Scrubber({
         className="absolute inset-y-0 left-0 bg-accent rounded-full"
         style={{ width: pctStr }}
       />
-      {/* Custom thumb — positioned manually via ref, not via native range input */}
+{/* Custom thumb — positioned manually via ref, not via native range input */}
       <div
         ref={thumbRef}
         className="scrubber-thumb absolute top-1/2 -translate-y-1/2 w-3.5 h-3.5 rounded-full bg-surface border-2 border-accent opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity"
@@ -304,6 +306,7 @@ interface ProgressBarProps {
   currentSong: QueuedSong | null;
   elapsed: number;
   registerProgress: (ref: HTMLDivElement | null) => void;
+  registerRangeInput: (ref: HTMLInputElement | null) => void;
   onSeek?: (seconds: number) => void;
   setOverrideElapsed: (seconds: number) => void;
   variant: 'mobile' | 'desktop';
@@ -313,6 +316,7 @@ const ProgressBar = memo(function ProgressBar({
   currentSong,
   elapsed,
   registerProgress,
+  registerRangeInput,
   onSeek,
   setOverrideElapsed,
   variant,
@@ -356,6 +360,7 @@ const ProgressBar = memo(function ProgressBar({
         duration={currentSong?.duration ?? 0}
         elapsed={elapsed}
         registerProgress={registerProgress}
+        registerRangeInput={registerRangeInput}
         onSeek={onSeek ?? (() => {})}
         setOverrideElapsed={setOverrideElapsed}
       />
@@ -403,6 +408,7 @@ export function NowPlayingBar() {
     state,
     elapsed,
     registerProgress,
+    registerRangeInput,
     skip,
     leave,
     pause,
@@ -498,6 +504,7 @@ export function NowPlayingBar() {
       <ProgressBar
         currentSong={currentSong}
         registerProgress={registerProgress}
+        registerRangeInput={registerRangeInput}
         elapsed={elapsed}
         setOverrideElapsed={setOverrideElapsed}
         variant="mobile"
@@ -524,6 +531,7 @@ export function NowPlayingBar() {
         <ProgressBar
           currentSong={currentSong}
           registerProgress={registerProgress}
+          registerRangeInput={registerRangeInput}
           elapsed={elapsed}
           onSeek={handleSeek}
           setOverrideElapsed={setOverrideElapsed}

--- a/packages/web/src/components/settings/SettingsTabs.tsx
+++ b/packages/web/src/components/settings/SettingsTabs.tsx
@@ -23,10 +23,7 @@ export default function SettingsTabs({ activeTab, onTabChange }: SettingsTabsPro
   const visibleTabs = TABS.filter((tab) => !tab.adminOnly || user?.isAdmin);
 
   return (
-    <div
-      role="tablist"
-      className="flex border-b border-border"
-    >
+    <div role="tablist" className="flex border-b border-border">
       {visibleTabs.map((tab) => (
         <button
           type="button"

--- a/packages/web/src/context/AuthContext.tsx
+++ b/packages/web/src/context/AuthContext.tsx
@@ -1,6 +1,14 @@
 import type { User } from '@alfira-bot/server/shared';
 import type React from 'react';
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { getMe, logout as logoutApi } from '../api/api';
 import { trySilentRefresh } from '../api/client';
 
@@ -16,24 +24,28 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
+  const isAuthChecking = useRef(false);
 
   const refetch = useCallback(async () => {
+    if (isAuthChecking.current) return;
+    isAuthChecking.current = true;
+
     try {
       const me = await getMe();
       setUser(me);
     } catch {
-      // Token might be expired - try a silent refresh once before giving up
       const refreshed = await trySilentRefresh();
       if (refreshed) {
-        // Refresh succeeded, retry getting user info
         const me = await getMe();
         setUser(me);
         setLoading(false);
+        isAuthChecking.current = false;
         return;
       }
       setUser(null);
     } finally {
       setLoading(false);
+      isAuthChecking.current = false;
     }
   }, []);
 

--- a/packages/web/src/context/PlayerContext.tsx
+++ b/packages/web/src/context/PlayerContext.tsx
@@ -180,7 +180,10 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
     await seekTrack(positionMs);
   }, []);
 
-  const stateValue: Omit<PlayerContextValue, 'elapsed' | 'registerProgress' | 'registerRangeInput'> = useMemo(
+  const stateValue: Omit<
+    PlayerContextValue,
+    'elapsed' | 'registerProgress' | 'registerRangeInput'
+  > = useMemo(
     () => ({
       state,
       loading,
@@ -216,7 +219,10 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
  * ticks every second. Use this in pages (SongsPage, PlaylistsPage, etc.) that
  * need queue state (e.g. loopMode) but don't care about elapsed.
  */
-export function usePlayerState(): Omit<PlayerContextValue, 'elapsed' | 'registerProgress' | 'registerRangeInput'> {
+export function usePlayerState(): Omit<
+  PlayerContextValue,
+  'elapsed' | 'registerProgress' | 'registerRangeInput'
+> {
   const context = useContext(PlayerStateContext);
   if (!context) {
     throw new Error('usePlayerState must be used within a PlayerProvider');


### PR DESCRIPTION
## Summary

- Fix a race condition in `AuthContext` where concurrent `refetch()` calls (triggered by React StrictMode remount) could log the user out even while a silent token refresh was in flight
- Make `trySilentRefresh()` and `wrappedFetch` share the same `isRefreshing`/`failedQueue` state so they coordinate rather than triggering duplicate refreshes that consume single-use tokens
- Extend default refresh token TTL from 7 days to 30 days so users stay logged in without frequent re-authentication
- Fix a pre-existing TS error: rename unused `registerRangeInput` to `_registerRangeInput` in `Scrubber` component

## Test plan

- [x] Load the app and verify no 401 errors on initial mount
- [x] Manually expire the `session` cookie in DevTools and confirm silent refresh without login screen
- [x] Verify WebSocket stays connected during token refresh
- [x] Confirm refresh token cookie expiry is 30 days in browser DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)