### PR TITLE
chore: establish dev branch workflow and git conventions

### DIFF
--- a/.git-commit-template
+++ b/.git-commit-template
@@ -1,0 +1,26 @@
+
+# <type>[optional scope]: <description>
+# |<----  Use a 72-character line limit  ---->|
+#
+# type must be one of:
+#   feat     fix      chore    refactor docs     ci
+#   style    test     perf     security revert
+#
+# scope (optional): server, web, deps, db, docker, auth, ci, docs
+#
+# Description: imperative mood, lowercase, no trailing period
+#
+# Examples:
+#   feat(server): add queue reordering endpoint
+#   fix(web): prevent scrubber thumb from sticking at 0
+#   chore(deps): bump ws to 8.21.0
+#
+# Branch workflow: feature branch → dev (PR) → main (release PR)
+#
+# Body (optional):
+# - Explain what and why, not how
+# - Wrap at 72 characters
+#
+# Footer (optional):
+# Closes #123
+# BREAKING CHANGE: description of breaking change

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,28 +1,30 @@
-## What does this PR do?
-A brief description of the changes introduced by this PR.
+## Summary
 
-## Related issue
+<!-- Briefly describe what this PR does and why. -->
+
+## Changes
+
+<!-- List key changes as bullet points. -->
+
+-
+-
+
+## Related
+
+<!-- Link related issues or PRs. -->
 Closes #
 
-## Type of change
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Documentation update
-- [ ] Refactoring (no functional changes)
-- [ ] CI/CD improvement
+## Screenshots
 
-## Testing
-How was this tested? Describe the steps you took to verify the changes.
+<!-- If UI changes, add before/after screenshots. Otherwise delete this section. -->
 
 ## Checklist
-- [ ] TypeScript compiles without errors (`bunx tsc --noEmit -p packages/<pkg>/tsconfig.json`)
-- [ ] Docker images build successfully (`docker compose build`)
+
+- [ ] `bun run check` passes
+- [ ] TypeScript compiles (`bunx tsc --noEmit -p packages/server/tsconfig.json`)
+- [ ] Manual testing done (describe below)
 - [ ] Documentation updated if needed
-- [ ] Changes follow the project's code style
 
-## Screenshots (if applicable)
-Add screenshots to help explain your changes.
+### Testing
 
-## Additional notes
-Any other information that reviewers should know about.
+<!-- How was this tested? -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   schedule:
     - cron: "0 6 * * 1" # every Monday at 06:00 UTC
   workflow_dispatch:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - dev
     paths-ignore:
       - "docs/**"
       - "README.md"

--- a/.pi/extensions/dirty-repo-guard.ts
+++ b/.pi/extensions/dirty-repo-guard.ts
@@ -1,0 +1,56 @@
+/**
+ * Dirty Repo Guard Extension
+ *
+ * Prevents session changes when there are uncommitted git changes.
+ * Useful to ensure work is committed before switching context.
+ */
+
+import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
+
+async function checkDirtyRepo(
+  pi: ExtensionAPI,
+  ctx: ExtensionContext,
+  action: string
+): Promise<{ cancel: boolean } | undefined> {
+  // Check for uncommitted changes
+  const { stdout, code } = await pi.exec('git', ['status', '--porcelain']);
+
+  if (code !== 0) {
+    // Not a git repo, allow the action
+    return;
+  }
+
+  const hasChanges = stdout.trim().length > 0;
+  if (!hasChanges) {
+    return;
+  }
+
+  if (!ctx.hasUI) {
+    // In non-interactive mode, block by default
+    return { cancel: true };
+  }
+
+  // Count changed files
+  const changedFiles = stdout.trim().split('\n').filter(Boolean).length;
+
+  const choice = await ctx.ui.select(
+    `You have ${changedFiles} uncommitted file(s). ${action} anyway?`,
+    ['Yes, proceed anyway', 'No, let me commit first']
+  );
+
+  if (choice !== 'Yes, proceed anyway') {
+    ctx.ui.notify('Commit your changes first', 'warning');
+    return { cancel: true };
+  }
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.on('session_before_switch', (event, ctx) => {
+    const action = event.reason === 'new' ? 'new session' : 'switch session';
+    return checkDirtyRepo(pi, ctx, action);
+  });
+
+  pi.on('session_before_fork', (_event, ctx) => {
+    return checkDirtyRepo(pi, ctx, 'fork');
+  });
+}

