### PR TITLE
chore(deps-dev): bump typescript from 6.0.2 to 6.0.3 (manual merge)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.10",
     "@types/node": "25.6.0",
-    "typescript": "6.0.2"
+    "typescript": "6.0.3"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -29,6 +29,6 @@
     "@types/jsonwebtoken": "9.0.10",
     "@types/node": "25.5.2",
     "bun-types": "1.3.14",
-    "typescript": "6.0.2"
+    "typescript": "6.0.3"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -24,6 +24,6 @@
     "bun-types": "1.3.14",
     "postcss": "8.5.10",
     "tailwindcss": "4.2.2",
-    "typescript": "6.0.2"
+    "typescript": "6.0.3"
   }
 }


### PR DESCRIPTION
Manual merge of dependabot PR #477 which had conflicts due to other dependabot PRs being merged first.