### PR TITLE
fix(web): smooth scrubber positioning via rAF-driven DOM updates

### DIFF
--- a/packages/web/src/components/NowPlayingBar.tsx
+++ b/packages/web/src/components/NowPlayingBar.tsx
@@ -189,9 +189,8 @@ const LoopShuffleControls = memo(function LoopShuffleControls({
 interface ScrubberProps {
   isSeekable: boolean;
   duration: number; // seconds
-  elapsed: number; // seconds
   registerProgress: (ref: HTMLDivElement | null) => void;
-  registerRangeInput: (ref: HTMLInputElement | null) => void;
+  registerThumb: (ref: HTMLDivElement | null) => void;
   onSeek: (seconds: number) => void;
   setOverrideElapsed: (seconds: number) => void;
 }
@@ -199,9 +198,8 @@ interface ScrubberProps {
 const Scrubber = memo(function Scrubber({
   isSeekable,
   duration,
-  elapsed,
   registerProgress,
-  registerRangeInput: _registerRangeInput,
+  registerThumb,
   onSeek,
   setOverrideElapsed,
 }: ScrubberProps) {
@@ -213,8 +211,20 @@ const Scrubber = memo(function Scrubber({
   // Last known slider value during drag (used to commit seek on pointer up)
   const lastDragValueRef = useRef<number>(0);
 
-  const pct = duration > 0 ? elapsed / duration : 0;
-  const pctStr = `${pct * 100}%`;
+  // Register the thumb div with the rAF loop so it glides at display-native rate.
+  useEffect(() => {
+    if (thumbRef.current) {
+      registerThumb(thumbRef.current);
+    }
+  }, [registerThumb]);
+
+  // Position both fill bar and thumb directly in the DOM during drag.
+  // Bypasses React + rAF entirely — immediate, jank-free visual feedback.
+  const seekElements = useCallback((trackPct: number) => {
+    const pctStr = `${trackPct * 100}%`;
+    if (fillRef.current) fillRef.current.style.width = pctStr;
+    if (thumbRef.current) thumbRef.current.style.left = pctStr;
+  }, []);
 
   const handlePointerMove = useCallback(
     (e: PointerEvent) => {
@@ -224,12 +234,9 @@ const Scrubber = memo(function Scrubber({
       const seekSec = Math.round(trackPct * duration);
       lastDragValueRef.current = seekSec;
       setOverrideElapsed(seekSec);
-      // Directly position the thumb to avoid waiting for React re-render
-      if (thumbRef.current) {
-        thumbRef.current.style.left = `${trackPct * 100}%`;
-      }
+      seekElements(trackPct);
     },
-    [duration, setOverrideElapsed]
+    [duration, setOverrideElapsed, seekElements]
   );
 
   const handlePointerUp = useCallback(() => {
@@ -247,30 +254,29 @@ const Scrubber = memo(function Scrubber({
       if (!isSeekable) return;
       e.currentTarget.setPointerCapture(e.pointerId);
       isDraggingRef.current = true;
-      // Compute initial position from click location
       if (trackRef.current) {
         const rect = trackRef.current.getBoundingClientRect();
         const trackPct = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
         const seekSec = Math.round(trackPct * duration);
         lastDragValueRef.current = seekSec;
         setOverrideElapsed(seekSec);
-        if (thumbRef.current) {
-          thumbRef.current.style.left = `${trackPct * 100}%`;
-        }
+        seekElements(trackPct);
       }
       document.addEventListener('pointermove', handlePointerMove);
       document.addEventListener('pointerup', handlePointerUp);
     },
-    [isSeekable, duration, handlePointerMove, handlePointerUp, setOverrideElapsed]
+    [isSeekable, duration, handlePointerMove, handlePointerUp, setOverrideElapsed, seekElements]
   );
 
   if (!isSeekable) {
     return (
       <div className="w-full h-2 clay-inset rounded-full relative overflow-hidden cursor-not-allowed opacity-50">
         <div
-          ref={fillRef}
+          ref={(ref) => {
+            fillRef.current = ref;
+            registerProgress(ref);
+          }}
           className="absolute inset-y-0 left-0 bg-accent rounded-full"
-          style={{ width: pctStr }}
         />
       </div>
     );
@@ -288,13 +294,12 @@ const Scrubber = memo(function Scrubber({
           registerProgress(ref);
         }}
         className="absolute inset-y-0 left-0 bg-accent rounded-full"
-        style={{ width: pctStr }}
       />
-      {/* Custom thumb — positioned manually via ref, not via native range input */}
+      {/* Fill & thumb — positioned entirely by useProgressBar (rAF + effect).
+           No React style props. */}
       <div
         ref={thumbRef}
         className="scrubber-thumb absolute top-1/2 -translate-y-1/2 w-3.5 h-3.5 rounded-full bg-surface border-2 border-accent opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity"
-        style={{ left: pctStr }}
       />
       {/* Invisible hit area for hovering */}
       <div className="absolute inset-0" />
@@ -306,7 +311,7 @@ interface ProgressBarProps {
   currentSong: QueuedSong | null;
   elapsed: number;
   registerProgress: (ref: HTMLDivElement | null) => void;
-  registerRangeInput: (ref: HTMLInputElement | null) => void;
+  registerThumb: (ref: HTMLDivElement | null) => void;
   onSeek?: (seconds: number) => void;
   setOverrideElapsed: (seconds: number) => void;
   variant: 'mobile' | 'desktop';
@@ -316,7 +321,7 @@ const ProgressBar = memo(function ProgressBar({
   currentSong,
   elapsed,
   registerProgress,
-  registerRangeInput,
+  registerThumb,
   onSeek,
   setOverrideElapsed,
   variant,
@@ -358,9 +363,8 @@ const ProgressBar = memo(function ProgressBar({
       <Scrubber
         isSeekable={currentSong?.isSeekable ?? false}
         duration={currentSong?.duration ?? 0}
-        elapsed={elapsed}
         registerProgress={registerProgress}
-        registerRangeInput={registerRangeInput}
+        registerThumb={registerThumb}
         onSeek={onSeek ?? (() => undefined)}
         setOverrideElapsed={setOverrideElapsed}
       />
@@ -408,7 +412,7 @@ export function NowPlayingBar() {
     state,
     elapsed,
     registerProgress,
-    registerRangeInput,
+    registerThumb,
     skip,
     leave,
     pause,
@@ -496,7 +500,7 @@ export function NowPlayingBar() {
       <ProgressBar
         currentSong={currentSong}
         registerProgress={registerProgress}
-        registerRangeInput={registerRangeInput}
+        registerThumb={registerThumb}
         elapsed={elapsed}
         setOverrideElapsed={setOverrideElapsed}
         variant="mobile"
@@ -523,7 +527,7 @@ export function NowPlayingBar() {
         <ProgressBar
           currentSong={currentSong}
           registerProgress={registerProgress}
-          registerRangeInput={registerRangeInput}
+          registerThumb={registerThumb}
           elapsed={elapsed}
           onSeek={handleSeek}
           setOverrideElapsed={setOverrideElapsed}

--- a/packages/web/src/context/PlayerContext.tsx
+++ b/packages/web/src/context/PlayerContext.tsx
@@ -39,8 +39,8 @@ interface PlayerContextValue {
   elapsed: number;
   // Register a progress bar DOM element for direct rAF-driven updates.
   registerProgress: (ref: HTMLDivElement | null) => void;
-  // Register a range input whose thumb tracks progress at rAF speed.
-  registerRangeInput: (ref: HTMLInputElement | null) => void;
+  // Register a thumb div whose position tracks progress at rAF speed.
+  registerThumb: (ref: HTMLDivElement | null) => void;
   // Override elapsed time (e.g. after a seek).
   setOverrideElapsed: (elapsed: number | undefined) => void;
   // Actions — each calls the API; state updates arrive via real-time events.
@@ -65,13 +65,13 @@ interface PlayerContextValue {
 // ---------------------------------------------------------------------------
 const PlayerStateContext = createContext<Omit<
   PlayerContextValue,
-  'elapsed' | 'registerProgress' | 'registerRangeInput'
+  'elapsed' | 'registerProgress' | 'registerThumb'
 > | null>(null);
 const PlayerElapsedContext = createContext<number>(0);
 const PlayerProgressContext = createContext<(ref: HTMLDivElement | null) => void>(() => {
   /* noop */
 });
-const PlayerRangeInputContext = createContext<(ref: HTMLInputElement | null) => void>(() => {
+const PlayerThumbContext = createContext<(ref: HTMLDivElement | null) => void>(() => {
   /* noop */
 });
 const PlayerOverrideContext = createContext<(elapsed: number | undefined) => void>(() => {
@@ -86,7 +86,7 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
   useSocket();
 
   // Use the progress bar hook (rAF + 1-sec interval)
-  const { elapsed, registerProgress, registerRangeInput } = useProgressBar(
+  const { elapsed, registerProgress, registerThumb } = useProgressBar(
     state,
     overrideElapsed,
     setOverrideElapsed
@@ -186,35 +186,33 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
     await seekTrack(positionMs);
   }, []);
 
-  const stateValue: Omit<
-    PlayerContextValue,
-    'elapsed' | 'registerProgress' | 'registerRangeInput'
-  > = useMemo(
-    () => ({
-      state,
-      loading,
-      skip,
-      leave,
-      pause,
-      clear,
-      setLoop,
-      shuffle,
-      unshuffle,
-      seek,
-      refetch,
-      setOverrideElapsed,
-    }),
-    [state, loading, skip, leave, pause, clear, setLoop, shuffle, unshuffle, seek, refetch]
-  );
+  const stateValue: Omit<PlayerContextValue, 'elapsed' | 'registerProgress' | 'registerThumb'> =
+    useMemo(
+      () => ({
+        state,
+        loading,
+        skip,
+        leave,
+        pause,
+        clear,
+        setLoop,
+        shuffle,
+        unshuffle,
+        seek,
+        refetch,
+        setOverrideElapsed,
+      }),
+      [state, loading, skip, leave, pause, clear, setLoop, shuffle, unshuffle, seek, refetch]
+    );
 
   return (
     <PlayerStateContext value={stateValue}>
       <PlayerProgressContext value={registerProgress}>
-        <PlayerRangeInputContext value={registerRangeInput}>
+        <PlayerThumbContext value={registerThumb}>
           <PlayerOverrideContext.Provider value={setOverrideElapsed}>
             <PlayerElapsedContext value={elapsed}>{children}</PlayerElapsedContext>
           </PlayerOverrideContext.Provider>
-        </PlayerRangeInputContext>
+        </PlayerThumbContext>
       </PlayerProgressContext>
     </PlayerStateContext>
   );
@@ -227,7 +225,7 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
  */
 export function usePlayerState(): Omit<
   PlayerContextValue,
-  'elapsed' | 'registerProgress' | 'registerRangeInput'
+  'elapsed' | 'registerProgress' | 'registerThumb'
 > {
   const context = useContext(PlayerStateContext);
   if (!context) {
@@ -245,10 +243,10 @@ export function usePlayer(): PlayerContextValue {
   const stateContext = useContext(PlayerStateContext);
   const elapsed = useContext(PlayerElapsedContext);
   const registerProgress = useContext(PlayerProgressContext);
-  const registerRangeInput = useContext(PlayerRangeInputContext);
+  const registerThumb = useContext(PlayerThumbContext);
   const setOverrideElapsed = useContext(PlayerOverrideContext);
   if (!stateContext) {
     throw new Error('usePlayer must be used within a PlayerProvider');
   }
-  return { ...stateContext, elapsed, registerProgress, registerRangeInput, setOverrideElapsed };
+  return { ...stateContext, elapsed, registerProgress, registerThumb, setOverrideElapsed };
 }

--- a/packages/web/src/hooks/useProgressBar.ts
+++ b/packages/web/src/hooks/useProgressBar.ts
@@ -20,7 +20,7 @@ export function useProgressBar(
 ) {
   const [elapsed, setElapsed] = useState(0);
   const progressBars = useRef<Set<HTMLDivElement>>(new Set());
-  const rangeInputs = useRef<Set<HTMLInputElement>>(new Set());
+  const thumbs = useRef<Set<HTMLDivElement>>(new Set());
   const rafIdRef = useRef(0);
   // biome-ignore lint/suspicious/noExplicitAny: setInterval return type differs across environments
   const intervalIdRef = useRef<any>(0);
@@ -38,12 +38,13 @@ export function useProgressBar(
     }
   }, []);
 
-  // Register a <input type="range"> whose thumb position should track progress.
-  // Its value is updated in the rAF loop so the thumb glides smoothly instead
-  // of jumping once per second (which happens when driven by React state alone).
-  const registerRangeInput = useCallback((ref: HTMLInputElement | null) => {
+  // Register a thumb div whose left position should track progress.
+  // Its style.left is updated in the rAF loop so the thumb glides smoothly
+  // instead of jumping once per second (which happens when driven by React
+  // state alone).
+  const registerThumb = useCallback((ref: HTMLDivElement | null) => {
     if (ref) {
-      rangeInputs.current.add(ref);
+      thumbs.current.add(ref);
     }
   }, []);
 
@@ -54,11 +55,22 @@ export function useProgressBar(
   const trackStartedAt = state.trackStartedAt;
 
   useEffect(() => {
-    // When overrideElapsed is provided (after a seek), reset effectiveStart
-    // so the rAF loop picks up the new position immediately.
+    // When overrideElapsed is provided (after a seek), sync the React
+    // elapsed state immediately so that any React re-render uses the correct
+    // position and doesn't fight the rAF-driven thumb placement.
     if (overrideElapsed !== undefined) {
       accumulatedMsRef.current = overrideElapsed * 1000;
       effectiveStartRef.current = Date.now() - overrideElapsed * 1000;
+      setElapsed(overrideElapsed);
+      // Immediately position fill bar and thumb at the seek target so they
+      // don't flicker to stale positions when React re-renders.
+      const seekPct = (overrideElapsed / currentSongDuration) * 100;
+      for (const ref of progressBars.current) {
+        ref.style.width = `${seekPct}%`;
+      }
+      for (const ref of thumbs.current) {
+        ref.style.left = `${seekPct}%`;
+      }
     }
 
     const prevSongId = prevSongIdRef.current;
@@ -96,13 +108,18 @@ export function useProgressBar(
         accumulatedMsRef.current = 0;
         setElapsed(0);
         for (const ref of progressBars.current) ref.style.width = '0%';
+        for (const ref of thumbs.current) ref.style.left = '0%';
       }
 
       // When pausing (song exists + paused), capture current elapsed
       if (hasSong && isPaused) {
         accumulatedMsRef.current =
           effectiveStartRef.current > 0 ? Date.now() - effectiveStartRef.current : 0;
-        setElapsed(Math.min(Math.round(accumulatedMsRef.current / 1000), duration));
+        const pausedSec = Math.min(Math.round(accumulatedMsRef.current / 1000), duration);
+        setElapsed(pausedSec);
+        const pct = (pausedSec / duration) * 100;
+        for (const ref of progressBars.current) ref.style.width = `${pct}%`;
+        for (const ref of thumbs.current) ref.style.left = `${pct}%`;
       }
 
       return;
@@ -133,19 +150,18 @@ export function useProgressBar(
 
     effectiveStartRef.current = effectiveStart;
 
-    // rAF loop — directly sets style.width on registered progress bars AND
-    // syncs range input values so the thumb glides at rAF speed, not 1-sec intervals.
+    // rAF loop — directly sets style.width on registered progress bars and
+    // style.left on registered thumbs so both glide at display-native rate.
     const tick = () => {
       const elapsedMs = Date.now() - effectiveStart;
       const pct = Math.min((elapsedMs / (duration * 1000)) * 100, 100);
       if (pct >= 100) return;
+      const pctStr = `${pct}%`;
       for (const ref of progressBars.current) {
-        ref.style.width = `${pct}%`;
+        ref.style.width = pctStr;
       }
-      // Update range input values so thumb position is smooth (not 1-sec jumps)
-      const sec = elapsedMs / 1000;
-      for (const input of rangeInputs.current) {
-        input.value = String(sec);
+      for (const ref of thumbs.current) {
+        ref.style.left = pctStr;
       }
       rafIdRef.current = requestAnimationFrame(tick);
     };
@@ -173,5 +189,5 @@ export function useProgressBar(
     setOverrideElapsed,
   ]);
 
-  return { elapsed, registerProgress, registerRangeInput };
+  return { elapsed, registerProgress, registerThumb };
 }


### PR DESCRIPTION
## Summary

Fixes the progress bar scrubber where the thumb lagged behind the fill bar (updating only once per second via React state) and both elements flickered during seeks due to React's stale `style` props fighting rAF-driven DOM updates.

## Changes

- **`useProgressBar` hook** — now owns ALL DOM positioning for both the fill bar (`style.width`) and thumb (`style.left`) across all states: rAF loop during playback, direct DOM writes during seeks, and effect-driven positioning during pause/idle
- **Scrubber component** — removes all React `style={{ width/left }}` props from the fill bar and thumb divs, eliminating stale-state overwrites after React re-renders. Adds `seekElements()` helper so both elements move together immediately on pointer events
- **Dead code removed** — `registerRangeInput` / `PlayerRangeInputContext` targeted a native `<input type="range">` that never existed in the DOM. Replaced with `registerThumb` / `PlayerThumbContext` that registers the actual custom thumb div