### PR TITLE
security: pin exact versions, fix vulnerabilities, add supply-chain protections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /app
 FROM build AS dev
 RUN apk add --no-cache git
 WORKDIR /usr/local/nodelink
-ARG NODELINK_VERSION=v3
+ARG NODELINK_VERSION=v3.7.0
 RUN git clone --depth 1 --branch ${NODELINK_VERSION} https://github.com/PerformanC/NodeLink.git . && \
     bun install && \
     bun run build
@@ -23,7 +23,7 @@ WORKDIR /app
 COPY package.json bun.lock ./
 COPY packages ./packages
 
-RUN bun install
+RUN bun install --frozen-lockfile
 RUN bun run --filter @alfira-bot/server build && \
     bun run --filter @alfira-bot/web build
 
@@ -43,7 +43,7 @@ FROM build AS builder
 COPY package.json bun.lock ./
 COPY packages ./packages
 
-RUN bun install
+RUN bun install --frozen-lockfile
 # NOTE: NODE_ENV is not set here because bun build produces broken bundles
 # with NODE_ENV=production due to how React 19's JSX runtime is bundled.
 # NODE_ENV=production is set in the runtime stage instead.
@@ -72,7 +72,7 @@ COPY --from=builder --chown=nodejs:nodejs /app/bun.lock ./bun.lock
 COPY --from=builder --chown=nodejs:nodejs /app/packages ./packages
 
 # Let Bun install workspace dependencies in the runtime image
-RUN bun install --production
+RUN bun install --frozen-lockfile --production
 
 # server and web are workspace:* deps - copy their built output
 COPY --from=builder --chown=nodejs:nodejs /app/packages/server/dist ./packages/server/dist

