### PR TITLE
feat(server): rework volume system to use NodeLink volume param

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -137,3 +137,6 @@ DISCORD_REDIRECT_URI=https://alfira.example.com/auth/callback
 
 - [Installation Guide](installation.md) — Setting up Alfira
 - [Troubleshooting](troubleshooting.md) — Common issues and solutions
+
+---
+

--- a/packages/server/src/GuildPlayer.ts
+++ b/packages/server/src/GuildPlayer.ts
@@ -269,6 +269,25 @@ export class GuildPlayer {
     return this.currentSong;
   }
 
+  /**
+   * Update volume of the currently-playing track without restarting it.
+   * Does nothing if no track is currently playing.
+   */
+  public updateVolumeBoost(boost: number): void {
+    const hoshimi = getHoshimi();
+    if (!hoshimi) return;
+    const hoshimiPlayer = hoshimi.players.get(this.guildId);
+    if (!hoshimiPlayer || !this.currentSong) return;
+    // Use NodeLink REST API directly to bypass Hoshimi's volume filter
+    // NodeLink volume: 0-1000 where 100 = 100%. finalVolume = 100 + boost
+    const node = hoshimiPlayer.node;
+    if (!node) return;
+    node.rest.updatePlayer({
+      guildId: this.guildId,
+      playerOptions: { volume: 100 + boost },
+    });
+  }
+
   getQueue(): QueuedSong[] {
     return this.queue.toRemaining();
   }
@@ -409,10 +428,7 @@ export class GuildPlayer {
     }
 
     // Apply volume via NodeLink volume filter.
