### PR TITLE
chore: modernize dependencies and tsconfig targets

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -18,7 +18,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "a11y": {
         "useButtonType": "error",
         "noStaticElementInteractions": "warn",

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "alfira-bot",
       "devDependencies": {
-        "@biomejs/biome": "2.4.10",
+        "@biomejs/biome": "2.5.2",
         "@types/node": "25.6.0",
         "typescript": "6.0.3",
       },
@@ -14,7 +14,6 @@
       "name": "@alfira-bot/server",
       "version": "0.1.0",
       "dependencies": {
-        "cookie": "1.1.1",
         "drizzle-orm": "0.45.2",
         "jsonwebtoken": "9.0.3",
         "pino": "10.3.1",
@@ -45,15 +44,15 @@
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
         "bun-types": "1.3.14",
-        "tailwindcss": "4.2.2",
+        "tailwindcss": "4.3.1",
         "typescript": "6.0.3",
       },
     },
   },
   "overrides": {
     "lodash": "4.17.23",
-    "react": "19.2.4",
-    "react-dom": "19.2.4",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
     "serialize-javascript": "7.0.4",
     "undici": "6.24.0",
     "ws": "8.21.0",
@@ -63,23 +62,23 @@
 
     "@alfira-bot/web": ["@alfira-bot/web@workspace:packages/web"],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.10", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.10", "@biomejs/cli-darwin-x64": "2.4.10", "@biomejs/cli-linux-arm64": "2.4.10", "@biomejs/cli-linux-arm64-musl": "2.4.10", "@biomejs/cli-linux-x64": "2.4.10", "@biomejs/cli-linux-x64-musl": "2.4.10", "@biomejs/cli-win32-arm64": "2.4.10", "@biomejs/cli-win32-x64": "2.4.10" }, "bin": { "biome": "bin/biome" } }, "sha512-xxA3AphFQ1geij4JTHXv4EeSTda1IFn22ye9LdyVPoJU19fNVl0uzfEuhsfQ4Yue/0FaLs2/ccVi4UDiE7R30w=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.2", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.2", "@biomejs/cli-darwin-x64": "2.5.2", "@biomejs/cli-linux-arm64": "2.5.2", "@biomejs/cli-linux-arm64-musl": "2.5.2", "@biomejs/cli-linux-x64": "2.5.2", "@biomejs/cli-linux-x64-musl": "2.5.2", "@biomejs/cli-win32-arm64": "2.5.2", "@biomejs/cli-win32-x64": "2.5.2" }, "bin": { "biome": "bin/biome" } }, "sha512-VQ3RCqr7JmDIX+w6stWYl+g/3bYofN3q2wDBHUKKc/c7i5QWrFKFBZYCYPWTE6agsUPMIZZe6/CMmVUfUAhkKA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vuzzI1cWqDVzOMIkYyHbKqp+AkQq4K7k+UCXWpkYcY/HDn1UxdsbsfgtVpa40shem8Kax4TLDLlx8kMAecgqiw=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-e7P3P7EkwFc/KiX2AHw4YDLIBOMfG9CPCAwy52k5Bp0dfhkozx9hf6wCmIr2QeXy2XeccJ3V/Sg+hDmzYEqxSg=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.10", "", { "os": "darwin", "cpu": "x64" }, "sha512-14fzASRo+BPotwp7nWULy2W5xeUyFnTaq1V13Etrrxkrih+ez/2QfgFm5Ehtf5vSjtgx/IJycMMpn5kPd5ZNaA=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-ymzMvjC1Jg0b9K0D26ZdARqFQXs7MocfLC5FOCGfkC0Ss+ACUJkX5364ZM5nT4NLZanHRZNVrZEy+Ibwcvux/g=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-7MH1CMW5uuxQ/s7FLST63qF8B3Hgu2HRdZ7tA1X1+mk+St4JOuIrqdhIBnnyqeyWJNI+Bww7Es5QZ0wIc1Cmkw=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-t7sseOmqND57uUWTwlawU6BYj+J06T/9EkydzBhkrgw/FK3QVhjU2wsJR0frljrKZ0/I8A/rYw7284QgqjQfIQ=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-WrJY6UuiSD/Dh+nwK2qOTu8kdMDlLV3dLMmychIghHPAysWFq1/DGC1pVZx8POE3ZkzKR3PUUnVrtZfMfaJjyQ=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-w+ANG0ZvTu9IeEg9QnstoOnk6L0fpwJifW6aHR18+cb5Z39bkANItYjAfMrnvce5tmMK+IQ6nPX7/kQFdam5iw=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.10", "", { "os": "linux", "cpu": "x64" }, "sha512-tZLvEEi2u9Xu1zAqRjTcpIDGVtldigVvzug2fTuPG0ME/g8/mXpRPcNgLB22bGn6FvLJpHHnqLnwliOu8xjYrg=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.2", "", { "os": "linux", "cpu": "x64" }, "sha512-M/lOZrewzTCRDINbjhQ1gYYru37KlD3kJBQwwKCG0ckz5E9IZwIoJ3X0wBwRXA+yBDIwWUuPBHS67HzJY4dTfA=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.10", "", { "os": "linux", "cpu": "x64" }, "sha512-kDTi3pI6PBN6CiczsWYOyP2zk0IJI08EWEQyDMQWW221rPaaEz6FvjLhnU07KMzLv8q3qSuoB93ua6inSQ55Tw=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.2", "", { "os": "linux", "cpu": "x64" }, "sha512-VArNLAzND063tF+XY0yPyM+DyahpzOMzOAvb7qs259nhjJWRjvjZdssuA+Rfl+l07+NOesKZ0Xu2yFrXyBMtzw=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-umwQU6qPzH+ISTf/eHyJ/QoQnJs3V9Vpjz2OjZXe9MVBZ7prgGafMy7yYeRGnlmDAn87AKTF3Q6weLoMGpeqdQ=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-kbjFFKyZlzYnAuw7sRy5qDoFG6zrP40UK08oPQsWK0ct3NMnGSt+Bs1iviEEyEIP57N5MrykGXdO/wRiaR4lww=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.10", "", { "os": "win32", "cpu": "x64" }, "sha512-aW/JU5GuyH4uxMrNYpoC2kjaHlyJGLgIa3XkhPEZI0uKhZhJZU8BuEyJmvgzSPQNGozBwWjC972RaNdcJ9KyJg=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.2", "", { "os": "win32", "cpu": "x64" }, "sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -273,9 +272,9 @@
 
     "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
 