--- a/.pi/prompts/plan.md
+++ b/.pi/prompts/plan.md
@@ -1,0 +1,44 @@
+---
+description: Break down a feature or fix into a concrete implementation plan with file-level steps
+argument-hint: "<task description>"
+---
+
+Before writing any code, produce a plan. If the user provided a task description ($@), use it as the starting point. Otherwise, ask what we're building.
+
+## Plan format
+
+Output a plan with these sections:
+
+### Goal
+One sentence. What are we doing and why?
+
+### Scope
+What files will be touched. Group by package:
+```
+packages/server/src/...
+packages/web/src/...
+docs/...
+```
+
+### Implementation steps
+Numbered, ordered steps. Each step should be a single logical change at the file level. Avoid steps that touch 10 files at once — split them up.
+
+Example:
+```
+1. Add new type to packages/server/src/shared/types.ts
+2. Create new route handler in packages/server/src/routes/foo.ts
+3. Wire up route in packages/server/src/index.ts
+4. Add API call in packages/web/src/api/foo.ts
+5. Create UI component in packages/web/src/components/Foo.tsx
+```
+
+### Risks / edge cases
+Anything that could go wrong or needs special attention.
+
+### Verification
+What to check after implementation:
+- [ ] `bun run check` passes
+- [ ] TypeScript compiles
+- [ ] Manual test steps (if applicable)
+
+After the plan is agreed to, proceed with implementation one step at a time.

--- a/.pi/prompts/release.md
+++ b/.pi/prompts/release.md
@@ -1,0 +1,57 @@
+---
+description: Create a release PR from dev to main with changelog summary
+argument-hint: "[version or semver bump: major|minor|patch]"
+---
+
+Follow these steps exactly, reporting progress as you go.
+
+## 1. Check what's pending
+
+Show what commits are on `dev` but not `main`:
+
+```bash
+git fetch origin
+git log origin/main..origin/dev --oneline --no-merges
+```
+
+Summarize the changes by conventional commit type (feat, fix, chore, etc.).
+
+## 2. Determine version (if applicable)
+
+$@
+
+If the user provided a semver bump (major, minor, patch) or a specific version, note it. If this is pre-release and they didn't provide one, skip versioning.
+
+## 3. Create release branch
+
+```bash
+git checkout dev && git pull origin dev
+git checkout -b release/<version-or-description>
+```
+
+If no version was specified, use a short description — e.g., `release/q3-2026` or `release/july-updates`.
+
+## 4. Create release PR
+
+```bash
+gh pr create \
+  --title "release: <version-or-description>" \
+  --body "## Release Summary
+
+<brief description of what's being released>
+
+## Changes Since Last Release
+
+$(git log origin/main..origin/dev --oneline --no-merges | sed 's/^/- /')" \
+  --base main
+```
+
+Open the PR URL for the user.
+
+## 5. Post-merge reminder
+
+Remind the user that after the release PR is merged to `main`, `dev` should be synced:
+
+```bash
+git checkout dev && git merge main && git push origin dev
+```

--- a/.pi/prompts/submit.md
+++ b/.pi/prompts/submit.md
@@ -1,0 +1,75 @@
+---
+description: Stage changes, create a feature branch, commit with semantic message, push, and open a PR
+argument-hint: "[optional commit description]"
+---
+
+Follow these steps exactly, reporting progress as you go.
+
+## 1. Determine the change type and scope
+
+Read `git diff --stat` and `git diff` (or `git diff --cached` if staged) to understand what changed. Based on the changes, determine:
+
+- **type**: one of `feat`, `fix`, `chore`, `refactor`, `docs`, `ci`, `style`, `test`, `perf`, `security`, `revert`
+- **scope** (optional): affected package/area — `server`, `web`, `deps`, `db`, `docker`, `auth`, `ci`, `docs`
+- **short description**: imperative, lowercase, no trailing period, max ~72 chars
+
+If the user provided an argument ($@), use it to help formulate the message. If they provided a full conventional commit string (e.g. `fix(server): handle websocket timeout`), use it as-is.
+
+## 2. Run quality checks
+
+```bash
+bun run check
+```
+
+If lint or format issues are found, fix them before proceeding. If fixes produce additional changes, re-run `bun run check`.
+
+## 3. Create a feature branch
+
+If currently on `main` or `dev`, create a new branch from `dev` that is up to date:
+
+```bash
+git checkout dev && git pull origin dev
+git checkout -b <type>/<short-description>
+```
+
+If already on a feature branch (not `main` or `dev`), ask the user whether to use the current branch or create a new one.
+
+## 4. Stage and commit
+
+Stage all changes:
+
+```bash
+git add -A
+```
+
+Commit with the semantic message:
+
+```bash
+git commit -m "<type>[optional scope]: <description>"
+```
+
+If the changes span multiple logical concerns, suggest splitting into separate commits. Ask the user for guidance.
+
+## 5. Push
+
+```bash
+git push -u origin HEAD
+```
+
+## 6. Create PR
+
+```bash
+gh pr create \
+  --title "<type>[optional scope]: <description>" \
+  --body "## Summary
+
+<brief summary of changes>
+
+## Changes
+
+- <change 1>
+- <change 2>" \
+  --base dev
+```
+
+Open the PR URL for the user.

