### PR TITLE
fix(ci): add explicit permissions block to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary

Adds an explicit `permissions: contents: read` block to the CI workflow, resolving CodeQL alert **#1** (`actions/missing-workflow-permissions`).

## Details

The CI workflow (`.github/workflows/ci.yml`) had no `permissions` key, which means it inherits the repository/organization default — potentially read-write if created before February 2023. Per [GitHub's recommendation](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/assigning-permissions-to-jobs), workflows should declare explicit permissions following the principle of least privilege.

All steps in this workflow are read-only:
- `actions/checkout` — reads repo contents
- `trivy-action` — scans filesystem
- `oven-sh/setup-bun` — installs Bun
- `bun install` / `bun run lint` / `bun run build` / `bunx tsc` — all read-only operations

No write access is required, so `contents: read` is sufficient.