### PR TITLE
ci: pin GitHub Actions to commit SHAs and upgrade codeql-action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
     name: Lint & Typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Trivy — dependency vulns + secrets
-        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scan-ref: .
@@ -29,7 +29,7 @@ jobs:
           severity: CRITICAL,HIGH
           exit-code: 1
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           cache: true
       - name: Install dependencies

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@b0c4fd77f6c559021d78430ec4d0d169ae74a4eb # v3
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
@@ -46,6 +46,6 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@b0c4fd77f6c559021d78430ec4d0d169ae74a4eb # v3
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           category: ${{ matrix.language }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -23,10 +23,10 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Trivy — Dockerfile misconfigs + vulns + secrets
-        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scan-ref: .
@@ -35,11 +35,11 @@ jobs:
           exit-code: 1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Log in to GHCR
         if: github.ref == 'refs/heads/main'
-        uses: docker/login-action@v4.2.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -47,7 +47,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v6.1.0
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ghcr.io/${{ github.repository_owner }}/alfira
           tags: |
@@ -58,7 +58,7 @@ jobs:
             type=sha,prefix=
 
       - name: Build and push
-        uses: docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
## Summary

Pins all GitHub Actions to verified commit SHAs and upgrades `github/codeql-action` from v3 to v4 to resolve deprecation warnings.

## Changes

| File | Action | Change |
|------|--------|--------|
| `codeql.yml` | `github/codeql-action/init` | v3 → v4 (pinned `8aad20d1...`) |
| `codeql.yml` | `github/codeql-action/analyze` | v3 → v4 (pinned `8aad20d1...`) |
| `ci.yml` | `actions/checkout` | `@v7` → pinned `9c091bb2...` |
| `ci.yml` | `oven-sh/setup-bun` | `@v2` → pinned `0c5077e5...` |
| `ci.yml` | `aquasecurity/trivy-action` | tag-object SHA → commit SHA `ed142fd0...` |
| `docker-build.yml` | `actions/checkout` | `@v7` → pinned `9c091bb2...` |
| `docker-build.yml` | `aquasecurity/trivy-action` | tag-object SHA → commit SHA `ed142fd0...` |
| `docker-build.yml` | `docker/setup-buildx-action` | `@v4` → pinned `d7f5e7f5...` |
| `docker-build.yml` | `docker/login-action` | `@v4.2.0` → pinned `650006c6...` |
| `docker-build.yml` | `docker/metadata-action` | `@v6.1.0` → pinned `80c7e94d...` |
| `docker-build.yml` | `docker/build-push-action` | `@v7.2.0` → pinned `f9f3042f...` |

All commit SHAs were verified against their respective tags via the GitHub API.

Fixes warnings:
- _CodeQL Action v3 will be deprecated in December 2026_
- _Node.js 20 is deprecated_ (actions targeting Node.js 20 forced to run on Node.js 24)