### PR TITLE
fix(server): convert spaces to hyphens in tag names

### DIFF
--- a/packages/server/src/lib/migrateExistingTags.ts
+++ b/packages/server/src/lib/migrateExistingTags.ts
@@ -12,6 +12,8 @@ import { canonicalizeTags } from './tagCanonicalization';
 
 const { song: songTable } = tables;
 
+const normalizeTag = (t: string) => t.replace(/\s+/g, '-').trim();
+
 async function migrateExistingTags() {
   console.log('Starting tag normalization migration...');
 
@@ -29,7 +31,7 @@ async function migrateExistingTags() {
     if (!song.tags || !Array.isArray(song.tags) || song.tags.length === 0) continue;
 
     try {
-      const canonicalTags = await canonicalizeTags(song.tags);
+      const canonicalTags = await canonicalizeTags(song.tags.map(normalizeTag));
 
       if (JSON.stringify(canonicalTags) !== JSON.stringify(song.tags)) {
         await db

--- a/packages/server/src/lib/validation.ts
+++ b/packages/server/src/lib/validation.ts
@@ -188,7 +188,7 @@ export function validateTags(value: unknown): ValidationResult<string[]> {
     return { ok: false, response: json({ error: 'tags must be an array.' }, 400) };
   const trimmed = value
     .filter((t): t is string => typeof t === 'string' && t.trim().length > 0)
-    .map((t) => t.trim());
+    .map((t) => t.replace(/\s+/g, '-').trim());
   return { ok: true, value: [...new Set(trimmed)] };
 }
 


### PR DESCRIPTION
## Summary
- Normalize whitespace in tag names to hyphens during validation and canonicalization
- Updates one-time migration script to also apply this normalization

## Test plan
- [x] Run `bun run lint` — should pass
- [x] Run `bun run db:migrate` to apply migrations
- [x] Run `bun run packages/server/src/lib/migrateExistingTags.ts` to normalize existing tags
- [x] Verify tags with spaces are rejected and stored as hyphenated

🤖 Generated with [Claude Code](https://claude.com/claude-code)