### PR TITLE
fix(web): search bar filtering not working on SongsPage

### DIFF
--- a/packages/web/src/hooks/useVirtualizedInfiniteScroll.ts
+++ b/packages/web/src/hooks/useVirtualizedInfiniteScroll.ts
@@ -20,7 +20,7 @@ export interface UseInfiniteScrollReturn<T> {
   prepend: (item: T) => void;
   updateItem: (item: T) => void;
   removeItem: (id: string) => void;
-  reset: () => void;
+  reset: (searchQuery?: string) => void;
   retry: () => void;
   sentinelRef: (el: HTMLDivElement | null) => void;
 }
@@ -56,7 +56,7 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[]>({
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally uses deps inside via fetchPageRef; deps changes trigger refetch via useEffect
   const loadPage = useCallback(
-    async (page: number, isInitial = false) => {
+    async (page: number, isInitial = false, searchOverride?: string) => {
       if (isFetchingRef.current) return;
       if (!isInitial && !hasMoreRef.current) return;
 
@@ -67,8 +67,10 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[]>({
       }
       setIsError(false);
 
+      const searchArgs = (searchOverride !== undefined ? [searchOverride] : deps) as A;
+
       try {
-        const result = await fetchPageRef.current(page, limit, ...deps);
+        const result = await fetchPageRef.current(page, limit, ...searchArgs);
         if (!isMountedRef.current) return;
 
         if (isInitial) {
@@ -125,24 +127,27 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[]>({
     setItems((prev) => prev.filter((i) => (i as { id: string }).id !== id));
   }, []);
 
-  const reset = useCallback(() => {
-    setItems([]);
-    pageRef.current = 1;
-    setHasMore(true);
-    setIsError(false);
-    void loadPage(1, true);
-  }, [loadPage]);
+  const reset = useCallback(
+    (searchQuery?: string) => {
+      setItems([]);
+      pageRef.current = 1;
+      setHasMore(true);
+      setIsError(false);
+      void loadPage(1, true, searchQuery);
+    },
+    [loadPage]
+  );
 
   // Initial load
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally depends on deps to refetch on search change; loadPage is stable via ref
   useEffect(() => {
     isMountedRef.current = true;
-    void loadPage(1, true);
+    void loadPage(1, true, deps[0] as string | undefined);
 
     return () => {
       isMountedRef.current = false;
     };
-  }, [...deps]);
+  }, [...deps, loadPage]);
 
   // IntersectionObserver — created once, reads fetchMore via ref so it never goes stale
   const setSentinelRef = useCallback((el: HTMLDivElement | null) => {

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -53,7 +53,6 @@ export default function SongsPage() {
     prepend,
     updateItem,
     removeItem,
-    reset,
     retry,
     sentinelRef,
   } = useVirtualizedInfiniteScroll<Song, [string]>({
@@ -163,10 +162,7 @@ export default function SongsPage() {
             placeholder="Search by title, nickname, artist, album, or tag..."
             value={search}
             onChange={(e) => {
-              startTransition(() => {
-                setSearch(e.target.value);
-                reset();
-              });
+              setSearch(e.target.value);
             }}
           />
         </div>


### PR DESCRIPTION
## Summary

- Fix search bar filtering on SongsPage that was showing all songs instead of filtered results
- Root cause was a stale closure race condition in `useVirtualizedInfiniteScroll`

## Root Cause

When the user typed in the search bar, `reset()` was called in `onChange` which called `loadPage` - but `loadPage` captured the OLD search value from the previous render's closure via `deps`. The `useEffect` dependency mechanism also fired, calling `loadPage` with its own stale closure. The stale fetch often returned AFTER the correct fetch and overwrote the results with unfiltered data.

## Fix

- Removed `reset()` from `onChange` - search now relies solely on the `useEffect` dependency mechanism
- Updated `useEffect` to pass `deps[0]` directly to `loadPage` ensuring it uses the current value, not a stale closure

## Test plan

- [x] Type in the SongsPage search bar and verify results are filtered correctly
- [x] Verify infinite scroll still works correctly after search
- [x] Verify total count updates correctly based on filtered results

🤖 Generated with [Claude Code](https://claude.com/claude-code)