### PR TITLE
fix(web): reset progress bar when replaying same song after seek

### DIFF
--- a/packages/web/src/context/PlayerContext.tsx
+++ b/packages/web/src/context/PlayerContext.tsx
@@ -84,7 +84,11 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
   useSocket();
 
   // Use the progress bar hook (rAF + 1-sec interval)
-  const { elapsed, registerProgress, registerRangeInput } = useProgressBar(state, overrideElapsed);
+  const { elapsed, registerProgress, registerRangeInput } = useProgressBar(
+    state,
+    overrideElapsed,
+    setOverrideElapsed
+  );
 
   // ---------------------------------------------------------------------------
   // REST fetch — used for initial load and after actions where we want the

--- a/packages/web/src/hooks/useProgressBar.ts
+++ b/packages/web/src/hooks/useProgressBar.ts
@@ -13,7 +13,11 @@ import { useCallback, useEffect, useRef, useState } from 'react';
  * Pause/resume is handled by tracking accumulated elapsed when pausing,
  * then computing a new effective start time on resume.
  */
-export function useProgressBar(state: QueueState, overrideElapsed?: number) {
+export function useProgressBar(
+  state: QueueState,
+  overrideElapsed: number | undefined,
+  setOverrideElapsed: (elapsed: number | undefined) => void
+) {
   const [elapsed, setElapsed] = useState(0);
   const progressBars = useRef<Set<HTMLDivElement>>(new Set());
   const rangeInputs = useRef<Set<HTMLInputElement>>(new Set());
@@ -67,6 +71,17 @@ export function useProgressBar(state: QueueState, overrideElapsed?: number) {
       prevSongIdRef.current = currentSongId;
     } else if (!hasSong) {
       prevSongIdRef.current = null;
+    } else if (overrideElapsed !== undefined) {
+      // Same song is playing but elapsedFromTrackStarted is far less than
+      // overrideElapsed — the song must have been restarted (e.g. play again
+      // after a seek). Clear the override so we seed from the fresh
+      // trackStartedAt instead.
+      const elapsedFromTrackStarted = trackStartedAt ? (Date.now() - trackStartedAt) / 1000 : 0;
+      if (elapsedFromTrackStarted < overrideElapsed / 2) {
+        accumulatedMsRef.current = 0;
+        effectiveStartRef.current = 0;
+        setOverrideElapsed(undefined);
+      }
     }
 
     if (!isPlaying) {
@@ -148,7 +163,15 @@ export function useProgressBar(state: QueueState, overrideElapsed?: number) {
       rafIdRef.current = 0;
       intervalIdRef.current = 0;
     };
-  }, [currentSongId, currentSongDuration, isPlaying, isPaused, trackStartedAt, overrideElapsed]);
+  }, [
+    currentSongId,
+    currentSongDuration,
+    isPlaying,
+    isPaused,
+    trackStartedAt,
+    overrideElapsed,
+    setOverrideElapsed,
+  ]);
 
   return { elapsed, registerProgress, registerRangeInput };
 }


### PR DESCRIPTION
## Summary
- Fix bug where progress bar stayed at seeked position when restarting the same song
- The same-song case didn't trigger song-change detection, so `overrideElapsed` was never cleared

## Test plan
- [x] Play a song and seek forward
- [x] Play the same song again (restart)
- [x] Verify progress bar resets to 0 and tracks correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)