-    "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
+    "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
-    "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
+    "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
 
     "react-router": ["react-router@7.18.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ=="],
 
@@ -301,7 +300,7 @@
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
-    "tailwindcss": ["tailwindcss@4.2.2", "", {}, "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q=="],
+    "tailwindcss": ["tailwindcss@4.3.1", "", {}, "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
@@ -316,10 +315,6 @@
     "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "@alfira-bot/server/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
-
-    "@tailwindcss/cli/tailwindcss": ["tailwindcss@4.3.1", "", {}, "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q=="],
-
-    "@tailwindcss/node/tailwindcss": ["tailwindcss@4.3.1", "", {}, "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 

--- a/package.json
+++ b/package.json
@@ -19,15 +19,15 @@
     "check": "biome check --write ."
   },
   "overrides": {
-    "react": "19.2.4",
-    "react-dom": "19.2.4",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
     "serialize-javascript": "7.0.4",
     "undici": "6.24.0",
     "lodash": "4.17.23",
     "ws": "8.21.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.10",
+    "@biomejs/biome": "2.5.2",
     "@types/node": "25.6.0",
     "typescript": "6.0.3"
   }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,7 +17,6 @@
     "db:studio": "cd ../.. && drizzle-kit studio"
   },
   "dependencies": {
-    "cookie": "1.1.1",
     "drizzle-orm": "0.45.2",
     "jsonwebtoken": "9.0.3",
     "pino": "10.3.1",
@@ -26,9 +25,9 @@
   },
   "devDependencies": {
     "@types/jsonwebtoken": "9.0.10",
+    "bun-types": "1.3.14",
     "@types/node": "25.5.2",
     "@types/ws": "8.18.1",
-    "bun-types": "1.3.14",
     "typescript": "6.0.3"
   }
 }

