### PR TITLE
fix: use artwork URL as display image with thumbnailUrl fallback

### DIFF
--- a/packages/web/src/components/AddSongsModal.tsx
+++ b/packages/web/src/components/AddSongsModal.tsx
@@ -211,7 +211,7 @@ const SongRow = memo(function SongRow({
     <div className="flex items-center gap-2 md:gap-3 px-4 md:px-5 py-3 hover:bg-elevated active:bg-elevated/80 transition-colors duration-100">
       <div className="overflow-hidden w-10 h-10 md:w-8 md:h-8 rounded border border-border shrink-0">
         <img
-          src={song.thumbnailUrl}
+          src={song.artwork ?? song.thumbnailUrl}
           alt={song.nickname || song.title}
           className="w-full h-full object-cover scale-[1.33]"
           loading="lazy"

--- a/packages/web/src/components/NowPlayingBar.tsx
+++ b/packages/web/src/components/NowPlayingBar.tsx
@@ -384,7 +384,7 @@ const AlbumArt = memo(function AlbumArt({ currentSong, isPlaying, isPaused }: Al
       )}
       {currentSong ? (
         <img
-          src={currentSong.thumbnailUrl}
+          src={currentSong.artwork ?? currentSong.thumbnailUrl}
           alt={currentSong.title}
           className="w-full h-full object-cover scale-[1.33]"
           decoding="async"

--- a/packages/web/src/components/QueuePanel.tsx
+++ b/packages/web/src/components/QueuePanel.tsx
@@ -368,7 +368,7 @@ const QueueSongItem = memo(function QueueSongItem({
       </span>
       <div className="overflow-hidden w-8 h-8 rounded border border-border shrink-0">
         <img
-          src={song.thumbnailUrl}
+          src={song.artwork ?? song.thumbnailUrl}
           alt={song.nickname || song.title}
           className="w-full h-full object-cover scale-[1.33]"
           loading="lazy"
@@ -508,7 +508,7 @@ const NowPlayingCard = memo(function NowPlayingCard({
       <div className="flex gap-3 p-3">
         <div className="relative shrink-0 overflow-hidden rounded-xl">
           <img
-            src={song.thumbnailUrl}
+            src={song.artwork ?? song.thumbnailUrl}
             alt={song.nickname || song.title}
             className="w-20 h-20 rounded-xl border border-border object-cover scale-[1.33]"
             decoding="async"

--- a/packages/web/src/components/SongCard.tsx
+++ b/packages/web/src/components/SongCard.tsx
@@ -67,7 +67,7 @@ const SongCardInner = ({
         className="relative aspect-square bg-elevated overflow-hidden rounded-xl clay-flat m-3 mb-0"
       >
         <img
-          src={song.thumbnailUrl}
+          src={song.artwork ?? song.thumbnailUrl}
           alt=""
           className="w-full h-full object-cover scale-[1.33]"
           loading="lazy"

--- a/packages/web/src/components/SongRow.tsx
+++ b/packages/web/src/components/SongRow.tsx
@@ -115,7 +115,7 @@ export const SongRow = memo(
         >
           <div className="overflow-hidden w-14 h-14 md:w-12 md:h-12 rounded border border-border shrink-0">
             <img
-              src={song.thumbnailUrl}
+              src={song.artwork ?? song.thumbnailUrl}
               alt={song.nickname || song.title}
               className="w-full h-full object-cover scale-[1.33]"
               loading="lazy"


### PR DESCRIPTION
All song display components now check for the custom `artwork` field first and fall back to YouTube's `thumbnailUrl` if not set. This makes the editable artwork field actually visible in the UI.

Fixed components:
- SongCard (library grid view)
- SongRow (playlist/library list view)
- QueuePanel (queue items + now playing card)
- NowPlayingBar (album art)
- AddSongsModal (song picker for playlists)