### PR TITLE
fix(web): match More Actions button bg to sidebar

### DIFF
--- a/packages/web/src/components/ContextMenu.tsx
+++ b/packages/web/src/components/ContextMenu.tsx
@@ -73,7 +73,7 @@ export function ContextMenuTrigger({
       aria-haspopup="true"
       aria-expanded={isOpen}
       title="More actions"
-      surface={surface ?? 'surface'}
+      surface={surface ?? 'elevated'}
       onClick={(e) => {
         e.stopPropagation();
         onToggle();

--- a/packages/web/src/components/QueuePanel.tsx
+++ b/packages/web/src/components/QueuePanel.tsx
@@ -481,6 +481,7 @@ const PanelHeader = memo(function PanelHeader({
           aria-haspopup="true"
           aria-expanded={menuOpen}
           title="More actions"
+          surface="elevated"
           className={`${menuOpen ? 'pressed text-accent' : ''}`}
           onClick={onToggleMenu}
         >


### PR DESCRIPTION
## Summary
- Change "More actions" buttons in `ContextMenu` and `QueuePanel` to use `surface="elevated"` instead of the default `surface="surface"`, matching the sidebar's background color

## Test plan
- [x] Verify More Actions buttons now use the same elevated background as the sidebar
- [x] Check both dark and light themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)