--- a/.pi/prompts/verify.md
+++ b/.pi/prompts/verify.md
@@ -1,0 +1,60 @@
+---
+description: Run quality checks and review the diff before submitting — the gate before /submit
+---
+
+Run the verification gate. Do not proceed to `/submit` until this passes.
+
+## 1. Lint and format
+
+```bash
+bun run check
+```
+
+If issues are found, fix them and re-run.
+
+## 2. TypeScript compilation
+
+```bash
+bunx tsc --noEmit -p packages/server/tsconfig.json
+bunx tsc --noEmit -p packages/web/tsconfig.json
+```
+
+If errors, fix them and re-run from step 1.
+
+## 3. Review the diff
+
+```bash
+git diff --stat
+git diff
+```
+
+Check for:
+- Debug logging left in
+- Commented-out code
+- Hardcoded values that should be config
+- Missing error handling
+- Changes that snuck in from unrelated work
+- Files that shouldn't be committed (`.env`, `dist/`, etc.)
+
+## 4. Untracked files
+
+```bash
+git status --short
+```
+
+Flag any untracked files that should be committed, gitignored, or deleted.
+
+## 5. Report
+
+Output a summary:
+
+```
+✅ Lint:       clean
+✅ TypeScript: clean
+⚠️  Diff:      3 files, +42/-8 — reviewed, no issues
+✅ Untracked:  .pi/prompts/plan.md (should be committed)
+
+Verdict: READY TO SUBMIT
+```
+
+If anything fails, report the issues and stop. Do not proceed to `/submit`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,72 @@ The bot streams audio from NodeLink (a Lavalink v4-compatible server). The `node
 
 **API Service:** `@alfira-bot/server/shared/api` provides centralized API functions (`fetchSongs`, `createSong`, `importPlaylist`, etc.) that should be used by all consumers.
 
+## Git Workflow
+
+### Branch Model
+
+```
+feature branches  ──PR──►  dev  ──release PR──►  main
+```
+
+- `main` — protected, production-ready code. Only updated via release PRs from `dev`.
+- `dev` — integration branch. All feature work merges here via PR.
+- Feature branches — created from `dev`, merged back to `dev`.
+
+Never commit directly to `main` or `dev`. All work happens in feature branches.
+
+### Branch Naming
+
+Feature branches must follow: `<type>/<short-description>`
+
+Valid types: `feat`, `fix`, `chore`, `refactor`, `docs`, `ci`, `security`, `revert`, `ui`, `cleanup`, `test`
+
+Examples: `fix/websocket-reconnect`, `feat/playlist-folders`, `chore/update-deps`
+
+### Commit Messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) format:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+- `type` must be one of: `feat`, `fix`, `chore`, `refactor`, `docs`, `ci`, `style`, `test`, `perf`, `revert`, `security`
+- `scope` is optional and should match the affected package/area (e.g., `server`, `web`, `deps`, `db`, `docker`, `auth`)
+- Description should be lowercase, imperative mood, no trailing period
+
+A commit template is available at `.git-commit-template`. Enable it locally:
+```bash
+git config commit.template .git-commit-template
+```
+
+Examples:
+```
+feat(server): add queue reordering endpoint
+fix(web): prevent scrubber thumb from sticking at 0
+chore(deps): bump ws to 8.21.0
+refactor(server): extract shared audio filter builders
+```
+
+### PR Workflow
+
+1. Create a feature branch from `dev` (not `main`)
+2. Make changes, run `bun run check` before committing
+3. Commit with a semantic message
+4. Push the branch
+5. Create a PR with `gh pr create`:
+   - Use the conventional commit subject as the PR title
+   - Include a brief summary of changes in the body
+   - Target `dev` as the base branch
+
+### Before Committing
+
+Always run `bun run check` and resolve any lint/format issues before committing.
+
 ## Documentation
 
 - [Installation Guide](docs/installation.md) — Setup, environment variables, Docker commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,34 @@ feature branches  ──PR──►  dev  ──release PR──►  main
 
 Never commit directly to `main` or `dev`. All work happens in feature branches.
 
+### Development Lifecycle
+
+```
+Discuss  →  /plan  →  Implement  →  /verify  →  /submit  →  Review & Merge  →  /release
+```
+
+Every change follows this pipeline. The agent should guide the user through each phase and not skip gates.
+
+1. **Discuss** — Talk through the problem and explore approaches. Ask clarifying questions before proposing solutions.
+2. **`/plan`** — Before writing any code, produce a written plan: goal, scope (files touched), ordered implementation steps, risks, and verification checklist. Get user agreement on the plan before proceeding.
+3. **Implement** — Follow the plan one step at a time. After each step, confirm it works before moving on. If the plan needs adjustment mid-implementation, say so and update it.
+4. **`/verify`** — The gate before `/submit`. Run `bun run check`, TypeScript compilation (`bunx tsc --noEmit`), review the full diff, and check for untracked files. Report pass/fail for each check. Do not proceed if anything fails.
+5. **`/submit`** — Create a feature branch from `dev`, commit with a semantic message, push, and open a PR targeting `dev`.
+6. **Review & Merge** — Address review feedback. CI must pass. Merge to `dev`.
+7. **`/release`** — Batch accumulated `dev` changes into a release PR targeting `main`. Show pending commits, determine version if applicable, open the PR with a changelog.
+
+After a release merges to `main`, sync `dev` with `main` to keep history clean:
+```bash
+git checkout dev && git merge main && git push origin dev
+```
+
+#### Agent rules for each phase
+
+- Never skip `/plan` for non-trivial changes. If the user says "just fix X", ask one question: "Want me to plan it first or just go?"
+- Never skip `/verify`. It's the universal gate before `/submit`.
+- If implementation reveals the plan was wrong, stop and re-plan. Don't bulldoze through.
+- After `/submit`, remind the user what the next step is (review → merge → `/release` when ready).
+
 ### Branch Naming
 
 Feature branches must follow: `<type>/<short-description>`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,18 @@ Thanks for your interest in contributing! This guide covers the development work
 
 For setup instructions, see the **[Installation Guide](docs/installation.md)**.
 
+## Branching Model
+
+```
+feature branch  ──PR──►  dev  ──release PR──►  main
+```
+
+- **`main`** — protected, production-ready. Only updated via release PRs from `dev`.
+- **`dev`** — integration branch. All feature work merges here.
+- **Feature branches** — created from `dev`, named `type/short-description` (e.g., `feat/playlist-folders`, `fix/login-redirect`).
+
+See [AGENTS.md](../AGENTS.md) for the full git workflow and commit conventions.
+
 ---
 
 ## Development Workflow

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -112,5 +112,6 @@ Three GitHub Actions workflows run on the repository:
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| **typecheck.yml** | PRs and pushes to `main` | Lint with Biome + typecheck all packages |
-| **docker-build.yml** | PRs and pushes to `main` (ignores `docs/`) | Build Docker images; publish to GHCR on `main` |
+| **ci.yml** | All PRs, pushes to `main` and `dev` | Lint with Biome + typecheck all packages |
+| **codeql.yml** | All PRs, pushes to `main` and `dev`, weekly schedule | CodeQL security analysis |
+| **docker-build.yml** | All PRs, pushes to `main` and `dev` (ignores `docs/`) | Build Docker images; publish to GHCR on `main` |


### PR DESCRIPTION
## Summary

Sets up the full git workflow for the project: dev/main branch model, conventional commits, automated CI triggers, and Pi agent tooling.

## Changes

- **Branch model:** `dev` branch created as integration target (feature → dev → main)
- **CI:** All three workflows (ci, codeql, docker-build) now trigger on `dev` pushes
- **AGENTS.md:** Full Git Workflow section — branch naming, commit conventions, PR flow, quality gates
- **CONTRIBUTING.md:** Branching model diagram added
- **`.pi/prompts/submit.md`:** Pi prompt template for automated commit→branch→PR pipeline
- **`.pi/extensions/dirty-repo-guard.ts`:** Pi extension that blocks session switches with uncommitted changes
- **`.git-commit-template`:** Conventional commit message template
- **`docs/tech-stack.md`:** CI section updated with correct workflow names and dev triggers