### PR TITLE
feat(setup): add in-app setup wizard and admin settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,13 @@
 # ---------------------------------------------------------------------------
-# Alfira Bot - Production Environment Configuration
+# Alfira Bot - Environment Configuration
 # ---------------------------------------------------------------------------
-# Copy this file to .env and fill in your values:
+# Copy this file to .env and fill in the required values:
 #   cp .env.example .env
 #
 # Then start the stack:
 #   docker compose -f docker-compose.prod.yml up -d
+#
+# After first login, complete the setup wizard to configure your server.
 # ---------------------------------------------------------------------------
 
 # ===========================================
@@ -19,25 +21,6 @@ DISCORD_BOT_TOKEN=your-bot-token-here
 
 # OAuth2 callback URL (must match what you configured in Discord Developer Portal)
 DISCORD_REDIRECT_URI=https://your-domain.com/auth/callback
-
-# ===========================================
-# SERVER CONFIGURATION (Required)
-# ===========================================
-
-# Public URL where users access the web interface
-WEB_UI_ORIGIN=https://your-domain.com
-
-# Your Discord server ID (enable Developer Mode, right-click server, Copy ID).
-# Alfira is designed for a single community — one guild, one instance, one shared state.
-GUILD_ID=your-guild-id-here
-
-# Admin role ID(s) - comma-separated for multiple (enable Developer Mode, right-click role, Copy ID)
-# REQUIRED: Users with this role can add songs, manage playlists, use quick-add.
-# Also requires "Server Members Intent" enabled in Discord Developer Portal → Bot → Privileged Gateway Intents.
-ADMIN_ROLE_IDS=your-admin-role-id-here
-
-# Minutes the bot waits before leaving a voice channel when idle (paused or queue empty)
-VOICE_IDLE_TIMEOUT_MINUTES=5
 
 # ===========================================
 # SECURITY (Required)
@@ -58,6 +41,15 @@ JWT_SECRET=your-secure-random-string-here
 # ===========================================
 # ADVANCED (Optional)
 # ===========================================
+
+# Pre-seed guild and admin settings (for existing deployments or automated setup).
+# New installs can leave these empty and configure via the in-app setup wizard.
+# GUILD_ID=your-guild-id-here
+# ADMIN_ROLE_IDS=your-admin-role-id-here
+
+# Minutes the bot waits before leaving a voice channel when idle.
+# Can also be changed via the setup wizard / admin settings. Default: 5
+# VOICE_IDLE_TIMEOUT_MINUTES=5
 
 # JWT refresh token expiration (e.g., "30d", "7d", "24h"). Default: 30d
 # JWT_EXPIRES_IN=30d

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ The server is compiled to `packages/server/dist/` during Docker image build. If 
 
 ### Environment Configuration
 
-A single `.env` file at the project root is used for all configuration. Copy `.env.example` to `.env` and fill in all values before running. Required: `DISCORD_BOT_TOKEN`, `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET`, `GUILD_ID`, `JWT_SECRET`, `ADMIN_ROLE_IDS`, `DATABASE_URL`.
+A single `.env` file at the project root is used for all configuration. Copy `.env.example` to `.env` and fill in all values before running. Required: `DISCORD_BOT_TOKEN`, `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET`, `DISCORD_REDIRECT_URI`, `JWT_SECRET`. Guild ID, admin roles, idle timeout, and notification channel are configured via the in-app setup wizard (or optionally via `GUILD_ID` / `ADMIN_ROLE_IDS` env vars for existing deployments).
 
 ### NodeLink Audio Service
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ vi .env
 
 # 3. Start the stack — web UI at http://localhost:8180
 docker compose up -d
+
+# 4. Open the web UI, log in with Discord, and complete the setup wizard.
 ```
 
 See the **[Installation Guide](docs/installation.md)** for full details.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,6 +9,7 @@ This guide covers everything you need to set up Alfira for both development and 
 - [Configuration](#configuration)
 - [Development Setup](#development-setup)
 - [Production Setup](#production-setup)
+- [Setup Wizard](#setup-wizard)
 - [Upgrading](#upgrading)
 
 ---
@@ -56,47 +57,39 @@ docker compose up -d
 
 ### Environment Variables
 
-#### Required (API)
+#### Required
 
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `DISCORD_CLIENT_ID` | Discord application client ID | `123456789012345678` |
 | `DISCORD_CLIENT_SECRET` | Discord application client secret | `abc123...` |
 | `DISCORD_BOT_TOKEN` | Discord bot token | `MTAwMC4...` |
-| `GUILD_ID` | Discord server ID | `987654321098765432` |
+| `DISCORD_REDIRECT_URI` | OAuth2 redirect URI | `https://your-domain.com/auth/callback` |
 | `JWT_SECRET` | Secret for signing JWT tokens | `your-secure-random-string` |
-| `ADMIN_ROLE_IDS` | Discord role ID(s) for admin permissions (comma-separated) | `123456789012345678` |
 
 > **Security:** Use a strong, random `JWT_SECRET`. Generate one with: `openssl rand -hex 32`
-
-#### Required (Bot)
-
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `DISCORD_BOT_TOKEN` | Discord bot token (same as API) | `MTAwMC4...` |
-| `DISCORD_CLIENT_ID` | Discord application client ID (same as API) | `123456789012345678` |
 
 #### Optional
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `DATABASE_URL` | SQLite database path | `/data/alfira.db` |
-| `WEB_UI_ORIGIN` | Public URL of the web UI | `http://localhost:3001` |
-| `DISCORD_REDIRECT_URI` | OAuth2 redirect URI | `http://localhost:3001/auth/callback` |
-| `VOICE_IDLE_TIMEOUT_MINUTES` | Minutes before bot leaves voice channel when idle | `5` |
+| `DATABASE_URL` | SQLite database path | Set automatically in Docker |
+| `GUILD_ID` | Pre-seed Discord server ID (for existing deployments) | — |
+| `ADMIN_ROLE_IDS` | Pre-seed admin role IDs (for existing deployments) | — |
+| `VOICE_IDLE_TIMEOUT_MINUTES` | Override idle timeout (can also be set via wizard/settings) | `5` |
 | `LOG_LEVEL` | Log verbosity: `debug`, `info`, `warn`, `error`, `fatal` | `info` |
-| `LOG_FORMAT` | Set to `json` for machine-readable structured logging; defaults to human-readable colored output | — |
+| `LOG_FORMAT` | Set to `json` for machine-readable structured logging | — |
 | `NO_COLOR` | Set to any value to disable colored log output | — |
+| `JWT_EXPIRES_IN` | JWT refresh token expiration (e.g., `30d`, `7d`, `24h`) | `30d` |
 
-> **Note:** `DATABASE_URL` is set automatically. You typically don't need to set it manually.
+> **Note:** `GUILD_ID` and `ADMIN_ROLE_IDS` are **not required** for new installs — these are configured through the in-app setup wizard. They're only needed for existing deployments migrating from an earlier version.
 
 ### Reverse Proxy
 
-For use with a reverse proxy, change WEB_UI_ORIGIN and DISCORD_REDIRECT_URI so they're pointing to your custom domain:
+For use with a reverse proxy, change `DISCORD_REDIRECT_URI` to point to your custom domain:
 
 | Variable | Local | Reverse Proxy |
 |----------|-------------|---------|
-| `WEB_UI_ORIGIN` | `http://localhost:3001` | `https://your-domain.com` |
 | `DISCORD_REDIRECT_URI` | `http://localhost:3001/auth/callback` | `https://your-domain.com/auth/callback` |
 
 > **Important:** Ensure your redirect URL in the Discord Developer Portal also uses the custom domain.
@@ -118,7 +111,7 @@ For use with a reverse proxy, change WEB_UI_ORIGIN and DISCORD_REDIRECT_URI so t
 4. Copy the token — this is your `DISCORD_BOT_TOKEN`. You won't be able to see it again!
 5. Under **Privileged Gateway Intents**, enable:
    - **Message Content Intent**
-   - **Server Members Intent** (optional, for role-based features)
+   - **Server Members Intent** (required for admin role detection)
 6. Click **"Save Changes"**.
 
 #### 3. Configure OAuth2
@@ -132,36 +125,33 @@ For use with a reverse proxy, change WEB_UI_ORIGIN and DISCORD_REDIRECT_URI so t
 
 #### 4. Invite the Bot to Your Server
 
+You can invite the bot during the setup wizard (it shows an invite link), or manually:
+
 1. Navigate to **OAuth2** → **URL Generator**.
 2. Under **Scopes**, check:
    - `bot`
 3. Under **Bot Permissions**, check:
    - `Connect`
    - `Speak`
-   - `Use Voice Activity`
    - `View Channels`
    - `Send Messages`
-   - `Embed Links`
-4. Copy the generated URL at the bottom, open it in your browser, and authorize the bot for your server.
+4. Copy the generated URL, open it in your browser, and authorize the bot for your server.
 
-#### 5. Get Your Guild and Role IDs
+---
 
-1. Enable **Developer Mode** in Discord: Settings → Advanced → Developer Mode.
-2. Right-click your server icon and select **"Copy Server ID"** — this is your `GUILD_ID`.
-3. Right-click the **admin role** (the role that should have permission to add songs/manage the bot) and select **"Copy Role ID"** — this is your `ADMIN_ROLE_IDS`.
-   - For multiple admin roles, use comma-separated IDs: `123456789012345678,987654321098765432`
-   - **Important:** Only users with this role will see the "Add Song" button and other admin features in the web UI. Non-admin users can only play existing songs from the library.
+## Setup Wizard
 
-#### 6. Enable Server Members Intent (Required for Admin Detection)
+After starting Alfira and logging in for the first time, you'll be guided through a setup wizard that configures:
 
-The bot needs to fetch guild member roles to determine admin status. This requires the **Server Members Intent**:
+1. **Discord Server** — Choose which server Alfira operates in
+2. **Admin Roles** — Select which Discord roles can manage the bot
+3. **Notification Channel** — (Optional) Channel where Alfira posts idle-leave messages
+4. **Idle Timeout** — Minutes before the bot auto-leaves an empty voice channel
+5. **Public URL** — (Optional) Your public-facing URL
 
