### PR TITLE
fix(server): resolve addedByDisplayName for playlist song context menu

### DIFF
--- a/packages/server/src/routes/playlists.ts
+++ b/packages/server/src/routes/playlists.ts
@@ -56,11 +56,17 @@ function formatPlaylist(pl: typeof playlistTable.$inferSelect, songCount?: numbe
 
 function formatPlaylistSongWithSong(
   ps: typeof playlistSongTable.$inferSelect,
-  song: typeof tables.song.$inferSelect
+  song: typeof tables.song.$inferSelect,
+  addedByDisplayName?: string
 ) {
   return {
     ...ps,
-    song: { ...song, createdAt: song.createdAt.toISOString(), tags: song.tags ?? [] },
+    song: {
+      ...song,
+      createdAt: song.createdAt.toISOString(),
+      tags: song.tags ?? [],
+      addedByDisplayName,
+    },
   };
 }
 
@@ -234,6 +240,15 @@ async function handleGetPlaylist(
       : [];
   const songMap = new Map(songs.map((s) => [s.id, s]));
 
+  // Resolve Discord display names for unique addedBy IDs
+  const uniqueIds = [...new Set(songs.map((s) => s.addedBy))];
+  const nameMap = new Map<string, string>();
+  await Promise.all(
+    uniqueIds.map(async (id) => {
+      nameMap.set(id, await getUserDisplayName(id));
+    })
+  );
+
   return json({
     ...playlist,
     createdAt:
@@ -241,7 +256,8 @@ async function handleGetPlaylist(
     songs: playlistSongs
       .map((ps) => {
         const song = songMap.get(ps.songId);
-        return song ? formatPlaylistSongWithSong(ps, song) : null;
+        if (!song) return null;
+        return formatPlaylistSongWithSong(ps, song, nameMap.get(song.addedBy) ?? song.addedBy);
       })
       .filter((x): x is NonNullable<typeof x> => x !== null),
     createdByDisplayName: await getUserDisplayName(playlist.createdBy),


### PR DESCRIPTION
## Summary

- Fix `handleGetPlaylist` to resolve Discord display names for `addedBy` IDs, matching the behavior of `handleGetSongs`
- Without this, the "requested by" context menu item on the Playlist details page shows raw Discord IDs (e.g. `171044872780906497`) instead of usernames (e.g. `Thom`)

## Test plan

- [x] Open a Playlist details page and verify the context menu shows the Discord username (not the raw ID)
- [x] Verify Songs page context menu still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)