### PR TITLE
refactor(web): redesign Color Theme selector as palette UI

### DIFF
--- a/packages/web/src/components/settings/AppearanceTab.tsx
+++ b/packages/web/src/components/settings/AppearanceTab.tsx
@@ -61,26 +61,35 @@ export default function AppearanceTab() {
       {/* Color Theme Selector */}
       <div className="space-y-2">
         <h3 className="font-mono text-[11px] text-muted uppercase tracking-wider">Color Theme</h3>
-        <div className="grid grid-cols-3 gap-2">
-          {colorThemes.map((t) => (
-            <Button
-              key={t.name}
-              variant="inherit"
-              surface="base"
-              className={`flex items-center gap-2 ${colorTheme === t.name ? 'pressed' : ''}`}
-              onClick={() => setColorTheme(t.name)}
-            >
-              <span
-                className="w-3 h-3 rounded-full shrink-0"
-                style={{ backgroundColor: t.accentColor }}
-              />
-              <span className="truncate">{t.displayName}</span>
-            </Button>
-          ))}
+        <div className="flex flex-wrap gap-2">
+          {colorThemes.map((t) => {
+            const isSelected = colorTheme === t.name;
+            return (
+              <button
+                key={t.name}
+                type="button"
+                onClick={() => setColorTheme(t.name)}
+                className={`flex flex-col items-center gap-1.5 p-1 rounded-lg transition-opacity ${
+                  isSelected ? 'opacity-100' : 'opacity-60 hover:opacity-80'
+                }`}
+              >
+                <span
+                  className={`w-12 h-12 rounded-full flex items-center justify-center ${
+                    isSelected ? 'ring-2 ring-offset-2 ring-offset-background ring-foreground' : ''
+                  }`}
+                  style={{ backgroundColor: t.accentColor }}
+                >
+                  {isSelected ? (
+                    <svg className="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 12 12" aria-hidden="true">
+                      <path d="M10.28 2.28L4.5 8.06l-2.78-2.79a.5.5 0 0 0-.71.71l3.15 3.15a.5.5 0 0 0 .71 0l6.36-6.36a.5.5 0 0 0 0-.71.5.5 0 0 0-.71 0z" />
+                    </svg>
+                  ) : null}
+                </span>
+                <span className="text-xs text-muted leading-none">{t.displayName}</span>
+              </button>
+            );
+          })}
         </div>
-        <p className="text-xs text-faint">
-          {colorThemes.find((t) => t.name === colorTheme)?.description}
-        </p>
       </div>
     </div>
   );

--- a/packages/web/src/context/ThemeContext.tsx
+++ b/packages/web/src/context/ThemeContext.tsx
@@ -22,7 +22,6 @@ export type ColorMode = 'light' | 'dark' | 'auto';
 export interface ColorTheme {
   name: ColorThemeName;
   displayName: string;
-  description: string;
   accentColor: string; // Preview color for UI
 }
 
@@ -30,79 +29,66 @@ export const COLOR_THEMES: ColorTheme[] = [
   {
     name: 'artificer',
     displayName: 'Artificer',
-    description: 'Ingenuity and invention',
     accentColor: '#f97316', // Orange
   },
   {
     name: 'barbarian',
     displayName: 'Barbarian',
-    description: 'Rage and fury',
     accentColor: '#dc2626', // Red
   },
   {
     name: 'bard',
     displayName: 'Bard',
-    description: 'Performance and charisma',
     accentColor: '#ec4899', // Magenta/Pink
   },
   {
     name: 'cleric',
     displayName: 'Cleric',
-    description: 'Divine light',
     accentColor: '#eab308', // Gold/Yellow
   },
   {
     name: 'druid',
     displayName: 'Druid',
-    description: 'Nature and wilderness',
     accentColor: '#fb7185', // Rose
   },
   {
     name: 'fighter',
     displayName: 'Fighter',
-    description: 'Steel and resolve',
     accentColor: '#64748b', // Slate
   },
   {
     name: 'monk',
     displayName: 'Monk',
-    description: 'Discipline and harmony',
     accentColor: '#14b8a6', // Cyan/Teal
   },
   {
     name: 'paladin',
     displayName: 'Paladin',
-    description: 'Holy warrior',
     accentColor: '#cbd5e1', // Silver
   },
   {
     name: 'ranger',
     displayName: 'Ranger',
-    description: 'Wilderness tracker',
     accentColor: '#15803d', // Forest Green
   },
   {
     name: 'rogue',
     displayName: 'Rogue',
-    description: 'Shadows and stealth',
     accentColor: '#6366f1', // Indigo
   },
   {
     name: 'sorcerer',
     displayName: 'Sorcerer',
-    description: 'Innate magic',
     accentColor: '#e11d48', // Crimson
   },
   {
     name: 'warlock',
     displayName: 'Warlock',
-    description: 'Eldritch pact',
     accentColor: '#a855f7', // Dark Purple
   },
   {
     name: 'wizard',
     displayName: 'Wizard',
-    description: 'Arcane knowledge',
     accentColor: '#3b82f6', // Deep Blue
   },
 ];


### PR DESCRIPTION
## Summary

- Replace Color Theme buttons with palette-style circular swatches showing theme name below each color
- Remove unused `description` field from theme definitions
- Add `aria-hidden` to decorative SVG for accessibility

## Changes

- `packages/web/src/components/settings/AppearanceTab.tsx` — Redesigned color theme selector UI
- `packages/web/src/context/ThemeContext.tsx` — Removed `description` from interface and all theme entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)