### PR TITLE
fix(web): stop context menu clicks from bubbling to song card

### DIFF
--- a/packages/web/src/components/ContextMenu.tsx
+++ b/packages/web/src/components/ContextMenu.tsx
@@ -262,6 +262,7 @@ export function ContextMenu({
       style={{ position: 'fixed', top: position.top, left: position.left }}
       className="z-9999 min-w-48"
       onKeyDown={activeEditItemId ? undefined : handleKeyDown}
+      onClick={(e) => e.stopPropagation()}
     >
       <div className="bg-base rounded-2xl clay-floating overflow-hidden animate-fade-up">
         {activeSubmenu ? (


### PR DESCRIPTION
## Problem

Clicking an item in the More Actions context menu (e.g. "Add to Up Next") on a Song Card or Song Row also triggered the parent card's `onClick` handler, unexpectedly opening the song edit panel.

## Root Cause

In React 17+, synthetic events from portal content bubble through the **React component tree**, not just the DOM tree. The ContextMenu is rendered via `createPortal(document.body)`, so in the React fiber tree it's still a child of SongCard/SongRow. Clicks on menu items propagated up the fiber tree and fired the card's `onClick`.

## Fix

Added `onClick={(e) => e.stopPropagation()}` to the ContextMenu's outermost portal div. This one-line change prevents any click inside the menu from bubbling up the React component tree, fixing the issue for both SongCard and SongRow.

## Testing

- [x] Click "Add to Up Next" in a song card's context menu → only the queue action fires, edit panel stays closed
- [x] Same test on song rows in list view
- [x] Play button still works independently
- [x] Clicking the card directly still opens the edit panel
- [x] Keyboard navigation (Escape, Arrow keys) unaffected