### PR TITLE
feat(web): improve button and context menu styling

### DIFF
--- a/packages/web/src/components/ContextMenu.tsx
+++ b/packages/web/src/components/ContextMenu.tsx
@@ -40,6 +40,7 @@ export interface MenuItem {
     placeholder?: string;
   };
   info?: { label: string; icon?: ReactNode };
+  separatorBefore?: boolean;
 }
 
 interface ContextMenuProps {
@@ -58,12 +59,14 @@ export function ContextMenuTrigger({
   ref,
   className,
   surface,
+  onMouseDown,
 }: {
   onToggle: () => void;
   isOpen: boolean;
   ref: RefObject<HTMLButtonElement | null>;
   className?: string;
   surface?: 'base' | 'surface' | 'elevated';
+  onMouseDown?: (e: React.MouseEvent) => void;
 }) {
   return (
     <Button
@@ -74,6 +77,7 @@ export function ContextMenuTrigger({
       aria-expanded={isOpen}
       title="More actions"
       surface={surface ?? 'elevated'}
+      onMouseDown={onMouseDown}
       onClick={(e) => {
         e.stopPropagation();
         onToggle();
@@ -165,16 +169,6 @@ export function ContextMenu({
       setActiveSubmenu(null);
       setActiveEditItemId(null);
       setFocusedIndex(0);
-    }
-  }, [isOpen]);
-
-  // Focus first item on open
-  useEffect(() => {
-    if (isOpen && menuRef.current) {
-      const firstItem = menuRef.current.querySelector(
-        '[role="menuitem"]:not([disabled])'
-      ) as HTMLElement | null;
-      firstItem?.focus();
     }
   }, [isOpen]);
 
@@ -298,11 +292,18 @@ export function ContextMenu({
         ) : (
           items.map((item, index) => {
             if (item.info) {
-              return <InfoRow key={item.id} item={item} />;
+              return (
+                <div key={item.id}>
+                  {(index > 0 || item.separatorBefore) && (
+                    <div className="border-b border-muted/50" />
+                  )}
+                  <InfoRow item={item} />
+                </div>
+              );
             }
             return (
               <div key={item.id}>
-                {index > 0 && <div className="border-b border-border" />}
+                {index > 0 && <div className="border-b border-muted/50" />}
                 <MenuItemButton
                   item={item}
                   onClick={() => {

--- a/packages/web/src/components/ContextMenu/MenuItemButton.tsx
+++ b/packages/web/src/components/ContextMenu/MenuItemButton.tsx
@@ -27,7 +27,7 @@ export function MenuItemButton({ item, onClick }: MenuItemButtonProps) {
 				flex items-center gap-2
 				transition-colors duration-100
 				disabled:opacity-50 disabled:cursor-not-allowed
-				${item.danger ? 'text-danger hover:bg-danger/10' : 'text-fg hover:bg-border/50'}
+				${item.danger ? 'text-danger hover:bg-danger/10' : 'text-fg hover:bg-muted/20'}
 			`}
     >
       {item.icon && <span className="shrink-0">{item.icon}</span>}

--- a/packages/web/src/components/SongCard.tsx
+++ b/packages/web/src/components/SongCard.tsx
@@ -75,6 +75,34 @@ const SongCardInner = ({
         />
         <div className="absolute inset-0 bg-linear-to-t from-black/60 to-transparent" />
 
+        {/* Action buttons — bottom left */}
+        <div className="absolute bottom-2 left-2 z-20 flex items-center gap-1">
+          <Button
+            variant="primary"
+            size="icon"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={(e) => {
+              e.stopPropagation();
+              handlePlay();
+            }}
+            disabled={isPlaying}
+            className="shrink-0 disabled:cursor-default"
+            title="Play from this song"
+          >
+            {isPlaying ? (
+              <CircleNotchIcon size={18} weight="bold" className="animate-spin" />
+            ) : (
+              <PlayIcon size={18} weight="duotone" />
+            )}
+          </Button>
+          <ContextMenuTrigger
+            ref={triggerRef}
+            onToggle={() => setMenuOpen((v) => !v)}
+            isOpen={menuOpen}
+            onMouseDown={(e) => e.preventDefault()}
+          />
+        </div>
+
         {/* Duration badge + volume indicator — bottom right */}
         <div className="absolute bottom-2 right-2 z-20 flex flex-col items-end gap-px">
           <span className="font-mono text-[10px] text-white/80 bg-black/50 px-1.5 py-0.5 rounded">
@@ -108,30 +136,6 @@ const SongCardInner = ({
           <p className="font-body font-semibold text-sm text-fg leading-tight line-clamp-2 min-w-0">
             {song.nickname || song.title}
           </p>
-          <div className="flex items-center gap-1 shrink-0 ml-auto">
-            <Button
-              variant="primary"
-              size="icon"
-              onClick={(e) => {
-                e.stopPropagation();
-                handlePlay();
-              }}
-              disabled={isPlaying}
-              className="shrink-0 disabled:cursor-default"
-              title="Play from this song"
-            >
-              {isPlaying ? (
-                <CircleNotchIcon size={18} weight="bold" className="animate-spin" />
-              ) : (
-                <PlayIcon size={18} weight="duotone" />
-              )}
-            </Button>
-            <ContextMenuTrigger
-              ref={triggerRef}
-              onToggle={() => setMenuOpen((v) => !v)}
-              isOpen={menuOpen}
-            />
-          </div>
         </div>
         {song.nickname && <p className="text-[11px] text-faint truncate">{song.title}</p>}
       </div>

--- a/packages/web/src/components/SongRow.tsx
+++ b/packages/web/src/components/SongRow.tsx
@@ -167,6 +167,7 @@ export const SongRow = memo(
           <Button
             variant="primary"
             size="icon"
+            onMouseDown={(e) => e.preventDefault()}
             onClick={(e) => {
               e.stopPropagation();
               onPlay();
@@ -185,6 +186,7 @@ export const SongRow = memo(
             ref={triggerRef}
             onToggle={() => setMenuOpen((v) => !v)}
             isOpen={menuOpen}
+            onMouseDown={(e) => e.preventDefault()}
           />
           {menuOpen && (
             <ContextMenu

--- a/packages/web/src/components/settings/AppearanceTab.tsx
+++ b/packages/web/src/components/settings/AppearanceTab.tsx
@@ -33,8 +33,7 @@ export default function AppearanceTab() {
         <div className="flex gap-2">
           <Button
             variant="inherit"
-            surface="base"
-            className={`flex-1 flex items-center gap-2 ${mode === 'auto' ? 'pressed' : ''}`}
+            className={`flex-1 flex justify-center gap-2 ${mode === 'auto' ? 'pressed' : ''}`}
             onClick={() => setMode('auto')}
           >
             <DesktopIcon size={16} weight="duotone" />
@@ -42,8 +41,7 @@ export default function AppearanceTab() {
           </Button>
           <Button
             variant="inherit"
-            surface="base"
-            className={`flex-1 flex items-center gap-2 ${mode === 'light' ? 'pressed' : ''}`}
+            className={`flex-1 flex justify-center gap-2 ${mode === 'light' ? 'pressed' : ''}`}
             onClick={() => setMode('light')}
           >
             <SunIcon size={16} weight="duotone" />
@@ -51,8 +49,7 @@ export default function AppearanceTab() {
           </Button>
           <Button
             variant="inherit"
-            surface="base"
-            className={`flex-1 flex items-center gap-2 ${mode === 'dark' ? 'pressed' : ''}`}
+            className={`flex-1 flex justify-center gap-2 ${mode === 'dark' ? 'pressed' : ''}`}
             onClick={() => setMode('dark')}
           >
             <MoonIcon size={16} weight="duotone" />

--- a/packages/web/src/hooks/useSongActions.tsx
+++ b/packages/web/src/hooks/useSongActions.tsx
@@ -119,6 +119,7 @@ export function useSongActions({
                       label: song.addedByDisplayName || song.addedBy || '',
                       icon: <UserIcon size={14} weight="duotone" />,
                     },
+                    separatorBefore: true,
                   },
                 ]
               : []),

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -459,16 +459,20 @@
     /* Clay elevation tokens — 4 deliberate depth levels */
     --clay-shadow-resting:
         0 2px 0 0 color-mix(in srgb, var(--color-surface) 60%, black),
-        inset 0 1px 2px 0 rgba(255, 255, 255, 0.12);
+        inset 0 2px 3px 0 rgba(0, 0, 0, 0.15),
+        inset 0 1px 1px 0 rgba(255, 255, 255, 0.04);
     --clay-shadow-lifted:
         0 3px 0 0 color-mix(in srgb, var(--color-surface) 60%, black),
-        inset 0 1px 2px 0 rgba(255, 255, 255, 0.12);
+        inset 0 2px 3px 0 rgba(0, 0, 0, 0.15),
+        inset 0 1px 1px 0 rgba(255, 255, 255, 0.04);
     --clay-shadow-raised:
         0 4px 0 0 color-mix(in srgb, var(--color-surface) 60%, black),
-        inset 0 1px 2px 0 rgba(255, 255, 255, 0.12);
+        inset 0 2px 3px 0 rgba(0, 0, 0, 0.15),
+        inset 0 1px 1px 0 rgba(255, 255, 255, 0.04);
     --clay-shadow-floating:
         0 7px 0 0 color-mix(in srgb, var(--color-surface) 60%, black),
-        inset 0 1px 2px 0 rgba(255, 255, 255, 0.12);
+        inset 0 2px 3px 0 rgba(0, 0, 0, 0.15),
+        inset 0 1px 1px 0 rgba(255, 255, 255, 0.04);
     --clay-shadow-flat:
         inset 0 1px 3px 0 rgba(0, 0, 0, 0.15),
         inset 0 1px 1px 0 rgba(0, 0, 0, 0.1);
@@ -485,19 +489,19 @@
     --clay-shadow-resting:
         0 2px 0 0 color-mix(in srgb, var(--color-surface) 60%, black),
         0 3px 6px -2px rgba(0, 0, 0, 0.12),
-        inset 0 1px 2px 0 rgba(255, 255, 255, 0.12);
+        0 -4px 8px -4px rgba(0, 0, 0, 0.14);
     --clay-shadow-lifted:
         0 3px 0 0 color-mix(in srgb, var(--color-surface) 60%, black),
         0 4px 10px -2px rgba(0, 0, 0, 0.14),
-        inset 0 1px 2px 0 rgba(255, 255, 255, 0.12);
+        0 -5px 10px -4px rgba(0, 0, 0, 0.16);
     --clay-shadow-raised:
         0 4px 0 0 color-mix(in srgb, var(--color-surface) 60%, black),
         0 5px 12px -2px rgba(0, 0, 0, 0.16),
-        inset 0 1px 2px 0 rgba(255, 255, 255, 0.12);
+        0 -6px 14px -4px rgba(0, 0, 0, 0.18);
     --clay-shadow-floating:
         0 7px 0 0 color-mix(in srgb, var(--color-surface) 60%, black),
         0 8px 16px -4px rgba(0, 0, 0, 0.2),
-        inset 0 1px 2px 0 rgba(255, 255, 255, 0.12);
+        0 -9px 18px -6px rgba(0, 0, 0, 0.20);
     --clay-shadow-sidebar: 4px 0 16px -4px rgba(0, 0, 0, 0.2);
     --clay-shadow-player: 0 -4px 16px -4px rgba(0, 0, 0, 0.2);
 }
@@ -654,11 +658,15 @@
     .light .btn-inherit {
         background: var(--btn-surface);
         border: 1px solid color-mix(in srgb, var(--btn-surface) 80%, white);
-        box-shadow: var(--clay-shadow-resting);
+        box-shadow:
+            0 3px 6px -2px rgba(0, 0, 0, 0.12),
+            0 -4px 8px -4px rgba(0, 0, 0, 0.15);
     }
     .light .btn-inherit:hover {
         border-color: color-mix(in srgb, var(--btn-surface) 70%, white);
-        box-shadow: var(--clay-shadow-raised);
+        box-shadow:
+            0 4px 8px -2px rgba(0, 0, 0, 0.14),
+            0 -5px 10px -4px rgba(0, 0, 0, 0.18);
     }
     .light .btn-inherit:active {
         border-color: transparent;
@@ -861,7 +869,8 @@
         box-shadow:
             0 1px 0 0 color-mix(in srgb, var(--color-surface) 60%, black),
             0 2px 4px -1px rgba(0, 0, 0, 0.2),
-            inset 0 1px 1px 0 rgba(255, 255, 255, 0.08);
+            inset 0 1px 1px 0 rgba(0, 0, 0, 0.15),
+            inset 0 1px 1px 0 rgba(255, 255, 255, 0.04);
     }
     .btn-icon-inherit:hover {
         transform: var(--btn-transform-hover);
@@ -869,7 +878,8 @@
         box-shadow:
             0 2px 0 0 color-mix(in srgb, var(--color-surface) 60%, black),
             0 3px 6px -1px rgba(0, 0, 0, 0.25),
-            inset 0 1px 1px 0 rgba(255, 255, 255, 0.08);
+            inset 0 2px 3px 0 rgba(0, 0, 0, 0.20),
+            inset 0 1px 1px 0 rgba(255, 255, 255, 0.05);
     }
     .btn-icon-inherit:active {
         transform: var(--btn-transform-active-sm);
@@ -881,39 +891,38 @@
     }
     .btn-icon-inherit.pressed {
         transform: var(--btn-transform-active-sm);
-        background: var(--btn-surface);
+        background: color-mix(in srgb, var(--btn-surface) 80%, black);
         box-shadow:
             0 0 0 0 color-mix(in srgb, var(--color-surface) 60%, black),
             inset 0 2px 3px 0 rgba(0, 0, 0, 0.2);
     }
 
     /* Light mode: distinguish via shadow + border */
-    .light .btn-icon-inherit {
+    [data-mode="light"] .btn-icon-inherit {
         background: var(--btn-surface);
         border: 1px solid color-mix(in srgb, var(--btn-surface) 80%, white);
         box-shadow:
-            0 1px 0 0 color-mix(in srgb, var(--color-surface) 60%, black),
             0 2px 4px -1px rgba(0, 0, 0, 0.2),
-            inset 0 1px 1px 0 rgba(255, 255, 255, 0.08);
+            0 -3px 6px -2px rgba(0, 0, 0, 0.15);
     }
-    .light .btn-icon-inherit:hover {
+    [data-mode="light"] .btn-icon-inherit:hover {
         border-color: color-mix(in srgb, var(--btn-surface) 70%, white);
         box-shadow:
-            0 2px 0 0 color-mix(in srgb, var(--color-surface) 60%, black),
             0 3px 6px -1px rgba(0, 0, 0, 0.25),
-            inset 0 1px 1px 0 rgba(255, 255, 255, 0.08);
+            0 -4px 8px -2px rgba(0, 0, 0, 0.18);
     }
-    .light .btn-icon-inherit:active {
+    [data-mode="light"] .btn-icon-inherit:active {
         border-color: transparent;
         box-shadow:
-            0 0 0 0 color-mix(in srgb, var(--color-surface) 60%, black),
-            inset 0 2px 3px 0 rgba(0, 0, 0, 0.2);
+            0 1px 0 0 color-mix(in srgb, var(--color-surface) 60%, black),
+            0 2px 4px -1px rgba(0, 0, 0, 0.2);
     }
-    .light .btn-icon-inherit.pressed {
+    [data-mode="light"] .btn-icon-inherit.pressed {
+        background: color-mix(in srgb, var(--btn-surface) 85%, black);
         border-color: transparent;
         box-shadow:
-            0 0 0 0 color-mix(in srgb, var(--color-surface) 60%, black),
-            inset 0 2px 3px 0 rgba(0, 0, 0, 0.2);
+            0 1px 0 0 color-mix(in srgb, var(--color-surface) 60%, black),
+            0 2px 4px -1px rgba(0, 0, 0, 0.2);
     }
 
     .btn-icon-danger {

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -1,6 +1,6 @@
 import type { Playlist, Song } from '@alfira-bot/server/shared';
 import { ListIcon, MagnifyingGlassIcon, SquaresFourIcon } from '@phosphor-icons/react';
-import { startTransition, useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { deleteSong, getPlaylistsPage, getSongsPage, startPlayback } from '../api/api';
 import AddSongModal from '../components/AddSongModal';
 import ConfirmModal from '../components/ConfirmModal';
@@ -173,10 +173,8 @@ export default function SongsPage() {
             surface="surface"
             size="icon"
             onClick={() => {
-              startTransition(() => {
-                setViewMode('grid');
-                localStorage.setItem('alfira-library-view', 'grid');
-              });
+              setViewMode('grid');
+              localStorage.setItem('alfira-library-view', 'grid');
             }}
             className={isGrid ? 'pressed text-accent' : ''}
             title="Grid view"
@@ -188,10 +186,8 @@ export default function SongsPage() {
             surface="surface"
             size="icon"
             onClick={() => {
-              startTransition(() => {
-                setViewMode('list');
-                localStorage.setItem('alfira-library-view', 'list');
-              });
+              setViewMode('list');
+              localStorage.setItem('alfira-library-view', 'list');
             }}
             className={isGrid ? '' : 'pressed text-accent'}
             title="List view"


### PR DESCRIPTION
## Summary

- **More Actions buttons**: Darker pressed state background, outward shadow in light mode
- **Context menu**: Improved hover visibility and separator contrast, removed auto-focus ring
- **Song cards/rows**: Prevent press animation when clicking Play or More Actions buttons  
- **View mode toggle**: Removed `startTransition` for more responsive feel
- **Appearance tab**: Centered button text/icons, improved styling

## Test plan

- [x] Test More Actions button pressed state in dark and light mode
- [x] Test context menu hover and separators in both modes
- [x] Verify Play and More Actions buttons don't trigger card press animation
- [x] Test view mode switching feels responsive
- [x] Verify Appearance buttons are centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)