-1. Go to the [Discord Developer Portal](https://discord.com/developers/applications) → your application.
-2. Navigate to **Bot** in the left sidebar.
-3. Under **Privileged Gateway Intents**, enable **Server Members Intent** (in addition to Message Content Intent).
-4. Click **"Save Changes"**.
+All of these settings can be changed later from the **Settings → Admin** page.
 
-> **Without this intent**, the bot cannot verify admin roles — all users will be treated as non-admin, and the "Add Song" button will not appear for anyone.
+> **Note:** If you're upgrading from a previous version that used `GUILD_ID` and `ADMIN_ROLE_IDS` in `.env`, those values are automatically migrated — you won't see the wizard.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -34,19 +34,17 @@ Common issues and solutions for Alfira.
 1. Verify `DISCORD_REDIRECT_URI` matches exactly in:
    - Discord Developer Portal → OAuth2 → Redirects
    - Your `.env` file
-2. Check that `WEB_UI_ORIGIN` matches your actual domain.
-3. Ensure you're using `https://` in production.
+2. Ensure you're using `https://` in production.
 
 ### "Add Song" button not visible / Admin features missing
 
 **Symptoms:** Logged in but no "Add Song" button, can't use quick-add, can't manage playlists.
 
 **Solutions:**
-1. **Check `ADMIN_ROLE_IDS` in `.env`** — must be set to your actual Discord role ID (not the placeholder).
+1. **Check admin role configuration** — Go to **Settings → Admin** and verify the correct roles are selected under "Admin Roles". Save changes if needed.
 2. **Enable Server Members Intent** — Go to Discord Developer Portal → Bot → Privileged Gateway Intents → enable **Server Members Intent** → Save Changes.
-3. **Verify role ID** — Enable Developer Mode in Discord (Settings → Advanced), right-click the admin role → "Copy Role ID".
-4. **Re-login** — Admin status is cached in the JWT token. Log out and log back in after fixing the above.
-5. **Check logs** — Run `docker compose logs alfira | grep -i admin` to verify the bot detects your admin status.
+3. **Re-login** — Admin status is cached in the JWT token. Log out and log back in after fixing the above.
+4. **Check logs** — Run `docker compose logs alfira | grep -i admin` to verify the bot detects your admin status.
 
 ### "undefined command does not have 'run' callback" / Slash commands not working
 

--- a/packages/server/src/GuildPlayer.ts
+++ b/packages/server/src/GuildPlayer.ts
@@ -53,16 +53,38 @@ export class GuildPlayer {
   // Auto-leave idle timer.
   private idleLeaveTimer: ReturnType<typeof setTimeout> | null = null;
 
-  private getIdleTimeoutMinutes(): number {
+  private async getIdleTimeoutMinutes(): Promise<number> {
+    // Read from DB first (set via setup wizard or admin settings).
+    try {
+      const row = await db
+        .select({ timeout: tables.guildSettings.voiceIdleTimeoutMinutes })
+        .from(tables.guildSettings)
+        .where(eq(tables.guildSettings.id, 1))
+        .get();
+      if (row && Number.isFinite(row.timeout) && row.timeout > 0) {
+        return row.timeout;
+      }
+    } catch {
+      // DB not available — fall through to env / default.
+    }
+
+    // Fall back to env var, then default.
     const raw = process.env.VOICE_IDLE_TIMEOUT_MINUTES;
     const parsed = Number(raw);
     return Number.isFinite(parsed) && parsed > 0 ? parsed : 5;
   }
 
-  private scheduleIdleLeave(): void {
+  private async scheduleIdleLeave(): Promise<void> {
     this.cancelIdleLeave();
-    const minutes = this.getIdleTimeoutMinutes();
-    this.idleLeaveTimer = setTimeout(() => this.leaveOnIdle(), minutes * 60 * 1000);
+    const minutes = await this.getIdleTimeoutMinutes();
+    this.idleLeaveTimer = setTimeout(
+      () => {
+        this.leaveOnIdle().catch(() => {
+          // noop — errors are already logged inside leaveOnIdle
+        });
+      },
+      minutes * 60 * 1000
+    );
   }
 
   private cancelIdleLeave(): void {
@@ -81,13 +103,40 @@ export class GuildPlayer {
     '💀 Alfira failed the last death saving throw.',
   ];
 
-  private leaveOnIdle(): void {
+  private async leaveOnIdle(): Promise<void> {
+    const timeoutMinutes = await this.getIdleTimeoutMinutes();
     logger.info(
       { guildId: this.guildId },
-      `Auto-leaving voice channel after idle (${this.getIdleTimeoutMinutes()} minutes).`
+      `Auto-leaving voice channel after idle (${timeoutMinutes} minutes).`
     );
     const phrase = this.LEAVE_PHRASES[Math.floor(Math.random() * this.LEAVE_PHRASES.length)];
     logger.info({ guildId: this.guildId }, `${phrase} (Left the voice channel due to inactivity.)`);
+
+    // Send notification to the configured channel, if any.
+    try {
+      const row = await db
+        .select({ channelId: tables.guildSettings.notificationChannelId })
+        .from(tables.guildSettings)
+        .where(eq(tables.guildSettings.id, 1))
+        .get();
+
+      if (row?.channelId) {
+        const token = process.env.DISCORD_BOT_TOKEN;
+        if (token) {
+          await fetch(`https://discord.com/api/v10/channels/${row.channelId}/messages`, {
+            method: 'POST',
+            headers: {
+              Authorization: `Bot ${token}`,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ content: phrase }),
+          });
+        }
+      }
+    } catch (err) {
+      logger.warn({ err, guildId: this.guildId }, 'Failed to send idle-leave notification');
+    }
+
     this.stop();
   }
 
@@ -306,7 +355,7 @@ export class GuildPlayer {
       this.pausedAt = Date.now();
       await updateNodeLinkPlayer(this.guildId, sessionId, { paused: true });
       this.paused = true;
-      this.scheduleIdleLeave();
+      await this.scheduleIdleLeave();
     }
 
     this.broadcast();
@@ -443,7 +492,7 @@ export class GuildPlayer {
         this.currentSong = null;
         this.queue.clear();
         this.broadcast();
-        this.scheduleIdleLeave();
+        await this.scheduleIdleLeave();
         return;
       }
     }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -20,7 +20,7 @@ function parseCookies(header: string): Record<string, string> {
 }
 
 import { sql } from 'drizzle-orm';
-import { VERSION } from './lib/config';
+import { initGuildId, VERSION } from './lib/config';
 import { ensureTagsMigrated } from './lib/ensureTagsMigrated';
 import { json } from './lib/json';
 import { lavalink } from './lib/lavalink';
@@ -30,8 +30,10 @@ import { verifySessionToken } from './middleware/requireAuth';
 import { handleAuth } from './routes/auth';
 import { handleCompressor } from './routes/compressor';
 import { handleEqualizer } from './routes/equalizer';
+import { handleGeneralSettings } from './routes/generalSettings';
 import { handlePlayer } from './routes/player';
 import { handlePlaylists } from './routes/playlists';
+import { handleSetup } from './routes/setup';
 import { handleSongs } from './routes/songs';
 import { handleTags } from './routes/tags';
 import { $client, db } from './shared/db';
@@ -46,7 +48,6 @@ const requiredVars = [
   'DISCORD_CLIENT_ID',
   'DISCORD_CLIENT_SECRET',
   'DISCORD_REDIRECT_URI',
-  'GUILD_ID',
   'DATABASE_URL',
   'JWT_SECRET',
 ];
@@ -248,6 +249,12 @@ function startServer(): void {
       if (url.pathname.startsWith('/api/settings/equalizer')) {
         return setSecurityHeaders(await handleEqualizer(ctx, request));
       }
+      if (url.pathname.startsWith('/api/settings/general')) {
+        return setSecurityHeaders(await handleGeneralSettings(ctx, request));
+      }
+      if (url.pathname.startsWith('/api/setup')) {
+        return setSecurityHeaders(await handleSetup(ctx, request));
+      }
       if (url.pathname.startsWith('/auth')) {
         return setSecurityHeaders(await handleAuth(ctx, request));
       }
@@ -403,6 +410,14 @@ async function main(): Promise<void> {
   } catch (error) {
     logger.error(error, 'Could not connect to the database');
     process.exit(1);
+  }
+
+  // 2.5. Initialize guild ID cache.
+  try {
+    await initGuildId();
+    logger.info('Guild ID cache initialized');
+  } catch (error) {
+    logger.error(error, 'Failed to initialize guild settings');
   }
 
   // 3. Start NodeLink in-process.

--- a/packages/server/src/lib/config.ts
+++ b/packages/server/src/lib/config.ts
@@ -1,7 +1,5 @@
 import { execSync } from 'node:child_process';
 
-export const WEB_UI_ORIGIN = process.env.WEB_UI_ORIGIN ?? 'http://localhost:3001';
-
 function resolveVersion(): string {
   const envVersion = process.env.ALFIRA_VERSION;
   // Explicit non-dev version — use as-is (e.g., v0.1.0 from Docker build arg).
@@ -24,8 +22,47 @@ function resolveVersion(): string {
 
 export const VERSION = resolveVersion();
 
-const _GUILD_ID = process.env.GUILD_ID;
-if (!_GUILD_ID) {
-  throw new Error('GUILD_ID environment variable is not set');
+// ---------------------------------------------------------------------------
+// Guild ID — lazy-loaded from DB on first access, falling back to env var.
+// The DB value is set by the setup wizard and can be updated at runtime.
+// Use getGuildId() instead of importing a constant — it reads the cached
+// value synchronously after the first async population.
+// ---------------------------------------------------------------------------
+
+let _cachedGuildId: string | null = null;
+let _guildIdLoaded = false;
+
+export function getGuildId(): string {
+  return _cachedGuildId ?? '';
 }
-export const GUILD_ID = _GUILD_ID as string;
+
+/** Must be called once during startup, after migrations and DB are ready. */
+export async function initGuildId(): Promise<void> {
+  if (_guildIdLoaded) return;
+
+  try {
+    // Lazy import to avoid circular dependency at module load time.
+    const { db, tables, eq } = await import('../shared/db');
+    const row = await db
+      .select({ guildId: tables.guildSettings.guildId })
+      .from(tables.guildSettings)
+      .where(eq(tables.guildSettings.id, 1))
+      .get();
+
+    if (row?.guildId) {
+      _cachedGuildId = row.guildId;
+    } else {
+      _cachedGuildId = process.env.GUILD_ID ?? null;
+    }
+  } catch {
+    // DB not available yet — fall back to env var.
+    _cachedGuildId = process.env.GUILD_ID ?? null;
+  }
+
+  _guildIdLoaded = true;
+}
+
+/** Called after the setup wizard saves a guild ID. Updates the in-memory cache. */
+export function refreshGuildId(guildId: string): void {
+  _cachedGuildId = guildId;
+}

--- a/packages/server/src/lib/displayName.ts
+++ b/packages/server/src/lib/displayName.ts
@@ -1,12 +1,12 @@
 import { getClient } from '../startDiscord';
-import { GUILD_ID } from './config';
+import { getGuildId } from './config';
 
 export async function getUserDisplayName(discordId: string): Promise<string> {
   const client = getClient();
   if (!client) return discordId;
 
   try {
-    const guild = await client.guilds.fetch(GUILD_ID);
+    const guild = await client.guilds.fetch(getGuildId());
     const member = await guild.members.resolve(discordId);
     if (!member) return discordId;
     // GuildMemberStructure has 'nick' (server nickname) and the user object

--- a/packages/server/src/lib/player.ts
+++ b/packages/server/src/lib/player.ts
@@ -1,12 +1,12 @@
 import type { GuildPlayer } from '../startDiscord';
 import { getPlayer } from '../startDiscord';
-import { GUILD_ID } from './config';
+import { getGuildId } from './config';
 import { json } from './json';
 
 export function requirePlaying():
   | { ok: true; player: GuildPlayer }
   | { ok: false; response: Response } {
-  const player = getPlayer(GUILD_ID);
+  const player = getPlayer(getGuildId());
   if (!player?.getCurrentSong()) {
     return {
       ok: false,
@@ -19,7 +19,7 @@ export function requirePlaying():
 export function requirePlayer():
   | { ok: true; player: GuildPlayer }
   | { ok: false; response: Response } {
-  const player = getPlayer(GUILD_ID);
+  const player = getPlayer(getGuildId());
   if (!player) {
     return {
       ok: false,

--- a/packages/server/src/lib/routeGuards.ts
+++ b/packages/server/src/lib/routeGuards.ts
@@ -8,6 +8,9 @@ interface GuardOptions {
   auth?: boolean;
   /** Require admin role. Defaults to false. */
   admin?: boolean;
+  /** Allow access during first-run setup (user must have isSetupAdmin flag).
+   *  Overrides the normal admin check. Defaults to false. */
+  setupMode?: boolean;
   /** Require user is in a voice channel. Defaults to false. Requires auth. */
   voice?: boolean;
 }
@@ -27,11 +30,21 @@ export async function checkGuards(
   ctx: RouteContext,
   options: GuardOptions = {}
 ): Promise<GuardResult | Response> {
-  const { admin = false, voice = false } = options;
+  const { admin = false, setupMode = false, voice = false } = options;
 
   const authResult = requireAuth(ctx);
   if (authResult instanceof Response) return authResult;
   const user = authResult;
+
+  // Setup mode: grant access to the first user who logs in during setup.
+  // This bypasses the normal admin check since admin roles aren't configured yet.
+  if (setupMode && user.isSetupAdmin) {
+    if (voice) {
+      const inVoice = await requireUserInVoice(user.discordId);
+      if (inVoice instanceof Response) return inVoice;
+    }
+    return { user };
+  }
 
   if (admin) {
     const adminErr = requireAdmin(ctx);

--- a/packages/server/src/lib/voice.ts
+++ b/packages/server/src/lib/voice.ts
@@ -1,6 +1,6 @@
 import { logger } from '../shared/logger';
 import { connectToVoice, createPlayer, getClient, getPlayer } from '../startDiscord';
-import { GUILD_ID } from './config';
+import { getGuildId } from './config';
 import { json } from './json';
 import { lavalink } from './lavalink';
 
@@ -15,7 +15,7 @@ export async function requireUserInVoice(discordId: string): Promise<true | Resp
   }
 
   try {
-    const guild = await client.guilds.fetch(GUILD_ID);
+    const guild = await client.guilds.fetch(getGuildId());
     const member = await guild.members.resolve(discordId);
 
     if (!member) {
@@ -50,9 +50,10 @@ export async function resolveOrAutoJoinPlayer(
   | { ok: true; player: NonNullable<ReturnType<typeof getPlayer>> }
   | { ok: false; response: Response }
 > {
-  const existingPlayer = getPlayer(GUILD_ID);
+  const guildId = getGuildId();
+  const existingPlayer = getPlayer(guildId);
   if (existingPlayer) {
-    if (lavalink.isGuildConnected(GUILD_ID)) {
+    if (lavalink.isGuildConnected(guildId)) {
       return { ok: true, player: existingPlayer };
     }
   }
@@ -66,7 +67,7 @@ export async function resolveOrAutoJoinPlayer(
   }
 
   try {
-    const guild = await discordClient.guilds.fetch(GUILD_ID);
+    const guild = await discordClient.guilds.fetch(guildId);
     const member = await guild.members.resolve(discordId);
 
     if (!member) {
@@ -93,12 +94,12 @@ export async function resolveOrAutoJoinPlayer(
     }
 
     // Connect to voice via the Discord gateway, then create the GuildPlayer.
-    await connectToVoice(GUILD_ID, voiceChannelId);
+    await connectToVoice(guildId, voiceChannelId);
     // Give NodeLink time to fully establish the voice connection
     // before we start sending track data.
     await new Promise((resolve) => setTimeout(resolve, 500));
 
-    return { ok: true, player: createPlayer(GUILD_ID, voiceChannelId) };
+    return { ok: true, player: createPlayer(guildId, voiceChannelId) };
   } catch (error) {
     logger.error({ err: error as Error }, 'Failed to auto-join voice channel');
     return {

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -2,21 +2,19 @@ import crypto from 'node:crypto';
 import { and, eq, lt } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
 import type { RouteContext } from '../index';
-import { WEB_UI_ORIGIN } from '../lib/config';
+import { getGuildId } from '../lib/config';
 import { json } from '../lib/json';
 import { db, tables } from '../shared/db';
 import { logger } from '../shared/logger';
 
-const { refreshToken: refreshTokenTable } = tables;
+const { refreshToken: refreshTokenTable, guildSettings: guildSettingsTable } = tables;
 
 const {
   DISCORD_CLIENT_ID,
   DISCORD_CLIENT_SECRET,
   DISCORD_REDIRECT_URI,
   DISCORD_BOT_TOKEN,
-  GUILD_ID,
   JWT_SECRET,
-  ADMIN_ROLE_IDS,
 } = process.env;
 
 if (
@@ -24,7 +22,6 @@ if (
   !DISCORD_CLIENT_SECRET ||
   !DISCORD_REDIRECT_URI ||
   !DISCORD_BOT_TOKEN ||
-  !GUILD_ID ||
   !JWT_SECRET
 ) {
   throw new Error('Missing required environment variables for auth');
@@ -35,20 +32,51 @@ const DISCORD_CLIENT_ID_: string = DISCORD_CLIENT_ID;
 const DISCORD_CLIENT_SECRET_: string = DISCORD_CLIENT_SECRET;
 const DISCORD_REDIRECT_URI_: string = DISCORD_REDIRECT_URI;
 const DISCORD_BOT_TOKEN_: string = DISCORD_BOT_TOKEN;
-const GUILD_ID_: string = GUILD_ID;
 const JWT_SECRET_: string = JWT_SECRET;
-
-const ADMIN_ROLE_ID_SET = new Set(
-  (ADMIN_ROLE_IDS ?? '')
-    .split(',')
-    .map((id) => id.trim())
-    .filter(Boolean)
-);
 
 const isProduction = process.env.NODE_ENV === 'production';
 
-function isAdminUser(memberRoles: string[]): boolean {
-  return memberRoles.some((roleId) => ADMIN_ROLE_ID_SET.has(roleId));
+/** Read admin role IDs from the database (set via setup wizard or admin settings). */
+async function getAdminRoleIdSet(): Promise<Set<string>> {
+  try {
+    const row = await db
+      .select({ adminRoleIds: guildSettingsTable.adminRoleIds })
+      .from(guildSettingsTable)
+      .where(eq(guildSettingsTable.id, 1))
+      .get();
+
+    if (row?.adminRoleIds) {
+      return new Set(
+        row.adminRoleIds
+          .split(',')
+          .map((id: string) => id.trim())
+          .filter(Boolean)
+      );
+    }
+  } catch {
+    // DB not ready yet.
+  }
+
+  return new Set();
+}
+
+/** Check whether the setup wizard has been completed. */
+async function isSetupCompleted(): Promise<boolean> {
+  try {
+    const row = await db
+      .select({ setupCompleted: guildSettingsTable.setupCompleted })
+      .from(guildSettingsTable)
+      .where(eq(guildSettingsTable.id, 1))
+      .get();
+    return row?.setupCompleted ?? false;
+  } catch {
+    return false;
+  }
+}
+
+async function isAdminUser(memberRoles: string[]): Promise<boolean> {
+  const adminSet = await getAdminRoleIdSet();
+  return memberRoles.some((roleId) => adminSet.has(roleId));
 }
 
 // Access tokens are short-lived (1h). Refresh tokens are long-lived (30d default),
@@ -139,9 +167,12 @@ function authRateLimit(ip: string): boolean {
 
 /** Fetches guild member roles. Returns 'not-in-guild' on 404, null on other errors. */
 async function fetchGuildMemberRoles(discordId: string): Promise<string[] | null | 'not-in-guild'> {
+  const guildId = getGuildId();
+  if (!guildId) return null; // guild not configured yet
+
   try {
     const memberRes = await fetch(
-      `https://discord.com/api/guilds/${GUILD_ID_}/members/${discordId}`,
+      `https://discord.com/api/guilds/${guildId}/members/${discordId}`,
       { headers: { Authorization: `Bot ${DISCORD_BOT_TOKEN_}` } }
     );
     if (memberRes.status === 404) {
@@ -157,6 +188,30 @@ async function fetchGuildMemberRoles(discordId: string): Promise<string[] | null
       { err: err instanceof Error ? err.message : String(err) },
       'Failed to fetch guild member roles'
     );
+    return null;
+  }
+}
+
+/**
+ * Fetch a Discord user's basic profile (username, avatar).
+ * Does NOT check guild membership. Used during setup mode.
+ */
+async function fetchDiscordUserProfile(
+  discordId: string
+): Promise<{ username: string; avatar: string | null } | null> {
+  try {
+    const res = await fetch(`https://discord.com/api/users/${discordId}`, {
+      headers: { Authorization: `Bot ${DISCORD_BOT_TOKEN_}` },
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { username: string; avatar: string | null };
+    return {
+      username: data.username,
+      avatar: data.avatar
+        ? `https://cdn.discordapp.com/avatars/${discordId}/${data.avatar}.png`
+        : null,
+    };
+  } catch {
     return null;
   }
 }
@@ -179,7 +234,7 @@ async function fetchUserAdminStatus(
     if (roles === null || roles === 'not-in-guild') return null;
 
     return {
-      isAdmin: isAdminUser(roles),
+      isAdmin: await isAdminUser(roles),
       username,
       avatar: avatar ? `https://cdn.discordapp.com/avatars/${discordId}/${avatar}.png` : null,
     };
@@ -244,7 +299,8 @@ async function fetchDiscordIdentity(
  */
 async function generateAndStoreTokens(
   discordUser: { id: string; username: string; avatar: string | null },
-  isAdmin: boolean
+  isAdmin: boolean,
+  isSetupAdmin = false
 ): Promise<{ accessToken: string; refreshToken: string }> {
   const payload = {
     discordId: discordUser.id,
@@ -253,6 +309,7 @@ async function generateAndStoreTokens(
       ? `https://cdn.discordapp.com/avatars/${discordUser.id}/${discordUser.avatar}.png`
       : null,
     isAdmin,
+    ...(isSetupAdmin ? { isSetupAdmin: true } : {}),
   };
   const accessToken = generateAccessToken(payload);
   const refreshToken = generateRefreshToken(discordUser.id);
@@ -345,20 +402,70 @@ async function handleCallback(request: Request, url: URL): Promise<Response> {
     return json({ error: 'Failed to fetch Discord user info.' }, 502);
   }
 
-  // 3. Verify guild membership and get member roles.
+  // 3. Check if setup has been completed.
+  const setupDone = await isSetupCompleted();
+
+  if (!setupDone) {
+    // If GUILD_ID and ADMIN_ROLE_IDS are in env (existing deployment),
+    // auto-complete setup. Otherwise, redirect to the setup wizard.
+    const envGuildId = process.env.GUILD_ID;
+    if (envGuildId) {
+      // Seed env vars into DB and mark setup complete.
+      await db
+        .insert(guildSettingsTable)
+        .values({
+          id: 1,
+          guildId: envGuildId,
+          setupCompleted: true,
+          adminRoleIds: process.env.ADMIN_ROLE_IDS ?? '',
+        })
+        .onConflictDoUpdate({
+          target: guildSettingsTable.id,
+          set: {
+            guildId: envGuildId,
+            setupCompleted: true,
+            adminRoleIds: process.env.ADMIN_ROLE_IDS ?? '',
+          },
+        })
+        .run();
+
+      // Refresh the in-memory guild ID cache.
+      const { refreshGuildId } = await import('../lib/config');
+      refreshGuildId(envGuildId);
+
+      // Fall through to normal auth flow below.
+    } else {
+      // Fresh install — redirect to setup wizard.
+      const { accessToken, refreshToken } = await generateAndStoreTokens(discordUser, true, true);
+
+      const headers = new Headers();
+      headers.append(
+        'Set-Cookie',
+        buildCookieHeader(ACCESS_COOKIE_NAME, accessToken, { maxAge: 60 * 60 * 1000 })
+      );
+      headers.append(
+        'Set-Cookie',
+        buildCookieHeader(REFRESH_COOKIE_NAME, refreshToken, { maxAge: REFRESH_TOKEN_MAX_AGE })
+      );
+      headers.append('Location', '/setup');
+      return new Response(null, { status: 302, headers });
+    }
+  }
+
+  // 4. Normal flow — verify guild membership and get member roles.
   const rolesResult = await fetchGuildMemberRoles(discordUser.id);
   if (rolesResult === null || rolesResult === 'not-in-guild') {
     return json({ error: 'You must be a member of the server to use this app.' }, 403);
   }
   const memberRoles = rolesResult;
 
-  // 4. Determine admin status.
-  const isAdmin = isAdminUser(memberRoles);
+  // 5. Determine admin status.
+  const isAdmin = await isAdminUser(memberRoles);
 
-  // 5. Generate and store tokens.
+  // 6. Generate and store tokens.
   const { accessToken, refreshToken } = await generateAndStoreTokens(discordUser, isAdmin);
 
-  // 6. Set cookies and redirect.
+  // 7. Set cookies and redirect.
   const headers = new Headers();
   headers.append(
     'Set-Cookie',
@@ -368,7 +475,7 @@ async function handleCallback(request: Request, url: URL): Promise<Response> {
     'Set-Cookie',
     buildCookieHeader(REFRESH_COOKIE_NAME, refreshToken, { maxAge: REFRESH_TOKEN_MAX_AGE })
   );
-  headers.append('Location', WEB_UI_ORIGIN);
+  headers.append('Location', '/');
   return new Response(null, { status: 302, headers });
 }
 
@@ -420,18 +527,43 @@ async function handleRefresh(ctx: RouteContext): Promise<Response> {
     );
 
   // 6. Re-fetch user info from Discord (including admin status).
-  const userInfo = await fetchUserAdminStatus(decoded.discordId);
-  if (!userInfo) {
-    await db.delete(refreshTokenTable).where(eq(refreshTokenTable.discordId, decoded.discordId));
-    return json({ error: 'Unable to verify user membership. Please log in again.' }, 401);
+  //    During setup mode, skip guild membership check.
+  const setupDone = await isSetupCompleted();
+  let username: string;
+  let avatar: string | null;
+  let isAdmin: boolean;
+  let isSetupAdmin = false;
+
+  if (!setupDone) {
+    // Setup not complete — fetch basic profile, grant admin.
+    const profile = await fetchDiscordUserProfile(decoded.discordId);
+    if (!profile) {
+      await db.delete(refreshTokenTable).where(eq(refreshTokenTable.discordId, decoded.discordId));
+      return json({ error: 'Unable to verify user identity. Please log in again.' }, 401);
+    }
+    username = profile.username;
+    avatar = profile.avatar;
+    isAdmin = true;
+    isSetupAdmin = true;
+  } else {
+    // Normal flow — verify guild membership and roles.
+    const userInfo = await fetchUserAdminStatus(decoded.discordId);
+    if (!userInfo) {
+      await db.delete(refreshTokenTable).where(eq(refreshTokenTable.discordId, decoded.discordId));
+      return json({ error: 'Unable to verify user membership. Please log in again.' }, 401);
+    }
+    username = userInfo.username;
+    avatar = userInfo.avatar;
+    isAdmin = userInfo.isAdmin;
   }
 
   // 7. Generate new tokens.
   const payload = {
     discordId: decoded.discordId,
-    username: userInfo.username,
-    avatar: userInfo.avatar,
-    isAdmin: userInfo.isAdmin,
+    username,
+    avatar,
+    isAdmin,
+    ...(isSetupAdmin ? { isSetupAdmin: true } : {}),
   };
   const newAccessToken = generateAccessToken(payload);
   const newRefreshToken = generateRefreshToken(decoded.discordId);

--- a/packages/server/src/routes/generalSettings.ts
+++ b/packages/server/src/routes/generalSettings.ts
@@ -1,0 +1,129 @@
+import { eq } from 'drizzle-orm';
+import type { RouteContext } from '../index';
+import { json } from '../lib/json';
+import { checkGuards } from '../lib/routeGuards';
+import type { GeneralSettings } from '../shared';
+import { db, tables } from '../shared/db';
+
+const SETTINGS_COLUMNS = {
+  guildId: tables.guildSettings.guildId,
+  setupCompleted: tables.guildSettings.setupCompleted,
+  adminRoleIds: tables.guildSettings.adminRoleIds,
+  voiceIdleTimeoutMinutes: tables.guildSettings.voiceIdleTimeoutMinutes,
+  notificationChannelId: tables.guildSettings.notificationChannelId,
+  publicUrl: tables.guildSettings.publicUrl,
+};
+
+// ---------------------------------------------------------------------------
+// GET /api/settings/general
+// ---------------------------------------------------------------------------
+async function handleGetGeneral(ctx: RouteContext): Promise<Response> {
+  const guards = await checkGuards(ctx, { admin: true });
+  if (guards instanceof Response) return guards;
+
+  const row = await db
+    .select(SETTINGS_COLUMNS)
+    .from(tables.guildSettings)
+    .where(eq(tables.guildSettings.id, 1))
+    .get();
+
+  if (!row) {
+    return json({
+      guildId: null,
+      setupCompleted: false,
+      adminRoleIds: '',
+      voiceIdleTimeoutMinutes: 5,
+      notificationChannelId: null,
+      publicUrl: null,
+    });
+  }
+
+  return json(row as GeneralSettings);
+}
+
+// ---------------------------------------------------------------------------
+// PATCH /api/settings/general
+// ---------------------------------------------------------------------------
+interface GeneralSettingsPatch {
+  adminRoleIds?: string;
+  voiceIdleTimeoutMinutes?: number;
+  notificationChannelId?: string | null;
+  publicUrl?: string | null;
+}
+
+async function handlePatchGeneral(ctx: RouteContext, request: Request): Promise<Response> {
+  const guards = await checkGuards(ctx, { admin: true });
+  if (guards instanceof Response) return guards;
+
+  let body: GeneralSettingsPatch;
+  try {
+    body = (await request.json()) as GeneralSettingsPatch;
+  } catch {
+    return json({ error: 'Invalid JSON' }, 400);
+  }
+
+  const updates: Record<string, unknown> = {};
+
+  if (body.adminRoleIds !== undefined) {
+    if (typeof body.adminRoleIds !== 'string') {
+      return json({ error: 'adminRoleIds must be a string' }, 400);
+    }
+    updates.adminRoleIds = body.adminRoleIds;
+  }
+
+  if (body.voiceIdleTimeoutMinutes !== undefined) {
+    const v = body.voiceIdleTimeoutMinutes;
+    if (!Number.isInteger(v) || v < 1 || v > 120) {
+      return json({ error: 'voiceIdleTimeoutMinutes must be an integer between 1 and 120' }, 400);
+    }
+    updates.voiceIdleTimeoutMinutes = v;
+  }
+
+  if (body.notificationChannelId !== undefined) {
+    if (body.notificationChannelId !== null && typeof body.notificationChannelId !== 'string') {
+      return json({ error: 'notificationChannelId must be a string or null' }, 400);
+    }
+    updates.notificationChannelId = body.notificationChannelId;
+  }
+
+  if (body.publicUrl !== undefined) {
+    if (body.publicUrl !== null && typeof body.publicUrl !== 'string') {
+      return json({ error: 'publicUrl must be a string or null' }, 400);
+    }
+    updates.publicUrl = body.publicUrl;
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return json({ error: 'No fields to update' }, 400);
+  }
+
+  await db
+    .insert(tables.guildSettings)
+    .values({ id: 1, ...updates })
+    .onConflictDoUpdate({
+      target: tables.guildSettings.id,
+      set: updates,
+    })
+    .run();
+
+  // Return the full updated row.
+  const row = await db
+    .select(SETTINGS_COLUMNS)
+    .from(tables.guildSettings)
+    .where(eq(tables.guildSettings.id, 1))
+    .get();
+
+  return json(row as GeneralSettings);
+}
+
+// ---------------------------------------------------------------------------
+// Dispatcher
+// ---------------------------------------------------------------------------
+export async function handleGeneralSettings(
+  ctx: RouteContext,
+  request: Request
+): Promise<Response> {
+  if (request.method === 'GET') return await handleGetGeneral(ctx);
+  if (request.method === 'PATCH') return await handlePatchGeneral(ctx, request);
+  return json({ error: 'Not Found' }, 404);
+}

--- a/packages/server/src/routes/player.ts
+++ b/packages/server/src/routes/player.ts
@@ -1,6 +1,6 @@
 import type { GuildPlayer } from '../GuildPlayer';
 import type { RouteContext } from '../index';
-import { GUILD_ID } from '../lib/config';
+import { getGuildId } from '../lib/config';
 import { json } from '../lib/json';
 import { lavalink } from '../lib/lavalink';
 import { requirePlayer, requirePlaying } from '../lib/player';
@@ -34,13 +34,13 @@ function handleGetQueue(ctx: RouteContext): Response {
   const guards = checkGuards(ctx);
   if (guards instanceof Response) return guards;
 
-  const player = getPlayer(GUILD_ID);
+  const player = getPlayer(getGuildId());
 
   if (!player) {
     return json({
       isPlaying: false,
       isPaused: false,
-      isConnectedToVoice: lavalink.isGuildConnected(GUILD_ID),
+      isConnectedToVoice: lavalink.isGuildConnected(getGuildId()),
       loopMode: 'off',
       isShuffled: false,
       currentSong: null,
@@ -154,9 +154,9 @@ async function handleLeave(ctx: RouteContext): Promise<Response> {
   const guards = await checkGuards(ctx, { voice: true });
   if (guards instanceof Response) return guards;
 
-  const player = getPlayer(GUILD_ID);
+  const player = getPlayer(getGuildId());
 
-  if (!player && !lavalink.isGuildConnected(GUILD_ID)) {
+  if (!player && !lavalink.isGuildConnected(getGuildId())) {
     return json({ error: 'The bot is not in a voice channel.' }, 409);
   }
 
@@ -199,7 +199,7 @@ async function handleShuffle(ctx: RouteContext): Promise<Response> {
   const guards = await checkGuards(ctx, { admin: true, voice: true });
   if (guards instanceof Response) return guards;
 
-  const player = getPlayer(GUILD_ID);
+  const player = getPlayer(getGuildId());
 
   if (!player || player.getQueue().length === 0) {
     return json({ error: 'No songs in the queue to shuffle.' }, 409);

--- a/packages/server/src/routes/setup.ts
+++ b/packages/server/src/routes/setup.ts
@@ -1,0 +1,305 @@
+import { eq } from 'drizzle-orm';
+import type { RouteContext } from '../index';
+import { refreshGuildId } from '../lib/config';
+import { json } from '../lib/json';
+import { checkGuards } from '../lib/routeGuards';
+import type { SetupChannel, SetupGuild, SetupRole } from '../shared';
+import { db, tables } from '../shared/db';
+import { logger } from '../shared/logger';
+
+const DISCORD_API = 'https://discord.com/api/v10';
+
+function botHeaders(): Record<string, string> {
+  const token = process.env.DISCORD_BOT_TOKEN;
+  if (!token) throw new Error('DISCORD_BOT_TOKEN not set');
+  return { Authorization: `Bot ${token}` };
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/setup/status
+// Public — the frontend needs this to decide whether to show the wizard.
+// ---------------------------------------------------------------------------
+async function handleGetStatus(): Promise<Response> {
+  try {
+    const row = await db
+      .select({
+        setupCompleted: tables.guildSettings.setupCompleted,
+        guildId: tables.guildSettings.guildId,
+      })
+      .from(tables.guildSettings)
+      .where(eq(tables.guildSettings.id, 1))
+      .get();
+
+    if (!row) {
+      return json({
+        setupCompleted: false,
+        guildName: null,
+        clientId: process.env.DISCORD_CLIENT_ID ?? '',
+      });
+    }
+
+    let guildName: string | null = null;
+    if (row.setupCompleted && row.guildId) {
+      try {
+        const res = await fetch(`${DISCORD_API}/guilds/${row.guildId}`, {
+          headers: botHeaders(),
+        });
+        if (res.ok) {
+          const guild = (await res.json()) as { name: string };
+          guildName = guild.name;
+        }
+      } catch {
+        // Guild name is cosmetic — don't fail the request.
+      }
+    }
+
+    return json({
+      setupCompleted: row.setupCompleted,
+      guildName,
+      clientId: process.env.DISCORD_CLIENT_ID ?? '',
+    });
+  } catch {
+    return json({
+      setupCompleted: false,
+      guildName: null,
+      clientId: process.env.DISCORD_CLIENT_ID ?? '',
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/setup/guilds
+// Setup-mode guard — returns guilds the bot is a member of.
+// ---------------------------------------------------------------------------
+async function handleGetGuilds(ctx: RouteContext): Promise<Response> {
+  const guards = await checkGuards(ctx, { setupMode: true });
+  if (guards instanceof Response) return guards;
+
+  try {
+    const res = await fetch(`${DISCORD_API}/users/@me/guilds`, {
+      headers: botHeaders(),
+    });
+
+    if (!res.ok) {
+      logger.error({ status: res.status }, 'Failed to fetch bot guilds from Discord');
+      return json({ error: 'Could not fetch guild list from Discord.' }, 502);
+    }
+
+    const guilds = (await res.json()) as Array<{
+      id: string;
+      name: string;
+      icon: string | null;
+    }>;
+
+    const result: SetupGuild[] = guilds.map((g) => ({
+      id: g.id,
+      name: g.name,
+      icon: g.icon,
+    }));
+
+    return json({ guilds: result });
+  } catch (err) {
+    logger.error({ err }, 'Error fetching bot guilds');
+    return json({ error: 'Could not fetch guild list.' }, 502);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/setup/roles?guildId=...
+// Setup-mode guard — returns roles for a specific guild.
+// ---------------------------------------------------------------------------
+async function handleGetRoles(ctx: RouteContext, url: URL): Promise<Response> {
+  const guards = await checkGuards(ctx, { setupMode: true });
+  if (guards instanceof Response) return guards;
+
+  const guildId = url.searchParams.get('guildId');
+  if (!guildId) {
+    return json({ error: 'guildId query parameter is required.' }, 400);
+  }
+
+  try {
+    const res = await fetch(`${DISCORD_API}/guilds/${guildId}/roles`, {
+      headers: botHeaders(),
+    });
+
+    if (!res.ok) {
+      logger.error({ guildId, status: res.status }, 'Failed to fetch guild roles from Discord');
+      return json({ error: 'Could not fetch roles from Discord.' }, 502);
+    }
+
+    const roles = (await res.json()) as Array<{
+      id: string;
+      name: string;
+      color: number;
+      managed: boolean;
+    }>;
+
+    // Filter out @everyone (id matches guildId) and managed roles (bot integrations).
+    const result: SetupRole[] = roles
+      .filter((r) => r.id !== guildId && !r.managed)
+      .map((r) => ({
+        id: r.id,
+        name: r.name,
+        color: r.color,
+      }));
+
+    return json({ roles: result });
+  } catch (err) {
+    logger.error({ err }, 'Error fetching guild roles');
+    return json({ error: 'Could not fetch roles.' }, 502);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/setup/channels?guildId=...
+// Setup-mode guard — returns text channels for a specific guild.
+// ---------------------------------------------------------------------------
+async function handleGetChannels(ctx: RouteContext, url: URL): Promise<Response> {
+  const guards = await checkGuards(ctx, { setupMode: true });
+  if (guards instanceof Response) return guards;
+
+  const guildId = url.searchParams.get('guildId');
+  if (!guildId) {
+    return json({ error: 'guildId query parameter is required.' }, 400);
+  }
+
+  try {
+    const res = await fetch(`${DISCORD_API}/guilds/${guildId}/channels`, {
+      headers: botHeaders(),
+    });
+
+    if (!res.ok) {
+      logger.error({ guildId, status: res.status }, 'Failed to fetch guild channels from Discord');
+      return json({ error: 'Could not fetch channels from Discord.' }, 502);
+    }
+
+    const channels = (await res.json()) as Array<{
+      id: string;
+      name: string;
+      type: number;
+    }>;
+
+    // Type 0 = GUILD_TEXT. Filter to text channels only.
+    const result: SetupChannel[] = channels
+      .filter((c) => c.type === 0)
+      .map((c) => ({
+        id: c.id,
+        name: c.name,
+      }));
+
+    return json({ channels: result });
+  } catch (err) {
+    logger.error({ err }, 'Error fetching guild channels');
+    return json({ error: 'Could not fetch channels.' }, 502);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/setup/complete
+// Setup-mode guard — saves the configuration and marks setup as done.
+// ---------------------------------------------------------------------------
+async function handlePostComplete(ctx: RouteContext, request: Request): Promise<Response> {
+  const guards = await checkGuards(ctx, { setupMode: true });
+  if (guards instanceof Response) return guards;
+
+  let body: {
+    guildId?: unknown;
+    adminRoleIds?: unknown;
+    voiceIdleTimeoutMinutes?: unknown;
+    notificationChannelId?: unknown;
+    publicUrl?: unknown;
+  };
+
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return json({ error: 'Invalid JSON body.' }, 400);
+  }
+
+  // Validate guildId
+  if (!body.guildId || typeof body.guildId !== 'string') {
+    return json({ error: 'guildId is required and must be a string.' }, 400);
+  }
+
+  // Validate adminRoleIds
+  if (!body.adminRoleIds || typeof body.adminRoleIds !== 'string') {
+    return json({ error: 'adminRoleIds is required and must be a comma-separated string.' }, 400);
+  }
+
+  // Validate voiceIdleTimeoutMinutes
+  const timeout = Number(body.voiceIdleTimeoutMinutes);
+  if (
+    body.voiceIdleTimeoutMinutes === undefined ||
+    !Number.isInteger(timeout) ||
+    timeout < 1 ||
+    timeout > 120
+  ) {
+    return json({ error: 'voiceIdleTimeoutMinutes must be an integer between 1 and 120.' }, 400);
+  }
+
+  // Validate notificationChannelId (optional)
+  const notificationChannelId =
+    body.notificationChannelId && typeof body.notificationChannelId === 'string'
+      ? body.notificationChannelId
+      : null;
+
+  // Validate publicUrl (optional)
+  const publicUrl =
+    body.publicUrl && typeof body.publicUrl === 'string' ? body.publicUrl.trim() : null;
+
+  try {
+    await db
+      .insert(tables.guildSettings)
+      .values({
+        id: 1,
+        guildId: body.guildId,
+        setupCompleted: true,
+        adminRoleIds: body.adminRoleIds,
+        voiceIdleTimeoutMinutes: timeout,
+        notificationChannelId,
+        publicUrl,
+      })
+      .onConflictDoUpdate({
+        target: tables.guildSettings.id,
+        set: {
+          guildId: body.guildId,
+          setupCompleted: true,
+          adminRoleIds: body.adminRoleIds,
+          voiceIdleTimeoutMinutes: timeout,
+          notificationChannelId,
+          publicUrl,
+        },
+      })
+      .run();
+
+    // Update the in-memory guild ID cache so getGuildId() returns the new value.
+    refreshGuildId(body.guildId);
+
+    return json({ success: true });
+  } catch (err) {
+    logger.error({ err }, 'Failed to save setup configuration');
+    return json({ error: 'Could not save configuration.' }, 500);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Dispatcher
+// ---------------------------------------------------------------------------
+export async function handleSetup(ctx: RouteContext, request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  const path = url.pathname.slice('/api/setup'.length);
+
+  if (path === '' || path === '/') {
+    if (request.method === 'GET') return await handleGetStatus();
+    return json({ error: 'Method Not Allowed' }, 405);
+  }
+
+  if (path === '/status' && request.method === 'GET') return await handleGetStatus();
+  if (path === '/guilds' && request.method === 'GET') return await handleGetGuilds(ctx);
+  if (path === '/roles' && request.method === 'GET') return await handleGetRoles(ctx, url);
+  if (path === '/channels' && request.method === 'GET') return await handleGetChannels(ctx, url);
+  if (path === '/complete' && request.method === 'POST')
+    return await handlePostComplete(ctx, request);
+
+  return json({ error: 'Not Found' }, 404);
+}

--- a/packages/server/src/routes/songs.ts
+++ b/packages/server/src/routes/songs.ts
@@ -1,6 +1,6 @@
 import { eq, inArray, or, sql } from 'drizzle-orm';
 import type { RouteContext } from '../index';
-import { GUILD_ID } from '../lib/config';
+import { getGuildId } from '../lib/config';
 import { getUserDisplayName, resolveDisplayNames } from '../lib/displayName';
 import { json } from '../lib/json';
 import { parsePagination } from '../lib/pagination';
@@ -363,7 +363,7 @@ async function handlePatchSong(ctx: RouteContext, request: Request, id: string):
   emitSongUpdated(formatSong(updatedSong));
 
   // If this song is currently playing, update volume live without restarting
-  const player = getPlayer(GUILD_ID);
+  const player = getPlayer(getGuildId());
   if (player && data.volumeBoost !== undefined) {
     const currentSong = player.getCurrentSong();
     if (currentSong?.id === id) {

--- a/packages/server/src/shared/api.ts
+++ b/packages/server/src/shared/api.ts
@@ -1,10 +1,15 @@
 import type {
+  GeneralSettings,
   LoopMode,
   PaginatedResult,
   PaginationMeta,
   Playlist,
   PlaylistDetail,
   QueueState,
+  SetupChannel,
+  SetupGuild,
+  SetupRole,
+  SetupStatus,
   Song,
   User,
 } from './types';
@@ -343,4 +348,55 @@ export function importPlaylist(
   maxVideos?: number
 ): Promise<ImportPlaylistResult> {
   return post('/api/songs/import-playlist', { youtubeUrl, ...(maxVideos && { maxVideos }) });
+}
+
+// ---------------------------------------------------------------------------
+// Setup API Functions
+// ---------------------------------------------------------------------------
+
+export function fetchSetupStatus(): Promise<SetupStatus> {
+  return get('/api/setup/status');
+}
+
+export function fetchSetupGuilds(): Promise<{ guilds: SetupGuild[] }> {
+  return get('/api/setup/guilds');
+}
+
+export function fetchSetupRoles(guildId: string): Promise<{ roles: SetupRole[] }> {
+  return get(`/api/setup/roles?guildId=${encodeURIComponent(guildId)}`);
+}
+
+export function fetchSetupChannels(guildId: string): Promise<{ channels: SetupChannel[] }> {
+  return get(`/api/setup/channels?guildId=${encodeURIComponent(guildId)}`);
+}
+
+export interface CompleteSetupPayload {
+  guildId: string;
+  adminRoleIds: string;
+  voiceIdleTimeoutMinutes: number;
+  notificationChannelId?: string | null;
+  publicUrl?: string | null;
+}
+
+export function completeSetup(data: CompleteSetupPayload): Promise<{ success: boolean }> {
+  return post('/api/setup/complete', data);
+}
+
+// ---------------------------------------------------------------------------
+// General Settings API Functions
+// ---------------------------------------------------------------------------
+
+export function fetchGeneralSettings(): Promise<GeneralSettings> {
+  return get('/api/settings/general');
+}
+
+export type GeneralSettingsUpdate = Partial<
+  Pick<
+    GeneralSettings,
+    'adminRoleIds' | 'voiceIdleTimeoutMinutes' | 'notificationChannelId' | 'publicUrl'
+  >
+>;
+
+export function updateGeneralSettings(data: GeneralSettingsUpdate): Promise<GeneralSettings> {
+  return patch('/api/settings/general', data);
 }

--- a/packages/server/src/shared/db/migrations/0053_add_setup_fields.sql
+++ b/packages/server/src/shared/db/migrations/0053_add_setup_fields.sql
@@ -1,0 +1,11 @@
+ALTER TABLE "guildSettings" ADD COLUMN "guildId" text;
+--> statement-breakpoint
+ALTER TABLE "guildSettings" ADD COLUMN "setupCompleted" integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE "guildSettings" ADD COLUMN "adminRoleIds" text NOT NULL DEFAULT '';
+--> statement-breakpoint
+ALTER TABLE "guildSettings" ADD COLUMN "voiceIdleTimeoutMinutes" integer NOT NULL DEFAULT 5;
+--> statement-breakpoint
+ALTER TABLE "guildSettings" ADD COLUMN "notificationChannelId" text;
+--> statement-breakpoint
+ALTER TABLE "guildSettings" ADD COLUMN "publicUrl" text;

--- a/packages/server/src/shared/db/schema.ts
+++ b/packages/server/src/shared/db/schema.ts
@@ -100,4 +100,12 @@ export const guildSettings = sqliteTable('guildSettings', {
   eqBand12: integer('eqBand12').notNull().default(50),
   eqBand13: integer('eqBand13').notNull().default(50),
   eqBand14: integer('eqBand14').notNull().default(50),
+
+  // General setup / admin settings
+  guildId: text('guildId'),
+  setupCompleted: integer('setupCompleted', { mode: 'boolean' }).notNull().default(false),
+  adminRoleIds: text('adminRoleIds').notNull().default(''),
+  voiceIdleTimeoutMinutes: integer('voiceIdleTimeoutMinutes').notNull().default(5),
+  notificationChannelId: text('notificationChannelId'),
+  publicUrl: text('publicUrl'),
 });

--- a/packages/server/src/shared/index.ts
+++ b/packages/server/src/shared/index.ts
@@ -4,6 +4,7 @@ export { toQueuedSong } from './queue';
 export { fisherYatesShuffle } from './shuffle';
 export type {
   CompressorSettings,
+  GeneralSettings,
   LoopMode,
   PaginatedResult,
   PaginationMeta,
@@ -11,6 +12,10 @@ export type {
   PlaylistDetail,
   QueuedSong,
   QueueState,
+  SetupChannel,
+  SetupGuild,
+  SetupRole,
+  SetupStatus,
   Song,
   User,
 } from './types';

--- a/packages/server/src/shared/types.ts
+++ b/packages/server/src/shared/types.ts
@@ -75,6 +75,66 @@ export interface EqualizerSettings {
 }
 
 // ---------------------------------------------------------------------------
+// GeneralSettings
+//
+// Guild-level general configuration. Stored in guildSettings table,
+// configured via the setup wizard and the Admin Settings page.
+// ---------------------------------------------------------------------------
+export interface GeneralSettings {
+  guildId: string | null;
+  setupCompleted: boolean;
+  adminRoleIds: string;
+  voiceIdleTimeoutMinutes: number;
+  notificationChannelId: string | null;
+  publicUrl: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// SetupStatus
+//
+// Returned by GET /api/setup/status to tell the frontend whether to show
+// the setup wizard.
+// ---------------------------------------------------------------------------
+export interface SetupStatus {
+  setupCompleted: boolean;
+  guildName: string | null;
+  clientId: string;
+}
+
+// ---------------------------------------------------------------------------
+// SetupRole
+//
+// A simplified role object returned by the setup API for the role picker.
+// ---------------------------------------------------------------------------
+export interface SetupRole {
+  id: string;
+  name: string;
+  color: number;
+}
+
+// ---------------------------------------------------------------------------
+// SetupChannel
+//
+// A simplified text-channel object returned by the setup API for the
+// channel picker.
+// ---------------------------------------------------------------------------
+export interface SetupChannel {
+  id: string;
+  name: string;
+}
+
+// ---------------------------------------------------------------------------
+// SetupGuild
+//
+// A simplified guild object returned by the setup API for the guild picker.
+// ---------------------------------------------------------------------------
+export interface SetupGuild {
+  id: string;
+  name: string;
+  icon: string | null;
+}
+
+// ---------------------------------------------------------------------------
 // QueueState
 //
 // A snapshot of the GuildPlayer's current state. This is the payload for
@@ -144,4 +204,6 @@ export interface User {
   username: string;
   avatar: string | null;
   isAdmin: boolean;
+  /** Temporarily granted during first-run setup before admin roles are configured. */
+  isSetupAdmin?: boolean;
 }

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -13,6 +13,7 @@ import AudioPage from './pages/AudioPage';
 import LoginPage from './pages/LoginPage';
 import PlaylistDetailPage from './pages/PlaylistDetailPage';
 import PlaylistsPage from './pages/PlaylistsPage';
+import SetupWizard from './pages/SetupWizard';
 import SongsPage from './pages/SongsPage';
 import TagsPage from './pages/TagsPage';
 
@@ -26,6 +27,14 @@ export default function App() {
               <SongEditProvider>
                 <Routes>
                   <Route path="/login" element={<LoginPage />} />
+                  <Route
+                    path="/setup"
+                    element={
+                      <ProtectedRoute>
+                        <SetupWizard />
+                      </ProtectedRoute>
+                    }
+                  />
                   <Route
                     path="/"
                     element={

--- a/packages/web/src/api/api.ts
+++ b/packages/web/src/api/api.ts
@@ -4,6 +4,18 @@ import { client } from './client';
 // Configure the shared API service with the web client
 configureApiClient(client);
 
+export type {
+  GeneralSettings,
+  SetupChannel,
+  SetupGuild,
+  SetupRole,
+  SetupStatus,
+} from '@alfira-bot/server/shared';
+
+export type {
+  CompleteSetupPayload,
+  GeneralSettingsUpdate,
+} from '@alfira-bot/server/shared/api';
 // ---------------------------------------------------------------------------
 // Re-export everything from shared API with web-compatible names
 // ---------------------------------------------------------------------------
@@ -11,10 +23,12 @@ export {
   addSongToPlaylist,
   addToPriorityQueue,
   clearQueue,
+  completeSetup,
   createPlaylist,
   createSong as addSong,
   deletePlaylist,
   deleteSong,
+  fetchGeneralSettings,
   fetchLogout as logout,
   // Auth
   fetchMe as getMe,
@@ -24,6 +38,11 @@ export {
   fetchPlaylistsPage as getPlaylistsPage,
   // Player
   fetchQueueState,
+  // Setup
+  fetchSetupChannels,
+  fetchSetupGuilds,
+  fetchSetupRoles,
+  fetchSetupStatus,
   // Songs
   fetchSongsPage as getSongsPage,
   // Version
@@ -42,4 +61,5 @@ export {
   togglePause,
   togglePlaylistVisibility,
   unshuffleQueue,
+  updateGeneralSettings,
 } from '@alfira-bot/server/shared/api';

--- a/packages/web/src/components/ProtectedRoute.tsx
+++ b/packages/web/src/components/ProtectedRoute.tsx
@@ -1,9 +1,10 @@
 import type React from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 
 export default function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { user, loading } = useAuth();
+  const location = useLocation();
 
   if (loading) {
     return (
@@ -17,6 +18,11 @@ export default function ProtectedRoute({ children }: { children: React.ReactNode
   }
 
   if (!user) return <Navigate to="/login" replace />;
+
+  // During first-run setup, lock all routes except /setup.
+  if (user.isSetupAdmin && location.pathname !== '/setup') {
+    return <Navigate to="/setup" replace />;
+  }
 
   return <>{children}</>;
 }

--- a/packages/web/src/components/settings/AdminTab.tsx
+++ b/packages/web/src/components/settings/AdminTab.tsx
@@ -1,0 +1,243 @@
+import { GlobeIcon, MegaphoneIcon, TimerIcon } from '@phosphor-icons/react';
+import { useEffect, useState } from 'react';
+import {
+  fetchGeneralSettings,
+  fetchSetupChannels,
+  fetchSetupRoles,
+  type GeneralSettings,
+  type SetupChannel,
+  type SetupRole,
+  updateGeneralSettings,
+} from '../../api/api';
+
+export default function AdminTab() {
+  const [saved, setSaved] = useState<GeneralSettings | null>(null);
+  const [adminRoleIds, setAdminRoleIds] = useState('');
+  const [timeoutMinutes, setTimeoutMinutes] = useState(5);
+  const [notificationChannelId, setNotificationChannelId] = useState<string | null>(null);
+  const [publicUrl, setPublicUrl] = useState<string | null>(null);
+
+  const [roles, setRoles] = useState<SetupRole[]>([]);
+  const [channels, setChannels] = useState<SetupChannel[]>([]);
+
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const settings = await fetchGeneralSettings();
+        setSaved(settings);
+        setAdminRoleIds(settings.adminRoleIds);
+        setTimeoutMinutes(settings.voiceIdleTimeoutMinutes);
+        setNotificationChannelId(settings.notificationChannelId);
+        setPublicUrl(settings.publicUrl);
+
+        // Load roles and channels for the pickers.
+        if (settings.guildId) {
+          const [rolesRes, channelsRes] = await Promise.all([
+            fetchSetupRoles(settings.guildId),
+            fetchSetupChannels(settings.guildId),
+          ]);
+          setRoles(rolesRes.roles);
+          setChannels(channelsRes.channels);
+        }
+      } catch {
+        setError('Could not load settings.');
+      }
+    }
+    load();
+  }, []);
+
+  const hasChanges = saved
+    ? adminRoleIds !== saved.adminRoleIds ||
+      timeoutMinutes !== saved.voiceIdleTimeoutMinutes ||
+      notificationChannelId !== saved.notificationChannelId ||
+      publicUrl !== saved.publicUrl
+    : false;
+
+  async function handleSave() {
+    setSaving(true);
+    setError(null);
+    setSuccessMsg(null);
+    try {
+      const updated = await updateGeneralSettings({
+        adminRoleIds,
+        voiceIdleTimeoutMinutes: timeoutMinutes,
+        notificationChannelId,
+        publicUrl,
+      });
+      setSaved(updated);
+      setSuccessMsg('Settings saved.');
+      setTimeout(() => setSuccessMsg(null), 3000);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to save settings.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function toggleRole(id: string) {
+    const current = adminRoleIds
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const set = new Set(current);
+    if (set.has(id)) set.delete(id);
+    else set.add(id);
+    setAdminRoleIds([...set].join(','));
+  }
+
+  const selectedRoleIdSet = new Set(
+    adminRoleIds
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+  );
+
+  return (
+    <div className="space-y-6">
+      {error && (
+        <div className="p-3 rounded-lg bg-danger/10 border border-danger/20 text-danger text-sm">
+          {error}
+        </div>
+      )}
+
+      {successMsg && (
+        <div className="p-3 rounded-lg bg-accent/10 border border-accent/20 text-accent text-sm">
+          {successMsg}
+        </div>
+      )}
+
+      {/* Admin Roles */}
+      <div className="space-y-2">
+        <h3 className="font-mono text-[11px] text-muted uppercase tracking-wider">Admin Roles</h3>
+        <p className="text-xs text-muted">
+          Users with these roles can manage songs, control playback, and access admin settings.
+        </p>
+        {roles.length === 0 ? (
+          <p className="text-xs text-muted italic">No roles loaded.</p>
+        ) : (
+          <div className="space-y-1.5 max-h-48 overflow-y-auto">
+            {roles.map((r) => (
+              <label
+                key={r.id}
+                className={`flex items-center gap-3 p-2.5 rounded-lg border cursor-pointer transition-colors ${
+                  selectedRoleIdSet.has(r.id)
+                    ? 'border-accent bg-accent/5'
+                    : 'border-border hover:border-muted'
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  checked={selectedRoleIdSet.has(r.id)}
+                  onChange={() => toggleRole(r.id)}
+                  className="accent-accent"
+                />
+                <span
+                  className="w-2.5 h-2.5 rounded-full shrink-0"
+                  style={{
+                    backgroundColor: r.color
+                      ? `#${r.color.toString(16).padStart(6, '0')}`
+                      : 'var(--color-muted)',
+                  }}
+                />
+                <span className="text-sm text-fg">{r.name}</span>
+              </label>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="border-t border-muted/20" />
+
+      {/* Notification Channel */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <MegaphoneIcon size={14} weight="duotone" className="text-muted" />
+          <h3 className="font-mono text-[11px] text-muted uppercase tracking-wider">
+            Notification Channel
+          </h3>
+        </div>
+        <p className="text-xs text-muted">
+          Alfira posts a message here when it leaves a voice channel due to inactivity.
+        </p>
+        {channels.length > 0 ? (
+          <select
+            value={notificationChannelId ?? ''}
+            onChange={(e) => setNotificationChannelId(e.target.value || null)}
+            className="w-full px-3 py-2 rounded-lg bg-base border border-border text-fg text-sm focus:outline-none focus:border-accent transition-colors"
+          >
+            <option value="">— Disabled —</option>
+            {channels.map((c) => (
+              <option key={c.id} value={c.id}>
+                # {c.name}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <p className="text-xs text-muted italic">No channels loaded.</p>
+        )}
+      </div>
+
+      <div className="border-t border-muted/20" />
+
+      {/* Idle Timeout */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <TimerIcon size={14} weight="duotone" className="text-muted" />
+          <h3 className="font-mono text-[11px] text-muted uppercase tracking-wider">
+            Idle Timeout
+          </h3>
+        </div>
+        <div className="flex items-center gap-4">
+          <input
+            type="range"
+            min={1}
+            max={120}
+            value={timeoutMinutes}
+            onChange={(e) => setTimeoutMinutes(Number(e.target.value))}
+            className="flex-1 accent-accent"
+          />
+          <span className="font-mono text-sm text-fg w-20 text-right whitespace-nowrap">
+            {timeoutMinutes} min
+          </span>
+        </div>
+      </div>
+
+      <div className="border-t border-muted/20" />
+
+      {/* Public URL */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <GlobeIcon size={14} weight="duotone" className="text-muted" />
+          <h3 className="font-mono text-[11px] text-muted uppercase tracking-wider">Public URL</h3>
+        </div>
+        <input
+          type="text"
+          value={publicUrl ?? ''}
+          onChange={(e) => setPublicUrl(e.target.value.trim() || null)}
+          placeholder="https://music.yourserver.com"
+          className="w-full px-3 py-2 rounded-lg bg-base border border-border text-fg text-sm font-mono placeholder:text-muted/50 focus:outline-none focus:border-accent transition-colors"
+        />
+      </div>
+
+      {/* Save */}
+      <div className="flex gap-3 pt-1 justify-end">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!hasChanges || saving}
+          className={`font-body text-sm px-4 py-1.5 rounded transition-colors ${
+            hasChanges && !saving
+              ? 'bg-accent text-elevated cursor-pointer'
+              : 'bg-elevated text-muted cursor-not-allowed'
+          }`}
+        >
+          {saving ? 'Saving…' : 'Save Changes'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/SettingsPage.tsx
+++ b/packages/web/src/components/settings/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { fetchVersion } from '../../api/api';
 import { useAuth } from '../../context/AuthContext';
+import AdminTab from './AdminTab';
 import AppearanceTab from './AppearanceTab';
 
 export default function SettingsPage() {
@@ -33,7 +34,7 @@ export default function SettingsPage() {
         <section>
           <h2 className="font-mono text-xs text-muted uppercase tracking-wider mb-4">Admin</h2>
           <div className="bg-elevated border border-border rounded-xl p-5">
-            <p className="text-sm text-muted">Server-side settings will appear here.</p>
+            <AdminTab />
           </div>
         </section>
       )}

--- a/packages/web/src/pages/SetupWizard.tsx
+++ b/packages/web/src/pages/SetupWizard.tsx
@@ -1,0 +1,600 @@
+import {
+  CaretLeftIcon,
+  CheckIcon,
+  GlobeIcon,
+  MegaphoneIcon,
+  ShieldCheckIcon,
+  TimerIcon,
+} from '@phosphor-icons/react';
+import { useEffect, useState } from 'react';
+import { Navigate, useNavigate } from 'react-router-dom';
+import {
+  completeSetup,
+  fetchSetupChannels,
+  fetchSetupGuilds,
+  fetchSetupRoles,
+  fetchSetupStatus,
+  logout,
+  type SetupChannel,
+  type SetupGuild,
+  type SetupRole,
+} from '../api/api';
+import { useAuth } from '../context/AuthContext';
+
+type Step = 'welcome' | 'guild' | 'roles' | 'channel' | 'timeout' | 'publicUrl' | 'confirm';
+
+const STEP_ORDER: Step[] = [
+  'welcome',
+  'guild',
+  'roles',
+  'channel',
+  'timeout',
+  'publicUrl',
+  'confirm',
+];
+
+export default function SetupWizard() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+
+  const [step, setStep] = useState<Step>('welcome');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Form state
+  const [guilds, setGuilds] = useState<SetupGuild[]>([]);
+  const [selectedGuildId, setSelectedGuildId] = useState<string>('');
+  const [roles, setRoles] = useState<SetupRole[]>([]);
+  const [selectedRoleIds, setSelectedRoleIds] = useState<Set<string>>(new Set());
+  const [channels, setChannels] = useState<SetupChannel[]>([]);
+  const [selectedChannelId, setSelectedChannelId] = useState<string>('');
+  const [timeoutMinutes, setTimeoutMinutes] = useState(5);
+  const [publicUrl, setPublicUrl] = useState('');
+  const [clientId, setClientId] = useState('');
+  const [refreshingGuilds, setRefreshingGuilds] = useState(false);
+
+  // Check setup status on mount
+  useEffect(() => {
+    async function check() {
+      try {
+        const status = await fetchSetupStatus();
+        if (status.setupCompleted) {
+          navigate('/', { replace: true });
+          return;
+        }
+        setClientId(status.clientId);
+      } catch {
+        // If we can't check status, proceed to wizard.
+      }
+      setLoading(false);
+    }
+    check();
+  }, [navigate]);
+
+  // Auto-refresh guild list when on the guild step and no guilds are found.
+  useEffect(() => {
+    if (step !== 'guild' || guilds.length > 0) return;
+
+    let cancelled = false;
+    async function poll() {
+      setRefreshingGuilds(true);
+      try {
+        const { guilds: list } = await fetchSetupGuilds();
+        if (!cancelled) {
+          setGuilds(list);
+          if (list.length === 1) {
+            setSelectedGuildId(list[0]?.id ?? '');
+          }
+        }
+      } catch {
+        // Silently retry on next interval.
+      } finally {
+        if (!cancelled) setRefreshingGuilds(false);
+      }
+    }
+
+    poll();
+    const interval = setInterval(poll, 3000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [step, guilds.length]);
+
+  // Only the first user (setup admin) can access the wizard.
+  if (!user?.isSetupAdmin && !loading) {
+    return <Navigate to="/" replace />;
+  }
+
+  if (loading) {
+    return (
+      <div className="h-full flex items-center justify-center bg-elevated">
+        <div className="w-8 h-8 border-2 border-accent border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  async function loadGuilds() {
+    setError(null);
+    try {
+      const { guilds: list } = await fetchSetupGuilds();
+      setGuilds(list);
+      if (list.length === 1) {
+        setSelectedGuildId(list[0]?.id ?? '');
+      }
+      setStep('guild');
+    } catch {
+      setError('Could not fetch server list. Is the bot connected to Discord?');
+    }
+  }
+
+  async function loadRoles() {
+    if (!selectedGuildId) return;
+    setError(null);
+    try {
+      const { roles: list } = await fetchSetupRoles(selectedGuildId);
+      setRoles(list);
+      setStep('roles');
+    } catch {
+      setError('Could not fetch roles.');
+    }
+  }
+
+  async function loadChannels() {
+    if (!selectedGuildId) return;
+    setError(null);
+    try {
+      const { channels: list } = await fetchSetupChannels(selectedGuildId);
+      setChannels(list);
+      setStep('channel');
+    } catch {
+      setError('Could not fetch channels.');
+    }
+  }
+
+  async function handleSubmit() {
+    if (!selectedGuildId || selectedRoleIds.size === 0) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await completeSetup({
+        guildId: selectedGuildId,
+        adminRoleIds: [...selectedRoleIds].join(','),
+        voiceIdleTimeoutMinutes: timeoutMinutes,
+        notificationChannelId: selectedChannelId || null,
+        publicUrl: publicUrl.trim() || null,
+      });
+      // Clear the old session (still has isSetupAdmin in the JWT),
+      // then redirect to /login for a fresh OAuth flow.
+      await logout();
+      window.location.href = '/login';
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to save configuration.');
+      setSaving(false);
+      setStep('confirm');
+    }
+  }
+
+  function toggleRole(id: string) {
+    setSelectedRoleIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  const stepIndex = STEP_ORDER.indexOf(step);
+
+  return (
+    <div className="min-h-full bg-surface flex items-center justify-center p-4">
+      <div className="w-full max-w-lg">
+        {/* Progress dots */}
+        <div className="flex justify-center gap-2 mb-8">
+          {STEP_ORDER.slice(1).map((s, i) => (
+            <div
+              key={s}
+              className={`w-2 h-2 rounded-full transition-colors ${
+                i < stepIndex - 1
+                  ? 'bg-accent'
+                  : i === stepIndex - 1
+                    ? 'bg-accent/60'
+                    : 'bg-muted/30'
+              }`}
+            />
+          ))}
+        </div>
+
+        {/* Error banner */}
+        {error && (
+          <div className="mb-6 p-3 rounded-lg bg-danger/10 border border-danger/20 text-danger text-sm">
+            {error}
+          </div>
+        )}
+
+        {/* Step content */}
+        <div className="bg-elevated border border-border rounded-xl p-6 md:p-8">
+          {step === 'welcome' && (
+            <div className="text-center space-y-6">
+              <div className="flex justify-center">
+                <div className="w-16 h-16 rounded-full bg-accent/10 border border-accent/30 flex items-center justify-center">
+                  <ShieldCheckIcon size={32} weight="duotone" className="text-accent" />
+                </div>
+              </div>
+              <div>
+                <h1 className="font-display text-2xl text-fg tracking-wider mb-2">
+                  Welcome to Alfira
+                </h1>
+                <p className="text-sm text-muted leading-relaxed">
+                  Let&apos;s get your music bot configured. You&apos;ll pick your server, choose
+                  admin roles, and set a few preferences.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={loadGuilds}
+                className="btn-primary px-6 py-2.5 rounded-xl font-body text-sm cursor-pointer"
+              >
+                Get Started
+              </button>
+            </div>
+          )}
+
+          {step === 'guild' && (
+            <div className="space-y-5">
+              <h2 className="font-display text-xl text-fg">Choose a Server</h2>
+              <p className="text-sm text-muted">
+                Select the Discord server Alfira will operate in.
+              </p>
+              {guilds.length === 0 ? (
+                <div className="p-4 rounded-lg bg-warning/10 text-warning text-sm space-y-3">
+                  <p>No servers found. Invite the bot to a Discord server first.</p>
+                  {clientId && (
+                    <a
+                      href={`https://discord.com/oauth2/authorize?client_id=${clientId}&permissions=3148800&scope=bot+applications.commands`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-block px-4 py-2 rounded-lg bg-accent text-elevated text-sm font-body hover:opacity-90 transition-opacity"
+                    >
+                      Invite Alfira to a Server
+                    </a>
+                  )}
+                  <p className="text-xs text-warning/70">Checking for servers every few seconds…</p>
+                  {refreshingGuilds && (
+                    <div className="w-4 h-4 border-2 border-accent border-t-transparent rounded-full animate-spin mx-auto" />
+                  )}
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  {guilds.map((g) => (
+                    <label
+                      key={g.id}
+                      className={`flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+                        selectedGuildId === g.id
+                          ? 'border-accent bg-accent/5'
+                          : 'border-border hover:border-muted'
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name="guild"
+                        value={g.id}
+                        checked={selectedGuildId === g.id}
+                        onChange={() => setSelectedGuildId(g.id)}
+                        className="accent-accent"
+                      />
+                      <span className="text-sm text-fg">{g.name}</span>
+                    </label>
+                  ))}
+                </div>
+              )}
+              <div className="flex justify-between pt-2">
+                <button
+                  type="button"
+                  onClick={() => setStep('welcome')}
+                  className="flex items-center gap-1 text-sm text-muted hover:text-fg transition-colors cursor-pointer"
+                >
+                  <CaretLeftIcon size={14} />
+                  Back
+                </button>
+                <button
+                  type="button"
+                  onClick={loadRoles}
+                  disabled={!selectedGuildId}
+                  className={`px-5 py-2 rounded-xl font-body text-sm transition-colors ${
+                    selectedGuildId
+                      ? 'btn-primary cursor-pointer'
+                      : 'bg-elevated text-muted cursor-not-allowed'
+                  }`}
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          )}
+
+          {step === 'roles' && (
+            <div className="space-y-5">
+              <h2 className="font-display text-xl text-fg">Admin Roles</h2>
+              <p className="text-sm text-muted">
+                Select which roles can manage Alfira (add songs, control playback, etc.).
+              </p>
+              {roles.length === 0 ? (
+                <div className="p-4 rounded-lg bg-warning/10 text-warning text-sm">
+                  No roles found in this server. Create roles in Discord first.
+                </div>
+              ) : (
+                <div className="space-y-2 max-h-64 overflow-y-auto">
+                  {roles.map((r) => (
+                    <label
+                      key={r.id}
+                      className={`flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+                        selectedRoleIds.has(r.id)
+                          ? 'border-accent bg-accent/5'
+                          : 'border-border hover:border-muted'
+                      }`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selectedRoleIds.has(r.id)}
+                        onChange={() => toggleRole(r.id)}
+                        className="accent-accent"
+                      />
+                      <span
+                        className="w-3 h-3 rounded-full shrink-0"
+                        style={{
+                          backgroundColor: r.color
+                            ? `#${r.color.toString(16).padStart(6, '0')}`
+                            : 'var(--color-muted)',
+                        }}
+                      />
+                      <span className="text-sm text-fg">{r.name}</span>
+                    </label>
+                  ))}
+                </div>
+              )}
+              <div className="flex justify-between pt-2">
+                <button
+                  type="button"
+                  onClick={() => setStep('guild')}
+                  className="flex items-center gap-1 text-sm text-muted hover:text-fg transition-colors cursor-pointer"
+                >
+                  <CaretLeftIcon size={14} />
+                  Back
+                </button>
+                <button
+                  type="button"
+                  onClick={loadChannels}
+                  disabled={selectedRoleIds.size === 0}
+                  className={`px-5 py-2 rounded-xl font-body text-sm transition-colors ${
+                    selectedRoleIds.size > 0
+                      ? 'btn-primary cursor-pointer'
+                      : 'bg-elevated text-muted cursor-not-allowed'
+                  }`}
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          )}
+
+          {step === 'channel' && (
+            <div className="space-y-5">
+              <div className="flex items-center gap-3">
+                <MegaphoneIcon size={24} weight="duotone" className="text-accent" />
+                <h2 className="font-display text-xl text-fg">Notification Channel</h2>
+              </div>
+              <p className="text-sm text-muted">
+                Alfira can post a message when it leaves a voice channel due to inactivity. Choose a
+                text channel, or skip this step.
+              </p>
+              {channels.length === 0 ? (
+                <p className="text-sm text-muted">No text channels found.</p>
+              ) : (
+                <div className="space-y-2 max-h-64 overflow-y-auto">
+                  {channels.map((c) => (
+                    <label
+                      key={c.id}
+                      className={`flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+                        selectedChannelId === c.id
+                          ? 'border-accent bg-accent/5'
+                          : 'border-border hover:border-muted'
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name="channel"
+                        value={c.id}
+                        checked={selectedChannelId === c.id}
+                        onChange={() => setSelectedChannelId(c.id)}
+                        className="accent-accent"
+                      />
+                      <span className="text-sm text-fg"># {c.name}</span>
+                    </label>
+                  ))}
+                </div>
+              )}
+              <div className="flex justify-between pt-2">
+                <button
+                  type="button"
+                  onClick={() => setStep('roles')}
+                  className="flex items-center gap-1 text-sm text-muted hover:text-fg transition-colors cursor-pointer"
+                >
+                  <CaretLeftIcon size={14} />
+                  Back
+                </button>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setSelectedChannelId('');
+                      setStep('timeout');
+                    }}
+                    className="px-4 py-2 rounded-xl font-body text-sm text-muted hover:text-fg transition-colors cursor-pointer"
+                  >
+                    Skip
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setStep('timeout')}
+                    className="px-5 py-2 rounded-xl btn-primary font-body text-sm cursor-pointer"
+                  >
+                    Next
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {step === 'timeout' && (
+            <div className="space-y-5">
+              <div className="flex items-center gap-3">
+                <TimerIcon size={24} weight="duotone" className="text-accent" />
+                <h2 className="font-display text-xl text-fg">Idle Timeout</h2>
+              </div>
+              <p className="text-sm text-muted">
+                How many minutes before Alfira automatically leaves when nobody is listening?
+              </p>
+              <div className="flex items-center gap-4">
+                <input
+                  type="range"
+                  min={1}
+                  max={120}
+                  value={timeoutMinutes}
+                  onChange={(e) => setTimeoutMinutes(Number(e.target.value))}
+                  className="flex-1 accent-accent"
+                />
+                <span className="font-mono text-lg text-fg w-20 text-right whitespace-nowrap">
+                  {timeoutMinutes} min
+                </span>
+              </div>
+              <div className="flex justify-between pt-2">
+                <button
+                  type="button"
+                  onClick={() => setStep('channel')}
+                  className="flex items-center gap-1 text-sm text-muted hover:text-fg transition-colors cursor-pointer"
+                >
+                  <CaretLeftIcon size={14} />
+                  Back
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setStep('publicUrl')}
+                  className="px-5 py-2 rounded-xl btn-primary font-body text-sm cursor-pointer"
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          )}
+
+          {step === 'publicUrl' && (
+            <div className="space-y-5">
+              <div className="flex items-center gap-3">
+                <GlobeIcon size={24} weight="duotone" className="text-accent" />
+                <h2 className="font-display text-xl text-fg">Public URL</h2>
+              </div>
+              <p className="text-sm text-muted">
+                Optional — the URL your users will use to access Alfira (e.g.,
+                https://music.yourserver.com). This can be changed later in settings.
+              </p>
+              <input
+                type="text"
+                value={publicUrl}
+                onChange={(e) => setPublicUrl(e.target.value)}
+                placeholder="https://music.yourserver.com"
+                className="w-full px-4 py-2.5 rounded-lg bg-base border border-border text-fg text-sm font-mono placeholder:text-muted/50 focus:outline-none focus:border-accent transition-colors"
+              />
+              <div className="flex justify-between pt-2">
+                <button
+                  type="button"
+                  onClick={() => setStep('timeout')}
+                  className="flex items-center gap-1 text-sm text-muted hover:text-fg transition-colors cursor-pointer"
+                >
+                  <CaretLeftIcon size={14} />
+                  Back
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setStep('confirm')}
+                  className="px-5 py-2 rounded-xl btn-primary font-body text-sm cursor-pointer"
+                >
+                  Review
+                </button>
+              </div>
+            </div>
+          )}
+
+          {step === 'confirm' && (
+            <div className="space-y-5">
+              <h2 className="font-display text-xl text-fg text-center">Ready to Go</h2>
+              <p className="text-sm text-muted text-center">
+                Review your settings below, then finish setup.
+              </p>
+
+              <div className="space-y-3 bg-base rounded-lg p-4">
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted">Server</span>
+                  <span className="text-fg">
+                    {guilds.find((g) => g.id === selectedGuildId)?.name ?? selectedGuildId}
+                  </span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted">Admin Roles</span>
+                  <span className="text-fg">
+                    {[...selectedRoleIds]
+                      .map((id) => roles.find((r) => r.id === id)?.name ?? id)
+                      .join(', ')}
+                  </span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted">Notifications</span>
+                  <span className="text-fg">
+                    {selectedChannelId
+                      ? `# ${channels.find((c) => c.id === selectedChannelId)?.name ?? selectedChannelId}`
+                      : 'Disabled'}
+                  </span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted">Idle Timeout</span>
+                  <span className="text-fg">{timeoutMinutes} minutes</span>
+                </div>
+                {publicUrl.trim() && (
+                  <div className="flex justify-between text-sm">
+                    <span className="text-muted">Public URL</span>
+                    <span className="text-fg font-mono">{publicUrl.trim()}</span>
+                  </div>
+                )}
+              </div>
+
+              <div className="flex justify-between pt-2">
+                <button
+                  type="button"
+                  onClick={() => setStep('publicUrl')}
+                  className="flex items-center gap-1 text-sm text-muted hover:text-fg transition-colors cursor-pointer"
+                >
+                  <CaretLeftIcon size={14} />
+                  Back
+                </button>
+                <button
+                  type="button"
+                  onClick={handleSubmit}
+                  disabled={saving}
+                  className={`flex items-center gap-2 px-5 py-2 rounded-xl font-body text-sm transition-colors ${
+                    saving
+                      ? 'bg-elevated text-muted cursor-not-allowed'
+                      : 'btn-primary cursor-pointer'
+                  }`}
+                >
+                  <CheckIcon size={16} weight="bold" />
+                  {saving ? 'Saving…' : 'Finish Setup'}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Replaces 4 environment variables (`GUILD_ID`, `ADMIN_ROLE_IDS`, `VOICE_IDLE_TIMEOUT_MINUTES`, `WEB_UI_ORIGIN`) with an in-app setup wizard and admin settings page. New installs only need 5 env vars to get started.

## Changes

**Setup wizard:**
- Multi-step wizard at `/setup` with live Discord pickers for guilds, roles, and channels
- Auto-refreshes guild list when bot isn't in any servers yet, with invite link
- First user to log in becomes setup admin; all other routes locked until setup completes
- Idle timeout, notification channel, and public URL configurable during setup

**Admin settings:**
- Settings → Admin page with role picker, notification channel, idle timeout, and public URL
- Follows same save pattern as compressor/equalizer settings

**Backend:**
- `GUILD_ID` refactored from module constant to `getGuildId()` function with DB-backed cache
- Auth callback detects setup state: fresh installs redirect to wizard, existing deployments auto-migrate from env vars
- GuildPlayer reads idle timeout from DB, sends idle-leave notification to configured Discord channel
- Setup mode route guard bypasses normal admin checks

**DB:**
- Migration 0053 adds `guildId`, `setupCompleted`, `adminRoleIds`, `voiceIdleTimeoutMinutes`, `notificationChannelId`, `publicUrl` to `guildSettings`

**Docs:**
- Updated installation guide, troubleshooting, README, and AGENTS.md