### PR TITLE
refactor(server): extract shared pagination and display-name utilities

### DIFF
--- a/packages/server/src/lib/displayName.ts
+++ b/packages/server/src/lib/displayName.ts
@@ -16,3 +16,20 @@ export async function getUserDisplayName(discordId: string): Promise<string> {
     return discordId;
   }
 }
+
+/**
+ * Resolve Discord display names for a batch of items that have an `addedBy`
+ * field (Discord user ID). Returns a Map of userId → displayName.
+ */
+export async function resolveDisplayNames(
+  items: { addedBy: string }[]
+): Promise<Map<string, string>> {
+  const uniqueIds = [...new Set(items.map((s) => s.addedBy))];
+  const nameMap = new Map<string, string>();
+  await Promise.all(
+    uniqueIds.map(async (id) => {
+      nameMap.set(id, await getUserDisplayName(id));
+    })
+  );
+  return nameMap;
+}

--- a/packages/server/src/routes/playlists.ts
+++ b/packages/server/src/routes/playlists.ts
@@ -1,7 +1,8 @@
 import { and, count, desc, eq, inArray } from 'drizzle-orm';
 import type { RouteContext } from '../index';
-import { getUserDisplayName } from '../lib/displayName';
+import { getUserDisplayName, resolveDisplayNames } from '../lib/displayName';
 import { json } from '../lib/json';
+import { parsePagination } from '../lib/pagination';
 import { canAccessPlaylist } from '../lib/playlistAccess';
 import { checkGuards } from '../lib/routeGuards';
 import { buildSongSearchClause } from '../lib/search';
@@ -82,12 +83,7 @@ async function handleGetPlaylists(ctx: RouteContext, request: Request): Promise<
 
   const url = new URL(request.url);
   const adminView = url.searchParams.get('adminView') === 'true';
-  const page = Math.max(1, parseInt(url.searchParams.get('page') ?? '1', 10) || 1);
-  const limit = Math.min(
-    100,
-    Math.max(1, parseInt(url.searchParams.get('limit') ?? '30', 10) || 30)
-  );
-  const skip = (page - 1) * limit;
+  const { page, limit, skip } = parsePagination(url);
 
   const [playlists, totalResult] = await Promise.all([
     db.select().from(playlistTable).orderBy(playlistTable.createdAt).limit(limit).offset(skip),
@@ -176,12 +172,7 @@ async function handleGetPlaylist(
 
   const url = new URL(request.url);
   const adminView = url.searchParams.get('adminView') === 'true';
-  const page = Math.max(1, parseInt(url.searchParams.get('page') ?? '1', 10) || 1);
-  const limit = Math.min(
-    100,
-    Math.max(1, parseInt(url.searchParams.get('limit') ?? '30', 10) || 30)
-  );
-  const skip = (page - 1) * limit;
+  const { page, limit, skip } = parsePagination(url);
   const search = url.searchParams.get('search')?.trim() ?? '';
 
   const playlist = await findPlaylistOr404(id, true);
@@ -249,13 +240,7 @@ async function handleGetPlaylist(
   const songMap = new Map(songs.map((s) => [s.id, s]));
 
   // Resolve Discord display names for unique addedBy IDs
-  const uniqueIds = [...new Set(songs.map((s) => s.addedBy))];
-  const nameMap = new Map<string, string>();
-  await Promise.all(
-    uniqueIds.map(async (id) => {
-      nameMap.set(id, await getUserDisplayName(id));
-    })
-  );
+  const nameMap = await resolveDisplayNames(songs);
 
   return json({
     ...playlist,

--- a/packages/server/src/routes/songs.ts
+++ b/packages/server/src/routes/songs.ts
@@ -1,8 +1,9 @@
 import { eq, inArray, or, sql } from 'drizzle-orm';
 import type { RouteContext } from '../index';
 import { GUILD_ID } from '../lib/config';
-import { getUserDisplayName } from '../lib/displayName';
+import { resolveDisplayNames } from '../lib/displayName';
 import { json } from '../lib/json';
+import { parsePagination } from '../lib/pagination';
 import { checkGuards } from '../lib/routeGuards';
 import { buildSongSearchClause } from '../lib/search';
 import { formatSong } from '../lib/serialization';
@@ -34,12 +35,7 @@ async function handleGetSongs(ctx: RouteContext, request: Request): Promise<Resp
   if (guards instanceof Response) return guards;
 
   const url = new URL(request.url);
-  const page = Math.max(1, parseInt(url.searchParams.get('page') ?? '1', 10) || 1);
-  const limit = Math.min(
-    100,
-    Math.max(1, parseInt(url.searchParams.get('limit') ?? '30', 10) || 30)
-  );
-  const skip = (page - 1) * limit;
+  const { page, limit, skip } = parsePagination(url);
   const search = url.searchParams.get('search')?.trim() ?? '';
 
   const where = buildSongSearchClause(search || undefined);
@@ -57,13 +53,7 @@ async function handleGetSongs(ctx: RouteContext, request: Request): Promise<Resp
   const total = parseInt(String(countResult[0]?.count ?? 0), 10);
 
   // Resolve Discord display names for unique addedBy IDs
-  const uniqueIds = [...new Set(songs.map((s) => s.addedBy))];
-  const nameMap = new Map<string, string>();
-  await Promise.all(
-    uniqueIds.map(async (id) => {
-      nameMap.set(id, await getUserDisplayName(id));
-    })
-  );
+  const nameMap = await resolveDisplayNames(songs);
 
   const songsWithNames = songs.map((s) => ({
     ...formatSong(s),


### PR DESCRIPTION
## Summary

Eliminates 5 instances of duplicated code across route handlers by using/extracting shared utilities.

### Changes

- **`lib/displayName.ts`** — New `resolveDisplayNames()` batch utility that deduplicates user IDs and resolves all display names in parallel via `Promise.all`

- **`routes/songs.ts`** — Uses `parsePagination(url)` (previously unused) and `resolveDisplayNames(songs)` instead of inline duplicates

- **`routes/playlists.ts`** — Same in both `handleGetPlaylists` and `handleGetPlaylist`

### Net delta
- +10 lines shared utility
- −18 lines duplicated inline code
- 0 functional changes
- Clean lint pass