### PR TITLE
refactor: replace inline auth/admin checks with shared guard functions

### DIFF
--- a/packages/server/src/lib/guards.ts
+++ b/packages/server/src/lib/guards.ts
@@ -1,9 +1,9 @@
 import type { RouteContext } from '../index';
 import { json } from './json';
 
-export function requireAuth(ctx: RouteContext): Response | null {
-  if (!ctx.user) return json({ error: 'Login required.' }, 401);
-  return null;
+export function requireAuth(ctx: RouteContext): NonNullable<RouteContext['user']> | Response {
+  if (!ctx.user) return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
+  return ctx.user;
 }
 
 export function requireAdmin(ctx: RouteContext): Response | null {

--- a/packages/server/src/routes/compressor.ts
+++ b/packages/server/src/routes/compressor.ts
@@ -1,4 +1,5 @@
 import type { RouteContext } from '../index';
+import { requireAdmin } from '../lib/guards';
 import { json } from '../lib/json';
 import { db, tables } from '../shared/db';
 import { logger } from '../shared/logger';
@@ -26,7 +27,8 @@ function buildFilters(payload: CompressorPayload) {
 }
 
 export async function handleCompressor(ctx: RouteContext, request: Request): Promise<Response> {
-  if (!ctx.isAdmin) return json({ error: 'Admin access required.' }, 403);
+  const adminErr = requireAdmin(ctx);
+  if (adminErr) return adminErr;
 
   let body: CompressorPayload;
   try {

--- a/packages/server/src/routes/equalizer.ts
+++ b/packages/server/src/routes/equalizer.ts
@@ -1,5 +1,6 @@
 import { eq } from 'drizzle-orm';
 import type { RouteContext } from '../index';
+import { requireAdmin } from '../lib/guards';
 import { json } from '../lib/json';
 import { db, tables } from '../shared/db';
 import { logger } from '../shared/logger';
@@ -19,7 +20,8 @@ function buildEqualizerFilter(bands: number[]) {
 }
 
 export async function handleEqualizerGet(ctx: RouteContext): Promise<Response> {
-  if (!ctx.isAdmin) return json({ error: 'Admin access required.' }, 403);
+  const adminErr = requireAdmin(ctx);
+  if (adminErr) return adminErr;
 
   const row = await db
     .select({
@@ -67,7 +69,8 @@ export async function handleEqualizerGet(ctx: RouteContext): Promise<Response> {
 }
 
 export async function handleEqualizerPatch(ctx: RouteContext, request: Request): Promise<Response> {
-  if (!ctx.isAdmin) return json({ error: 'Admin access required.' }, 403);
+  const adminErr = requireAdmin(ctx);
+  if (adminErr) return adminErr;
 
   let body: EqualizerPayload;
   try {

--- a/packages/server/src/routes/player.ts
+++ b/packages/server/src/routes/player.ts
@@ -1,5 +1,6 @@
 import type { RouteContext } from '../index';
 import { GUILD_ID } from '../lib/config';
+import { requireAdmin, requireAuth } from '../lib/guards';
 import { json } from '../lib/json';
 import { requirePlayer, requirePlaying } from '../lib/player';
 import { canAccessPlaylist } from '../lib/playlistAccess';
@@ -26,9 +27,8 @@ const { song: songTable } = tables;
 // GET /api/player/queue — returns current queue state
 // ---------------------------------------------------------------------------
 function handleGetQueue(ctx: RouteContext): Response {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
 
   const hoshimi = getHoshimi();
   const player = getPlayer(GUILD_ID);
@@ -55,11 +55,11 @@ function handleGetQueue(ctx: RouteContext): Response {
 // POST /api/player/play — load songs and start playback
 // ---------------------------------------------------------------------------
 async function handlePlay(ctx: RouteContext, request: Request): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const user = userOrErr;
 
-  const inVoice = await requireUserInVoice(ctx.user.discordId ?? '');
+  const inVoice = await requireUserInVoice(user.discordId);
   if (inVoice instanceof Response) return inVoice;
 
   let body: {
@@ -76,7 +76,7 @@ async function handlePlay(ctx: RouteContext, request: Request): Promise<Response
 
   const { playlistId, mode, loop, startFromSongId } = body;
 
-  const playerResult = await resolveOrAutoJoinPlayer(ctx.user.discordId ?? '');
+  const playerResult = await resolveOrAutoJoinPlayer(user.discordId);
   if (!playerResult.ok) return playerResult.response;
   const player = playerResult.player;
 
@@ -89,7 +89,7 @@ async function handlePlay(ctx: RouteContext, request: Request): Promise<Response
       return json({ error: 'Playlist not found.' }, 404);
     }
 
-    const accessResult = canAccessPlaylist(playlist, ctx.user, undefined);
+    const accessResult = canAccessPlaylist(playlist, user, undefined);
     if (!accessResult.ok) {
       return json({ error: accessResult.error }, 403);
     }
@@ -120,7 +120,7 @@ async function handlePlay(ctx: RouteContext, request: Request): Promise<Response
   const targetLoopMode = loop ?? player.getLoopMode();
   player.setLoopMode(targetLoopMode);
 
-  const requestedBy = ctx.user.username;
+  const requestedBy = user.username;
   const queuedSongs = dbSongs.map((song) =>
     toQueuedSong({ ...song, createdAt: song.createdAt.toISOString() }, requestedBy)
   );
@@ -138,11 +138,11 @@ async function handlePlay(ctx: RouteContext, request: Request): Promise<Response
 // POST /api/player/skip — skip current song
 // ---------------------------------------------------------------------------
 async function handleSkip(ctx: RouteContext): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const user = userOrErr;
 
-  const inVoice = await requireUserInVoice(ctx.user.discordId ?? '');
+  const inVoice = await requireUserInVoice(user.discordId);
   if (inVoice instanceof Response) return inVoice;
 
   const playingResult = requirePlaying();
@@ -156,11 +156,11 @@ async function handleSkip(ctx: RouteContext): Promise<Response> {
 // POST /api/player/leave — stop and disconnect
 // ---------------------------------------------------------------------------
 async function handleLeave(ctx: RouteContext): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const user = userOrErr;
 
-  const inVoice = await requireUserInVoice(ctx.user.discordId ?? '');
+  const inVoice = await requireUserInVoice(user.discordId);
   if (inVoice instanceof Response) return inVoice;
 
   const player = getPlayer(GUILD_ID);
@@ -180,11 +180,11 @@ async function handleLeave(ctx: RouteContext): Promise<Response> {
 // POST /api/player/loop — set loop mode
 // ---------------------------------------------------------------------------
 async function handleLoop(ctx: RouteContext, request: Request): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const user = userOrErr;
 
-  const inVoice = await requireUserInVoice(ctx.user.discordId ?? '');
+  const inVoice = await requireUserInVoice(user.discordId);
   if (inVoice instanceof Response) return inVoice;
 
   let body: { mode?: LoopMode };
@@ -211,14 +211,13 @@ async function handleLoop(ctx: RouteContext, request: Request): Promise<Response
 // POST /api/player/shuffle — shuffle queue (admin only)
 // ---------------------------------------------------------------------------
 async function handleShuffle(ctx: RouteContext): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
-  if (!ctx.isAdmin) {
-    return json({ error: 'Admin access required.' }, 403);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const user = userOrErr;
+  const adminErr = requireAdmin(ctx);
+  if (adminErr) return adminErr;
 
-  const inVoice = await requireUserInVoice(ctx.user.discordId ?? '');
+  const inVoice = await requireUserInVoice(user.discordId);
   if (inVoice instanceof Response) return inVoice;
 
   const player = getPlayer(GUILD_ID);
@@ -235,14 +234,13 @@ async function handleShuffle(ctx: RouteContext): Promise<Response> {
 // POST /api/player/unshuffle — restore original queue order (admin only)
 // ---------------------------------------------------------------------------
 async function handleUnshuffle(ctx: RouteContext): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
-  if (!ctx.isAdmin) {
-    return json({ error: 'Admin access required.' }, 403);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const user = userOrErr;
+  const adminErr = requireAdmin(ctx);
+  if (adminErr) return adminErr;
 
-  const inVoice = await requireUserInVoice(ctx.user.discordId ?? '');
+  const inVoice = await requireUserInVoice(user.discordId);
   if (inVoice instanceof Response) return inVoice;
 
   const playerResult = requirePlayer();
@@ -256,14 +254,13 @@ async function handleUnshuffle(ctx: RouteContext): Promise<Response> {
 // POST /api/player/quick-add — add YouTube URL to priority queue (admin only)
 // ---------------------------------------------------------------------------
 async function handleQuickAdd(ctx: RouteContext, request: Request): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
-  if (!ctx.isAdmin) {
-    return json({ error: 'Admin access required.' }, 403);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const user = userOrErr;
+  const adminErr = requireAdmin(ctx);
+  if (adminErr) return adminErr;
 
-  const inVoice = await requireUserInVoice(ctx.user.discordId ?? '');
+  const inVoice = await requireUserInVoice(user.discordId);
   if (inVoice instanceof Response) return inVoice;
 
   let body: { youtubeUrl?: unknown };
@@ -277,7 +274,7 @@ async function handleQuickAdd(ctx: RouteContext, request: Request): Promise<Resp
   if (!urlResult.ok) return urlResult.response;
   const url = urlResult.value;
 
-  const playerResult = await resolveOrAutoJoinPlayer(ctx.user.discordId ?? '');
+  const playerResult = await resolveOrAutoJoinPlayer(user.discordId);
   if (!playerResult.ok) return playerResult.response;
   const player = playerResult.player;
 
@@ -285,8 +282,8 @@ async function handleQuickAdd(ctx: RouteContext, request: Request): Promise<Resp
   if (!metadataResult.ok) return metadataResult.response;
   const metadata = metadataResult.value;
 
-  const requestedBy = ctx.user.username;
-  const addedBy = ctx.user.discordId ?? '';
+  const requestedBy = user.username;
+  const addedBy = user.discordId;
   const queuedSong = {
     id: `temp-${Date.now()}`,
     title: metadata.title,
@@ -311,14 +308,13 @@ async function handleQuickAdd(ctx: RouteContext, request: Request): Promise<Resp
 // POST /api/player/quick-add-playlist — add playlist to queue (admin only)
 // ---------------------------------------------------------------------------
 async function handleQuickAddPlaylist(ctx: RouteContext, request: Request): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
-  if (!ctx.isAdmin) {
-    return json({ error: 'Admin access required.' }, 403);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const user = userOrErr;
+  const adminErr = requireAdmin(ctx);
+  if (adminErr) return adminErr;
 
-  const inVoice = await requireUserInVoice(ctx.user.discordId ?? '');
+  const inVoice = await requireUserInVoice(user.discordId);
   if (inVoice instanceof Response) return inVoice;
 
   let body: { youtubeUrl?: unknown; maxVideos?: number };
@@ -333,7 +329,7 @@ async function handleQuickAddPlaylist(ctx: RouteContext, request: Request): Prom
   if (!urlResult.ok) return urlResult.response;
   const url = urlResult.value;
 
-  const playerResult = await resolveOrAutoJoinPlayer(ctx.user.discordId ?? '');
+  const playerResult = await resolveOrAutoJoinPlayer(user.discordId);
   if (!playerResult.ok) return playerResult.response;
   const player = playerResult.player;
 
@@ -341,8 +337,8 @@ async function handleQuickAddPlaylist(ctx: RouteContext, request: Request): Prom
   if (!playlistResult.ok) return playlistResult.response;
   const playlistMetadata = playlistResult.value;
 
-  const requestedBy = ctx.user.username;
-  const addedBy = ctx.user.discordId ?? '';
+  const requestedBy = user.username;
+  const addedBy = user.discordId;
   const queuedSongs = playlistMetadata.videos.map((video) => ({
     id: `temp-${Date.now()}-${video.id}`,
     title: video.title,
@@ -370,11 +366,11 @@ async function handleQuickAddPlaylist(ctx: RouteContext, request: Request): Prom
 // POST /api/player/pause-toggle — pause/resume
 // ---------------------------------------------------------------------------
 async function handlePauseToggle(ctx: RouteContext): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const user = userOrErr;
 
-  const inVoice = await requireUserInVoice(ctx.user.discordId ?? '');
+  const inVoice = await requireUserInVoice(user.discordId);
   if (inVoice instanceof Response) return inVoice;
 
   const playingResult = requirePlaying();
@@ -388,11 +384,11 @@ async function handlePauseToggle(ctx: RouteContext): Promise<Response> {
 // POST /api/player/seek — seek to position in current track
 // ---------------------------------------------------------------------------
 async function handleSeek(ctx: RouteContext, request: Request): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const user = userOrErr;
 
-  const inVoice = await requireUserInVoice(ctx.user.discordId ?? '');
+  const inVoice = await requireUserInVoice(user.discordId);
   if (inVoice instanceof Response) return inVoice;
 
   let body: { position?: unknown };
@@ -419,14 +415,13 @@ async function handleSeek(ctx: RouteContext, request: Request): Promise<Response
 // POST /api/player/clear — clear queue (admin only)
 // ---------------------------------------------------------------------------
 async function handleClear(ctx: RouteContext): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
-  if (!ctx.isAdmin) {
-    return json({ error: 'Admin access required.' }, 403);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const user = userOrErr;
+  const adminErr = requireAdmin(ctx);
+  if (adminErr) return adminErr;
 
-  const inVoice = await requireUserInVoice(ctx.user.discordId ?? '');
+  const inVoice = await requireUserInVoice(user.discordId);
   if (inVoice instanceof Response) return inVoice;
 
   const playerResult = requirePlayer();
@@ -440,14 +435,13 @@ async function handleClear(ctx: RouteContext): Promise<Response> {
 // POST /api/player/add-to-priority — add library song to Up Next (admin only)
 // ---------------------------------------------------------------------------
 async function handleAddToPriority(ctx: RouteContext, request: Request): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
-  if (!ctx.isAdmin) {
-    return json({ error: 'Admin access required.' }, 403);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const user = userOrErr;
+  const adminErr = requireAdmin(ctx);
+  if (adminErr) return adminErr;
 
-  const inVoice = await requireUserInVoice(ctx.user.discordId ?? '');
+  const inVoice = await requireUserInVoice(user.discordId);
   if (inVoice instanceof Response) return inVoice;
 
   let body: { songId?: unknown };
@@ -469,11 +463,11 @@ async function handleAddToPriority(ctx: RouteContext, request: Request): Promise
     return json({ error: 'Song not found.' }, 404);
   }
 
-  const playerResult = await resolveOrAutoJoinPlayer(ctx.user.discordId ?? '');
+  const playerResult = await resolveOrAutoJoinPlayer(user.discordId);
   if (!playerResult.ok) return playerResult.response;
   const player = playerResult.player;
 
-  const requestedBy = ctx.user.username;
+  const requestedBy = user.username;
   const queuedSong = toQueuedSong(
     { ...song, createdAt: song.createdAt.toISOString() },
     requestedBy
@@ -491,14 +485,13 @@ async function handleAddToPriority(ctx: RouteContext, request: Request): Promise
 // POST /api/player/override — immediately play YouTube URL (admin only)
 // ---------------------------------------------------------------------------
 async function handleOverride(ctx: RouteContext, request: Request): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
-  if (!ctx.isAdmin) {
-    return json({ error: 'Admin access required.' }, 403);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const user = userOrErr;
+  const adminErr = requireAdmin(ctx);
+  if (adminErr) return adminErr;
 
-  const inVoice = await requireUserInVoice(ctx.user.discordId ?? '');
+  const inVoice = await requireUserInVoice(user.discordId);
   if (inVoice instanceof Response) return inVoice;
 
   let body: { youtubeUrl?: unknown };
@@ -512,7 +505,7 @@ async function handleOverride(ctx: RouteContext, request: Request): Promise<Resp
   if (!urlResult.ok) return urlResult.response;
   const url = urlResult.value;
 
-  const playerResult = await resolveOrAutoJoinPlayer(ctx.user.discordId ?? '');
+  const playerResult = await resolveOrAutoJoinPlayer(user.discordId);
   if (!playerResult.ok) return playerResult.response;
   const player = playerResult.player;
 
@@ -520,8 +513,8 @@ async function handleOverride(ctx: RouteContext, request: Request): Promise<Resp
   if (!metadataResult.ok) return metadataResult.response;
   const metadata = metadataResult.value;
 
-  const requestedBy = ctx.user.username;
-  const addedBy = ctx.user.discordId ?? '';
+  const requestedBy = user.username;
+  const addedBy = user.discordId;
   const queuedSong = {
     id: `temp-${Date.now()}`,
     title: metadata.title,

--- a/packages/server/src/routes/playlists.ts
+++ b/packages/server/src/routes/playlists.ts
@@ -1,6 +1,7 @@
 import { and, count, desc, eq, inArray, sql } from 'drizzle-orm';
 import type { RouteContext } from '../index';
 import { getUserDisplayName } from '../lib/displayName';
+import { requireAuth } from '../lib/guards';
 import { json } from '../lib/json';
 import { canAccessPlaylist } from '../lib/playlistAccess';
 import { emitPlaylistUpdated } from '../lib/socket';
@@ -74,9 +75,9 @@ function formatPlaylistSongWithSong(
 // GET /api/playlists — paginated list of playlists
 // ---------------------------------------------------------------------------
 async function handleGetPlaylists(ctx: RouteContext, request: Request): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const user = userOrErr;
 
   const url = new URL(request.url);
   const adminView = url.searchParams.get('adminView') === 'true';
@@ -103,7 +104,7 @@ async function handleGetPlaylists(ctx: RouteContext, request: Request): Promise<
 
   // Filter private playlists: only visible to creator and admins (in Admin View)
   const filteredPlaylists = playlistsWithCounts.filter(
-    (pl) => canAccessPlaylist(pl, ctx.user ?? undefined, adminView).ok
+    (pl) => canAccessPlaylist(pl, user, adminView).ok
   );
 
   // Fetch creator display names for each playlist
@@ -129,9 +130,9 @@ async function handleGetPlaylists(ctx: RouteContext, request: Request): Promise<
 // POST /api/playlists — create a new empty playlist
 // ---------------------------------------------------------------------------
 async function handlePostPlaylist(ctx: RouteContext, request: Request): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const user = userOrErr;
 
   let body: { name?: unknown };
   try {
@@ -148,7 +149,7 @@ async function handlePostPlaylist(ctx: RouteContext, request: Request): Promise<
     .insert(playlistTable)
     .values({
       name: trimmedName,
-      createdBy: ctx.user.discordId ?? '',
+      createdBy: user.discordId,
     })
     .returning();
 
@@ -168,9 +169,9 @@ async function handleGetPlaylist(
   request: Request,
   id: string
 ): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const user = userOrErr;
 
   const url = new URL(request.url);
   const adminView = url.searchParams.get('adminView') === 'true';
@@ -187,7 +188,7 @@ async function handleGetPlaylist(
     return json({ error: 'Playlist not found.' }, 404);
   }
 
-  const accessResult = canAccessPlaylist(playlist, ctx.user ?? undefined, adminView);
+  const accessResult = canAccessPlaylist(playlist, user, adminView);
   if (!accessResult.ok) {
     return json({ error: accessResult.error }, 403);
   }
@@ -284,9 +285,9 @@ async function handlePatchVisibility(
   request: Request,
   id: string
 ): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const user = userOrErr;
 
   let body: { isPrivate?: unknown; adminView?: unknown };
   try {
@@ -305,7 +306,7 @@ async function handlePatchVisibility(
   }
 
   const adminView = body.adminView === true;
-  const accessResult = canAccessPlaylist(existing, ctx.user ?? undefined, adminView);
+  const accessResult = canAccessPlaylist(existing, user, adminView);
   if (!accessResult.ok) {
     return json({ error: accessResult.error }, 403);
   }
@@ -334,9 +335,9 @@ async function handlePatchPlaylist(
   request: Request,
   id: string
 ): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const user = userOrErr;
 
   let body: { name?: unknown };
   try {
@@ -354,7 +355,7 @@ async function handlePatchPlaylist(
     return json({ error: 'Playlist not found.' }, 404);
   }
 
-  const accessResult = canAccessPlaylist(existing, ctx.user ?? undefined, undefined);
+  const accessResult = canAccessPlaylist(existing, user, undefined);
   if (!accessResult.ok) {
     return json({ error: `Only the playlist owner or admins can rename this playlist.` }, 403);
   }
@@ -383,16 +384,16 @@ async function handleDeletePlaylist(
   _request: Request,
   id: string
 ): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const user = userOrErr;
 
   const existing = await findPlaylistOr404(id);
   if (!existing) {
     return json({ error: 'Playlist not found.' }, 404);
   }
 
-  const accessResult = canAccessPlaylist(existing, ctx.user ?? undefined, undefined);
+  const accessResult = canAccessPlaylist(existing, user, undefined);
   if (!accessResult.ok) {
     return json({ error: `Only the playlist owner or admins can delete this playlist.` }, 403);
   }
@@ -406,9 +407,9 @@ async function handleDeletePlaylist(
 // POST /api/playlists/:id/songs — add a song to a playlist
 // ---------------------------------------------------------------------------
 async function handleAddSong(ctx: RouteContext, request: Request, id: string): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const user = userOrErr;
 
   let body: { songId?: unknown };
   try {
@@ -426,7 +427,7 @@ async function handleAddSong(ctx: RouteContext, request: Request, id: string): P
     return json({ error: 'Playlist not found.' }, 404);
   }
 
-  const accessResult = canAccessPlaylist(playlist, ctx.user ?? undefined, undefined);
+  const accessResult = canAccessPlaylist(playlist, user, undefined);
   if (!accessResult.ok) {
     return json(
       { error: `Only the playlist owner or admins can add songs to this playlist.` },
@@ -498,16 +499,16 @@ async function handleRemoveSong(
   playlistId: string,
   songId: string
 ): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const user = userOrErr;
 
   const playlist = await findPlaylistOr404(playlistId);
   if (!playlist) {
     return json({ error: 'Playlist not found.' }, 404);
   }
 
-  const accessResult = canAccessPlaylist(playlist, ctx.user ?? undefined, undefined);
+  const accessResult = canAccessPlaylist(playlist, user, undefined);
   if (!accessResult.ok) {
     return json({ error: `Only the playlist owner or admins can remove songs.` }, 403);
   }

--- a/packages/server/src/routes/songs.ts
+++ b/packages/server/src/routes/songs.ts
@@ -2,6 +2,7 @@ import { eq, inArray, or, sql } from 'drizzle-orm';
 import type { RouteContext } from '../index';
 import { GUILD_ID } from '../lib/config';
 import { getUserDisplayName } from '../lib/displayName';
+import { requireAdmin, requireAuth } from '../lib/guards';
 import { json } from '../lib/json';
 import { formatSong } from '../lib/serialization';
 import { emitSongAdded, emitSongDeleted, emitSongUpdated } from '../lib/socket';
@@ -28,9 +29,8 @@ const { song: songTable } = tables;
 // GET /api/songs — paginated list of songs, newest first.
 // ---------------------------------------------------------------------------
 async function handleGetSongs(ctx: RouteContext, request: Request): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
 
   const url = new URL(request.url);
   const page = Math.max(1, parseInt(url.searchParams.get('page') ?? '1', 10) || 1);
@@ -100,12 +100,11 @@ async function handleGetSongs(ctx: RouteContext, request: Request): Promise<Resp
 // POST /api/songs — add a song by YouTube URL. Admin only.
 // ---------------------------------------------------------------------------
 async function handlePostSong(ctx: RouteContext, request: Request): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
-  if (!ctx.isAdmin) {
-    return json({ error: 'Admin access required.' }, 403);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const user = userOrErr;
+  const adminErr = requireAdmin(ctx);
+  if (adminErr) return adminErr;
 
   let body: { youtubeUrl?: unknown; nickname?: unknown; asPlaylist?: unknown };
   try {
@@ -167,7 +166,7 @@ async function handlePostSong(ctx: RouteContext, request: Request): Promise<Resp
       youtubeId: metadata.youtubeId,
       duration: metadata.duration,
       thumbnailUrl: metadata.thumbnailUrl ?? '',
-      addedBy: ctx.user.discordId ?? '',
+      addedBy: user.discordId,
       nickname: nicknameResult.value,
     })
     .returning();
@@ -186,12 +185,11 @@ async function handlePostSong(ctx: RouteContext, request: Request): Promise<Resp
 // POST /api/songs/import-playlist — import YouTube playlist. Admin only.
 // ---------------------------------------------------------------------------
 async function handleImportPlaylist(ctx: RouteContext, request: Request): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
-  if (!ctx.isAdmin) {
-    return json({ error: 'Admin access required.' }, 403);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const user = userOrErr;
+  const adminErr = requireAdmin(ctx);
+  if (adminErr) return adminErr;
 
   let body: { youtubeUrl?: unknown; maxVideos?: number };
   try {
@@ -253,8 +251,7 @@ async function handleImportPlaylist(ctx: RouteContext, request: Request): Promis
     });
   }
 
-  // Capture discordId before transaction to avoid TypeScript narrowing issues in callbacks
-  const addedByDiscordId = ctx.user?.discordId ?? '';
+  const addedByDiscordId = user.discordId;
 
   // Create songs in a transaction
   const createdSongs = await db.transaction((tx) => {
@@ -299,12 +296,10 @@ async function handleDeleteSong(
   _request: Request,
   id: string
 ): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
-  if (!ctx.isAdmin) {
-    return json({ error: 'Admin access required.' }, 403);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const adminErr = requireAdmin(ctx);
+  if (adminErr) return adminErr;
 
   const [existing] = await db.select().from(songTable).where(eq(songTable.id, id)).limit(1);
   if (!existing) {
@@ -323,12 +318,10 @@ async function handleDeleteSong(
 // PATCH /api/songs/:id — update song fields. Admin only.
 // ---------------------------------------------------------------------------
 async function handlePatchSong(ctx: RouteContext, request: Request, id: string): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
-  if (!ctx.isAdmin) {
-    return json({ error: 'Admin access required.' }, 403);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const adminErr = requireAdmin(ctx);
+  if (adminErr) return adminErr;
 
   let body: Record<string, unknown>;
   try {

--- a/packages/server/src/routes/tags.ts
+++ b/packages/server/src/routes/tags.ts
@@ -1,5 +1,6 @@
 import { eq, sql } from 'drizzle-orm';
 import type { RouteContext } from '../index';
+import { requireAdmin, requireAuth } from '../lib/guards';
 import { json } from '../lib/json';
 import { db, tables } from '../shared/db';
 
@@ -9,9 +10,8 @@ const TAG_COLORS = ['orange', 'sky', 'emerald', 'amber', 'violet'] as const;
 type TagColor = (typeof TAG_COLORS)[number];
 
 async function handleGetTagSongs(ctx: RouteContext, nameLower: string): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
 
   // Fetch all songs where tags JSON array contains this tag (case-insensitive match)
   const songs = await db
@@ -29,12 +29,10 @@ async function handlePatchTag(
   nameLower: string,
   body: Record<string, unknown>
 ): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
-  if (!ctx.isAdmin) {
-    return json({ error: 'Admin access required.' }, 403);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const adminErr = requireAdmin(ctx);
+  if (adminErr) return adminErr;
 
   const [existing] = await db
     .select()
@@ -78,12 +76,10 @@ async function handlePatchTag(
 }
 
 async function handleDeleteTag(ctx: RouteContext, nameLower: string): Promise<Response> {
-  if (!ctx.user) {
-    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-  }
-  if (!ctx.isAdmin) {
-    return json({ error: 'Admin access required.' }, 403);
-  }
+  const userOrErr = requireAuth(ctx);
+  if (userOrErr instanceof Response) return userOrErr;
+  const adminErr = requireAdmin(ctx);
+  if (adminErr) return adminErr;
 
   const [existing] = await db
     .select()
@@ -123,9 +119,8 @@ export async function handleTags(ctx: RouteContext, request: Request): Promise<R
 
   // GET /api/tags
   if (request.method === 'GET' && pathname === '/api/tags') {
-    if (!ctx.user) {
-      return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-    }
+    const userOrErr = requireAuth(ctx);
+    if (userOrErr instanceof Response) return userOrErr;
 
     const tags = await db
       .select({
@@ -151,9 +146,8 @@ export async function handleTags(ctx: RouteContext, request: Request): Promise<R
   // GET /api/tags/:nameLower — get single tag
   if (request.method === 'GET' && pathname.startsWith('/api/tags/')) {
     const nameLower = pathname.slice('/api/tags/'.length);
-    if (!ctx.user) {
-      return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
-    }
+    const userOrErr = requireAuth(ctx);
+    if (userOrErr instanceof Response) return userOrErr;
     const [tag] = await db
       .select()
       .from(tagTable)


### PR DESCRIPTION
## Summary

The codebase had `lib/guards.ts` with `requireAuth()` and `requireAdmin()` functions — but nothing was importing them. Every route handler was manually duplicating the same inline auth and admin checks instead.

## What changed

- **`lib/guards.ts`**: Updated `requireAuth()` to return the user object (enabling TypeScript narrowing after the guard), and updated the error message to match the route convention
- **6 route files**: Replaced all inline `if (!ctx.user)` and `if (!ctx.isAdmin)` checks with guard function calls

## By the numbers


| -  | - |
| ------------- | ------------- |
| Auth checks removed | 32 |
| Admin checks removed | 16 |
| **Total inline blocks eliminated** | **48** |
| Files changed | 7 |
| Behavioral changes | none |

## Files

- `lib/guards.ts` — updated guard signatures
- `routes/player.ts` — 14 auth + 7 admin
- `routes/playlists.ts` — 8 auth
- `routes/songs.ts` — 5 auth + 4 admin
- `routes/tags.ts` — 5 auth + 2 admin
- `routes/equalizer.ts` — 2 admin
- `routes/compressor.ts` — 1 admin