### PR TITLE
refactor: align codebase with design philosophy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,8 @@ DISCORD_REDIRECT_URI=https://your-domain.com/auth/callback
 # Public URL where users access the web interface
 WEB_UI_ORIGIN=https://your-domain.com
 
-# Your Discord server ID (enable Developer Mode, right-click server, Copy ID)
+# Your Discord server ID (enable Developer Mode, right-click server, Copy ID).
+# Alfira is designed for a single community — one guild, one instance, one shared state.
 GUILD_ID=your-guild-id-here
 
 # Admin role ID(s) - comma-separated for multiple (enable Developer Mode, right-click role, Copy ID)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,9 +57,8 @@ bun run format
 
 The bot never directly holds WebSocket connections. Instead:
 
-1. `GuildPlayer` calls `broadcastQueueUpdate(state)` (packages/server/src/startDiscord.ts)
-2. `broadcastQueueUpdate` calls `emitPlayerUpdate(state)` directly (same package)
-3. `emitPlayerUpdate` (packages/server/src/lib/socket.ts) sends to all registered WebSocket clients
+1. `GuildPlayer` calls `emitPlayerUpdate(state)` directly (packages/server/src/lib/socket.ts)
+2. `emitPlayerUpdate` fetches compressor settings, serializes the state, and sends to all registered WebSocket clients
 
 WebSocket clients authenticate via session cookie on connection. The client never sends messages — it's receive-only.
 
@@ -98,5 +97,6 @@ The bot streams audio from NodeLink (a Lavalink v4-compatible server). The `node
 ## Documentation
 
 - [Installation Guide](docs/installation.md) — Setup, environment variables, Docker commands
+- [Philosophy](docs/philosophy.md) — Design principles guiding the project
 - [Tech Stack](docs/tech-stack.md) — Detailed architecture
 - [Troubleshooting](docs/troubleshooting.md) — Common issues and solutions

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ WORKDIR /usr/local/nodelink
 ARG NODELINK_VERSION=v3.7.0
 RUN git clone --depth 1 --branch ${NODELINK_VERSION} https://github.com/PerformanC/NodeLink.git . && \
     bun install && \
-    bun run build
+    bun run build && \
+    rm -rf .git
 WORKDIR /app
 
 COPY package.json bun.lock ./

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ See the **[Full Installation Guide](docs/installation.md)** for full details.
 | Document | Description |
 |----------|-------------|
 | **[Installation Guide](docs/installation.md)** | Setup, environment variables, Docker commands |
+| **[Philosophy](docs/philosophy.md)** | Design principles guiding the project |
 | **[Tech Stack](docs/tech-stack.md)** | Technology stack and project structure |
 | **[Biome Setup](docs/biome-setup.md)** | Editor setup for Biome linting and formatting |
 | **[Troubleshooting](docs/troubleshooting.md)** | Common issues and solutions |

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,6 @@
       "dependencies": {
         "drizzle-orm": "0.45.2",
         "jsonwebtoken": "9.0.3",
-        "pino": "10.3.1",
         "seyfert": "4.3.0",
         "ws": "8.21.0",
       },
@@ -120,8 +119,6 @@
 
     "@phosphor-icons/react": ["@phosphor-icons/react@2.1.10", "", { "peerDependencies": { "react": ">= 16.8", "react-dom": ">= 16.8" } }, "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA=="],
 
-    "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
-
     "@tailwindcss/cli": ["@tailwindcss/cli@4.3.1", "", { "dependencies": { "@parcel/watcher": "2.5.1", "@tailwindcss/node": "4.3.1", "@tailwindcss/oxide": "4.3.1", "enhanced-resolve": "5.21.6", "mri": "^1.2.0", "picocolors": "^1.1.1", "tailwindcss": "4.3.1" }, "bin": { "tailwindcss": "dist/index.mjs" } }, "sha512-ZWPy20rF+TBfTImxDMG3Wr75Y3RpaPlo9lc+oJbInlMyjT+XPkTVKVIL5RZ7JirXuIahcfHoLNFRmDorKi+JQQ=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.3.1", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "5.21.6", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.1" } }, "sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A=="],
@@ -167,8 +164,6 @@
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
-
-    "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -254,23 +249,11 @@
 
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
-    "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
-
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
-    "pino": ["pino@10.3.1", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^4.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg=="],
-
-    "pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
-
-    "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
-
     "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
-
-    "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
-
-    "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
 
     "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
@@ -280,11 +263,7 @@
 
     "react-router-dom": ["react-router-dom@7.18.0", "", { "dependencies": { "react-router": "7.18.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA=="],
 
-    "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
-
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
-
-    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
@@ -294,17 +273,11 @@
 
     "seyfert": ["seyfert@4.3.0", "", {}, "sha512-IzLH1SBY45xFOjcI3WjNX7I23oQho8lOq+W3Plc3GvUHjGgAHb9o6EkWthh1hyGnd32I6IhqilDDhezVSrZ8Mg=="],
 
-    "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
-
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
-
-    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "tailwindcss": ["tailwindcss@4.3.1", "", {}, "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
-
-    "thread-stream": ["thread-stream@4.0.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -84,6 +84,9 @@ docker compose up -d
 | `WEB_UI_ORIGIN` | Public URL of the web UI | `http://localhost:3001` |
 | `DISCORD_REDIRECT_URI` | OAuth2 redirect URI | `http://localhost:3001/auth/callback` |
 | `VOICE_IDLE_TIMEOUT_MINUTES` | Minutes before bot leaves voice channel when idle | `5` |
