### PR TITLE
fix: remove current track from gapless preload PATCH body

### DIFF
--- a/packages/server/src/utils/nodelink.ts
+++ b/packages/server/src/utils/nodelink.ts
@@ -201,7 +201,7 @@ export async function preloadTrack(
   guildId: string,
   sessionId: string,
   youtubeUrl: string,
-  currentEncoded?: string
+  _currentEncoded?: string
 ): Promise<void> {
   try {
     const response = await restRequest<LoadTrackResponse>(
@@ -216,13 +216,12 @@ export async function preloadTrack(
     };
     if (NODELINK_AUTH) headers.Authorization = NODELINK_AUTH;
 
+    // Only send nextTrack — do NOT include the current track in the PATCH
+    // body. The Lavalink v4 spec expects noReplace as a query parameter, not
+    // a body field. Including track in the body without a proper noReplace
+    // query param causes NodeLink to restart the currently-playing track
+    // (audible restart glitch ~500ms into playback).
     const body: Record<string, unknown> = { nextTrack: { encoded } };
-    // Include the current track so NodeLink can validate the session
-    // association. noReplace ensures it doesn't restart playback.
-    if (currentEncoded) {
-      body.track = { encoded: currentEncoded };
-      body.noReplace = true;
-    }
 
     await fetch(url, {
       method: 'PATCH',


### PR DESCRIPTION
## Problem

Songs restart ~500ms into playback on roughly half of all tracks — an audible glitch where the same song plays twice in quick succession.

## Root Cause

In `preloadTrack()` (`packages/server/src/utils/nodelink.ts`), the gapless preload PATCH request included the current track in the body with `noReplace: true` as a JSON field:

```json
{ "track": { "encoded": "..." }, "noReplace": true, "nextTrack": { "encoded": "..." } }
```

The Lavalink v4 spec expects `noReplace` as a **query parameter** (`?noReplace=true`), not a body field. NodeLink ignores it in the body, so the `track` field unconditionally replaces the currently-playing track with itself — restarting it from the beginning.

The ~500ms delay matches the `setTimeout` in `playSong()` that fires the preload after playback starts. The "about half" variability is a timing race: whether NodeLink has finished registering the track as "playing" before the preload PATCH arrives.

## Fix

Remove the `track` and `noReplace` fields from the preload body. Only `nextTrack` is needed — the session is already identified by the REST endpoint URL. The `currentEncoded` parameter is preserved (now prefixed with `_` ) to keep the caller compiling without changes.