### PR TITLE
fix(web): prevent phantom login screen from auth refresh failures

### DIFF
--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -95,7 +95,11 @@ export async function trySilentRefresh(): Promise<boolean> {
   return ok;
 }
 
-async function wrappedFetch(url: string, options: RequestInit = {}): Promise<unknown> {
+async function wrappedFetch(
+  url: string,
+  options: RequestInit = {},
+  retryCount = 0
+): Promise<unknown> {
   const makeRequest = async (): Promise<Response> =>
     fetchWithTimeout(url, { ...options, credentials: 'include' });
 
@@ -109,11 +113,16 @@ async function wrappedFetch(url: string, options: RequestInit = {}): Promise<unk
       throw new Error('Unauthorized');
     }
 
+    // Prevent infinite refresh loops — only retry once per call chain
+    if (retryCount >= 1) {
+      throw new Error('Unauthorized');
+    }
+
     // If already refreshing, queue this request
     if (isRefreshing) {
       return new Promise((resolve, reject) => {
         failedQueue.push({ resolve: resolve as () => void, reject });
-      }).then(() => makeRequest());
+      }).then(() => wrappedFetch(url, options, retryCount + 1));
     }
 
     // Start refreshing

--- a/packages/web/src/context/AuthContext.tsx
+++ b/packages/web/src/context/AuthContext.tsx
@@ -34,15 +34,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       const me = await getMe();
       setUser(me);
     } catch {
+      // First attempt failed (network error, expired token, etc.).
+      // trySilentRefresh refreshes the token. If it succeeds, retry getMe
+      // once. wrappedFetch handles any further 401s transparently.
       const refreshed = await trySilentRefresh();
       if (refreshed) {
-        const me = await getMe();
-        setUser(me);
-        setLoading(false);
-        isAuthChecking.current = false;
-        return;
+        try {
+          const me = await getMe();
+          setUser(me);
+        } catch {
+          setUser(null);
+        }
+      } else {
+        setUser(null);
       }
-      setUser(null);
     } finally {
       setLoading(false);
       isAuthChecking.current = false;


### PR DESCRIPTION
## Summary

- Fixes the intermittent "phantom login screen" where authenticated users see the login page instead of their expected content, roughly every hour
- Root cause: two bugs in the auth token refresh flow that could leave the UI redirecting to `/login` even though valid cookies exist
- A simple page refresh always resolved the issue because the cookies were correctly persisted

## Root Cause

**Bug 1 — Unhandled rejection in `AuthContext.refetch`:** The catch block called `getMe()` a second time after a successful silent refresh, but this inner call wasn't wrapped in try-catch. If it threw (e.g., cookie propagation delay after refresh), the error went unhandled, `finally` set `loading=false` with `user=null`, and `ProtectedRoute` redirected to `/login`.

**Bug 2 — Infinite 401→refresh→retry loop in `wrappedFetch`:** After a successful refresh, the retry could get another 401 if the browser hadn't processed the Set-Cookie headers yet. `isRefreshing` was already `false`, so `wrappedFetch` would start a second refresh cycle that could consume the brand-new single-use refresh token, leaving the client in an inconsistent cookie state.

## Fix

- Wrapped the inner `getMe()` call in `AuthContext.refetch` in a try-catch
- Added a `retryCount` guard to `wrappedFetch` that limits 401→refresh→retry to one cycle per call chain, preventing the infinite refresh loop
- Both `bun run check` (lint/format) and `tsc --noEmit` pass

## Test Plan

- [x] Verify normal login flow still works (login via Discord, get redirected to songs)
- [x] Verify session persists across page refreshes
- [x] Verify no phantom login screen appears after access token expiry (1 hour) — can test by manually clearing the `session` cookie
- [x] Verify concurrent API calls during token refresh don't corrupt state

🤖 Generated with [Claude Code](https://claude.com/claude-code)