### PR TITLE
refactor: extract shared audio filter builders

### DIFF
--- a/packages/server/src/GuildPlayer.ts
+++ b/packages/server/src/GuildPlayer.ts
@@ -1,5 +1,6 @@
 import { eq } from 'drizzle-orm';
-import { EQ_BAND_COLUMNS, eqBandsFromRow } from './lib/eqBands';
+import { buildCompressorFilter } from './lib/applyNodeLinkFilter';
+import { buildEqualizerFilter, EQ_BAND_COLUMNS, eqBandsFromRow } from './lib/eqBands';
 import { lavalink, type TrackEndReason } from './lib/lavalink';
 import { PlaybackCursor } from './PlaybackCursor';
 import type { LoopMode, QueuedSong, QueueState } from './shared';
@@ -520,15 +521,7 @@ export class GuildPlayer {
     if (settings?.enabled) {
       try {
         await updateNodeLinkPlayer(this.guildId, sessionId, {
-          filters: {
-            compressor: {
-              threshold: settings.threshold,
-              ratio: settings.ratio,
-              attack: settings.attack,
-              release: settings.release,
-              gain: settings.gain,
-            },
-          },
+          filters: buildCompressorFilter(settings),
         });
       } catch (err) {
         logger.error(
@@ -542,10 +535,7 @@ export class GuildPlayer {
     const eqBands = eqBandsFromRow(settings);
     if (eqBands.some((b) => b !== 50)) {
       try {
-        const equalizerFilter = eqBands.map((value, index) => ({
-          band: index,
-          gain: (value - 50) / 100,
-        }));
+        const equalizerFilter = buildEqualizerFilter(eqBands);
         await updateNodeLinkPlayer(this.guildId, sessionId, {
           filters: {
             equalizer: equalizerFilter,

--- a/packages/server/src/lib/applyNodeLinkFilter.ts
+++ b/packages/server/src/lib/applyNodeLinkFilter.ts
@@ -2,6 +2,30 @@ import { updateNodeLinkPlayer } from '../utils/nodelink';
 import { logger } from './config';
 import { lavalink } from './lavalink';
 
+export interface CompressorFilterParams {
+  threshold: number;
+  ratio: number;
+  attack: number;
+  release: number;
+  gain: number;
+}
+
+/**
+ * Build a NodeLink compressor filter payload from numeric parameters.
+ * Does not send anything; purely a data transform.
+ */
+export function buildCompressorFilter(params: CompressorFilterParams) {
+  return {
+    compressor: {
+      threshold: params.threshold,
+      ratio: params.ratio,
+      attack: params.attack,
+      release: params.release,
+      gain: params.gain,
+    },
+  };
+}
+
 /**
  * Applies audio filters to the live NodeLink player for the configured guild.
  * Silently returns if the player is not connected.

--- a/packages/server/src/lib/eqBands.ts
+++ b/packages/server/src/lib/eqBands.ts
@@ -70,3 +70,14 @@ export function eqBandValues(bands: number[]): Record<EqBandKey, number> {
   }
   return result as Record<EqBandKey, number>;
 }
+
+/**
+ * Convert band values (0-100) to NodeLink equalizer filter format.
+ * Maps: 0 → -0.5, 50 → 0.0 (neutral/flat), 100 → 0.5
+ */
+export function buildEqualizerFilter(bands: number[]): Array<{ band: number; gain: number }> {
+  return bands.map((value, index) => ({
+    band: index,
+    gain: (value - 50) / 100,
+  }));
+}

--- a/packages/server/src/routes/compressor.ts
+++ b/packages/server/src/routes/compressor.ts
@@ -1,5 +1,5 @@
 import type { RouteContext } from '../index';
-import { applyNodeLinkFilter } from '../lib/applyNodeLinkFilter';
+import { applyNodeLinkFilter, buildCompressorFilter } from '../lib/applyNodeLinkFilter';
 import { json } from '../lib/json';
 import { checkGuards } from '../lib/routeGuards';
 import { db, tables } from '../shared/db';
@@ -11,18 +11,6 @@ interface CompressorPayload {
   attack: number;
   release: number;
   gain: number;
-}
-
-function buildFilters(payload: CompressorPayload) {
-  return {
-    compressor: {
-      threshold: payload.threshold,
-      ratio: payload.ratio,
-      attack: payload.attack,
-      release: payload.release,
-      gain: payload.gain,
-    },
-  };
 }
 
 export async function handleCompressor(ctx: RouteContext, request: Request): Promise<Response> {
@@ -77,7 +65,7 @@ export async function handleCompressor(ctx: RouteContext, request: Request): Pro
     .run();
 
   // Apply to live NodeLink player if connected
-  await applyNodeLinkFilter(enabled ? buildFilters(body) : {}, 'compressor');
+  await applyNodeLinkFilter(enabled ? buildCompressorFilter(body) : {}, 'compressor');
 
   return json({ enabled, threshold, ratio, attack, release, gain });
 }

--- a/packages/server/src/routes/equalizer.ts
+++ b/packages/server/src/routes/equalizer.ts
@@ -1,22 +1,18 @@
 import { eq } from 'drizzle-orm';
 import type { RouteContext } from '../index';
 import { applyNodeLinkFilter } from '../lib/applyNodeLinkFilter';
-import { EQ_BAND_COLUMNS, eqBandsFromRow, eqBandValues } from '../lib/eqBands';
+import {
+  buildEqualizerFilter,
+  EQ_BAND_COLUMNS,
+  eqBandsFromRow,
+  eqBandValues,
+} from '../lib/eqBands';
 import { json } from '../lib/json';
 import { checkGuards } from '../lib/routeGuards';
 import { db, tables } from '../shared/db';
 
 interface EqualizerPayload {
   bands: number[]; // length 15, each 0-100
-}
-
-// Build NodeLink equalizer filter array from band values (0-100)
-// Maps: 0→-0.5, 50→0.0 (neutral/flat), 100→0.5
-function buildEqualizerFilter(bands: number[]) {
-  return bands.map((value, index) => ({
-    band: index,
-    gain: (value - 50) / 100,
-  }));
 }
 
 async function handleEqualizerGet(ctx: RouteContext): Promise<Response> {


### PR DESCRIPTION
## Summary

Extracts two duplicated filter-construction functions into shared library modules, eliminating ~9 lines of duplicated inline logic across 3 files.

## Changes

- **`lib/eqBands.ts`** — Added `buildEqualizerFilter(bands)` alongside the existing band helpers
- **`lib/applyNodeLinkFilter.ts`** — Added `CompressorFilterParams` interface + `buildCompressorFilter(params)`  
- **`routes/equalizer.ts`** — Removed local `buildEqualizerFilter`; imports shared version
- **`routes/compressor.ts`** — Removed local `buildFilters`; imports `buildCompressorFilter`
- **`GuildPlayer.ts`** — Replaced two inline filter constructions with shared function calls

## Duplication found

| Filter | Duplicated in |
|--------|--------------|
| Equalizer `{ band, gain }` mapping | `routes/equalizer.ts` + `GuildPlayer.ts` |
| Compressor `{ threshold, ratio, ... }` object | `routes/compressor.ts` + `GuildPlayer.ts` |

No behavioral changes — same data, same signatures, same call sites.