--- a/bun.lock
+++ b/bun.lock
@@ -5,28 +5,28 @@
     "": {
       "name": "alfira-bot",
       "devDependencies": {
-        "@biomejs/biome": "^2.4.9",
-        "@types/node": "^25.6.0",
-        "typescript": "^6.0.0",
+        "@biomejs/biome": "2.4.10",
+        "@types/node": "25.6.0",
+        "typescript": "6.0.2",
       },
     },
     "packages/server": {
       "name": "@alfira-bot/server",
       "version": "0.1.0",
       "dependencies": {
-        "cookie": "^1.1.1",
-        "dotenv": "^17.3.1",
-        "drizzle-orm": "^0.45.2",
-        "hoshimi": "^0.3.9",
-        "jsonwebtoken": "^9.0.3",
-        "pino": "^10.0.0",
-        "seyfert": "^4.3.0",
+        "cookie": "1.1.1",
+        "dotenv": "17.4.1",
+        "drizzle-orm": "0.45.2",
+        "hoshimi": "0.3.9",
+        "jsonwebtoken": "9.0.3",
+        "pino": "10.3.1",
+        "seyfert": "4.3.0",
       },
       "devDependencies": {
-        "@types/jsonwebtoken": "^9.0.10",
-        "@types/node": "^25.4.0",
-        "bun-types": "^1.3.11",
-        "typescript": "^6.0.0",
+        "@types/jsonwebtoken": "9.0.10",
+        "@types/node": "25.5.2",
+        "bun-types": "1.3.11",
+        "typescript": "6.0.2",
       },
     },
     "packages/web": {
@@ -34,30 +34,31 @@
       "version": "0.1.0",
       "dependencies": {
         "@alfira-bot/server": "workspace:*",
-        "@phosphor-icons/react": "^2.1.10",
-        "@tanstack/react-virtual": "^3.13.23",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
-        "react-router-dom": "^7.13.2",
+        "@phosphor-icons/react": "2.1.10",
+        "@tanstack/react-virtual": "3.13.23",
+        "react": "19.2.4",
+        "react-dom": "19.2.4",
+        "react-router-dom": "7.18.0",
       },
       "devDependencies": {
-        "@tailwindcss/cli": "^4.2.2",
-        "@types/react": "^19.2.14",
-        "@types/react-dom": "^19.2.3",
-        "autoprefixer": "^10.4.20",
-        "bun-types": "^1.3.11",
-        "postcss": "^8.5.8",
-        "tailwindcss": "^4.2.2",
-        "typescript": "^6.0.0",
+        "@tailwindcss/cli": "4.2.2",
+        "@types/react": "19.2.14",
+        "@types/react-dom": "19.2.3",
+        "autoprefixer": "10.4.27",
+        "bun-types": "1.3.11",
+        "postcss": "8.5.10",
+        "tailwindcss": "4.2.2",
+        "typescript": "6.0.2",
       },
     },
   },
   "overrides": {
     "lodash": "4.17.23",
-    "react": "^19.2.4",
-    "react-dom": "^19.2.4",
+    "react": "19.2.4",
+    "react-dom": "19.2.4",
     "serialize-javascript": "7.0.4",
     "undici": "6.24.0",
+    "ws": "8.21.0",
   },
   "packages": {
     "@alfira-bot/server": ["@alfira-bot/server@workspace:packages/server"],
@@ -280,7 +281,7 @@
 
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
 
-    "postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
+    "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
@@ -294,9 +295,9 @@
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
-    "react-router": ["react-router@7.14.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ=="],
+    "react-router": ["react-router@7.18.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ=="],
 
-    "react-router-dom": ["react-router-dom@7.14.0", "", { "dependencies": { "react-router": "7.14.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-2G3ajSVSZMEtmTjIklRWlNvo8wICEpLihfD/0YMDxbWK2UyP5EGfnoIn9AIQGnF3G/FX0MRbHXdFcD+rL1ZreQ=="],
+    "react-router-dom": ["react-router-dom@7.18.0", "", { "dependencies": { "react-router": "7.18.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA=="],
 
     "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
@@ -330,7 +331,7 @@
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
-    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "@alfira-bot/server/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 

--- a/package.json
+++ b/package.json
@@ -18,15 +18,16 @@
     "check": "biome check --write ."
   },
   "overrides": {
-    "react": "^19.2.4",
-    "react-dom": "^19.2.4",
+    "react": "19.2.4",
+    "react-dom": "19.2.4",
     "serialize-javascript": "7.0.4",
     "undici": "6.24.0",
-    "lodash": "4.17.23"
+    "lodash": "4.17.23",
+    "ws": "8.21.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.9",
-    "@types/node": "^25.6.0",
-    "typescript": "^6.0.0"
+    "@biomejs/biome": "2.4.10",
+    "@types/node": "25.6.0",
+    "typescript": "6.0.2"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,18 +17,18 @@
     "db:studio": "cd ../.. && drizzle-kit studio"
   },
   "dependencies": {
-    "cookie": "^1.1.1",
-    "dotenv": "^17.3.1",
-    "drizzle-orm": "^0.45.2",
-    "hoshimi": "^0.3.9",
-    "jsonwebtoken": "^9.0.3",
-    "pino": "^10.0.0",
-    "seyfert": "^4.3.0"
+    "cookie": "1.1.1",
+    "dotenv": "17.4.1",
+    "drizzle-orm": "0.45.2",
+    "hoshimi": "0.3.9",
+    "jsonwebtoken": "9.0.3",
+    "pino": "10.3.1",
+    "seyfert": "4.3.0"
   },
   "devDependencies": {
-    "@types/jsonwebtoken": "^9.0.10",
-    "@types/node": "^25.4.0",
-    "bun-types": "^1.3.11",
-    "typescript": "^6.0.0"
+    "@types/jsonwebtoken": "9.0.10",
+    "@types/node": "25.5.2",
+    "bun-types": "1.3.11",
+    "typescript": "6.0.2"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -10,20 +10,20 @@
   },
   "dependencies": {
     "@alfira-bot/server": "workspace:*",
-    "@phosphor-icons/react": "^2.1.10",
-    "@tanstack/react-virtual": "^3.13.23",
-    "react": "^19.2.4",
-    "react-dom": "^19.2.4",
-    "react-router-dom": "^7.13.2"
+    "@phosphor-icons/react": "2.1.10",
+    "@tanstack/react-virtual": "3.13.23",
+    "react": "19.2.4",
+    "react-router-dom": "7.18.0",
+    "react-dom": "19.2.4"
   },
   "devDependencies": {
-    "@tailwindcss/cli": "^4.2.2",
-    "@types/react": "^19.2.14",
-    "@types/react-dom": "^19.2.3",
-    "autoprefixer": "^10.4.20",
-    "bun-types": "^1.3.11",
-    "postcss": "^8.5.8",
-    "tailwindcss": "^4.2.2",
-    "typescript": "^6.0.0"
+    "@tailwindcss/cli": "4.2.2",
+    "@types/react": "19.2.14",
+    "@types/react-dom": "19.2.3",
+    "autoprefixer": "10.4.27",
+    "bun-types": "1.3.11",
+    "postcss": "8.5.10",
+    "tailwindcss": "4.2.2",
+    "typescript": "6.0.2"
   }
 }


### PR DESCRIPTION
## Summary

Pins all dependency versions to exact versions (no caret ranges), fixes 7 security vulnerabilities, and adds defense-in-depth supply-chain protections.

## Changes

### Dependency Updates
- **postcss**: 8.5.9 → 8.5.10 (fixes XSS via unescaped `</style>`)
- **react-router-dom**: 7.13.2 → 7.18.0 (fixes RCE, DoS, open redirect, CSRF)
- **ws override**: 8.21.0 (fixes hoshimi's transitive DoS vulnerability)

### Version Pinning
- All `package.json` files: removed `^` prefixes → exact versions
- **NodeLink**: pinned to `v3.7.0` (v3.8.0 has TypeScript build error)

### Supply-Chain Protections
- `--frozen-lockfile` on all Dockerfile `bun install` stages (dev, builder, runtime)
- CI already enforced `--frozen-lockfile` (typecheck.yml)
- Lockfile contains SHA512 hashes for all transitive dependencies

## Security Impact

| Before | After |
|--------|-------|
| 7 vulnerabilities (3 high, 3 moderate, 1 low) | **0 vulnerabilities** |
| Caret ranges allowing auto-upgrades | Exact versions requiring intentional updates |
| Lockfile only | Lockfile + package.json pins + CI gate + Docker enforcement |

## Verification

- `bun audit`: 0 vulnerabilities
- `bun run check`: passes
- `bun run --filter @alfira-bot/server build`: passes
- `bun run --filter @alfira-bot/web build`: passes
- Docker build: passes (tested with `bun run dev`)

## Update Process Going Forward

To update a dependency:
1. Edit version in `package.json`
2. Run `bun install`
3. Test locally
4. Commit updated `bun.lock`