### PR TITLE
feat(ci): add Trivy vulnerability, secret, and misconfig scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+
+      - name: Trivy — dependency vulns + secrets
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln,secret
+          severity: CRITICAL,HIGH
+          exit-code: 1
+
       - uses: oven-sh/setup-bun@v2
         with:
           cache: true

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -25,6 +25,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
+      - name: Trivy — Dockerfile misconfigs + vulns + secrets
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln,misconfig,secret
+          severity: CRITICAL,HIGH
+          exit-code: 1
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 


### PR DESCRIPTION
## Summary

Adds Trivy security scanning to both CI workflows to catch vulnerabilities, secrets, and Dockerfile misconfigurations before they reach production.

### Changes

**`.github/workflows/ci.yml`** — runs on every push/PR:
- `scanners: vuln,secret` — scans `bun.lock` for known CVEs and the repo for leaked credentials
- `severity: CRITICAL,HIGH` with `exit-code: 1` — hard fail on critical/high findings

**`.github/workflows/docker-build.yml`** — runs on main pushes + Docker-relevant PRs:
- `scanners: vuln,misconfig,secret` — same as above, plus Dockerfile best-practice checks (non-root user, missing HEALTHCHECK, COPY `--chown`, exposed ports, etc.)
- Same severity threshold and fail behavior

### Why

- The project is a self-hosted Docker image distributed via GHCR with Discord OAuth secrets, JWT secrets, and a `bun.lock` with third-party audio/Discord libraries
- Dependabot handles updates but doesn't detect CVEs
- Trivy's filesystem scan supports Bun lockfiles natively (since v0.56+)