### PR TITLE
fix(web): flush tag state before save to prevent race condition

### DIFF
--- a/packages/web/src/components/SongEditPanel.tsx
+++ b/packages/web/src/components/SongEditPanel.tsx
@@ -2,7 +2,7 @@ import type { Song } from '@alfira-bot/server/shared';
 import type { SongUpdateData, TagItem } from '@alfira-bot/server/shared/api';
 import { fetchTags, updateSong } from '@alfira-bot/server/shared/api';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
+import { createPortal, flushSync } from 'react-dom';
 import { useTagColors } from '../context/TagsContext';
 import { getTagColorClasses } from '../utils/tagColors';
 
@@ -307,7 +307,9 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
                   highlightedIndex={highlightedIndex}
                   onToggle={(tag) => {
                     if (tags.includes(tag)) removeTag(tag);
-                    else setTags((prev) => [...prev, tag]);
+                    else {
+                      flushSync(() => setTags((prev) => [...prev, tag]));
+                    }
                   }}
                   onHighlight={setHighlightedIndex}
                   onClose={() => {


### PR DESCRIPTION
## Summary

- Fixed tag autocomplete save bug where clicking a tag in the dropdown and closing the panel would not persist the tag
- Root cause: React state updates were not flushed before the `isOpen` effect ran, causing `fieldsRef.current().tags` to read stale values
- Fix: Use `flushSync` in `onToggle` to synchronously commit the state update before `onToggle` returns

## Test plan

- [x] Open a song's edit panel
- [x] Click in the tags field to show autocomplete dropdown
- [x] Click a tag to add it — verify dropdown closes but panel stays open
- [x] Close the song edit panel — verify the tag appears on the song after
- [x] Test removing a tag via autocomplete click — verify removal persists after close

🤖 Generated with [Claude Code](https://claude.com/claude-code)