--- a/packages/server/src/GuildPlayer.ts
+++ b/packages/server/src/GuildPlayer.ts
@@ -532,7 +532,11 @@ export class GuildPlayer {
       }
 
       const t1 = Date.now();
-      await updateNodeLinkPlayer(this.guildId, sessionId, patch as Parameters<typeof updateNodeLinkPlayer>[2]);
+      await updateNodeLinkPlayer(
+        this.guildId,
+        sessionId,
+        patch as Parameters<typeof updateNodeLinkPlayer>[2]
+      );
       const t2 = Date.now();
 
       this.consecutiveFailures = 0;
@@ -658,10 +662,7 @@ export class GuildPlayer {
     if (!nextTrack) return;
 
     preloadTrack(this.guildId, sessionId, nextTrack.youtubeUrl).catch((err) => {
-      logger.warn(
-        { guildId: this.guildId, track: nextTrack.title, err },
-        'Gapless preload failed'
-      );
+      logger.warn({ guildId: this.guildId, track: nextTrack.title, err }, 'Gapless preload failed');
     });
   }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2,7 +2,23 @@ import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { parse } from 'cookie';
+
+function parseCookies(header: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const part of header.split(';')) {
+    const idx = part.indexOf('=');
+    if (idx === -1) continue;
+    const key = part.slice(0, idx).trim();
+    const raw = part.slice(idx + 1).trim();
+    try {
+      result[key] = decodeURIComponent(raw);
+    } catch {
+      result[key] = raw;
+    }
+  }
+  return result;
+}
+
 import { sql } from 'drizzle-orm';
 import { logger } from './lib/config';
 import { ensureTagsMigrated } from './lib/ensureTagsMigrated';
