### PR TITLE
feat: add 15-band equalizer to Audio settings tab

### DIFF
--- a/packages/server/src/GuildPlayer.ts
+++ b/packages/server/src/GuildPlayer.ts
@@ -540,9 +540,21 @@ export class GuildPlayer {
     // Apply equalizer filter if any band is non-neutral
     const eqBands = settings
       ? [
-          settings.eqBand0, settings.eqBand1, settings.eqBand2, settings.eqBand3, settings.eqBand4,
-          settings.eqBand5, settings.eqBand6, settings.eqBand7, settings.eqBand8, settings.eqBand9,
-          settings.eqBand10, settings.eqBand11, settings.eqBand12, settings.eqBand13, settings.eqBand14,
+          settings.eqBand0,
+          settings.eqBand1,
+          settings.eqBand2,
+          settings.eqBand3,
+          settings.eqBand4,
+          settings.eqBand5,
+          settings.eqBand6,
+          settings.eqBand7,
+          settings.eqBand8,
+          settings.eqBand9,
+          settings.eqBand10,
+          settings.eqBand11,
+          settings.eqBand12,
+          settings.eqBand13,
+          settings.eqBand14,
         ]
       : Array(15).fill(50);
 

--- a/packages/server/src/GuildPlayer.ts
+++ b/packages/server/src/GuildPlayer.ts
@@ -489,6 +489,21 @@ export class GuildPlayer {
         attack: tables.guildSettings.compressorAttack,
         release: tables.guildSettings.compressorRelease,
         gain: tables.guildSettings.compressorGain,
+        eqBand0: tables.guildSettings.eqBand0,
+        eqBand1: tables.guildSettings.eqBand1,
+        eqBand2: tables.guildSettings.eqBand2,
+        eqBand3: tables.guildSettings.eqBand3,
+        eqBand4: tables.guildSettings.eqBand4,
+        eqBand5: tables.guildSettings.eqBand5,
+        eqBand6: tables.guildSettings.eqBand6,
+        eqBand7: tables.guildSettings.eqBand7,
+        eqBand8: tables.guildSettings.eqBand8,
+        eqBand9: tables.guildSettings.eqBand9,
+        eqBand10: tables.guildSettings.eqBand10,
+        eqBand11: tables.guildSettings.eqBand11,
+        eqBand12: tables.guildSettings.eqBand12,
+        eqBand13: tables.guildSettings.eqBand13,
+        eqBand14: tables.guildSettings.eqBand14,
       })
       .from(tables.guildSettings)
       .where(eq(tables.guildSettings.id, 1))
