### PR TITLE
refactor: deduplicate EQ band column lists using shared utilities

### DIFF
--- a/packages/server/src/GuildPlayer.ts
+++ b/packages/server/src/GuildPlayer.ts
@@ -1,5 +1,6 @@
 import { eq } from 'drizzle-orm';
 import { DestroyReasons, type Player, SourceNames, Track, type TrackEndEvent } from 'hoshimi';
+import { EQ_BAND_COLUMNS, eqBandsFromRow } from './lib/eqBands';
 import { PlaybackCursor } from './PlaybackCursor';
 import type { LoopMode, QueuedSong, QueueState } from './shared';
 import { db, tables } from './shared/db';
@@ -489,21 +490,7 @@ export class GuildPlayer {
         attack: tables.guildSettings.compressorAttack,
         release: tables.guildSettings.compressorRelease,
         gain: tables.guildSettings.compressorGain,
-        eqBand0: tables.guildSettings.eqBand0,
-        eqBand1: tables.guildSettings.eqBand1,
-        eqBand2: tables.guildSettings.eqBand2,
-        eqBand3: tables.guildSettings.eqBand3,
-        eqBand4: tables.guildSettings.eqBand4,
-        eqBand5: tables.guildSettings.eqBand5,
-        eqBand6: tables.guildSettings.eqBand6,
-        eqBand7: tables.guildSettings.eqBand7,
-        eqBand8: tables.guildSettings.eqBand8,
-        eqBand9: tables.guildSettings.eqBand9,
-        eqBand10: tables.guildSettings.eqBand10,
-        eqBand11: tables.guildSettings.eqBand11,
-        eqBand12: tables.guildSettings.eqBand12,
-        eqBand13: tables.guildSettings.eqBand13,
-        eqBand14: tables.guildSettings.eqBand14,
+        ...EQ_BAND_COLUMNS,
       })
       .from(tables.guildSettings)
       .where(eq(tables.guildSettings.id, 1))
@@ -538,25 +525,7 @@ export class GuildPlayer {
     }
 
     // Apply equalizer filter if any band is non-neutral
