### PR TITLE
fix: queue UI not syncing after play — stop old track + off-by-one

### DIFF
--- a/packages/server/src/GuildPlayer.ts
+++ b/packages/server/src/GuildPlayer.ts
@@ -167,9 +167,16 @@ export class GuildPlayer {
     const arr = Array.isArray(songs) ? songs : [songs];
     this.queue.append(...arr);
 
-    // If paused, clear currentSong so newly added songs start playing
-    // instead of the previously-paused song resuming.
+    // If paused, stop the paused track and clear currentSong so newly
+    // added songs start playing instead of the previously-paused song
+    // resuming. stop(false) is needed so playSong() in the ensuing
+    // ensurePlaying() → playNext() chain doesn't hit the
+    // "player.playing && player.node" gapless-preload skip.
     if (this.paused && this.currentSong !== null) {
+      const hoshimiP = this.hoshimiPlayer();
+      if (hoshimiP) {
+        hoshimiP.stop(false);
+      }
       this.currentSong = null;
     }
 
@@ -183,6 +190,19 @@ export class GuildPlayer {
   }
 
   async replaceQueueAndPlay(songs: QueuedSong[]): Promise<void> {
+    // Stop any currently-playing track before we replace the queue.
+    // stop(false) stops playback without destroying the Hoshimi player or
+    // clearing its voice state, so the subsequent play() in playSong() for
+    // the new first track will start cleanly rather than hitting the
+    // "player.playing && player.node" gapless-preload skip in playSong().
+    //
+    // The async trackEnd event that stop(false) triggers is ignored because
+    // playNext() (called below) holds the playNextLock.
+    const hoshimiP = this.hoshimiPlayer();
+    if (hoshimiP) {
+      hoshimiP.stop(false);
+    }
+
     this.queue.clear();
     this.priorityQueue = [];
     this.currentSong = null;
@@ -190,14 +210,6 @@ export class GuildPlayer {
     this.consecutiveFailures = 0;
     this.queue.replace(songs);
     this.cancelIdleLeave();
-
-    // Note: we intentionally do NOT call player.stop() here. Calling stop(true)
-    // destroys the Hoshimi player, which sends a DELETE to NodeLink and clears its
-    // stored voice session (endpoint/sessionId/token). When the subsequent
-    // play() call then tries to play a new track, NodeLink has no voice state and
-    // logs "No voice state, track is enqueued". Instead, let playNext() call
-    // playSong() which will call play() on the existing player, replacing the
-    // track without destroying the voice session.
 
     await this.playNext();
     this.broadcast();

--- a/packages/server/src/PlaybackCursor.ts
+++ b/packages/server/src/PlaybackCursor.ts
@@ -159,13 +159,15 @@ export class PlaybackCursor<T> {
   // ---------------------------------------------------------------------------
 
   /**
-   * Convert remaining items after the current one to an array.
-   * Excludes the item at the current read position (for "queue" display
-   * that should not include the currently-playing song).
+   * Convert all unplayed items to an array for the queue display.
+   *
+   * After advance(), readIndex points to the next song to be played
+   * (not the currently-playing one). We start from readIndex to
+   * include all songs that haven't been played yet.
    */
   toRemaining(): T[] {
     const result: T[] = [];
-    for (let i = this.readIndex + 1; i < this.buffer.length; i++) {
+    for (let i = this.readIndex; i < this.buffer.length; i++) {
       const idx = this.playbackOrder?.[i] ?? i;
       // idx is always valid since i < this.buffer.length and playbackOrder contains valid indices
       const item = this.buffer[idx];


### PR DESCRIPTION
### Problem

When playing a song from the Songs page or a Playlist, the UI queue panel either showed nothing or was one song short of what was actually enqueued.  The queue  
was correctly populated on the server (skip worked fine), but the WebSocket  
`player:update` events either carried stale state or the queue display had an  
off-by-one error.

### Root cause

Commit `be0ef79` introduced a gapless-preload optimization in `playSong()`:

```ts
if (player.playing && player.node) {
  // skip play() — gapless preload already started this track
}
```

This correctly avoids an audible glitch when the gapless preload (PATCH  
`/nextTrack`) has already started the next track in NodeLink.  However it broke  
`replaceQueueAndPlay()`, which intentionally did **not** call `stop(false)` on  
the old track — it relied on `player.play(newTrack)` to replace it.  Now  
`playSong()` saw `player.playing === true` (old, unrelated track still loaded)  
and skipped `play()`, silently dropping the new queue's first track.

A second, independent bug existed in `PlaybackCursor.toRemaining()`: after  
`advance()`, `readIndex` already points to the **next** unplayed song, but  
the loop started from `readIndex + 1`, omitting one song from the queue  
display.

### Changes

| File | Change |
|---|---|
| `GuildPlayer.ts:replaceQueueAndPlay` | Call `stop(false)` before clearing the queue so the new first track gets a clean `play()`.  The async `trackEnd` is safely ignored thanks to `playNextLock`. |
| `GuildPlayer.ts:addToQueue` (paused path) | Same fix — a paused track still has `player.playing=true`, so `stop(false)` is needed before the ensuing `playNext()` chain. |
| `PlaybackCursor.ts:toRemaining()` | Loop from `readIndex` instead of `readIndex + 1` to include all unplayed songs in the queue display. |