### PR TITLE
chore: clean up stale gitignore entries and enhance zed config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,7 @@ node_modules/
 # Copy .env.example to .env and fill in values locally.
 # -----------------------------------------------
 .env
-packages/api/.env
-packages/bot/.env
+
 
 # -----------------------------------------------
 # Build output
@@ -24,11 +23,7 @@ data/
 *.tsbuildinfo
 
 # -----------------------------------------------
-# Drizzle ORM
-# Migrations are committed — they are part of the
-# project history. Generated files are not.
-# -----------------------------------------------
-packages/api/src/generated/
+
 
 # -----------------------------------------------
 # Logs

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -11,16 +11,29 @@
     "TypeScript": {
       "language_servers": ["biome", "..."],
       "formatter": "language_server",
-      "format_on_save": "on"
+      "format_on_save": "on",
+      "inlay_hints": {
+        "enabled": true,
+        "show_parameter_hints": true,
+        "show_type_hints": true
+      }
     },
     "TSX": {
       "language_servers": ["biome", "..."],
       "formatter": "language_server",
-      "format_on_save": "on"
+      "format_on_save": "on",
+      "inlay_hints": {
+        "enabled": true,
+        "show_parameter_hints": true,
+        "show_type_hints": true
+      }
     },
     "JSON": {
       "language_servers": ["biome", "..."],
       "formatter": "language_server",
+      "format_on_save": "on"
+    },
+    "Markdown": {
       "format_on_save": "on"
     }
   },

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -1,0 +1,32 @@
+[
+  {
+    "label": "dev",
+    "command": "bun run dev",
+    "cwd": "$ZED_WORKTREE_ROOT",
+    "use_new_terminal": true
+  },
+  {
+    "label": "check",
+    "command": "bun run check",
+    "cwd": "$ZED_WORKTREE_ROOT",
+    "use_new_terminal": true
+  },
+  {
+    "label": "web:build",
+    "command": "bun run web:build",
+    "cwd": "$ZED_WORKTREE_ROOT",
+    "use_new_terminal": true
+  },
+  {
+    "label": "db:migrate",
+    "command": "bun run db:migrate",
+    "cwd": "$ZED_WORKTREE_ROOT",
+    "use_new_terminal": true
+  },
+  {
+    "label": "db:generate",
+    "command": "bun run db:generate",
+    "cwd": "$ZED_WORKTREE_ROOT",
+    "use_new_terminal": true
+  }
+]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,15 @@ bun run format
 
 CI runs `bun run lint` in the typecheck workflow — your code must pass before merging. See the [Biome Setup](docs/biome-setup.md) doc for configuration details.
 
+## Editor Tooling
+
+The repo includes preconfigured settings for a couple of tools (optional — use whatever you prefer):
+
+- **Zed** (`.zed/`) — Biome integration, TypeScript inlay hints, Markdown formatting, and task shortcuts for common dev commands
+- **Pi** (`.pi/`) — Prompt templates and extensions for the project's development pipeline (plan, verify, submit, release)
+
+If you use Zed or Pi, you'll get a pre-tuned experience out of the box. Nothing is enforced — these are just defaults for convenience.
+
 ---
 
 ## Questions?


### PR DESCRIPTION
## Summary

Clean up stale .gitignore entries from the old architecture and enhance the Zed editor workspace configuration with inlay hints, Markdown formatting, and dev task shortcuts.

## Changes

- Remove stale .gitignore entries for `packages/api/` and `packages/bot/` (pre-refactor architecture)
- Add TypeScript/TSX inlay hints (parameter names + type hints)
- Add Markdown format-on-save
- Add `.zed/tasks.json` with dev, check, web:build, db:migrate, and db:generate tasks