### PR TITLE
fix: auto-unregister stale Discord slash commands on startup + admin docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,8 @@ WEB_UI_ORIGIN=https://your-domain.com
 GUILD_ID=your-guild-id-here
 
 # Admin role ID(s) - comma-separated for multiple (enable Developer Mode, right-click role, Copy ID)
+# REQUIRED: Users with this role can add songs, manage playlists, use quick-add.
+# Also requires "Server Members Intent" enabled in Discord Developer Portal → Bot → Privileged Gateway Intents.
 ADMIN_ROLE_IDS=your-admin-role-id-here
 
 # Minutes the bot waits before leaving a voice channel when idle (paused or queue empty)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,8 +22,10 @@ cp .env.example .env
 | `DISCORD_CLIENT_SECRET` | Discord application client secret | `abc123def456...` |
 | `DISCORD_BOT_TOKEN` | Discord bot token | `MTAwMC4xMjM0NTY3ODkw...` |
 | `GUILD_ID` | Discord server ID where the bot operates | `987654321098765432` |
-| `ADMIN_ROLE_IDS` | Discord role ID(s) for admin users (comma-separated) | `123456789012345678` |
+| `ADMIN_ROLE_IDS` | **Required for admin features.** Discord role ID(s) that grant admin permissions (comma-separated). Users with this role can add songs, manage playlists, and use quick-add. | `123456789012345678` or `123...,456...` |
 | `JWT_SECRET` | Secret key for signing JWT tokens | `your-secure-random-string` |
+
+> **⚠️ Critical:** `ADMIN_ROLE_IDS` is **required** for the "Add Song" button and other admin features to appear in the web UI. Without it, no one can add songs to the library. Also ensure **Server Members Intent** is enabled in the Discord Developer Portal (Bot → Privileged Gateway Intents).
 
 ### Database
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -82,7 +82,36 @@ No local Node.js installation needed — Docker handles everything.
 
 1. Enable **Developer Mode** in Discord: Settings → Advanced → Developer Mode.
 2. Right-click your server icon and select **"Copy Server ID"** — this is your `GUILD_ID`.