-    const eqBands = settings
-      ? [
-          settings.eqBand0,
-          settings.eqBand1,
-          settings.eqBand2,
-          settings.eqBand3,
-          settings.eqBand4,
-          settings.eqBand5,
-          settings.eqBand6,
-          settings.eqBand7,
-          settings.eqBand8,
-          settings.eqBand9,
-          settings.eqBand10,
-          settings.eqBand11,
-          settings.eqBand12,
-          settings.eqBand13,
-          settings.eqBand14,
-        ]
-      : Array(15).fill(50);
+    const eqBands = eqBandsFromRow(settings);
 
     const node = player.node;
     if (node && eqBands.some((b) => b !== 50)) {

--- a/packages/server/src/routes/equalizer.ts
+++ b/packages/server/src/routes/equalizer.ts
@@ -1,5 +1,6 @@
 import { eq } from 'drizzle-orm';
 import type { RouteContext } from '../index';
+import { EQ_BAND_COLUMNS, eqBandsFromRow, eqBandValues } from '../lib/eqBands';
 import { requireAdmin } from '../lib/guards';
 import { json } from '../lib/json';
 import { db, tables } from '../shared/db';
@@ -24,46 +25,12 @@ export async function handleEqualizerGet(ctx: RouteContext): Promise<Response> {
   if (adminErr) return adminErr;
 
   const row = await db
-    .select({
-      eqBand0: tables.guildSettings.eqBand0,
-      eqBand1: tables.guildSettings.eqBand1,
-      eqBand2: tables.guildSettings.eqBand2,
-      eqBand3: tables.guildSettings.eqBand3,
-      eqBand4: tables.guildSettings.eqBand4,
-      eqBand5: tables.guildSettings.eqBand5,
-      eqBand6: tables.guildSettings.eqBand6,
-      eqBand7: tables.guildSettings.eqBand7,
-      eqBand8: tables.guildSettings.eqBand8,
-      eqBand9: tables.guildSettings.eqBand9,
-      eqBand10: tables.guildSettings.eqBand10,
-      eqBand11: tables.guildSettings.eqBand11,
-      eqBand12: tables.guildSettings.eqBand12,
-      eqBand13: tables.guildSettings.eqBand13,
-      eqBand14: tables.guildSettings.eqBand14,
-    })
+    .select(EQ_BAND_COLUMNS)
     .from(tables.guildSettings)
     .where(eq(tables.guildSettings.id, 1))
     .get();
 
-  const bands = row
-    ? [
-        row.eqBand0,
-        row.eqBand1,
-        row.eqBand2,
-        row.eqBand3,
-        row.eqBand4,
-        row.eqBand5,
-        row.eqBand6,
-        row.eqBand7,
-        row.eqBand8,
-        row.eqBand9,
-        row.eqBand10,
-        row.eqBand11,
-        row.eqBand12,
-        row.eqBand13,
-        row.eqBand14,
-      ]
-    : Array(15).fill(50);
+  const bands = eqBandsFromRow(row);
 
   return json({ bands });
 }
@@ -95,43 +62,10 @@ export async function handleEqualizerPatch(ctx: RouteContext, request: Request):
   // Upsert into DB
   await db
     .insert(tables.guildSettings)
-    .values({
-      id: 1,
-      eqBand0: bands[0],
-      eqBand1: bands[1],
-      eqBand2: bands[2],
-      eqBand3: bands[3],
-      eqBand4: bands[4],
-      eqBand5: bands[5],
-      eqBand6: bands[6],
-      eqBand7: bands[7],
-      eqBand8: bands[8],
-      eqBand9: bands[9],
-      eqBand10: bands[10],
-      eqBand11: bands[11],
-      eqBand12: bands[12],
-      eqBand13: bands[13],
-      eqBand14: bands[14],
-    })
+    .values({ id: 1, ...eqBandValues(bands) })
     .onConflictDoUpdate({
       target: tables.guildSettings.id,
-      set: {
-        eqBand0: bands[0],
-        eqBand1: bands[1],
-        eqBand2: bands[2],
-        eqBand3: bands[3],
-        eqBand4: bands[4],
-        eqBand5: bands[5],
-        eqBand6: bands[6],
-        eqBand7: bands[7],
-        eqBand8: bands[8],
-        eqBand9: bands[9],
-        eqBand10: bands[10],
-        eqBand11: bands[11],
-        eqBand12: bands[12],
-        eqBand13: bands[13],
-        eqBand14: bands[14],
-      },
+      set: eqBandValues(bands),
     })
     .run();
 

--- a/packages/server/src/routes/playlists.ts
+++ b/packages/server/src/routes/playlists.ts
@@ -4,9 +4,9 @@ import { getUserDisplayName } from '../lib/displayName';
 import { requireAuth } from '../lib/guards';
 import { json } from '../lib/json';
 import { canAccessPlaylist } from '../lib/playlistAccess';
+import { buildSongSearchClause } from '../lib/search';
 import { emitPlaylistUpdated } from '../lib/socket';
 import { validatePlaylistName } from '../lib/validation';
-import { buildSongSearchClause } from '../lib/search';
 import { db, tables } from '../shared/db';
 
 const { playlist: playlistTable, playlistSong: playlistSongTable } = tables;
@@ -206,7 +206,10 @@ async function handleGetPlaylist(
     if (songIds.length === 0) {
       return json({
         ...playlist,
-        createdAt: playlist.createdAt instanceof Date ? playlist.createdAt.toISOString() : playlist.createdAt,
+        createdAt:
+          playlist.createdAt instanceof Date
+            ? playlist.createdAt.toISOString()
+            : playlist.createdAt,
         songs: [],
         createdByDisplayName: await getUserDisplayName(playlist.createdBy),
         pagination: { page, limit, total: 0, totalPages: 0 },

--- a/packages/server/src/routes/songs.ts
+++ b/packages/server/src/routes/songs.ts
@@ -4,6 +4,7 @@ import { GUILD_ID } from '../lib/config';
 import { getUserDisplayName } from '../lib/displayName';
 import { requireAdmin, requireAuth } from '../lib/guards';
 import { json } from '../lib/json';
+import { buildSongSearchClause } from '../lib/search';
 import { formatSong } from '../lib/serialization';
 import { emitSongAdded, emitSongDeleted, emitSongUpdated } from '../lib/socket';
 import { canonicalizeTags } from '../lib/tagCanonicalization';
@@ -21,7 +22,6 @@ import {
   youTubeUrl,
 } from '../lib/validation';
 import { db, tables } from '../shared/db';
-import { buildSongSearchClause } from '../lib/search';
 import { getPlayer } from '../startDiscord';
 
 const { song: songTable } = tables;


### PR DESCRIPTION
## Summary

Replaces 6 manual repetitions of the 15 `eqBand0`–`eqBand14` column references across `GuildPlayer.ts` and `equalizer.ts` with the existing `EQ_BAND_COLUMNS`, `eqBandsFromRow`, and `eqBandValues` helpers from `lib/eqBands.ts`.

## Changes

| File | What changed |
|---|---|
| `routes/equalizer.ts` | `handleEqualizerGet()` uses `EQ_BAND_COLUMNS` + `eqBandsFromRow()`; `handleEqualizerPatch()` uses `eqBandValues()` for both `.values()` and `.set()` |
| `GuildPlayer.ts` | `playSong()` uses `...EQ_BAND_COLUMNS` in `.select()` and `eqBandsFromRow()` for the band array |

## Why

The utilities in `lib/eqBands.ts` were already written for exactly this purpose but weren't being used. This reduces ~90 lines of boilerplate with zero behavioral change — manually tested, the equalizer still works correctly.