@@ -103,7 +119,7 @@ function serveStatic(filePath: string, pathname: string): Response | undefined {
 // ---------------------------------------------------------------------------
 
 function createContext(request: Request): RouteContext {
-  const parsedCookies = parse(request.headers.get('cookie') || '');
+  const parsedCookies = parseCookies(request.headers.get('cookie') || '');
   const token = parsedCookies.session;
   const user = token ? verifySessionToken(token) : null;
   const cookies: Record<string, string> = {};
@@ -142,7 +158,7 @@ const server = Bun.serve({
 
     // WebSocket upgrade — auth is handled here before upgrade
     if (url.pathname === '/ws') {
-      const cookies = parse(request.headers.get('cookie') || '');
+      const cookies = parseCookies(request.headers.get('cookie') || '');
       const token = cookies.session;
       const user = token ? verifySessionToken(token) : null;
       if (!user) {

--- a/packages/server/src/lib/lavalink.ts
+++ b/packages/server/src/lib/lavalink.ts
@@ -7,7 +7,13 @@ import { logger } from '../shared/logger';
 // Types
 // ---------------------------------------------------------------------------
 
-export type TrackEndReason = 'finished' | 'loadFailed' | 'stopped' | 'replaced' | 'cleanup' | 'gapless';
+export type TrackEndReason =
+  | 'finished'
+  | 'loadFailed'
+  | 'stopped'
+  | 'replaced'
+  | 'cleanup'
+  | 'gapless';
 
 interface LavalinkReady {
   op: 'ready';

--- a/packages/server/src/lib/tagCanonicalization.ts
+++ b/packages/server/src/lib/tagCanonicalization.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { db, eq, tables } from '../shared/db';
 
 const { tag: tagTable } = tables;
@@ -51,7 +50,7 @@ export async function canonicalizeTags(rawTags: string[]): Promise<string[]> {
         await tx
           .insert(tagTable)
           .values({
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             nameLower: spelling.toLowerCase(),
             canonicalName: spelling,
           })

--- a/packages/server/src/shared/db/schema.ts
+++ b/packages/server/src/shared/db/schema.ts
@@ -1,10 +1,9 @@
-import { randomUUID } from 'node:crypto';
 import { index, integer, real, sqliteTable, text, unique } from 'drizzle-orm/sqlite-core';
 
 export const song = sqliteTable('Song', {
   id: text('id')
     .primaryKey()
-    .$defaultFn(() => randomUUID()),
+    .$defaultFn(() => crypto.randomUUID()),
   title: text('title').notNull(),
   youtubeUrl: text('youtubeUrl').notNull().unique(),
   youtubeId: text('youtubeId').notNull().unique(),
@@ -25,7 +24,7 @@ export const song = sqliteTable('Song', {
 export const playlist = sqliteTable('Playlist', {
   id: text('id')
     .primaryKey()
-    .$defaultFn(() => randomUUID()),
+    .$defaultFn(() => crypto.randomUUID()),
   name: text('name').notNull(),
   createdBy: text('createdBy').notNull(),
   isPrivate: integer('isPrivate', { mode: 'boolean' }).default(false).notNull(),
@@ -39,7 +38,7 @@ export const playlistSong = sqliteTable(
   {
     id: text('id')
       .primaryKey()
-      .$defaultFn(() => randomUUID()),
+      .$defaultFn(() => crypto.randomUUID()),
     playlistId: text('playlistId').notNull(),
     songId: text('songId').notNull(),
     position: integer('position').notNull(),
@@ -55,7 +54,7 @@ export const refreshToken = sqliteTable(
   {
     id: text('id')
       .primaryKey()
-      .$defaultFn(() => randomUUID()),
+      .$defaultFn(() => crypto.randomUUID()),
     tokenHash: text('tokenHash').notNull().unique(),
     discordId: text('discordId').notNull(),
     expiresAt: integer('expiresAt', { mode: 'timestamp_ms' }).notNull(),
@@ -69,7 +68,7 @@ export const refreshToken = sqliteTable(
 export const tag = sqliteTable('Tag', {
   id: text('id')
     .primaryKey()
-    .$defaultFn(() => randomUUID()),
+    .$defaultFn(() => crypto.randomUUID()),
   nameLower: text('nameLower').notNull().unique(),
   canonicalName: text('canonicalName').notNull(),
   color: text('color'),

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "bundler",
     "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "rootDir": "./src",
     "paths": {},
-    "lib": ["ES2022"],
+    "lib": ["ESNext"],
     "types": ["bun-types", "node"],
     "outDir": "./dist",
     "strict": true,

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -17,11 +17,11 @@
     "react-dom": "19.2.7"
   },
   "devDependencies": {
+    "bun-types": "1.3.14",
     "@tailwindcss/cli": "4.3.1",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
-    "bun-types": "1.3.14",
-    "tailwindcss": "4.2.2",
+    "tailwindcss": "4.3.1",
     "typescript": "6.0.3"
   }
 }

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ESNext",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "bundler",
     "types": ["node"],


### PR DESCRIPTION
## Summary

Modernization pass across the monorepo — drops an unnecessary dependency, aligns versions, and modernizes compiler targets for the Bun-only runtime.

### Changes

**Bug fixes**
- `react`/`react-dom` overrides bumped from `19.2.4` → `19.2.7` to match the web package declaration (override was silently downgrading)
- `tailwindcss` aligned to `4.3.1` to match `@tailwindcss/cli` (were out of sync causing duplicate installs)

**Dependency slimming**
- Removed `cookie` package, replaced with a 7-line inline `parseCookies()` function
- Replaced `node:crypto` `randomUUID` imports with the globally available `crypto.randomUUID()` (Web Crypto API)

**Modernization**
- All three `tsconfig.json` targets set to `ESNext` (previously `ES2020`) since Bun is the sole runtime
- `lib` aligned to `ESNext` in server and web configs
- `@biomejs/biome` bumped from `2.4.10` → `2.5.2` with auto-migrated config

### Verification
- `packages/server` builds cleanly (`tsc --skipLibCheck`)
- `packages/web` type-checks cleanly (`tsc --noEmit`)
- `biome check --write` passes with no violations