### PR TITLE
refactor(server): move equalizer method dispatch into route module

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -11,7 +11,7 @@ import { closeAllClients, registerClient, unregisterClient } from './lib/socket'
 import { verifySessionToken } from './middleware/requireAuth';
 import { handleAuth } from './routes/auth';
 import { handleCompressor } from './routes/compressor';
-import { handleEqualizerGet, handleEqualizerPatch } from './routes/equalizer';
+import { handleEqualizer } from './routes/equalizer';
 import { handlePlayer } from './routes/player';
 import { handlePlaylists } from './routes/playlists';
 import { handleSongs } from './routes/songs';
@@ -190,9 +190,7 @@ const server = Bun.serve({
       return setSecurityHeaders(await handleCompressor(ctx, request));
     }
     if (url.pathname.startsWith('/api/settings/equalizer')) {
-      if (request.method === 'GET') return setSecurityHeaders(await handleEqualizerGet(ctx));
-      if (request.method === 'PATCH')
-        return setSecurityHeaders(await handleEqualizerPatch(ctx, request));
+      return setSecurityHeaders(await handleEqualizer(ctx, request));
     }
     if (url.pathname.startsWith('/auth')) {
       return setSecurityHeaders(await handleAuth(ctx, request));

--- a/packages/server/src/routes/equalizer.ts
+++ b/packages/server/src/routes/equalizer.ts
@@ -19,7 +19,7 @@ function buildEqualizerFilter(bands: number[]) {
   }));
 }
 
-export async function handleEqualizerGet(ctx: RouteContext): Promise<Response> {
+async function handleEqualizerGet(ctx: RouteContext): Promise<Response> {
   const guards = await checkGuards(ctx, { admin: true });
   if (guards instanceof Response) return guards;
 
@@ -34,7 +34,7 @@ export async function handleEqualizerGet(ctx: RouteContext): Promise<Response> {
   return json({ bands });
 }
 
-export async function handleEqualizerPatch(ctx: RouteContext, request: Request): Promise<Response> {
+async function handleEqualizerPatch(ctx: RouteContext, request: Request): Promise<Response> {
   const guards = await checkGuards(ctx, { admin: true });
   if (guards instanceof Response) return guards;
 
@@ -72,4 +72,14 @@ export async function handleEqualizerPatch(ctx: RouteContext, request: Request):
   await applyNodeLinkFilter({ equalizer: buildEqualizerFilter(bands) }, 'equalizer');
 
   return json({ bands });
+}
+
+// ---------------------------------------------------------------------------
+// Dispatcher
+// ---------------------------------------------------------------------------
+
+export async function handleEqualizer(ctx: RouteContext, request: Request): Promise<Response> {
+  if (request.method === 'GET') return await handleEqualizerGet(ctx);
+  if (request.method === 'PATCH') return await handleEqualizerPatch(ctx, request);
+  return json({ error: 'Not Found' }, 404);
 }


### PR DESCRIPTION
## Summary

Moves the HTTP method routing for `/api/settings/equalizer` from `index.ts` into `equalizer.ts`, matching the convention used by every other route module (auth, songs, playlists, player, tags, compressor).

## Changes

- **`equalizer.ts`**: Unexports `handleEqualizerGet` and `handleEqualizerPatch` (now module-private). Adds a single exported `handleEqualizer(ctx, request)` dispatcher that routes by HTTP method internally.
- **`index.ts`**: Changes import from two functions to one, collapses the 3-line method-dispatch block to a uniform call matching every other route.

## Verification

- TypeScript compiles cleanly
- Biome lint passes with no fixes needed
- Zero behavioral change