@@ -517,6 +532,42 @@ export class GuildPlayer {
           logger.error(
             { err, guildId: this.guildId },
             'Failed to apply compressor filter on playback start'
+          );
+        }
+      }
+    }
+
+    // Apply equalizer filter if any band is non-neutral
+    const eqBands = settings
+      ? [
+          settings.eqBand0, settings.eqBand1, settings.eqBand2, settings.eqBand3, settings.eqBand4,
+          settings.eqBand5, settings.eqBand6, settings.eqBand7, settings.eqBand8, settings.eqBand9,
+          settings.eqBand10, settings.eqBand11, settings.eqBand12, settings.eqBand13, settings.eqBand14,
+        ]
+      : Array(15).fill(50);
+
+    const hasNonFlatEq = eqBands.some((b) => b !== 50);
+
+    if (hasNonFlatEq) {
+      const node = player.node;
+      if (node) {
+        try {
+          const equalizerFilter = eqBands.map((value, index) => ({
+            band: index,
+            gain: (value - 50) / 100,
+          }));
+          await node.rest.updatePlayer({
+            guildId: this.guildId,
+            playerOptions: {
+              filters: {
+                equalizer: equalizerFilter,
+              },
+            },
+          } as Parameters<typeof node.rest.updatePlayer>[0]);
+        } catch (err) {
+          logger.error(
+            { err, guildId: this.guildId },
+            'Failed to apply equalizer filter on playback start'
           );
         }
       }

--- a/packages/server/src/GuildPlayer.ts
+++ b/packages/server/src/GuildPlayer.ts
@@ -546,30 +546,26 @@ export class GuildPlayer {
         ]
       : Array(15).fill(50);
 
-    const hasNonFlatEq = eqBands.some((b) => b !== 50);
-
-    if (hasNonFlatEq) {
-      const node = player.node;
-      if (node) {
-        try {
-          const equalizerFilter = eqBands.map((value, index) => ({
-            band: index,
-            gain: (value - 50) / 100,
-          }));
-          await node.rest.updatePlayer({
-            guildId: this.guildId,
-            playerOptions: {
-              filters: {
-                equalizer: equalizerFilter,
-              },
+    const node = player.node;
+    if (node && eqBands.some((b) => b !== 50)) {
+      try {
+        const equalizerFilter = eqBands.map((value, index) => ({
+          band: index,
+          gain: (value - 50) / 100,
+        }));
+        await node.rest.updatePlayer({
+          guildId: this.guildId,
+          playerOptions: {
+            filters: {
+              equalizer: equalizerFilter,
             },
-          } as Parameters<typeof node.rest.updatePlayer>[0]);
-        } catch (err) {
-          logger.error(
-            { err, guildId: this.guildId },
-            'Failed to apply equalizer filter on playback start'
-          );
-        }
+          },
+        } as Parameters<typeof node.rest.updatePlayer>[0]);
+      } catch (err) {
+        logger.error(
+          { err, guildId: this.guildId },
+          'Failed to apply equalizer filter on playback start'
+        );
       }
     }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -11,6 +11,7 @@ import { closeAllClients, registerClient, unregisterClient } from './lib/socket'
 import { verifySessionToken } from './middleware/requireAuth';
 import { handleAuth } from './routes/auth';
 import { handleCompressor } from './routes/compressor';
+import { handleEqualizerGet, handleEqualizerPatch } from './routes/equalizer';
 import { handlePlayer } from './routes/player';
 import { handlePlaylists } from './routes/playlists';
 import { handleSongs } from './routes/songs';
@@ -186,6 +187,11 @@ const server = Bun.serve({
     }
     if (url.pathname.startsWith('/api/settings/compressor')) {
       return setSecurityHeaders(await handleCompressor(ctx, request));
+    }
+    if (url.pathname.startsWith('/api/settings/equalizer')) {
+      if (request.method === 'GET') return setSecurityHeaders(await handleEqualizerGet(ctx));
+      if (request.method === 'PATCH')
+        return setSecurityHeaders(await handleEqualizerPatch(ctx, request));
     }
     if (url.pathname.startsWith('/auth')) {
       return setSecurityHeaders(await handleAuth(ctx, request));

--- a/packages/server/src/routes/equalizer.ts
+++ b/packages/server/src/routes/equalizer.ts
@@ -11,7 +11,6 @@ interface EqualizerPayload {
 
 // Build NodeLink equalizer filter array from band values (0-100)
 // Maps: 0→-0.5, 50→0.0 (neutral/flat), 100→0.5
-// NodeLink gain range is -0.25 to 1.0, but 50=neutral means 0 gain
 function buildEqualizerFilter(bands: number[]) {
   return bands.map((value, index) => ({
     band: index,
@@ -135,7 +134,9 @@ export async function handleEqualizerPatch(ctx: RouteContext, request: Request):
 
   // Apply to live NodeLink player if connected
   const guildId = process.env.GUILD_ID ?? '';
-  if (guildId) {
+  if (!guildId) {
+    logger.warn('GUILD_ID not set, skipping NodeLink equalizer filter update');
+  } else {
     const hoshimi = getHoshimi();
     if (hoshimi) {
       const player = hoshimi.players.get(guildId);

--- a/packages/server/src/routes/equalizer.ts
+++ b/packages/server/src/routes/equalizer.ts
@@ -1,0 +1,154 @@
+import { eq } from 'drizzle-orm';
+import type { RouteContext } from '../index';
+import { json } from '../lib/json';
+import { db, tables } from '../shared/db';
+import { logger } from '../shared/logger';
+import { getHoshimi } from '../startDiscord';
+
+interface EqualizerPayload {
+  bands: number[]; // length 15, each 0-100
+}
+
+// Build NodeLink equalizer filter array from band values (0-100 → -0.25 to 1.0)
+function buildEqualizerFilter(bands: number[]) {
+  return bands.map((value, index) => ({
+    band: index,
+    gain: (value - 50) / 100,
+  }));
+}
+
+export async function handleEqualizerGet(ctx: RouteContext): Promise<Response> {
+  if (!ctx.isAdmin) return json({ error: 'Admin access required.' }, 403);
+
+  const row = await db
+    .select({
+      eqBand0: tables.guildSettings.eqBand0,
+      eqBand1: tables.guildSettings.eqBand1,
+      eqBand2: tables.guildSettings.eqBand2,
+      eqBand3: tables.guildSettings.eqBand3,
+      eqBand4: tables.guildSettings.eqBand4,
+      eqBand5: tables.guildSettings.eqBand5,
+      eqBand6: tables.guildSettings.eqBand6,
+      eqBand7: tables.guildSettings.eqBand7,
+      eqBand8: tables.guildSettings.eqBand8,
+      eqBand9: tables.guildSettings.eqBand9,
+      eqBand10: tables.guildSettings.eqBand10,
+      eqBand11: tables.guildSettings.eqBand11,
+      eqBand12: tables.guildSettings.eqBand12,
+      eqBand13: tables.guildSettings.eqBand13,
+      eqBand14: tables.guildSettings.eqBand14,
+    })
+    .from(tables.guildSettings)
+    .where(eq(tables.guildSettings.id, 1))
+    .get();
+
+  const bands = row
+    ? [
+        row.eqBand0,
+        row.eqBand1,
+        row.eqBand2,
+        row.eqBand3,
+        row.eqBand4,
+        row.eqBand5,
+        row.eqBand6,
+        row.eqBand7,
+        row.eqBand8,
+        row.eqBand9,
+        row.eqBand10,
+        row.eqBand11,
+        row.eqBand12,
+        row.eqBand13,
+        row.eqBand14,
+      ]
+    : Array(15).fill(50);
+
+  return json({ bands });
+}
+
+export async function handleEqualizerPatch(ctx: RouteContext, request: Request): Promise<Response> {
+  if (!ctx.isAdmin) return json({ error: 'Admin access required.' }, 403);
+
+  let body: EqualizerPayload;
+  try {
+    body = (await request.json()) as EqualizerPayload;
+  } catch {
+    return json({ error: 'Invalid JSON' }, 400);
+  }
+
+  const { bands } = body;
+
+  // Validate: must be array of 15 integers, each 0-100
+  if (!Array.isArray(bands) || bands.length !== 15) {
+    return json({ error: 'bands must be array of 15 integers' }, 400);
+  }
+  for (let i = 0; i < 15; i++) {
+    const v = bands[i];
+    if (!Number.isInteger(v) || v < 0 || v > 100) {
+      return json({ error: `band[${i}] must be integer 0-100` }, 400);
+    }
+  }
+
+  // Upsert into DB
+  await db
+    .insert(tables.guildSettings)
+    .values({
+      id: 1,
+      eqBand0: bands[0],
+      eqBand1: bands[1],
+      eqBand2: bands[2],
+      eqBand3: bands[3],
+      eqBand4: bands[4],
+      eqBand5: bands[5],
+      eqBand6: bands[6],
+      eqBand7: bands[7],
+      eqBand8: bands[8],
+      eqBand9: bands[9],
+      eqBand10: bands[10],
+      eqBand11: bands[11],
+      eqBand12: bands[12],
+      eqBand13: bands[13],
+      eqBand14: bands[14],
+    })
+    .onConflictDoUpdate({
+      target: tables.guildSettings.id,
+      set: {
+        eqBand0: bands[0],
+        eqBand1: bands[1],
+        eqBand2: bands[2],
+        eqBand3: bands[3],
+        eqBand4: bands[4],
+        eqBand5: bands[5],
+        eqBand6: bands[6],
+        eqBand7: bands[7],
+        eqBand8: bands[8],
+        eqBand9: bands[9],
+        eqBand10: bands[10],
+        eqBand11: bands[11],
+        eqBand12: bands[12],
+        eqBand13: bands[13],
+        eqBand14: bands[14],
+      },
+    })
+    .run();
+
+  // Apply to live NodeLink player if connected
+  const guildId = process.env.GUILD_ID ?? '';
+  if (guildId) {
+    const hoshimi = getHoshimi();
+    if (hoshimi) {
+      const player = hoshimi.players.get(guildId);
+      if (player?.connected) {
+        try {
+          await player.node.rest.updatePlayer({
+            guildId,
+            playerOptions: { filters: { equalizer: buildEqualizerFilter(bands) } },
+          });
+        } catch (err) {
+          logger.error({ err }, 'Failed to update NodeLink equalizer filter');
+        }
+      }
+    }
+  }
+
+  return json({ bands });
+}

--- a/packages/server/src/routes/equalizer.ts
+++ b/packages/server/src/routes/equalizer.ts
@@ -9,7 +9,9 @@ interface EqualizerPayload {
   bands: number[]; // length 15, each 0-100
 }
 
-// Build NodeLink equalizer filter array from band values (0-100 → -0.25 to 1.0)
+// Build NodeLink equalizer filter array from band values (0-100)
+// Maps: 0→-0.5, 50→0.0 (neutral/flat), 100→0.5
+// NodeLink gain range is -0.25 to 1.0, but 50=neutral means 0 gain
 function buildEqualizerFilter(bands: number[]) {
   return bands.map((value, index) => ({
     band: index,

--- a/packages/server/src/shared/db/migrations/0052_add_eq_bands.sql
+++ b/packages/server/src/shared/db/migrations/0052_add_eq_bands.sql
@@ -1,0 +1,15 @@
+ALTER TABLE "guildSettings" ADD COLUMN "eqBand0" integer NOT NULL DEFAULT 50;
+ALTER TABLE "guildSettings" ADD COLUMN "eqBand1" integer NOT NULL DEFAULT 50;
+ALTER TABLE "guildSettings" ADD COLUMN "eqBand2" integer NOT NULL DEFAULT 50;
+ALTER TABLE "guildSettings" ADD COLUMN "eqBand3" integer NOT NULL DEFAULT 50;
+ALTER TABLE "guildSettings" ADD COLUMN "eqBand4" integer NOT NULL DEFAULT 50;
+ALTER TABLE "guildSettings" ADD COLUMN "eqBand5" integer NOT NULL DEFAULT 50;
+ALTER TABLE "guildSettings" ADD COLUMN "eqBand6" integer NOT NULL DEFAULT 50;
+ALTER TABLE "guildSettings" ADD COLUMN "eqBand7" integer NOT NULL DEFAULT 50;
+ALTER TABLE "guildSettings" ADD COLUMN "eqBand8" integer NOT NULL DEFAULT 50;
+ALTER TABLE "guildSettings" ADD COLUMN "eqBand9" integer NOT NULL DEFAULT 50;
+ALTER TABLE "guildSettings" ADD COLUMN "eqBand10" integer NOT NULL DEFAULT 50;
+ALTER TABLE "guildSettings" ADD COLUMN "eqBand11" integer NOT NULL DEFAULT 50;
+ALTER TABLE "guildSettings" ADD COLUMN "eqBand12" integer NOT NULL DEFAULT 50;
+ALTER TABLE "guildSettings" ADD COLUMN "eqBand13" integer NOT NULL DEFAULT 50;
+ALTER TABLE "guildSettings" ADD COLUMN "eqBand14" integer NOT NULL DEFAULT 50;

--- a/packages/server/src/shared/db/schema.ts
+++ b/packages/server/src/shared/db/schema.ts
@@ -86,4 +86,19 @@ export const guildSettings = sqliteTable('guildSettings', {
   compressorAttack: integer('compressorAttack').notNull().default(5), // ms, 0 to 100
   compressorRelease: integer('compressorRelease').notNull().default(50), // ms, 10 to 1000
   compressorGain: integer('compressorGain').notNull().default(3), // dB, 0 to 24
+  eqBand0: integer('eqBand0').notNull().default(50),
+  eqBand1: integer('eqBand1').notNull().default(50),
+  eqBand2: integer('eqBand2').notNull().default(50),
+  eqBand3: integer('eqBand3').notNull().default(50),
+  eqBand4: integer('eqBand4').notNull().default(50),
+  eqBand5: integer('eqBand5').notNull().default(50),
+  eqBand6: integer('eqBand6').notNull().default(50),
+  eqBand7: integer('eqBand7').notNull().default(50),
+  eqBand8: integer('eqBand8').notNull().default(50),
+  eqBand9: integer('eqBand9').notNull().default(50),
+  eqBand10: integer('eqBand10').notNull().default(50),
+  eqBand11: integer('eqBand11').notNull().default(50),
+  eqBand12: integer('eqBand12').notNull().default(50),
+  eqBand13: integer('eqBand13').notNull().default(50),
+  eqBand14: integer('eqBand14').notNull().default(50),
 });

--- a/packages/server/src/shared/types.ts
+++ b/packages/server/src/shared/types.ts
@@ -80,6 +80,15 @@ export interface CompressorSettings {
 }
 
 // ---------------------------------------------------------------------------
+// EqualizerSettings
+//
+// Guild-level 15-band equalizer configuration. Applied to NodeLink on playback.
+// ---------------------------------------------------------------------------
+export interface EqualizerSettings {
+  bands: number[]; // length 15, values 0–100, 50 = neutral (0 dB)
+}
+
+// ---------------------------------------------------------------------------
 // QueueState
 //
 // A snapshot of the GuildPlayer's current state. This is the payload for

--- a/packages/web/src/components/settings/AppearanceTab.tsx
+++ b/packages/web/src/components/settings/AppearanceTab.tsx
@@ -13,15 +13,18 @@ export default function AppearanceTab() {
   return (
     <div className="space-y-6">
       {user?.isAdmin && (
-        <div className="space-y-2">
-          <h3 className="font-mono text-[11px] text-muted uppercase tracking-wider">Admin</h3>
-          <SettingsToggle
-            label="Admin View"
-            description="Enable administrative features and controls"
-            checked={isAdminView}
-            onChange={toggleAdminView}
-          />
-        </div>
+        <>
+          <div className="space-y-2">
+            <h3 className="font-mono text-[11px] text-muted uppercase tracking-wider">Admin</h3>
+            <SettingsToggle
+              label="Admin View"
+              description="Enable administrative features and controls"
+              checked={isAdminView}
+              onChange={toggleAdminView}
+            />
+          </div>
+          <div className="border-t border-muted/20 my-4" />
+        </>
       )}
 
       {/* Appearance: Auto / Light / Dark */}
@@ -80,7 +83,12 @@ export default function AppearanceTab() {
                   style={{ backgroundColor: t.accentColor }}
                 >
                   {isSelected ? (
-                    <svg className="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 12 12" aria-hidden="true">
+                    <svg
+                      className="w-5 h-5 text-white"
+                      fill="currentColor"
+                      viewBox="0 0 12 12"
+                      aria-hidden="true"
+                    >
                       <path d="M10.28 2.28L4.5 8.06l-2.78-2.79a.5.5 0 0 0-.71.71l3.15 3.15a.5.5 0 0 0 .71 0l6.36-6.36a.5.5 0 0 0 0-.71.5.5 0 0 0-.71 0z" />
                     </svg>
                   ) : null}

--- a/packages/web/src/components/settings/AppearanceTab.tsx
+++ b/packages/web/src/components/settings/AppearanceTab.tsx
@@ -61,6 +61,8 @@ export default function AppearanceTab() {
         </div>
       </div>
 
+      <div className="border-t border-muted/20 my-4" />
+
       {/* Color Theme Selector */}
       <div className="space-y-2">
         <h3 className="font-mono text-[11px] text-muted uppercase tracking-wider">Color Theme</h3>

--- a/packages/web/src/components/settings/CompressorSection.tsx
+++ b/packages/web/src/components/settings/CompressorSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useAdminView } from '../../context/AdminViewContext';
 import SettingsToggle from './SettingsToggle';
 
@@ -28,6 +28,22 @@ export default function CompressorSection() {
   const [values, setValues] = useState<CompressorValues>(DEFAULTS);
   const [savedValues, setSavedValues] = useState<CompressorValues>(DEFAULTS);
   const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/settings/compressor');
+        if (res.ok) {
+          const data = (await res.json()) as CompressorValues;
+          setValues(data);
+          setSavedValues(data);
+        }
+      } catch {
+        // silently fail
+      }
+    }
+    if (isAdminView) load();
+  }, [isAdminView]);
 
   const hasChanges = JSON.stringify(values) !== JSON.stringify(savedValues);
 
@@ -94,7 +110,7 @@ export default function CompressorSection() {
         ))}
       </div>
 
-      <div className="flex gap-3 pt-1">
+      <div className="flex gap-3 pt-1 justify-end">
         <button
           type="button"
           onClick={handleSave}

--- a/packages/web/src/components/settings/CompressorSection.tsx
+++ b/packages/web/src/components/settings/CompressorSection.tsx
@@ -90,6 +90,13 @@ export default function CompressorSection() {
         {SLIDERS.map(({ key, label, min, max, step, unit }) => (
           <div key={key} className="flex items-center gap-3">
             <span className="font-mono text-[11px] text-muted w-20 shrink-0">{label}</span>
+            <span className="font-mono text-[11px] text-fg w-16 shrink-0">
+              {key === 'ratio'
+                ? `${values[key].toFixed(1)}:1`
+                : key === 'gain'
+                  ? `+${values[key]} ${unit}`
+                  : `${values[key]} ${unit}`}
+            </span>
             <input
               type="range"
               min={min}
@@ -99,13 +106,6 @@ export default function CompressorSection() {
               onChange={(e) => updateValue(key, parseFloat(e.target.value))}
               className="flex-1 accent-accent"
             />
-            <span className="font-mono text-[11px] text-fg w-16 text-right shrink-0">
-              {key === 'ratio'
-                ? `${values[key].toFixed(1)}:1`
-                : key === 'gain'
-                  ? `+${values[key]} ${unit}`
-                  : `${values[key]} ${unit}`}
-            </span>
           </div>
         ))}
       </div>

--- a/packages/web/src/components/settings/EqualizerSection.tsx
+++ b/packages/web/src/components/settings/EqualizerSection.tsx
@@ -73,9 +73,9 @@ export default function EqualizerSection() {
   }
 
   function gainDisplay(value: number): string {
-    const gain = value - 50;
-    if (gain === 0) return '0 dB';
-    return `${gain > 0 ? '+' : ''}${gain} dB`;
+    const offset = value - 50;
+    if (offset === 0) return '0';
+    return `${offset > 0 ? '+' : ''}${offset}`;
   }
 
   return (
@@ -96,7 +96,7 @@ export default function EqualizerSection() {
                 className="accent-accent"
                 style={{ writingMode: 'vertical-lr', direction: 'rtl', height: '80px' }}
               />
-              <span className="font-mono text-[10px] text-fg min-w-[3.5em] text-right">{gainDisplay(value)}</span>
+              <span className="font-mono text-[10px] text-fg min-w-[2em] text-right">{gainDisplay(value)}</span>
             </div>
           ))}
         </div>

--- a/packages/web/src/components/settings/EqualizerSection.tsx
+++ b/packages/web/src/components/settings/EqualizerSection.tsx
@@ -27,15 +27,19 @@ export default function EqualizerSection() {
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
-    if (!isAdminView) return;
-    fetch('/api/settings/equalizer')
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data) => {
-        if (data) {
+    async function load() {
+      try {
+        const res = await fetch('/api/settings/equalizer');
+        if (res.ok) {
+          const data = (await res.json()) as { bands: number[] };
           setBands(data.bands);
           setSavedBands(data.bands);
         }
-      });
+      } catch {
+        // silently fail
+      }
+    }
+    if (isAdminView) load();
   }, [isAdminView]);
 
   const hasChanges = JSON.stringify(bands) !== JSON.stringify(savedBands);
@@ -50,6 +54,8 @@ export default function EqualizerSection() {
       });
       if (res.ok) {
         setSavedBands(bands);
+      } else {
+        console.error('Failed to save equalizer settings:', res.status);
       }
     } finally {
       setSaving(false);
@@ -57,7 +63,7 @@ export default function EqualizerSection() {
   }
 
   function handleReset() {
-    setBands(DEFAULT_BANDS.slice());
+    setBands(DEFAULT_BANDS);
   }
 
   function updateBand(index: number, value: number) {
@@ -67,7 +73,7 @@ export default function EqualizerSection() {
   }
 
   function gainDisplay(value: number): string {
-    const gain = ((value - 50) / 100) * 100;
+    const gain = value - 50;
     if (gain === 0) return '0.0 dB';
     return `${gain > 0 ? '+' : ''}${gain.toFixed(1)} dB`;
   }
@@ -85,7 +91,7 @@ export default function EqualizerSection() {
                 max={100}
                 step={1}
                 value={value}
-                onChange={(e) => updateBand(i, parseInt(e.target.value))}
+                onChange={(e) => updateBand(i, parseInt(e.target.value, 10))}
                 className="accent-accent"
                 style={{ writingMode: 'vertical-lr', direction: 'rtl', height: '80px' }}
               />

--- a/packages/web/src/components/settings/EqualizerSection.tsx
+++ b/packages/web/src/components/settings/EqualizerSection.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from 'react';
+import { useAdminView } from '../../context/AdminViewContext';
+
+const FREQ_LABELS = [
+  '25',
+  '40',
+  '63',
+  '100',
+  '160',
+  '250',
+  '400',
+  '630',
+  '1k',
+  '1.6k',
+  '2.5k',
+  '4k',
+  '6.3k',
+  '10k',
+  '16k',
+];
+const DEFAULT_BANDS = Array(15).fill(50);
+
+export default function EqualizerSection() {
+  const { isAdminView } = useAdminView();
+  const [bands, setBands] = useState<number[]>(DEFAULT_BANDS);
+  const [savedBands, setSavedBands] = useState<number[]>(DEFAULT_BANDS);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!isAdminView) return;
+    fetch('/api/settings/equalizer')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data) {
+          setBands(data.bands);
+          setSavedBands(data.bands);
+        }
+      });
+  }, [isAdminView]);
+
+  const hasChanges = JSON.stringify(bands) !== JSON.stringify(savedBands);
+
+  async function handleSave() {
+    setSaving(true);
+    try {
+      const res = await fetch('/api/settings/equalizer', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ bands }),
+      });
+      if (res.ok) {
+        setSavedBands(bands);
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function handleReset() {
+    setBands(DEFAULT_BANDS.slice());
+  }
+
+  function updateBand(index: number, value: number) {
+    const next = [...bands];
+    next[index] = value;
+    setBands(next);
+  }
+
+  function gainDisplay(value: number): string {
+    const gain = ((value - 50) / 100) * 100;
+    if (gain === 0) return '0.0 dB';
+    return `${gain > 0 ? '+' : ''}${gain.toFixed(1)} dB`;
+  }
+
+  return (
+    <div className={`space-y-3 ${!isAdminView ? 'opacity-40 pointer-events-none' : ''}`}>
+      <h4 className="font-mono text-[11px] text-muted uppercase tracking-wider">Equalizer</h4>
+      <div className="overflow-x-auto pb-2">
+        <div className="flex gap-2 md:flex-nowrap flex-wrap min-w-[700px] md:min-w-0">
+          {bands.map((value, i) => (
+            <div key={i} className="flex flex-col items-center gap-1 shrink-0">
+              <input
+                type="range"
+                min={0}
+                max={100}
+                step={1}
+                value={value}
+                onChange={(e) => updateBand(i, parseInt(e.target.value))}
+                className="accent-accent"
+                style={{ writingMode: 'vertical-lr', direction: 'rtl', height: '80px' }}
+              />
+              <span className="font-mono text-[10px] text-muted">{FREQ_LABELS[i]}</span>
+              <span className="font-mono text-[10px] text-fg">{gainDisplay(value)}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="flex gap-3 pt-1">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!hasChanges || saving}
+          className={`font-body text-sm px-4 py-1.5 rounded transition-colors ${
+            hasChanges && !saving
+              ? 'bg-accent text-elevated cursor-pointer'
+              : 'bg-elevated text-muted cursor-not-allowed'
+          }`}
+        >
+          {saving ? 'Saving…' : 'Save Changes'}
+        </button>
+        <button
+          type="button"
+          onClick={handleReset}
+          className="font-body text-sm px-4 py-1.5 rounded bg-elevated text-muted hover:text-fg transition-colors cursor-pointer"
+        >
+          Reset to Defaults
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/EqualizerSection.tsx
+++ b/packages/web/src/components/settings/EqualizerSection.tsx
@@ -96,7 +96,7 @@ export default function EqualizerSection() {
                 style={{ writingMode: 'vertical-lr', direction: 'rtl', height: '80px' }}
               />
               <span className="font-mono text-[10px] text-muted">{FREQ_LABELS[i]}</span>
-              <span className="font-mono text-[10px] text-fg">{gainDisplay(value)}</span>
+              <span className="font-mono text-[10px] text-fg min-w-[3.5em] text-right">{gainDisplay(value)}</span>
             </div>
           ))}
         </div>

--- a/packages/web/src/components/settings/EqualizerSection.tsx
+++ b/packages/web/src/components/settings/EqualizerSection.tsx
@@ -81,8 +81,7 @@ export default function EqualizerSection() {
   return (
     <div className={`space-y-3 ${!isAdminView ? 'opacity-40 pointer-events-none' : ''}`}>
       <h4 className="font-mono text-[11px] text-muted uppercase tracking-wider">Equalizer</h4>
-      <div className="overflow-x-auto pb-2">
-        <div className="flex gap-2 md:flex-nowrap flex-wrap min-w-[700px] md:min-w-0">
+      <div className="flex flex-wrap justify-center gap-2 md:flex-nowrap">
           {bands.map((value, i) => (
             <div key={i} className="flex flex-col items-center gap-1 shrink-0">
               <span className="font-mono text-[10px] text-muted">{FREQ_LABELS[i]}</span>

--- a/packages/web/src/components/settings/EqualizerSection.tsx
+++ b/packages/web/src/components/settings/EqualizerSection.tsx
@@ -74,8 +74,8 @@ export default function EqualizerSection() {
 
   function gainDisplay(value: number): string {
     const gain = value - 50;
-    if (gain === 0) return '0.0 dB';
-    return `${gain > 0 ? '+' : ''}${gain.toFixed(1)} dB`;
+    if (gain === 0) return '0 dB';
+    return `${gain > 0 ? '+' : ''}${gain} dB`;
   }
 
   return (

--- a/packages/web/src/components/settings/EqualizerSection.tsx
+++ b/packages/web/src/components/settings/EqualizerSection.tsx
@@ -94,7 +94,7 @@ export default function EqualizerSection() {
                 value={value}
                 onChange={(e) => updateBand(i, parseInt(e.target.value, 10))}
                 className="accent-accent"
-                style={{ writingMode: 'vertical-lr', direction: 'rtl', height: '80px' }}
+                style={{ writingMode: 'vertical-lr', direction: 'rtl', height: '120px' }}
               />
               <span className="font-mono text-[10px] text-fg min-w-[2em] text-right">{gainDisplay(value)}</span>
             </div>

--- a/packages/web/src/components/settings/EqualizerSection.tsx
+++ b/packages/web/src/components/settings/EqualizerSection.tsx
@@ -85,6 +85,7 @@ export default function EqualizerSection() {
         <div className="flex gap-2 md:flex-nowrap flex-wrap min-w-[700px] md:min-w-0">
           {bands.map((value, i) => (
             <div key={i} className="flex flex-col items-center gap-1 shrink-0">
+              <span className="font-mono text-[10px] text-muted">{FREQ_LABELS[i]}</span>
               <input
                 type="range"
                 min={0}
@@ -95,7 +96,6 @@ export default function EqualizerSection() {
                 className="accent-accent"
                 style={{ writingMode: 'vertical-lr', direction: 'rtl', height: '80px' }}
               />
-              <span className="font-mono text-[10px] text-muted">{FREQ_LABELS[i]}</span>
               <span className="font-mono text-[10px] text-fg min-w-[3.5em] text-right">{gainDisplay(value)}</span>
             </div>
           ))}

--- a/packages/web/src/components/settings/EqualizerSection.tsx
+++ b/packages/web/src/components/settings/EqualizerSection.tsx
@@ -82,23 +82,24 @@ export default function EqualizerSection() {
     <div className={`space-y-3 ${!isAdminView ? 'opacity-40 pointer-events-none' : ''}`}>
       <h4 className="font-mono text-[11px] text-muted uppercase tracking-wider">Equalizer</h4>
       <div className="flex flex-wrap justify-center gap-2 md:flex-nowrap">
-          {bands.map((value, i) => (
-            <div key={i} className="flex flex-col items-center gap-1 shrink-0">
-              <span className="font-mono text-[10px] text-muted">{FREQ_LABELS[i]}</span>
-              <input
-                type="range"
-                min={0}
-                max={100}
-                step={1}
-                value={value}
-                onChange={(e) => updateBand(i, parseInt(e.target.value, 10))}
-                className="accent-accent"
-                style={{ writingMode: 'vertical-lr', direction: 'rtl', height: '120px' }}
-              />
-              <span className="font-mono text-[10px] text-fg min-w-[2em] text-right">{gainDisplay(value)}</span>
-            </div>
-          ))}
-        </div>
+        {bands.map((value, i) => (
+          <div key={i} className="flex flex-col items-center gap-1 shrink-0">
+            <span className="font-mono text-[10px] text-muted">{FREQ_LABELS[i]}</span>
+            <input
+              type="range"
+              min={0}
+              max={100}
+              step={1}
+              value={value}
+              onChange={(e) => updateBand(i, parseInt(e.target.value, 10))}
+              className="accent-accent"
+              style={{ writingMode: 'vertical-lr', direction: 'rtl', height: '120px' }}
+            />
+            <span className="font-mono text-[10px] text-fg min-w-[2em] text-right">
+              {gainDisplay(value)}
+            </span>
+          </div>
+        ))}
       </div>
       <div className="flex gap-3 pt-1">
         <button

--- a/packages/web/src/components/settings/EqualizerSection.tsx
+++ b/packages/web/src/components/settings/EqualizerSection.tsx
@@ -101,7 +101,7 @@ export default function EqualizerSection() {
           </div>
         ))}
       </div>
-      <div className="flex gap-3 pt-1">
+      <div className="flex gap-3 pt-1 justify-end">
         <button
           type="button"
           onClick={handleSave}

--- a/packages/web/src/components/settings/ServerTab.tsx
+++ b/packages/web/src/components/settings/ServerTab.tsx
@@ -1,5 +1,6 @@
 import { useAuth } from '../../context/AuthContext';
 import CompressorSection from './CompressorSection';
+import EqualizerSection from './EqualizerSection';
 
 export default function ServerTab() {
   const { user } = useAuth();
@@ -8,6 +9,7 @@ export default function ServerTab() {
     <div className="space-y-2">
       <h3 className="font-mono text-[11px] text-muted uppercase tracking-wider">Audio Settings</h3>
       {user?.isAdmin && <CompressorSection />}
+      {user?.isAdmin && <EqualizerSection />}
     </div>
   );
 }

--- a/packages/web/src/components/settings/ServerTab.tsx
+++ b/packages/web/src/components/settings/ServerTab.tsx
@@ -8,7 +8,12 @@ export default function ServerTab() {
   return (
     <div className="space-y-2">
       {user?.isAdmin && <EqualizerSection />}
-      {user?.isAdmin && <CompressorSection />}
+      {user?.isAdmin && (
+        <>
+          <div className="border-t border-muted/20 my-4" />
+          <CompressorSection />
+        </>
+      )}
     </div>
   );
 }

--- a/packages/web/src/components/settings/ServerTab.tsx
+++ b/packages/web/src/components/settings/ServerTab.tsx
@@ -7,7 +7,6 @@ export default function ServerTab() {
 
   return (
     <div className="space-y-2">
-      <h3 className="font-mono text-[11px] text-muted uppercase tracking-wider">Audio Settings</h3>
       {user?.isAdmin && <EqualizerSection />}
       {user?.isAdmin && <CompressorSection />}
     </div>

--- a/packages/web/src/components/settings/ServerTab.tsx
+++ b/packages/web/src/components/settings/ServerTab.tsx
@@ -8,8 +8,8 @@ export default function ServerTab() {
   return (
     <div className="space-y-2">
       <h3 className="font-mono text-[11px] text-muted uppercase tracking-wider">Audio Settings</h3>
-      {user?.isAdmin && <CompressorSection />}
       {user?.isAdmin && <EqualizerSection />}
+      {user?.isAdmin && <CompressorSection />}
     </div>
   );
 }

--- a/packages/web/src/components/settings/SettingsTabs.tsx
+++ b/packages/web/src/components/settings/SettingsTabs.tsx
@@ -23,7 +23,7 @@ export default function SettingsTabs({ activeTab, onTabChange }: SettingsTabsPro
   const visibleTabs = TABS.filter((tab) => !tab.adminOnly || user?.isAdmin);
 
   return (
-    <div role="tablist" className="flex border-b border-foreground/40">
+    <div role="tablist" className="flex border-b border-border">
       {visibleTabs.map((tab) => (
         <button
           type="button"

--- a/packages/web/src/components/settings/SettingsTabs.tsx
+++ b/packages/web/src/components/settings/SettingsTabs.tsx
@@ -23,7 +23,7 @@ export default function SettingsTabs({ activeTab, onTabChange }: SettingsTabsPro
   const visibleTabs = TABS.filter((tab) => !tab.adminOnly || user?.isAdmin);
 
   return (
-    <div role="tablist" className="flex border-b border-border">
+    <div role="tablist" className="flex border-b border-foreground/40">
       {visibleTabs.map((tab) => (
         <button
           type="button"


### PR DESCRIPTION
## Summary
- Add 15-band equalizer section to the Audio settings tab
- EQ bands: 25Hz to 16kHz, displayed as vertical sliders with offset labels
- Persisted to `guildSettings` table via new `GET/PATCH /api/settings/equalizer` API
- Applied to NodeLink player on every track play (when any band is non-neutral)
- Compressor section updated with initial fetch on mount and fixed button alignment
- Visual polish: separators added between sections, tab border differentiated, responsive wrapping on mobile, dB label removed

## Test Plan
- [x] Settings → Audio tab shows equalizer sliders (admin only)
- [x] Change a band → Save Changes → verified in Network tab
- [x] Reset to Defaults restores all bands to neutral
- [x] Play a track with non-flat EQ → filter applied (check NodeLink logs)
- [x] Mobile: sliders wrap properly across multiple rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)