### PR TITLE
chore(deps): bump ws from 8.19.0 to 8.21.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
         "jsonwebtoken": "9.0.3",
         "pino": "10.3.1",
         "seyfert": "4.3.0",
-        "ws": "8.19.0",
+        "ws": "8.21.0",
       },
       "devDependencies": {
         "@types/jsonwebtoken": "9.0.10",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -22,7 +22,7 @@
     "jsonwebtoken": "9.0.3",
     "pino": "10.3.1",
     "seyfert": "4.3.0",
-    "ws": "8.19.0"
+    "ws": "8.21.0"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "9.0.10",


### PR DESCRIPTION
Bumps `ws` in `packages/server` from 8.19.0 to 8.21.0 to match the version already specified in the root `overrides`.