-    const volume =
-      next.volumeOffset != null && next.volumeOffset !== 0
-        ? 10 ** (next.volumeOffset / 20) * 100
-        : 100;
+    const volume = 100 + (next.volumeBoost ?? 0);
 
     await player.play({
       track: new Track(

--- a/packages/server/src/lib/validation.ts
+++ b/packages/server/src/lib/validation.ts
@@ -193,13 +193,13 @@ export function validateTags(value: unknown): ValidationResult<string[]> {
 }
 
 /**
- * Validates an optional volume offset in dB.
+ * Validates an optional volume boost (0–200).
  * Returns `undefined` when absent (PATCH skips it),
  * `null` when explicitly cleared,
- * the integer when valid (-12 to +12),
+ * the integer when valid (0 to 100),
  * error Response when invalid.
  */
-export function validateVolumeOffset(
+export function validateVolumeBoost(
   value: unknown
 ): { ok: true; value: number | null | undefined } | { ok: false; response: Response } {
   if (value === undefined) return { ok: true, value: undefined };
@@ -207,13 +207,13 @@ export function validateVolumeOffset(
   if (typeof value !== 'number' || !Number.isInteger(value)) {
     return {
       ok: false,
-      response: json({ error: 'volumeOffset must be an integer.' }, 400),
+      response: json({ error: 'volumeBoost must be an integer.' }, 400),
     };
   }
-  if (value < -12 || value > 12) {
+  if (value < 0 || value > 200) {
     return {
       ok: false,
-      response: json({ error: 'volumeOffset must be between -12 and +12.' }, 400),
+      response: json({ error: 'volumeBoost must be between 0 and 200.' }, 400),
     };
   }
   return { ok: true, value };

--- a/packages/server/src/routes/songs.ts
+++ b/packages/server/src/routes/songs.ts
@@ -1,5 +1,6 @@
 import { eq, inArray, or, sql } from 'drizzle-orm';
 import type { RouteContext } from '../index';
+import { GUILD_ID } from '../lib/config';
 import { getUserDisplayName } from '../lib/displayName';
 import { json } from '../lib/json';
 import { formatSong } from '../lib/serialization';
@@ -13,12 +14,13 @@ import {
   validateNickname,
   validateOptionalString,
   validateTags,
-  validateVolumeOffset,
+  validateVolumeBoost,
   validateYouTubePlaylistUrl,
   validateYouTubeUrl,
   youTubeUrl,
 } from '../lib/validation';
 import { $client, db, tables } from '../shared/db';
+import { getPlayer } from '../startDiscord';
 
 const { song: songTable } = tables;
 
@@ -369,11 +371,11 @@ async function handlePatchSong(ctx: RouteContext, request: Request, id: string):
     data.tags = await canonicalizeTags(tagsResult.value);
   }
 
-  // Volume offset
-  if ('volumeOffset' in body) {
-    const volumeResult = validateVolumeOffset(body.volumeOffset);
+  // Volume boost
+  if ('volumeBoost' in body) {
+    const volumeResult = validateVolumeBoost(body.volumeBoost);
     if (!volumeResult.ok) return volumeResult.response;
-    data.volumeOffset = volumeResult.value;
+    data.volumeBoost = volumeResult.value;
   }
 
   const [updatedSong] = await db
@@ -383,6 +385,16 @@ async function handlePatchSong(ctx: RouteContext, request: Request, id: string):
     .returning();
 
   emitSongUpdated(formatSong(updatedSong));
+
+  // If this song is currently playing, update volume live without restarting
+  const player = getPlayer(GUILD_ID);
+  if (player && data.volumeBoost !== undefined) {
+    const currentSong = player.getCurrentSong();
+    if (currentSong?.id === id) {
+      player.updateVolumeBoost(data.volumeBoost as number);
+    }
+  }
+
   return json(formatSong(updatedSong));
 }
 

--- a/packages/server/src/shared/api.ts
+++ b/packages/server/src/shared/api.ts
@@ -133,7 +133,7 @@ export interface SongUpdateData {
   album?: string | null;
   artwork?: string | null;
   tags?: string[];
-  volumeOffset?: number | null;
+  volumeBoost?: number | null;
 }
 
 /**

--- a/packages/server/src/shared/db/migrations/0050_volume_boost.sql
+++ b/packages/server/src/shared/db/migrations/0050_volume_boost.sql
@@ -1,0 +1,5 @@
+-- Add new volumeBoost column
+ALTER TABLE "Song" ADD COLUMN "volumeBoost" integer;
+
+-- Drop old volumeOffset column (data discarded per design decision)
+ALTER TABLE "Song" DROP COLUMN "volumeOffset";

--- a/packages/server/src/shared/db/schema.ts
+++ b/packages/server/src/shared/db/schema.ts
@@ -16,7 +16,7 @@ export const song = sqliteTable('Song', {
   album: text('album'),
   artwork: text('artwork'),
   tags: text('tags', { mode: 'json' }).$type<string[]>().notNull().default([]),
-  volumeOffset: integer('volumeOffset'),
+  volumeBoost: integer('volumeBoost'),
   createdAt: integer('createdAt', { mode: 'timestamp_ms' })
     .notNull()
     .$defaultFn(() => new Date()),

--- a/packages/server/src/shared/types.ts
+++ b/packages/server/src/shared/types.ts
@@ -26,7 +26,7 @@ export interface Song {
   album?: string | null;
   artwork?: string | null;
   tags?: string[];
-  volumeOffset?: number | null;
+  volumeBoost?: number | null;
   createdAt: string; // ISO 8601 string (JSON wire format)
 }
 

--- a/packages/web/src/components/SongCard.tsx
+++ b/packages/web/src/components/SongCard.tsx
@@ -80,13 +80,9 @@ const SongCardInner = ({
           <span className="font-mono text-[10px] text-white/80 bg-black/50 px-1.5 py-0.5 rounded">
             {formatDuration(song.duration)}
           </span>
-          {song.volumeOffset != null && song.volumeOffset !== 0 && (
-            <span
-              className="flex items-center gap-0.5 text-[10px]"
-              style={{ color: song.volumeOffset > 0 ? '#22c55e' : '#eab308' }}
-            >
-              {song.volumeOffset > 0 ? '+' : '-'}
-              {Math.abs(song.volumeOffset)} dB
+          {song.volumeBoost != null && song.volumeBoost > 0 && (
+            <span className="flex items-center gap-0.5 text-[10px]" style={{ color: '#22c55e' }}>
+              +{song.volumeBoost}%
               <HeadphonesIcon size={11} weight="fill" />
             </span>
           )}

--- a/packages/web/src/components/SongEditPanel.tsx
+++ b/packages/web/src/components/SongEditPanel.tsx
@@ -43,8 +43,8 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
   const [artwork, setArtwork] = useState(songExtended.artwork ?? '');
   const [tags, setTags] = useState<string[]>(songExtended.tags ?? []);
   const [tagInput, setTagInput] = useState('');
-  const [volumeOffset, setVolumeOffset] = useState(
-    songExtended.volumeOffset != null ? String(songExtended.volumeOffset) : ''
+  const [volumeBoost, setVolumeBoost] = useState(
+    songExtended.volumeBoost != null ? String(songExtended.volumeBoost) : ''
   );
   const [showTagDropdown, setShowTagDropdown] = useState(false);
   const [availableTags, setAvailableTags] = useState<TagItem[]>([]);
@@ -57,8 +57,8 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
   // Refs for save logic so we don't recreate handlers on every render
   const songIdRef = useRef(song.id);
   songIdRef.current = song.id;
-  const fieldsRef = useRef(() => ({ nickname, artist, album, artwork, tags, volumeOffset }));
-  fieldsRef.current = () => ({ nickname, artist, album, artwork, tags, volumeOffset });
+  const fieldsRef = useRef(() => ({ nickname, artist, album, artwork, tags, volumeBoost }));
+  fieldsRef.current = () => ({ nickname, artist, album, artwork, tags, volumeBoost });
   const originalNicknameRef = useRef<string | null>(songExtended.nickname ?? null);
   originalNicknameRef.current = songExtended.nickname ?? null;
   const originalArtistRef = useRef<string | null>(songExtended.artist ?? null);
@@ -69,8 +69,8 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
   originalArtworkRef.current = songExtended.artwork ?? null;
   const originalTagsRef = useRef<string[]>(songExtended.tags ?? []);
   originalTagsRef.current = songExtended.tags ?? [];
-  const originalVolumeOffsetRef = useRef<number | null>(songExtended.volumeOffset ?? null);
-  originalVolumeOffsetRef.current = songExtended.volumeOffset ?? null;
+  const originalVolumeBoostRef = useRef<number | null>(songExtended.volumeBoost ?? null);
+  originalVolumeBoostRef.current = songExtended.volumeBoost ?? null;
   const savingRef = useRef(false);
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
@@ -142,9 +142,9 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
         album: al,
         artwork: aw,
         tags: t,
-        volumeOffset: vo,
+        volumeBoost: vo,
       } = fieldsRef.current();
-      const parsedOffset = vo.trim() === '' ? null : parseInt(vo.trim(), 10);
+      const parsedBoost = vo.trim() === '' ? null : parseInt(vo.trim(), 10);
 
       // Build a partial update — only include fields that actually changed.
       // This prevents concurrent edits from clobbering each other (last-write-wins).
@@ -154,8 +154,8 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
       if (al !== (originalAlbumRef.current ?? '')) data.album = al.trim() || null;
       if (aw !== (originalArtworkRef.current ?? '')) data.artwork = aw.trim() || null;
       if (JSON.stringify(t) !== JSON.stringify(originalTagsRef.current)) data.tags = t;
-      if (parsedOffset !== originalVolumeOffsetRef.current)
-        data.volumeOffset = Number.isNaN(parsedOffset) ? null : parsedOffset;
+      if (parsedBoost !== originalVolumeBoostRef.current)
+        data.volumeBoost = Number.isNaN(parsedBoost) ? null : parsedBoost;
 
       // Skip if nothing changed
       if (Object.keys(data).length === 0) {
@@ -179,9 +179,9 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
         album: al,
         artwork: aw,
         tags: t,
-        volumeOffset: vo,
+        volumeBoost: vo,
       } = fieldsRef.current();
-      const parsedOffset = vo.trim() === '' ? null : parseInt(vo.trim(), 10);
+      const parsedBoost = vo.trim() === '' ? null : parseInt(vo.trim(), 10);
 
       const data: SongUpdateData = {};
       if (nk !== (originalNicknameRef.current ?? '')) data.nickname = nk.trim() || null;
@@ -189,8 +189,8 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
       if (al !== (originalAlbumRef.current ?? '')) data.album = al.trim() || null;
       if (aw !== (originalArtworkRef.current ?? '')) data.artwork = aw.trim() || null;
       if (JSON.stringify(t) !== JSON.stringify(originalTagsRef.current)) data.tags = t;
-      if (parsedOffset !== originalVolumeOffsetRef.current)
-        data.volumeOffset = Number.isNaN(parsedOffset) ? null : parsedOffset;
+      if (parsedBoost !== originalVolumeBoostRef.current)
+        data.volumeBoost = Number.isNaN(parsedBoost) ? null : parsedBoost;
 
       if (Object.keys(data).length > 0) {
         void doSave();
@@ -324,10 +324,10 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
           </div>
 
           <VolumeSlider
-            value={volumeOffset}
-            onChange={setVolumeOffset}
-            min={-12}
-            max={12}
+            value={volumeBoost}
+            onChange={setVolumeBoost}
+            min={0}
+            max={200}
             onKeyDown={(e) => {
               if (e.key === 'Enter') void doSave();
             }}
@@ -356,16 +356,16 @@ function VolumeSlider({
 
   return (
     <div>
-      <span className="block font-mono text-[10px] text-muted uppercase mb-1">Volume Offset</span>
+      <span className="block font-mono text-[10px] text-muted uppercase mb-1">Volume Boost</span>
       <div className="flex items-center gap-3">
         <input
-          id="panel-volume-offset"
+          id="panel-volume-boost"
           className="input text-sm w-16 text-center"
           type="text"
           value={value}
           onChange={(e) => {
             const v = e.target.value;
-            if (v === '' || /^-?\d*$/.test(v)) onChange(v);
+            if (v === '' || /^\d*$/.test(v)) onChange(v);
           }}
           onKeyDown={onKeyDown}
           onBlur={() => {
@@ -379,7 +379,7 @@ function VolumeSlider({
             }
           }}
         />
-        <span className="text-xs text-muted font-mono w-8 text-left">dB</span>
+        <span className="text-xs text-muted font-mono w-8 text-left">%</span>
         <input
           type="range"
           min={min}

--- a/packages/web/src/components/SongRow.tsx
+++ b/packages/web/src/components/SongRow.tsx
@@ -31,13 +31,9 @@ function MetaInfo({ song, isHovered }: MetaInfoProps) {
         {formatDuration(song.duration)}
         <ClockIcon size={11} weight="fill" className="shrink-0" />
       </span>
-      {song.volumeOffset != null && song.volumeOffset !== 0 && (
-        <span
-          className="flex items-center gap-0.5 text-xs"
-          style={{ color: song.volumeOffset > 0 ? '#22c55e' : '#eab308' }}
-        >
-          {song.volumeOffset > 0 ? '+' : '-'}
-          {Math.abs(song.volumeOffset)} dB
+      {song.volumeBoost != null && song.volumeBoost > 0 && (
+        <span className="flex items-center gap-0.5 text-xs" style={{ color: '#22c55e' }}>
+          +{song.volumeBoost}%
           <HeadphonesIcon size={11} weight="fill" className="shrink-0" />
         </span>
       )}


### PR DESCRIPTION
## Summary

- Rename `volumeOffset` (dB, -12/+12) to `volumeBoost` (percentage, 0-200)
- Volume formula: `finalVolume = 100 + boost` (NodeLink 0-1000 scale, 100 = 100%)
- Add `updateVolumeBoost()` for live volume changes mid-playback via NodeLink REST API (bypasses Hoshimi's broken LavaLink-style volume filter)
- UI: slider 0-200, badge shows `+X%` instead of `±XdB`

## Test plan

- [x] Play a song, set volume boost to 50 in edit panel — badge shows `+50%`
- [x] While song is playing, change boost to 100 — volume updates immediately without restart
- [x] Verify playback still works normally with boost=0
- [x] Test edge cases: null boost (default), max boost 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)