### PR TITLE
fix: resolve Biome lint warnings

### DIFF
--- a/packages/server/src/routes/playlists.ts
+++ b/packages/server/src/routes/playlists.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, inArray, or, sql } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, sql } from 'drizzle-orm';
 import type { RouteContext } from '../index';
 import { getUserDisplayName } from '../lib/displayName';
 import { json } from '../lib/json';

--- a/packages/web/src/components/NowPlayingBar.tsx
+++ b/packages/web/src/components/NowPlayingBar.tsx
@@ -361,7 +361,7 @@ const ProgressBar = memo(function ProgressBar({
         elapsed={elapsed}
         registerProgress={registerProgress}
         registerRangeInput={registerRangeInput}
-        onSeek={onSeek ?? (() => {})}
+        onSeek={onSeek ?? (() => undefined)}
         setOverrideElapsed={setOverrideElapsed}
       />
     </div>

--- a/packages/web/src/components/SongEditPanel.tsx
+++ b/packages/web/src/components/SongEditPanel.tsx
@@ -546,7 +546,7 @@ function TagDropdown({
   const dropdown = (
     <div
       ref={dropdownRef}
-      className="fixed z-50 min-w-[180px] bg-surface rounded-lg border border-border shadow-lg max-h-48 overflow-y-auto"
+      className="fixed z-50 min-w-45 bg-surface rounded-lg border border-border shadow-lg max-h-48 overflow-y-auto"
       style={{ top: 0, left: 0 }}
     >
       {filtered.length === 0 ? (

--- a/packages/web/src/components/VirtualPlaylistList.tsx
+++ b/packages/web/src/components/VirtualPlaylistList.tsx
@@ -76,8 +76,8 @@ export const VirtualPlaylistList = memo(function VirtualPlaylistList({
         {isFetching && !isError && (
           <div className="flex justify-center py-4 gap-2">
             {Array.from({ length: 3 }).map((_, i) => (
-              // biome-ignore lint/suspicious/noArrayIndexKey: static loading indicator
               <div
+                // biome-ignore lint/suspicious/noArrayIndexKey: static loading indicator, order never changes
                 key={`loading-dot-${i}`}
                 className="skeleton h-3 w-3 rounded-full animate-pulse"
               />

--- a/packages/web/src/components/VirtualSongList.tsx
+++ b/packages/web/src/components/VirtualSongList.tsx
@@ -124,8 +124,8 @@ export const VirtualSongList = memo(function VirtualSongList({
           {isFetching && !isError && (
             <div className="flex justify-center py-4 gap-2">
               {Array.from({ length: 3 }).map((_, i) => (
-                // biome-ignore lint/suspicious/noArrayIndexKey: static loading indicator
                 <div
+                  // biome-ignore lint/suspicious/noArrayIndexKey: static loading indicator, order never changes
                   key={`loading-dot-${i}`}
                   className="skeleton h-3 w-3 rounded-full animate-pulse"
                 />
@@ -172,8 +172,8 @@ export const VirtualSongList = memo(function VirtualSongList({
         {isFetching && !isError && (
           <div className="flex justify-center py-4 gap-2">
             {Array.from({ length: 3 }).map((_, i) => (
-              // biome-ignore lint/suspicious/noArrayIndexKey: static loading indicator
               <div
+                // biome-ignore lint/suspicious/noArrayIndexKey: static loading indicator, order never changes
                 key={`loading-dot-${i}`}
                 className="skeleton h-3 w-3 rounded-full animate-pulse"
               />

--- a/packages/web/src/components/settings/EqualizerSection.tsx
+++ b/packages/web/src/components/settings/EqualizerSection.tsx
@@ -83,6 +83,7 @@ export default function EqualizerSection() {
       <h4 className="font-mono text-[11px] text-muted uppercase tracking-wider">Equalizer</h4>
       <div className="flex flex-wrap justify-center gap-2 md:flex-nowrap">
         {bands.map((value, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: static UI elements with stable order
           <div key={i} className="flex flex-col items-center gap-1 shrink-0">
             <span className="font-mono text-[10px] text-muted">{FREQ_LABELS[i]}</span>
             <input

--- a/packages/web/src/components/settings/TagsTab.tsx
+++ b/packages/web/src/components/settings/TagsTab.tsx
@@ -142,7 +142,7 @@ export default function TagsTab() {
     <div className="space-y-2">
       <h3 className="font-mono text-[11px] text-muted uppercase tracking-wider">Tags</h3>
 
-      <div className="flex gap-4 h-[420px]">
+      <div className="flex gap-4 h-105">
         {/* Left pane: tag list */}
         <div className="flex-1 flex flex-col min-w-0 border border-border rounded-md overflow-hidden bg-elevated">
           <div className="px-3 py-2 border-b border-border">

--- a/packages/web/src/context/TagsContext.tsx
+++ b/packages/web/src/context/TagsContext.tsx
@@ -12,7 +12,7 @@ const TagsContext = createContext<{
   refreshTags: () => void;
 }>({
   tagColorMap: {},
-  refreshTags: () => {},
+  refreshTags: () => undefined,
 });
 
 export function TagsProvider({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## Summary

- Remove unused `or` import from playlists.ts
- Fix empty block statements (`() => {}` → `() => undefined`)
- Move suppression comments to the `key` prop location where Biome can detect them
- Add missing suppression for EqualizerSection index key

🤖 Generated with [Claude Code](https://claude.com/claude-code)