### PR TITLE
chore(ci): pin trivy-action to commit hash v0.36.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Trivy — dependency vulns + secrets
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           scan-type: fs
           scan-ref: .

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Trivy — Dockerfile misconfigs + vulns + secrets
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           scan-type: fs
           scan-ref: .


### PR DESCRIPTION
## Summary

Replaces `aquasecurity/trivy-action@master` with a pinned commit SHA `@a9c7b0f` (tag `v0.36.0`) in both workflow files.

## Why

Pinning by commit hash prevents supply-chain attacks via tag mutation — a tag like `@master` or even `@v0.36.0` can be moved to point at a malicious commit. A full SHA cannot. The `# v0.36.0` comment keeps it human-readable for Dependabot/renovate update PRs.