### PR TITLE
Remove stale shared volume mount from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,6 @@ services:
     volumes:
       # Live-mount server source files — restart the service to pick up changes.
       - ./packages/server/src:/app/packages/server/src
-      # Mount shared source so hot-reload picks up DB changes.
-      - ./packages/shared/src:/app/packages/shared/src
       # Persistent SQLite database storage
       - alfira-data:/data
     healthcheck:


### PR DESCRIPTION
The packages/shared directory no longer exists — shared code now lives at packages/server/src/shared and is covered by the existing server source mount.