### PR TITLE
feat: search within playlist on detail page

### DIFF
--- a/packages/server/src/routes/playlists.ts
+++ b/packages/server/src/routes/playlists.ts
@@ -1,11 +1,11 @@
-import { and, count, desc, eq, inArray } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, or, sql } from 'drizzle-orm';
 import type { RouteContext } from '../index';
 import { getUserDisplayName } from '../lib/displayName';
 import { json } from '../lib/json';
 import { canAccessPlaylist } from '../lib/playlistAccess';
 import { emitPlaylistUpdated } from '../lib/socket';
 import { validatePlaylistName } from '../lib/validation';
-import { db, tables } from '../shared/db';
+import { $client, db, tables } from '../shared/db';
 
 const { playlist: playlistTable, playlistSong: playlistSongTable } = tables;
 
@@ -169,6 +169,7 @@ async function handleGetPlaylist(
     Math.max(1, parseInt(url.searchParams.get('limit') ?? '30', 10) || 30)
   );
   const skip = (page - 1) * limit;
+  const search = url.searchParams.get('search')?.trim() ?? '';
 
   const playlist = await findPlaylistOr404(id, true);
   if (!playlist) {
@@ -180,26 +181,56 @@ async function handleGetPlaylist(
     return json({ error: accessResult.error }, 403);
   }
 
+  // Build list of song IDs to filter by when searching
+  let songIds: string[] = [];
+  if (search) {
+    const tagMatchingIds = (
+      $client.query(`SELECT id FROM "Song" WHERE lower(tags) LIKE lower(?)`).all(`%${search}%`) as {
+        id: string;
+      }[]
+    ).map((r) => r.id);
+    const where =
+      tagMatchingIds.length > 0
+        ? sql`(lower(title) LIKE lower(${`%${search}%`}) OR lower(nickname) LIKE lower(${`%${search}%`}) OR lower(artist) LIKE lower(${`%${search}%`}) OR lower(album) LIKE lower(${`%${search}%`}) OR id IN (${sql.join(
+            tagMatchingIds.map((id) => sql.raw(`'${id}'`)),
+            sql`,`
+          )}))`
+        : sql`(lower(title) LIKE lower(${`%${search}%`}) OR lower(nickname) LIKE lower(${`%${search}%`}) OR lower(artist) LIKE lower(${`%${search}%`}) OR lower(album) LIKE lower(${`%${search}%`}))`;
+    const matching = await db
+      .select({ id: tables.song.id })
+      .from(tables.song)
+      .where(where)
+      .limit(500);
+    songIds = matching.map((s) => s.id);
+  }
+
   // Fetch paginated songs
+  const whereCondition =
+    songIds.length > 0
+      ? and(eq(playlistSongTable.playlistId, id), inArray(playlistSongTable.songId, songIds))
+      : eq(playlistSongTable.playlistId, id);
+
+  const countCondition =
+    songIds.length > 0
+      ? and(eq(playlistSongTable.playlistId, id), inArray(playlistSongTable.songId, songIds))
+      : eq(playlistSongTable.playlistId, id);
+
   const [playlistSongs, [{ count: total }]] = await Promise.all([
     db
       .select()
       .from(playlistSongTable)
-      .where(eq(playlistSongTable.playlistId, id))
+      .where(whereCondition)
       .orderBy(playlistSongTable.position)
       .limit(limit)
       .offset(skip),
-    db
-      .select({ count: count() })
-      .from(playlistSongTable)
-      .where(eq(playlistSongTable.playlistId, id)),
+    db.select({ count: count() }).from(playlistSongTable).where(countCondition),
   ]);
 
   // Fetch the actual song data for each playlist entry
-  const songIds = playlistSongs.map((ps) => ps.songId);
+  const playlistSongIds = playlistSongs.map((ps) => ps.songId);
   const songs =
-    songIds.length > 0
-      ? await db.select().from(tables.song).where(inArray(tables.song.id, songIds))
+    playlistSongIds.length > 0
+      ? await db.select().from(tables.song).where(inArray(tables.song.id, playlistSongIds))
       : [];
   const songMap = new Map(songs.map((s) => [s.id, s]));
 

--- a/packages/server/src/shared/api.ts
+++ b/packages/server/src/shared/api.ts
@@ -181,10 +181,12 @@ export function fetchPlaylistPage(
   id: string,
   adminView = false,
   page: number,
-  limit = 30
+  limit = 30,
+  search?: string
 ): Promise<PlaylistDetail & { pagination: PaginationMeta }> {
   const params = new URLSearchParams({ page: String(page), limit: String(limit) });
   if (adminView) params.set('adminView', 'true');
+  if (search) params.set('search', search);
   return get(`/api/playlists/${id}?${params}`);
 }
 

--- a/packages/web/src/components/SongEditPanel.tsx
+++ b/packages/web/src/components/SongEditPanel.tsx
@@ -1,8 +1,8 @@
 import type { Song } from '@alfira-bot/server/shared';
 import type { SongUpdateData, TagItem } from '@alfira-bot/server/shared/api';
 import { fetchTags, updateSong } from '@alfira-bot/server/shared/api';
-import { createPortal } from 'react-dom';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { getTagColorClasses } from '../utils/tagColors';
 
 interface SongEditPanelProps {

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -5,6 +5,7 @@ import {
   GhostIcon,
   LockIcon,
   LockOpenIcon,
+  MagnifyingGlassIcon,
   PencilSimple,
   PlayCircleIcon,
   PlayIcon,
@@ -75,6 +76,13 @@ export default function PlaylistDetailPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [isFetching, setIsFetching] = useState(false);
   const [isError, setIsError] = useState(false);
+  const [search, setSearch] = useState('');
+  const searchRef = useRef(search);
+
+  // Keep searchRef in sync with search state
+  useEffect(() => {
+    searchRef.current = search;
+  }, [search]);
 
   // Accumulated songs from all pages
   const [songs, setSongs] = useState<PlaylistDetail['songs']>([]);
@@ -82,7 +90,7 @@ export default function PlaylistDetailPage() {
   // IntersectionObserver ref for sentinel
   const observerRef = useRef<IntersectionObserver | null>(null);
 
-  const loadPage = useCallback(async (page: number, isInitial = false, isRefetch = false) => {
+  const loadPage = useCallback(async (page: number, isInitial = false, isRefetch = false, searchQuery?: string) => {
     if (!idRef.current) return;
 
     if (isInitial) {
@@ -94,7 +102,7 @@ export default function PlaylistDetailPage() {
     setIsError(false);
 
     try {
-      const pl = await getPlaylistPage(idRef.current, isAdminViewRef.current, page, ITEMS_PER_PAGE);
+      const pl = await getPlaylistPage(idRef.current, isAdminViewRef.current, page, ITEMS_PER_PAGE, searchQuery);
 
       if (isInitial) {
         setPlaylistDetail(pl);
@@ -307,11 +315,11 @@ export default function PlaylistDetailPage() {
   const loadMore = useCallback(() => {
     const nextPage = currentPage + 1;
     setCurrentPage(nextPage);
-    void loadPage(nextPage, false);
+    void loadPage(nextPage, false, false, searchRef.current);
   }, [currentPage, loadPage]);
 
   const retry = useCallback(() => {
-    void loadPage(currentPage, false);
+    void loadPage(currentPage, false, false, searchRef.current);
   }, [currentPage, loadPage]);
 
   // IntersectionObserver for infinite scroll
@@ -409,6 +417,30 @@ export default function PlaylistDetailPage() {
               triggerRef={menuTriggerRef}
             />
           )}
+        </div>
+      </div>
+
+      {/* Search */}
+      <div className="flex items-center gap-2 mb-4 md:mb-6">
+        <div className="relative flex-1">
+          <MagnifyingGlassIcon
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-faint w-4 h-4 md:w-3.5 md:h-3.5"
+            weight="duotone"
+          />
+          <input
+            className="input pl-10"
+            placeholder="Search by title, nickname, artist, album, or tag..."
+            value={search}
+            onChange={(e) => {
+              const value = e.target.value;
+              setSearch(value);
+              setCurrentPage(1);
+              setSongs([]);
+              setIsFetching(true);
+              setIsError(false);
+              void loadPage(1, false, false, value);
+            }}
+          />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Adds a search input to the Playlist Detail page that filters songs by title, nickname, artist, album, or tag — the same search behavior as the Songs page, scoped to the current playlist.

## Changes

**Backend** (`packages/server/src/routes/playlists.ts`):
- Parse `search` query param in `GET /api/playlists/:id`
- Match songs via title/nickname/artist/album `LIKE` and JSON tag search (same pattern as Songs endpoint)
- Filter playlist song query to matching song IDs only

**API** (`packages/server/src/shared/api.ts`):
- Add `search` parameter to `fetchPlaylistPage`

**Frontend** (`packages/web/src/pages/PlaylistDetailPage.tsx`):
- Add `search` state and `searchRef` to track and sync search value
- Render search input above the song list (matching SongsPage styling: `flex items-center gap-2`, icon + `input pl-10`)
- On input change: reset pagination, clear songs, refetch with search term

## Test plan

- [x] Navigate to a playlist with songs
- [x] Type a search term — songs should filter in real-time
- [x] Clear search — all songs should return
- [x] Pagination resets correctly when searching

🤖 Generated with [Claude Code](https://claude.com/claude-code)