### PR TITLE
docs(.github): fix service name in bug report log command

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,7 +25,7 @@ What actually happened.
 - Browser (if web UI issue):
 
 ## Relevant logs
-Please paste any relevant log output (from `docker compose logs -f api` or `docker compose logs -f web`):
+Please paste any relevant log output (from `docker compose logs -f alfira`):
 
 ```
 Paste logs here


### PR DESCRIPTION
## What does this PR do?

Fixes outdated service names in the bug report template's log command.

The docker-compose.yml only defines a single `alfira` service (not separate `api` and `web` services), so the template was pointing users at non-existent log commands.

## Related issue

N/A — discovered during template audit.

## Type of change

- [x] Documentation update