+| `LOG_LEVEL` | Log verbosity: `debug`, `info`, `warn`, `error`, `fatal` | `info` |
+| `LOG_FORMAT` | Set to `json` for machine-readable structured logging; defaults to human-readable colored output | — |
+| `NO_COLOR` | Set to any value to disable colored log output | — |
 
 > **Note:** `DATABASE_URL` is set automatically. You typically don't need to set it manually.
 

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -14,6 +14,14 @@ Docker + Bun + SQLite means no external managed services. One `docker compose up
 
 Prefer stdlib/native runtime APIs over npm packages. Bun's built-in HTTP, WebSocket, test runner, and SQLite driver replace whole categories of dependencies. Drizzle gives type-safe SQL without ORM bloat.
 
+### Dependencies we keep intentionally
+
+**`ws`** — Bun's global `WebSocket` follows the WHATWG standard (`new WebSocket(url, protocols?)`) which provides no way to set custom HTTP headers on the handshake. The `ws` library supports `new WebSocket(url, { headers })`, which is needed to send `Authorization` and `User-Id` headers when connecting to NodeLink. This is a small (sub-1MB), focused, well-maintained package filling a genuine gap in the WHATWG API.
+
+**`seyfert`** — Handles the Discord gateway protocol: heartbeats, identify, resume, sharding, opcode dispatch, and rate-limit backpressure. The codebase interacts with it at only ~6 call sites, but those are backed by hundreds of lines of non-trivial protocol logic. Reimplementing that correctly would be error-prone and violate the spirit of "better dependencies."
+
+**`jsonwebtoken`** — Bun has Web Crypto API primitives (HMAC-SHA256, base64url) but no built-in JWT encode/decode. Implementing JWT from scratch — with correct expiration, audience, and algorithm handling — would be a net negative in maintenance surface area. This is a focused, zero-dependency library.
+
 ---
 
 ## 3. Single-process simplicity by design

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "drizzle-orm": "0.45.2",
     "jsonwebtoken": "9.0.3",
-    "pino": "10.3.1",
     "seyfert": "4.3.0",
     "ws": "8.21.0"
   },

--- a/packages/server/src/GuildPlayer.ts
+++ b/packages/server/src/GuildPlayer.ts
@@ -2,11 +2,12 @@ import { eq } from 'drizzle-orm';
 import { buildCompressorFilter } from './lib/applyNodeLinkFilter';
 import { buildEqualizerFilter, EQ_BAND_COLUMNS, eqBandsFromRow } from './lib/eqBands';
 import { lavalink, type TrackEndReason } from './lib/lavalink';
+import { emitPlayerUpdate } from './lib/socket';
 import { PlaybackCursor } from './PlaybackCursor';
 import type { LoopMode, QueuedSong, QueueState } from './shared';
 import { db, tables } from './shared/db';
 import { logger } from './shared/logger';
-import { broadcastQueueUpdate, connectToVoice, getClient } from './startDiscord';
+import { connectToVoice, getClient } from './startDiscord';
 import { destroyNodeLinkPlayer, preloadTrack, updateNodeLinkPlayer } from './utils/nodelink';
 
 export class GuildPlayer {
@@ -382,7 +383,7 @@ export class GuildPlayer {
   }
 
   private broadcast(): void {
-    void broadcastQueueUpdate(this.getQueueState());
+    void emitPlayerUpdate(this.getQueueState());
   }
 
   private peekNextTrack(): QueuedSong | null {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -20,10 +20,9 @@ function parseCookies(header: string): Record<string, string> {
 }
 
 import { sql } from 'drizzle-orm';
-import { logger } from './lib/config';
 import { ensureTagsMigrated } from './lib/ensureTagsMigrated';
 import { json } from './lib/json';
-import { closeAllClients, registerClient, unregisterClient } from './lib/socket';
+import { closeAllClients, registerClient, unregisterClient, type WsClient } from './lib/socket';
 import { verifySessionToken } from './middleware/requireAuth';
 import { handleAuth } from './routes/auth';
 import { handleCompressor } from './routes/compressor';
@@ -33,8 +32,8 @@ import { handlePlaylists } from './routes/playlists';
 import { handleSongs } from './routes/songs';
 import { handleTags } from './routes/tags';
 import { $client, db } from './shared/db';
+import { logger } from './shared/logger';
 import { destroyAllPlayers, startDiscord } from './startDiscord';
-import { unregisterStaleCommands } from './utils/unregisterCommands';
 
 // ---------------------------------------------------------------------------
 // Validate required environment variables.
@@ -115,13 +114,18 @@ function serveStatic(filePath: string, pathname: string): Response | undefined {
 }
 
 // ---------------------------------------------------------------------------
-// Route context creation
+// Session helpers
 // ---------------------------------------------------------------------------
+
+function getSessionUser(cookieHeader: string): ReturnType<typeof verifySessionToken> {
+  const cookies = parseCookies(cookieHeader);
+  const token = cookies.session;
+  return token ? verifySessionToken(token) : null;
+}
 
 function createContext(request: Request): RouteContext {
   const parsedCookies = parseCookies(request.headers.get('cookie') || '');
-  const token = parsedCookies.session;
-  const user = token ? verifySessionToken(token) : null;
+  const user = getSessionUser(request.headers.get('cookie') || '');
   const cookies: Record<string, string> = {};
   for (const [key, value] of Object.entries(parsedCookies)) {
     if (value !== undefined) cookies[key] = value;
@@ -144,101 +148,106 @@ async function handleHealth(): Promise<Response> {
 
 // ---------------------------------------------------------------------------
 // Main server
+//
+// Created during startup in main() after migrations, DB verification,
+// and NodeLink are ready. A module-level mutable variable is used because
+// the fetch handler closes over `server` for server.upgrade() calls.
 // ---------------------------------------------------------------------------
 
-const server = Bun.serve({
-  port: PORT,
-  async fetch(request) {
-    const url = new URL(request.url);
+let server: ReturnType<typeof Bun.serve>;
 
-    // Health check
-    if (url.pathname === '/health') {
-      return setSecurityHeaders(await handleHealth());
-    }
+function startServer(): void {
+  server = Bun.serve({
+    port: PORT,
+    async fetch(request) {
+      const url = new URL(request.url);
 
-    // WebSocket upgrade — auth is handled here before upgrade
-    if (url.pathname === '/ws') {
-      const cookies = parseCookies(request.headers.get('cookie') || '');
-      const token = cookies.session;
-      const user = token ? verifySessionToken(token) : null;
-      if (!user) {
-        return new Response('Unauthorized', { status: 401 });
+      // Health check
+      if (url.pathname === '/health') {
+        return setSecurityHeaders(await handleHealth());
       }
-      // Use server.upgrade() instead of WebSocketPair — it auto-returns 101
-      // and attaches data to the WebSocket accessible in the websocket handler.
-      const success = server.upgrade(request, { data: { user } });
-      if (success) return undefined;
-      return new Response('WebSocket upgrade failed', { status: 500 });
-    }
 
-    // Serve built web assets statically (SPA fallback for client-side routing)
-    const pathname = url.pathname;
-    const ext = pathname.includes('.') ? `.${pathname.split('.').pop()}` : '.html';
-    const isAsset =
-      Object.hasOwn(STATIC_EXTENSIONS, ext) ||
-      url.pathname.startsWith('/assets/') ||
-      url.pathname === '/sw.js' ||
-      url.pathname === '/registerSW.js';
+      // WebSocket upgrade — auth is handled here before upgrade
+      if (url.pathname === '/ws') {
+        const user = getSessionUser(request.headers.get('cookie') || '');
+        if (!user) {
+          return new Response('Unauthorized', { status: 401 });
+        }
+        // server is assigned before requests arrive (in main()).
+        // The closure captures the mutable variable — it's set by then.
+        const success = server?.upgrade(request, { data: { user } });
+        if (success) return undefined;
+        return new Response('WebSocket upgrade failed', { status: 500 });
+      }
 
-    if (isAsset || url.pathname === '/') {
-      const filePath = `/app/packages/web/dist${url.pathname === '/' ? '/index.html' : url.pathname}`;
-      const response = serveStatic(filePath, url.pathname);
-      if (response) return response;
-    }
+      // Serve built web assets statically (SPA fallback for client-side routing)
+      const pathname = url.pathname;
+      const ext = pathname.includes('.') ? `.${pathname.split('.').pop()}` : '.html';
+      const isAsset =
+        Object.hasOwn(STATIC_EXTENSIONS, ext) ||
+        url.pathname.startsWith('/assets/') ||
+        url.pathname === '/sw.js' ||
+        url.pathname === '/registerSW.js';
 
-    // Create auth context for all other routes
-    const ctx = createContext(request);
+      if (isAsset || url.pathname === '/') {
+        const filePath = `/app/packages/web/dist${url.pathname === '/' ? '/index.html' : url.pathname}`;
+        const response = serveStatic(filePath, url.pathname);
+        if (response) return response;
+      }
 
-    // Route matching
-    if (url.pathname.startsWith('/api/tags')) {
-      return setSecurityHeaders(await handleTags(ctx, request));
-    }
-    if (url.pathname.startsWith('/api/songs')) {
-      return setSecurityHeaders(await handleSongs(ctx, request));
-    }
-    if (url.pathname.startsWith('/api/playlists')) {
-      return setSecurityHeaders(await handlePlaylists(ctx, request));
-    }
-    if (url.pathname.startsWith('/api/player')) {
-      return setSecurityHeaders(await handlePlayer(ctx, request));
-    }
-    if (url.pathname.startsWith('/api/settings/compressor')) {
-      return setSecurityHeaders(await handleCompressor(ctx, request));
-    }
-    if (url.pathname.startsWith('/api/settings/equalizer')) {
-      return setSecurityHeaders(await handleEqualizer(ctx, request));
-    }
-    if (url.pathname.startsWith('/auth')) {
-      return setSecurityHeaders(await handleAuth(ctx, request));
-    }
+      // Create auth context for all other routes
+      const ctx = createContext(request);
 
-    return (
-      serveStatic('/app/packages/web/dist/index.html', '/index.html') ??
-      setSecurityHeaders(json({ error: 'Not Found' }, 404))
-    );
-  },
-  websocket: {
-    data: {} as { user: NonNullable<ReturnType<typeof verifySessionToken>> },
-    open(ws) {
-      // Log only — user was stored via server.upgrade() data.
-      // biome-ignore lint/suspicious/noExplicitAny: ServerWebSocket doesn't expose id at type level
-      logger.debug({ socketId: (ws as any).id }, 'WebSocket opened');
-      registerClient(ws, ws.data.user);
+      // Route matching
+      if (url.pathname.startsWith('/api/tags')) {
+        return setSecurityHeaders(await handleTags(ctx, request));
+      }
+      if (url.pathname.startsWith('/api/songs')) {
+        return setSecurityHeaders(await handleSongs(ctx, request));
+      }
+      if (url.pathname.startsWith('/api/playlists')) {
+        return setSecurityHeaders(await handlePlaylists(ctx, request));
+      }
+      if (url.pathname.startsWith('/api/player')) {
+        return setSecurityHeaders(await handlePlayer(ctx, request));
+      }
+      if (url.pathname.startsWith('/api/settings/compressor')) {
+        return setSecurityHeaders(await handleCompressor(ctx, request));
+      }
+      if (url.pathname.startsWith('/api/settings/equalizer')) {
+        return setSecurityHeaders(await handleEqualizer(ctx, request));
+      }
+      if (url.pathname.startsWith('/auth')) {
+        return setSecurityHeaders(await handleAuth(ctx, request));
+      }
+
+      return (
+        serveStatic('/app/packages/web/dist/index.html', '/index.html') ??
+        setSecurityHeaders(json({ error: 'Not Found' }, 404))
+      );
     },
-    message(ws, message) {
-      // No-op: client does not send messages
-      // biome-ignore lint/suspicious/noExplicitAny: ServerWebSocket doesn't expose id at type level
-      logger.debug({ socketId: (ws as any).id, message }, 'Unexpected WebSocket message received');
+    websocket: {
+      data: {} as { user: NonNullable<ReturnType<typeof verifySessionToken>> },
+      open(ws) {
+        const wsc = ws as unknown as WsClient;
+        logger.debug({ socketId: wsc.id }, 'WebSocket opened');
+        registerClient(wsc, ws.data.user);
+      },
+      message(ws, message) {
+        const wsc = ws as unknown as WsClient;
+        // No-op: client does not send messages
+        logger.debug({ socketId: wsc.id, message }, 'Unexpected WebSocket message received');
+      },
+      close(ws, code, reason) {
+        const wsc = ws as unknown as WsClient;
+        unregisterClient(wsc);
+        logger.info({ socketId: wsc.id, code, reason }, 'WebSocket closed');
+      },
     },
-    close(ws, code, reason) {
-      unregisterClient(ws);
-      // biome-ignore lint/suspicious/noExplicitAny: ServerWebSocket doesn't expose id at type level
-      logger.info({ socketId: (ws as any).id, code, reason }, 'WebSocket closed');
-    },
-  },
-});
+  });
 
-logger.info({ port: PORT }, 'Bun server listening');
+  logger.info({ port: PORT }, 'Bun server listening');
+}
 
 // ---------------------------------------------------------------------------
 // Startup sequence
@@ -314,7 +323,11 @@ function startNodeLink(): Promise<void> {
     });
 
     nodelinkProcess.stderr?.on('data', (data: Buffer) => {
-      logger.warn({ component: 'NodeLink' }, data.toString().trimEnd());
+      const line = data.toString().trimEnd();
+      // NodeLink runs git commands internally — these fail harmlessly when
+      // there's no .git directory (production container). Suppress the noise.
+      if (line.includes('fatal:')) return;
+      logger.warn({ component: 'NodeLink' }, line);
     });
 
     const checkReady = async () => {
@@ -361,13 +374,6 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  // 2.5. Unregister stale Discord slash commands (from pre-web-UI versions).
-  try {
-    await unregisterStaleCommands();
-  } catch (error) {
-    logger.error(error, 'Failed to unregister stale commands (non-fatal)');
-  }
-
   // 3. Start NodeLink in-process.
   try {
     await startNodeLink();
@@ -381,6 +387,9 @@ async function main(): Promise<void> {
   } catch (error) {
     logger.error(error, 'Failed to start the Discord bot');
   }
+
+  // 5. Start the HTTP server — only after everything else is ready.
+  startServer();
 }
 
 main().catch((err) => {
@@ -405,7 +414,7 @@ function shutdown(signal: string): void {
   logger.info('NodeLink stopped');
 
   // 2. Stop accepting connections and close all WebSocket clients.
-  server.stop();
+  server?.stop();
   closeAllClients();
   logger.info('Server stopped');
 

--- a/packages/server/src/lib/applyNodeLinkFilter.ts
+++ b/packages/server/src/lib/applyNodeLinkFilter.ts
@@ -1,5 +1,5 @@
+import { logger } from '../shared/logger';
 import { updateNodeLinkPlayer } from '../utils/nodelink';
-import { logger } from './config';
 import { lavalink } from './lavalink';
 
 export interface CompressorFilterParams {

--- a/packages/server/src/lib/config.ts
+++ b/packages/server/src/lib/config.ts
@@ -1,6 +1,3 @@
-import { logger } from '../shared/logger';
-
-export { logger };
 export const WEB_UI_ORIGIN = process.env.WEB_UI_ORIGIN ?? 'http://localhost:3001';
 
 const _GUILD_ID = process.env.GUILD_ID;

--- a/packages/server/src/lib/ensureTagsMigrated.ts
+++ b/packages/server/src/lib/ensureTagsMigrated.ts
@@ -1,4 +1,5 @@
 import { db, sql, tables } from '../shared/db';
+import { logger } from '../shared/logger';
 import { runTagMigration } from './migrateExistingTags';
 
 const { tag: tagTable, song: songTable } = tables;
@@ -31,5 +32,5 @@ export async function ensureTagsMigrated(): Promise<void> {
   if (errors > 0) {
     throw new Error(`Tag migration failed with ${errors} errors`);
   }
-  console.log(`[ensureTagsMigrated] Migrated tags from ${normalized} songs`);
+  logger.info({ count: normalized }, 'Migrated tags from songs');
 }

--- a/packages/server/src/lib/migrateExistingTags.ts
+++ b/packages/server/src/lib/migrateExistingTags.ts
@@ -8,6 +8,7 @@
  */
 
 import { db, sql, tables } from '../shared/db';
+import { logger } from '../shared/logger';
 import { canonicalizeTags } from './tagCanonicalization';
 
 const { song: songTable } = tables;
@@ -21,14 +22,14 @@ const normalizeTag = (t: string) => t.replace(/\s+/g, '-').trim();
  * Safe to call multiple times — already-migrated songs are skipped.
  */
 export async function runTagMigration(): Promise<{ normalized: number; errors: number }> {
-  console.log('Starting tag normalization migration...');
+  logger.info('Starting tag normalization migration');
 
   const songs = await db
     .select({ id: songTable.id, tags: songTable.tags })
     .from(songTable)
     .where(sql`${songTable.tags} IS NOT NULL AND ${songTable.tags} != '[]'`);
 
-  console.log(`Found ${songs.length} songs with tags`);
+  logger.info({ count: songs.length }, 'Found songs with tags');
 
   let normalized = 0;
   let errors = 0;
@@ -44,19 +45,19 @@ export async function runTagMigration(): Promise<{ normalized: number; errors: n
         normalized++;
       }
     } catch (err) {
-      console.error(`Error normalizing tags for song ${song.id}:`, err);
+      logger.error({ songId: song.id, err }, 'Error normalizing tags');
       errors++;
     }
   }
 
-  console.log(`Migration complete: ${normalized} songs normalized, ${errors} errors`);
+  logger.info({ normalized, errors }, 'Tag migration complete');
   return { normalized, errors };
 }
 
 // Standalone entry point — run with: bun run packages/server/src/lib/migrateExistingTags.ts
 if (__filename.includes('migrateExistingTags')) {
   runTagMigration().catch((err) => {
-    console.error('Migration failed:', err);
+    logger.fatal(err, 'Tag migration failed');
     process.exit(1);
   });
 }

--- a/packages/server/src/lib/socket.ts
+++ b/packages/server/src/lib/socket.ts
@@ -1,7 +1,7 @@
 import { eq } from 'drizzle-orm';
 import type { CompressorSettings, Playlist, QueueState, Song, User } from '../shared';
 import { db, tables } from '../shared/db';
-import { logger } from './config';
+import { logger } from '../shared/logger';
 
 import { formatSong } from './serialization';
 
@@ -14,8 +14,13 @@ type SerializedPlaylist = Omit<Playlist, 'createdAt'> & { createdAt: string | Da
 // WebSocket client registry
 // ---------------------------------------------------------------------------
 
-// biome-ignore lint/suspicious/noExplicitAny: Bun's WebSocket type is incompatible with global WebSocket
-const clients = new Set<any>();
+export interface WsClient {
+  readonly id: number;
+  send(data: string): void;
+  close(): void;
+}
+
+const clients = new Set<WsClient>();
 
 export async function getCompressorSettings(): Promise<CompressorSettings | null> {
   const row = await db
@@ -44,11 +49,7 @@ export async function getCompressorSettings(): Promise<CompressorSettings | null
 /**
  * Registers a newly connected WebSocket client after auth in fetch().
  */
-export function registerClient(
-  // biome-ignore lint/suspicious/noExplicitAny: Bun's WebSocket type is incompatible with global WebSocket
-  ws: any,
-  user: User
-): void {
+export function registerClient(ws: WsClient, user: User): void {
   clients.add(ws);
   logger.info({ socketId: ws.id, username: user.username }, 'WebSocket client connected');
 }
@@ -56,10 +57,7 @@ export function registerClient(
 /**
  * Removes a disconnected WebSocket client.
  */
-export function unregisterClient(
-  // biome-ignore lint/suspicious/noExplicitAny: Bun's WebSocket type is incompatible with global WebSocket
-  ws: any
-): void {
+export function unregisterClient(ws: WsClient): void {
   clients.delete(ws);
   logger.info({ socketId: ws.id }, 'WebSocket client disconnected');
 }

--- a/packages/server/src/lib/voice.ts
+++ b/packages/server/src/lib/voice.ts
@@ -1,5 +1,6 @@
+import { logger } from '../shared/logger';
 import { connectToVoice, createPlayer, getClient, getPlayer } from '../startDiscord';
-import { GUILD_ID, logger } from './config';
+import { GUILD_ID } from './config';
 import { json } from './json';
 import { lavalink } from './lavalink';
 

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -2,9 +2,10 @@ import crypto from 'node:crypto';
 import { and, eq, lt } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
 import type { RouteContext } from '../index';
-import { logger, WEB_UI_ORIGIN } from '../lib/config';
+import { WEB_UI_ORIGIN } from '../lib/config';
 import { json } from '../lib/json';
 import { db, tables } from '../shared/db';
+import { logger } from '../shared/logger';
 
 const { refreshToken: refreshTokenTable } = tables;
 

--- a/packages/server/src/shared/logger.ts
+++ b/packages/server/src/shared/logger.ts
@@ -1,9 +1,95 @@
-import pino from 'pino';
+type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'fatal';
 
-// Browser-safe logger initialization
-// In browser, use info level; in Node.js, respect LOG_LEVEL env var
-const isBrowser = 'document' in globalThis;
+const LEVELS: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+  fatal: 50,
+};
 
-export const logger = pino({
-  level: isBrowser ? 'info' : (process.env.LOG_LEVEL ?? 'info'),
-});
+const LABELS: Record<LogLevel, string> = {
+  debug: 'DEBUG',
+  info: 'INFO ',
+  warn: 'WARN ',
+  error: 'ERROR',
+  fatal: 'FATAL',
+};
+
+const currentLevel: number =
+  LEVELS[(process.env.LOG_LEVEL as LogLevel | undefined) ?? 'info'] ?? LEVELS.info;
+
+const useJson = process.env.LOG_FORMAT === 'json';
+const noColor = process.env.NO_COLOR !== undefined || process.env.NODE_ENV === 'production';
+
+// ANSI escape codes — zero-dependency color support.
+// Respects https://no-color.org/ and production mode.
+const C = noColor
+  ? { dim: '', red: '', yellow: '', bold: '', reset: '' }
+  : { dim: '\x1b[2m', red: '\x1b[31m', yellow: '\x1b[33m', bold: '\x1b[1m', reset: '\x1b[0m' };
+
+const COLORS: Record<LogLevel, string> = {
+  debug: C.dim,
+  info: '',
+  warn: C.yellow,
+  error: C.red,
+  fatal: `${C.bold}${C.red}`,
+};
+
+type LogArg = unknown;
+
+function formatMeta(meta: Record<string, unknown>): string {
+  const pairs = Object.entries(meta)
+    .filter(([, v]) => v !== undefined && v !== null)
+    .map(([k, v]) => `${C.dim}${k}=${typeof v === 'string' ? v : JSON.stringify(v)}${C.reset}`)
+    .join(' ');
+  return pairs;
+}
+
+function log(level: LogLevel, first: LogArg, second?: string): void {
+  if (LEVELS[level] < currentLevel) return;
+
+  const msg: string = typeof first === 'string' ? first : (second ?? '');
+  const meta: Record<string, unknown> | undefined =
+    typeof first === 'object' && first !== null && !(first instanceof Error)
+      ? (first as Record<string, unknown>)
+      : first instanceof Error
+        ? { err: first.message, stack: first.stack }
+        : undefined;
+
+  if (useJson) {
+    const entry = JSON.stringify({
+      level,
+      time: new Date().toISOString(),
+      ...meta,
+      msg,
+    });
+    if (level === 'error' || level === 'fatal') {
+      console.error(entry);
+    } else {
+      console.log(entry);
+    }
+    return;
+  }
+
+  const color = COLORS[level];
+  const parts = [`${color}${LABELS[level]}${C.reset}`, msg];
+  if (meta) {
+    const metaStr = formatMeta(meta);
+    if (metaStr) parts.push(metaStr);
+  }
+
+  if (level === 'error' || level === 'fatal') {
+    console.error(parts.join('  '));
+  } else {
+    console.log(parts.join('  '));
+  }
+}
+
+export const logger = {
+  debug: (obj: LogArg, msg?: string) => log('debug', obj, msg),
+  info: (obj: LogArg, msg?: string) => log('info', obj, msg),
+  warn: (obj: LogArg, msg?: string) => log('warn', obj, msg),
+  error: (obj: LogArg, msg?: string) => log('error', obj, msg),
+  fatal: (obj: LogArg, msg?: string) => log('fatal', obj, msg),
+};

--- a/packages/server/src/startDiscord.ts
+++ b/packages/server/src/startDiscord.ts
@@ -1,8 +1,6 @@
 import { Client, createEvent } from 'seyfert';
 import { lavalink } from './lib/lavalink';
-import { emitPlayerUpdate } from './lib/socket';
 import { getPlayer } from './manager';
-import type { QueueState } from './shared';
 import { logger } from './shared/logger';
 import { updateNodeLinkPlayer } from './utils/nodelink';
 
@@ -112,17 +110,6 @@ export function connectToVoice(guildId: string, voiceChannelId: string): Promise
       },
     });
   });
-}
-
-// ---------------------------------------------------------------------------
-// Broadcast (inlined — calls emitPlayerUpdate directly, no more indirection)
-// ---------------------------------------------------------------------------
-
-/**
- * Called by GuildPlayer after every state-changing operation.
- */
-export function broadcastQueueUpdate(state: QueueState): void {
-  emitPlayerUpdate(state);
 }
 
 // ---------------------------------------------------------------------------
@@ -295,8 +282,12 @@ export async function startDiscord(): Promise<void> {
 
   // Register events before client.start(). The ready event handler
   // will connect to NodeLink once we have the bot's Discord user ID.
-  // biome-ignore lint/suspicious/noExplicitAny: createEvent return has `once?: boolean` but ClientEvent needs `once: boolean`; values are correct at runtime
-  client.events.set([readyEvent, rawEvent, voiceStateUpdateEvent] as any);
+  // Seyfert's ClientEvent type requires `once: boolean` on every event,
+  // but createEvent returns `once?: boolean`. The values are correct at
+  // runtime — events have `once` set where needed.
+  client.events.set([readyEvent, rawEvent, voiceStateUpdateEvent] as Parameters<
+    typeof client.events.set
+  >[0]);
 
   await client.start();
 }

--- a/packages/server/src/utils/unregisterCommands.ts
+++ b/packages/server/src/utils/unregisterCommands.ts
@@ -1,14 +1,16 @@
 /**
  * unregisterCommands.ts
  *
- * Unregisters stale Discord slash commands from the bot.
- * Runs automatically on server startup, or can be invoked manually:
+ * Standalone script to clean up Discord slash commands from the pre-web-UI era.
+ * No longer runs automatically on startup — Alfira is web-first now.
+ *
+ * Run manually if needed:
  *   bun run packages/server/src/utils/unregisterCommands.ts
  *
  * Requires: DISCORD_BOT_TOKEN, DISCORD_CLIENT_ID, GUILD_ID in .env
  */
 
-import { logger } from '../lib/config';
+import { logger } from '../shared/logger';
 
 /** Delay helper for rate limit pacing. */
 function delay(ms: number): Promise<void> {


### PR DESCRIPTION
## Summary

Aligns the codebase more closely with the project's [design philosophy](docs/philosophy.md).

### Removed `pino` — replaced with zero-dependency structured logger
Human-readable colored output by default (`INFO`/`WARN`/`ERROR` labels, dimmed `key=value` metadata). JSON via `LOG_FORMAT=json`. Respects `NO_COLOR`.

### Removed indirection
- Inlined `broadcastQueueUpdate` (was a one-line wrapper)
- Removed logger re-export from `lib/config.ts` — all files import from `shared/logger` directly
- Deduplicated cookie parsing in server entry

### Tightened type safety
- Replaced `Set<any>` and `any` casts with `WsClient` interface
- Wrapped Seyfert events cast in typed `Parameters<>` expression

### Fixed startup race condition
`Bun.serve` was at module top-level, accepting requests before migrations, DB verification, and Discord bot were ready. Moved into `main()` as the final startup step.

### Suppressed NodeLink git noise
Removed `.git` after NodeLink build and filter `fatal:` lines from stderr.

### Switched tag migration to structured logger
No more raw `console.log` outside the frontend.

### Removed stale slash command cleanup from startup
No longer hits Discord's API on every boot to delete already-gone commands.

### Updated documentation
- `philosophy.md` — documented why `ws`, `seyfert`, and `jsonwebtoken` are intentionally kept
- `README.md` / `AGENTS.md` — linked philosophy doc, updated WebSocket pipeline docs
- `.env.example` — clarified single-community design