-3. Right-click the admin role and select **"Copy Role ID"** — this is your `ADMIN_ROLE_IDS`.
+3. Right-click the **admin role** (the role that should have permission to add songs/manage the bot) and select **"Copy Role ID"** — this is your `ADMIN_ROLE_IDS`.
+   - For multiple admin roles, use comma-separated IDs: `123456789012345678,987654321098765432`
+   - **Important:** Only users with this role will see the "Add Song" button and other admin features in the web UI. Non-admin users can only play existing songs from the library.
+
+### 6. Enable Server Members Intent (Required for Admin Detection)
+
+The bot needs to fetch guild member roles to determine admin status. This requires the **Server Members Intent**:
+
+1. Go to the [Discord Developer Portal](https://discord.com/developers/applications) → your application.
+2. Navigate to **Bot** in the left sidebar.
+3. Under **Privileged Gateway Intents**, enable **Server Members Intent** (in addition to Message Content Intent).
+4. Click **"Save Changes"**.
+
+> **Without this intent**, the bot cannot verify admin roles — all users will be treated as non-admin, and the "Add Song" button will not appear for anyone.
+
+---
+
+### Stale Slash Commands Cleanup (Automatic)
+
+If you previously used an older version of Alfira with slash commands (`/play`, `/skip`, etc.), Discord may still have them registered. They were removed in April 2026 in favor of web-UI-only control.
+
+**This is now handled automatically on server startup.** The bot will unregister any stale guild/global commands when it starts. No manual step needed.
+
+If you need to run it manually (e.g., without restarting the container):
+
+```bash
+bun run discord:unregister-commands
+```
+
+After cleanup, commands disappear from Discord's menu immediately (guild) or within 1 hour (global).
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -37,6 +37,36 @@ Common issues and solutions for Alfira.
 2. Check that `WEB_UI_ORIGIN` matches your actual domain.
 3. Ensure you're using `https://` in production.
 
+### "Add Song" button not visible / Admin features missing
+
+**Symptoms:** Logged in but no "Add Song" button, can't use quick-add, can't manage playlists.
+
+**Solutions:**
+1. **Check `ADMIN_ROLE_IDS` in `.env`** — must be set to your actual Discord role ID (not the placeholder).
+2. **Enable Server Members Intent** — Go to Discord Developer Portal → Bot → Privileged Gateway Intents → enable **Server Members Intent** → Save Changes.
+3. **Verify role ID** — Enable Developer Mode in Discord (Settings → Advanced), right-click the admin role → "Copy Role ID".
+4. **Re-login** — Admin status is cached in the JWT token. Log out and log back in after fixing the above.
+5. **Check logs** — Run `docker compose logs alfira | grep -i admin` to verify the bot detects your admin status.
+
+### "undefined command does not have 'run' callback" / Slash commands not working
+
+**Symptoms:** Trying `/play`, `/skip`, `/leave`, etc. in Discord gives "The application did not respond" or similar errors.
+
+**Cause:** Alfira **removed Discord slash commands in April 2026** — all playback control is now done exclusively through the **web UI**. However, Discord may still have the old commands cached/registered.
+
+**Solutions:**
+1. **Use the web UI instead** — Play/pause/skip/seek via the Now Playing bar, Play buttons on songs/playlists, or queue management (Up Next, Quick Add, Override).
+2. **Restart the container** — Stale commands are now automatically unregistered on **every server startup**:
+   ```bash
+   docker compose restart alfira
+   ```
+3. **Manual unregister (if needed)** — Run this to clean up without a full restart:
+   ```bash
+   bun run discord:unregister-commands
+   ```
+   (Requires `.env` with `DISCORD_BOT_TOKEN`, `DISCORD_CLIENT_ID`, `GUILD_ID`)
+4. **Wait for Discord cache** — After unregistering, commands disappear from Discord's menu immediately for guild commands (global commands can take up to 1 hour).
+
 ## Database Issues
 
 ### Connection errors

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "db:migrate": "bun run --filter @alfira-bot/server db:migrate",
     "db:generate": "bun run --filter @alfira-bot/server db:generate",
     "db:studio": "bun run --filter @alfira-bot/server db:studio",
+    "discord:unregister-commands": "bun run packages/server/src/utils/unregisterCommands.ts",
     "lint": "biome lint .",
     "lint:fix": "biome lint --write .",
     "format": "biome format --write .",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -18,6 +18,7 @@ import { handleSongs } from './routes/songs';
 import { handleTags } from './routes/tags';
 import { $client, db } from './shared/db';
 import { destroyAllPlayers, startDiscord } from './startDiscord';
+import { unregisterStaleCommands } from './utils/unregisterCommands';
 
 // ---------------------------------------------------------------------------
 // Validate required environment variables.
@@ -344,6 +345,13 @@ async function main(): Promise<void> {
   } catch (error) {
     logger.error(error, 'Could not connect to the database');
     process.exit(1);
+  }
+
+  // 2.5. Unregister stale Discord slash commands (from pre-web-UI versions).
+  try {
+    await unregisterStaleCommands();
+  } catch (error) {
+    logger.error(error, 'Failed to unregister stale commands (non-fatal)');
   }
 
   // 3. Start NodeLink in-process.

--- a/packages/server/src/utils/unregisterCommands.ts
+++ b/packages/server/src/utils/unregisterCommands.ts
@@ -1,0 +1,126 @@
+/**
+ * unregisterCommands.ts
+ *
+ * Unregisters stale Discord slash commands from the bot.
+ * Runs automatically on server startup, or can be invoked manually:
+ *   bun run packages/server/src/utils/unregisterCommands.ts
+ *
+ * Requires: DISCORD_BOT_TOKEN, DISCORD_CLIENT_ID, GUILD_ID in .env
+ */
+
+import { logger } from '../lib/config';
+
+/** Delay helper for rate limit pacing. */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Delete a command with retry on rate limit (429). */
+async function deleteCommand(
+  url: string,
+  token: string,
+  cmdName: string,
+  type: 'guild' | 'global'
+): Promise<boolean> {
+  const headers = { Authorization: `Bot ${token}` };
+
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    const res = await fetch(url, { method: 'DELETE', headers });
+
+    if (res.ok) {
+      logger.info({ name: cmdName, type }, 'Removed command');
+      return true;
+    }
+
+    if (res.status === 429) {
+      const errText = await res.text();
+      let retryAfter = 1000; // default 1s
+      try {
+        const err = JSON.parse(errText);
+        retryAfter = Math.ceil((err.retry_after ?? 1) * 1000) + 100; // add buffer
+      } catch {
+        // ignore parse errors
+      }
+      logger.warn({ name: cmdName, type, attempt, retryAfter }, 'Rate limited, retrying...');
+      await delay(retryAfter);
+      continue;
+    }
+
+    // Other error (404, 403, etc.) - don't retry
+    const err = await res.text();
+    logger.error({ name: cmdName, type, status: res.status, err }, 'Failed to remove command');
+    return false;
+  }
+
+  logger.error({ name: cmdName, type }, 'Max retries exceeded for command removal');
+  return false;
+}
+
+/** Unregister all guild and global commands for this application. */
+export async function unregisterStaleCommands(): Promise<void> {
+  const { DISCORD_BOT_TOKEN, DISCORD_CLIENT_ID, GUILD_ID } = process.env;
+
+  if (!DISCORD_BOT_TOKEN || !DISCORD_CLIENT_ID || !GUILD_ID) {
+    logger.warn(
+      'Missing env vars for command unregistration (DISCORD_BOT_TOKEN, DISCORD_CLIENT_ID, GUILD_ID)'
+    );
+    return;
+  }
+
+  // Delete all guild commands
+  const res = await fetch(
+    `https://discord.com/api/v10/applications/${DISCORD_CLIENT_ID}/guilds/${GUILD_ID}/commands`,
+    { headers: { Authorization: `Bot ${DISCORD_BOT_TOKEN}` } }
+  );
+
+  if (!res.ok) {
+    const err = await res.text();
+    logger.error({ status: res.status, err }, 'Failed to fetch guild commands');
+    return;
+  }
+
+  const commands = (await res.json()) as { id: string; name: string }[];
+
+  if (commands.length === 0) {
+    logger.info('No guild commands to remove');
+  } else {
+    for (const cmd of commands) {
+      await deleteCommand(
+        `https://discord.com/api/v10/applications/${DISCORD_CLIENT_ID}/guilds/${GUILD_ID}/commands/${cmd.id}`,
+        DISCORD_BOT_TOKEN,
+        cmd.name,
+        'guild'
+      );
+      await delay(200); // pace requests to avoid rate limits
+    }
+  }
+
+  // Also clean up any global commands (if any were ever registered)
+  const globalRes = await fetch(
+    `https://discord.com/api/v10/applications/${DISCORD_CLIENT_ID}/commands`,
+    { headers: { Authorization: `Bot ${DISCORD_BOT_TOKEN}` } }
+  );
+
+  if (globalRes.ok) {
+    const globalCommands = (await globalRes.json()) as { id: string; name: string }[];
+    for (const cmd of globalCommands) {
+      await deleteCommand(
+        `https://discord.com/api/v10/applications/${DISCORD_CLIENT_ID}/commands/${cmd.id}`,
+        DISCORD_BOT_TOKEN,
+        cmd.name,
+        'global'
+      );
+      await delay(200);
+    }
+  }
+
+  logger.info('Stale command cleanup complete');
+}
+
+// Allow running as standalone script: `bun run unregisterCommands.ts`
+if (import.meta.main) {
+  // Load env when run directly (index.ts already loads it on startup)
+  await import('dotenv/config');
+  await unregisterStaleCommands();
+  process.exit(0);
+}


### PR DESCRIPTION
## Summary

Attempts to fix two related issues from #468:

### 1. Stale slash commands causing 'undefined command does not have run callback'

The bot removed Discord slash commands in April 2026 (commit bf91a07), but they were never unregistered from Discord. Users trying /play, /join, etc. got errors because Discord still had them registered.

**Solution:** Added automatic cleanup on server startup:
- New utility with rate-limit handling (respects , up to 3 retries, 200ms pacing)
- Runs automatically after DB verification, before NodeLink starts

### 2. Unclear admin role setup docs

ADMIN_ROLE_IDS is required for the 'Add Song' button, and Server Members Intent must be enabled.

**Solution:** Updated docs across multiple files:
-  Clearer comment on ADMIN_ROLE_IDS
-  Step for Server Members Intent, note about auto cleanup

## Testing

- Built Docker image and started container
- Verified startup logs show 'No guild commands to remove' on subsequent runs
- Rate limit handling tested during initial cleanup (retries worked)