### PR TITLE
feat(server): add soundcloud source support and genericize source fields

### DIFF
--- a/nodelink-config/config.js
+++ b/nodelink-config/config.js
@@ -135,7 +135,7 @@ export default {
       },
     },
     soundcloud: {
-      enabled: false,
+      enabled: true,
     },
     spotify: {
       enabled: false,

--- a/packages/server/src/GuildPlayer.ts
+++ b/packages/server/src/GuildPlayer.ts
@@ -622,7 +622,7 @@ export class GuildPlayer {
     let trackData: { track: string; isWebmOpus: boolean };
 
     try {
-      trackData = await this.fetchStreamWithRetry(next.youtubeUrl);
+      trackData = await this.fetchStreamWithRetry(next.sourceUrl);
     } catch (error) {
       logger.error(
         { guildId: this.guildId, track: next.title, error },
@@ -712,13 +712,13 @@ export class GuildPlayer {
     const nextTrack = this.peekNextTrack();
     if (!nextTrack) return;
 
-    preloadTrack(this.guildId, sessionId, nextTrack.youtubeUrl).catch((err) => {
+    preloadTrack(this.guildId, sessionId, nextTrack.sourceUrl).catch((err) => {
       logger.warn({ guildId: this.guildId, track: nextTrack.title, err }, 'Gapless preload failed');
     });
   }
 
   private async fetchStreamWithRetry(
-    youtubeUrl: string
+    sourceUrl: string
   ): Promise<{ track: string; isWebmOpus: boolean }> {
     const RETRY_ATTEMPTS = 3;
     const RETRY_DELAY_MS = 1_000;
@@ -726,7 +726,7 @@ export class GuildPlayer {
     for (let attempt = 0; attempt < RETRY_ATTEMPTS; attempt++) {
       try {
         const { getStreamFormat } = await import('./utils/nodelink');
-        return await getStreamFormat(youtubeUrl);
+        return await getStreamFormat(sourceUrl);
       } catch (error) {
         lastError = error;
         if (attempt < RETRY_ATTEMPTS - 1) {

--- a/packages/server/src/lib/validation.ts
+++ b/packages/server/src/lib/validation.ts
@@ -2,8 +2,8 @@ import { logger } from '../shared/logger';
 import {
   getMetadata,
   getPlaylistMetadataWithVideos,
-  isValidYouTubeUrl,
-  isYouTubePlaylistUrl,
+  isPlaylistUrl,
+  isValidSourceUrl,
 } from '../startDiscord';
 import { json } from './json';
 
@@ -15,14 +15,14 @@ type ValidationResult<T> = ValidationSuccess<T> | ValidationError;
 
 /**
  * Validates and trims a URL input. Returns null if validation fails.
- * Used by YouTube URL validators to avoid duplication.
+ * Used by URL validators to avoid duplication.
  */
-function validateUrlInput(youtubeUrl: unknown): ValidationResult<string> {
-  if (!youtubeUrl || typeof youtubeUrl !== 'string') {
-    return { ok: false, response: json({ error: 'youtubeUrl is required.' }, 400) };
+function validateUrlInput(sourceUrl: unknown): ValidationResult<string> {
+  if (!sourceUrl || typeof sourceUrl !== 'string') {
+    return { ok: false, response: json({ error: 'url is required.' }, 400) };
   }
 
-  const url = youtubeUrl.trim();
+  const url = sourceUrl.trim();
 
   if (url.length > MAX_URL_LENGTH) {
     return {
@@ -34,33 +34,38 @@ function validateUrlInput(youtubeUrl: unknown): ValidationResult<string> {
   return { ok: true, value: url };
 }
 
-/** Validates a YouTube URL for single video endpoints. */
-export function validateYouTubeUrl(youtubeUrl: unknown): ValidationResult<string> {
-  const result = validateUrlInput(youtubeUrl);
+/** Validates a source URL for single video endpoints. */
+export function validateSourceUrl(sourceUrl: unknown): ValidationResult<string> {
+  const result = validateUrlInput(sourceUrl);
   if (!result.ok) return result;
 
-  if (!isValidYouTubeUrl(result.value)) {
+  if (!isValidSourceUrl(result.value)) {
     return {
       ok: false,
-      response: json({ error: 'That does not look like a valid YouTube URL.' }, 400),
+      response: json(
+        {
+          error: "Supported sources are YouTube and SoundCloud. That URL doesn't look right.",
+        },
+        400
+      ),
     };
   }
 
   return result;
 }
 
-/** Validates a YouTube playlist URL. */
-export function validateYouTubePlaylistUrl(youtubeUrl: unknown): ValidationResult<string> {
-  const result = validateUrlInput(youtubeUrl);
+/** Validates a playlist URL. */
+export function validatePlaylistUrl(playlistUrl: unknown): ValidationResult<string> {
+  const result = validateUrlInput(playlistUrl);
   if (!result.ok) return result;
 
-  if (!isYouTubePlaylistUrl(result.value)) {
+  if (!isPlaylistUrl(result.value)) {
     return {
       ok: false,
       response: json(
         {
           error:
-            'That does not look like a valid YouTube playlist URL. It should contain a "list" parameter.',
+            'That does not look like a valid playlist URL. Supported sources are YouTube and SoundCloud.',
         },
         400
       ),
@@ -97,22 +102,22 @@ async function wrapBotCall<T>(
 }
 
 /**
- * Fetches YouTube metadata for a single video URL.
+ * Fetches metadata for a single source URL.
  * Returns error Response if fetch fails.
  */
-export function fetchYouTubeMetadata(
+export function fetchSourceMetadata(
   url: string
 ): Promise<
   { ok: true; value: Awaited<ReturnType<typeof getMetadata>> } | { ok: false; response: Response }
 > {
   return wrapBotCall(
     () => getMetadata(url),
-    'Could not fetch video info. The video may be private, age-restricted, or unavailable.'
+    'Could not fetch track info. The track may be private, age-restricted, or unavailable.'
   );
 }
 
 /**
- * Fetches YouTube playlist metadata with videos.
+ * Fetches playlist metadata with tracks.
  * Returns error Response if fetch fails.
  */
 export function fetchPlaylistMetadata(

--- a/packages/server/src/routes/player.ts
+++ b/packages/server/src/routes/player.ts
@@ -10,9 +10,9 @@ import { checkGuards } from '../lib/routeGuards';
 import {
   clampMaxVideos,
   fetchPlaylistMetadata,
-  fetchYouTubeMetadata,
-  validateYouTubePlaylistUrl,
-  validateYouTubeUrl,
+  fetchSourceMetadata,
+  validatePlaylistUrl,
+  validateSourceUrl,
   youTubeUrl,
 } from '../lib/validation';
 import { resolveOrAutoJoinPlayer } from '../lib/voice';
@@ -224,29 +224,26 @@ async function handleUnshuffle(ctx: RouteContext): Promise<Response> {
 }
 
 // ---------------------------------------------------------------------------
-// Shared: resolve a YouTube URL into a temp QueuedSong with player ready
+// Shared: resolve a source URL into a temp QueuedSong with player ready
 // ---------------------------------------------------------------------------
 
-type YoutubeTempSongResult =
+type UrlTempSongResult =
   | { ok: true; player: GuildPlayer; queuedSong: QueuedSong; metadataTitle: string }
   | { ok: false; response: Response };
 
-async function resolveYoutubeTempSong(
-  ctx: RouteContext,
-  request: Request
-): Promise<YoutubeTempSongResult> {
+async function resolveUrlTempSong(ctx: RouteContext, request: Request): Promise<UrlTempSongResult> {
   const guards = await checkGuards(ctx, { admin: true, voice: true });
   if (guards instanceof Response) return { ok: false, response: guards };
   const { user } = guards;
 
-  let body: { youtubeUrl?: unknown };
+  let body: { url?: unknown };
   try {
     body = (await request.json()) as typeof body;
   } catch {
     return { ok: false, response: json({ error: 'Invalid JSON body.' }, 400) };
   }
 
-  const urlResult = validateYouTubeUrl(body.youtubeUrl);
+  const urlResult = validateSourceUrl(body.url);
   if (!urlResult.ok) return { ok: false, response: urlResult.response };
   const url = urlResult.value;
 
@@ -254,15 +251,15 @@ async function resolveYoutubeTempSong(
   if (!playerResult.ok) return { ok: false, response: playerResult.response };
   const player = playerResult.player;
 
-  const metadataResult = await fetchYouTubeMetadata(url);
+  const metadataResult = await fetchSourceMetadata(url);
   if (!metadataResult.ok) return { ok: false, response: metadataResult.response };
   const metadata = metadataResult.value;
 
   const queuedSong: QueuedSong = {
     id: `temp-${Date.now()}`,
     title: metadata.title,
-    youtubeUrl: url,
-    youtubeId: metadata.youtubeId,
+    sourceUrl: url,
+    sourceId: metadata.sourceId,
     duration: metadata.duration,
     thumbnailUrl: metadata.thumbnailUrl ?? '',
     addedBy: user.discordId,
@@ -277,7 +274,7 @@ async function resolveYoutubeTempSong(
 // POST /api/player/quick-add — add YouTube URL to priority queue (admin only)
 // ---------------------------------------------------------------------------
 async function handleQuickAdd(ctx: RouteContext, request: Request): Promise<Response> {
-  const result = await resolveYoutubeTempSong(ctx, request);
+  const result = await resolveUrlTempSong(ctx, request);
   if (!result.ok) return result.response;
   await result.player.addToPriorityQueue(result.queuedSong);
   return json({
@@ -294,7 +291,7 @@ async function handleQuickAddPlaylist(ctx: RouteContext, request: Request): Prom
   if (guards instanceof Response) return guards;
   const { user } = guards;
 
-  let body: { youtubeUrl?: unknown; maxVideos?: number };
+  let body: { url?: unknown; maxVideos?: number };
   try {
     body = (await request.json()) as typeof body;
   } catch {
@@ -302,7 +299,7 @@ async function handleQuickAddPlaylist(ctx: RouteContext, request: Request): Prom
   }
 
   const maxVideos = clampMaxVideos(body.maxVideos);
-  const urlResult = validateYouTubePlaylistUrl(body.youtubeUrl);
+  const urlResult = validatePlaylistUrl(body.url);
   if (!urlResult.ok) return urlResult.response;
   const url = urlResult.value;
 
@@ -319,8 +316,8 @@ async function handleQuickAddPlaylist(ctx: RouteContext, request: Request): Prom
   const queuedSongs = playlistMetadata.videos.map((video) => ({
     id: `temp-${Date.now()}-${video.id}`,
     title: video.title,
-    youtubeUrl: youTubeUrl(video.id),
-    youtubeId: video.id,
+    sourceUrl: youTubeUrl(video.id),
+    sourceId: video.id,
     duration: video.duration,
     thumbnailUrl: video.thumbnailUrl,
     addedBy,
@@ -447,7 +444,7 @@ async function handleAddToPriority(ctx: RouteContext, request: Request): Promise
 // POST /api/player/override — immediately play YouTube URL (admin only)
 // ---------------------------------------------------------------------------
 async function handleOverride(ctx: RouteContext, request: Request): Promise<Response> {
-  const result = await resolveYoutubeTempSong(ctx, request);
+  const result = await resolveUrlTempSong(ctx, request);
   if (!result.ok) return result.response;
   await result.player.replaceQueueAndPlay([result.queuedSong]);
   return json({

--- a/packages/server/src/routes/songs.ts
+++ b/packages/server/src/routes/songs.ts
@@ -13,14 +13,14 @@ import { canonicalizeTags } from '../lib/tagCanonicalization';
 import {
   clampMaxVideos,
   fetchPlaylistMetadata,
-  fetchYouTubeMetadata,
+  fetchSourceMetadata,
   validateArtworkUrl,
   validateNickname,
   validateOptionalString,
+  validatePlaylistUrl,
+  validateSourceUrl,
   validateTags,
   validateVolumeBoost,
-  validateYouTubePlaylistUrl,
-  validateYouTubeUrl,
   youTubeUrl,
 } from '../lib/validation';
 import { db, tables } from '../shared/db';
@@ -73,14 +73,14 @@ async function handleGetSongs(ctx: RouteContext, request: Request): Promise<Resp
 }
 
 // ---------------------------------------------------------------------------
-// POST /api/songs — add a song by YouTube URL. Admin only.
+// POST /api/songs — add a song by source URL. Admin only.
 // ---------------------------------------------------------------------------
 async function handlePostSong(ctx: RouteContext, request: Request): Promise<Response> {
   const guards = await checkGuards(ctx, { admin: true });
   if (guards instanceof Response) return guards;
   const { user } = guards;
 
-  let body: { youtubeUrl?: unknown; nickname?: unknown; asPlaylist?: unknown };
+  let body: { url?: unknown; nickname?: unknown; asPlaylist?: unknown };
   try {
     body = (await request.json()) as typeof body;
   } catch {
@@ -91,13 +91,13 @@ async function handlePostSong(ctx: RouteContext, request: Request): Promise<Resp
   const nicknameResult = validateNickname(body.nickname);
   if (!nicknameResult.ok) return nicknameResult.response;
 
-  const urlResult = validateYouTubeUrl(body.youtubeUrl);
+  const urlResult = validateSourceUrl(body.url);
   if (!urlResult.ok) return urlResult.response;
   let url = urlResult.value;
 
   // If user wants to import as playlist, validate as playlist URL first.
   if (asPlaylist) {
-    const playlistResult = validateYouTubePlaylistUrl(url);
+    const playlistResult = validatePlaylistUrl(url);
     if (!playlistResult.ok) return playlistResult.response;
     url = playlistResult.value;
   } else {
@@ -111,15 +111,15 @@ async function handlePostSong(ctx: RouteContext, request: Request): Promise<Resp
     }
   }
 
-  const metadataResult = await fetchYouTubeMetadata(url);
+  const metadataResult = await fetchSourceMetadata(url);
   if (!metadataResult.ok) return metadataResult.response;
   const metadata = metadataResult.value;
 
-  // Check for duplicate by youtubeId.
+  // Check for duplicate by sourceId.
   const [existing] = await db
     .select()
     .from(songTable)
-    .where(eq(songTable.youtubeId, metadata.youtubeId))
+    .where(eq(songTable.sourceId, metadata.sourceId))
     .limit(1);
 
   if (existing) {
@@ -136,8 +136,8 @@ async function handlePostSong(ctx: RouteContext, request: Request): Promise<Resp
     .insert(songTable)
     .values({
       title: metadata.title,
-      youtubeUrl: url,
-      youtubeId: metadata.youtubeId,
+      sourceUrl: url,
+      sourceId: metadata.sourceId,
       duration: metadata.duration,
       thumbnailUrl: metadata.thumbnailUrl ?? '',
       addedBy: user.discordId,
@@ -158,14 +158,14 @@ async function handlePostSong(ctx: RouteContext, request: Request): Promise<Resp
 }
 
 // ---------------------------------------------------------------------------
-// POST /api/songs/import-playlist — import YouTube playlist. Admin only.
+// POST /api/songs/import-playlist — import playlist. Admin only.
 // ---------------------------------------------------------------------------
 async function handleImportPlaylist(ctx: RouteContext, request: Request): Promise<Response> {
   const guards = await checkGuards(ctx, { admin: true });
   if (guards instanceof Response) return guards;
   const { user } = guards;
 
-  let body: { youtubeUrl?: unknown; maxVideos?: number };
+  let body: { url?: unknown; maxVideos?: number };
   try {
     body = (await request.json()) as typeof body;
   } catch {
@@ -173,7 +173,7 @@ async function handleImportPlaylist(ctx: RouteContext, request: Request): Promis
   }
 
   const maxVideos = clampMaxVideos(body.maxVideos);
-  const urlResult = validateYouTubePlaylistUrl(body.youtubeUrl);
+  const urlResult = validatePlaylistUrl(body.url);
   if (!urlResult.ok) return urlResult.response;
   const url = urlResult.value;
 
@@ -187,19 +187,19 @@ async function handleImportPlaylist(ctx: RouteContext, request: Request): Promis
     canonicalUrl: youTubeUrl(v.id),
   }));
 
-  let existingSongs: { youtubeId: string; youtubeUrl: string }[] = [];
+  let existingSongs: { sourceId: string; sourceUrl: string }[] = [];
   if (videosWithUrls.length > 0) {
     existingSongs = await db
-      .select({ youtubeId: songTable.youtubeId, youtubeUrl: songTable.youtubeUrl })
+      .select({ sourceId: songTable.sourceId, sourceUrl: songTable.sourceUrl })
       .from(songTable)
       .where(
         or(
           inArray(
-            songTable.youtubeId,
+            songTable.sourceId,
             videosWithUrls.map((v) => v.id)
           ),
           inArray(
-            songTable.youtubeUrl,
+            songTable.sourceUrl,
             videosWithUrls.map((v) => v.canonicalUrl)
           )
         )
@@ -207,12 +207,12 @@ async function handleImportPlaylist(ctx: RouteContext, request: Request): Promis
   }
 
   // Create sets for quick lookup
-  const existingYoutubeIds = new Set(existingSongs.map((s) => s.youtubeId));
-  const existingYoutubeUrls = new Set(existingSongs.map((s) => s.youtubeUrl));
+  const existingSourceIds = new Set(existingSongs.map((s) => s.sourceId));
+  const existingSourceUrls = new Set(existingSongs.map((s) => s.sourceUrl));
 
-  // Filter out duplicates (check both youtubeId and youtubeUrl)
+  // Filter out duplicates (check both sourceId and sourceUrl)
   const newVideos = videosWithUrls.filter(
-    (v) => !existingYoutubeIds.has(v.id) && !existingYoutubeUrls.has(v.canonicalUrl)
+    (v) => !existingSourceIds.has(v.id) && !existingSourceUrls.has(v.canonicalUrl)
   );
 
   if (newVideos.length === 0) {
@@ -234,8 +234,8 @@ async function handleImportPlaylist(ctx: RouteContext, request: Request): Promis
       .values(
         newVideos.map((video) => ({
           title: video.title,
-          youtubeUrl: video.canonicalUrl,
-          youtubeId: video.id,
+          sourceUrl: video.canonicalUrl,
+          sourceId: video.id,
           duration: video.duration,
           thumbnailUrl: video.thumbnailUrl ?? '',
           addedBy: addedByDiscordId,

--- a/packages/server/src/shared/api.ts
+++ b/packages/server/src/shared/api.ts
@@ -121,13 +121,9 @@ export function fetchSongsPage(
   return get(`/api/songs?${params}`);
 }
 
-export function createSong(
-  youtubeUrl: string,
-  nickname?: string,
-  asPlaylist?: boolean
-): Promise<Song> {
+export function createSong(url: string, nickname?: string, asPlaylist?: boolean): Promise<Song> {
   return post('/api/songs', {
-    youtubeUrl,
+    url,
     ...(nickname && { nickname }),
     ...(asPlaylist && { asPlaylist }),
   });
@@ -293,15 +289,15 @@ export function seek(positionMs: number): Promise<void> {
   return post('/api/player/seek', { position: positionMs });
 }
 
-export function quickAddToQueue(youtubeUrl: string): Promise<{
+export function quickAddToQueue(url: string): Promise<{
   message: string;
   song: { title: string; duration: number; thumbnailUrl: string; requestedBy: string };
 }> {
-  return post('/api/player/quick-add', { youtubeUrl });
+  return post('/api/player/quick-add', { url });
 }
 
 export function quickAddPlaylistToQueue(
-  youtubeUrl: string,
+  url: string,
   maxVideos?: number
 ): Promise<{
   message: string;
@@ -311,7 +307,7 @@ export function quickAddPlaylistToQueue(
   songs: Array<{ title: string; duration: number; thumbnailUrl: string; requestedBy: string }>;
 }> {
   return post('/api/player/quick-add-playlist', {
-    youtubeUrl,
+    url,
     ...(maxVideos && { maxVideos }),
   });
 }
@@ -323,11 +319,11 @@ export function addToPriorityQueue(songId: string): Promise<{
   return post('/api/player/add-to-priority', { songId });
 }
 
-export function overridePlay(youtubeUrl: string): Promise<{
+export function overridePlay(url: string): Promise<{
   message: string;
   song: { title: string; duration: number; thumbnailUrl: string; requestedBy: string };
 }> {
-  return post('/api/player/override', { youtubeUrl });
+  return post('/api/player/override', { url });
 }
 
 // ---------------------------------------------------------------------------
@@ -343,11 +339,8 @@ export interface ImportPlaylistResult {
   songs: Song[];
 }
 
-export function importPlaylist(
-  youtubeUrl: string,
-  maxVideos?: number
-): Promise<ImportPlaylistResult> {
-  return post('/api/songs/import-playlist', { youtubeUrl, ...(maxVideos && { maxVideos }) });
+export function importPlaylist(url: string, maxVideos?: number): Promise<ImportPlaylistResult> {
+  return post('/api/songs/import-playlist', { url, ...(maxVideos && { maxVideos }) });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/shared/db/migrations/0054_rename_youtube_to_source.sql
+++ b/packages/server/src/shared/db/migrations/0054_rename_youtube_to_source.sql
@@ -1,0 +1,49 @@
+-- Rename youtubeUrl / youtubeId columns to sourceUrl / sourceId
+-- SQLite doesn't support ALTER TABLE RENAME COLUMN, so we recreate.
+
+CREATE TABLE "Song_new" (
+  "id" text PRIMARY KEY NOT NULL,
+  "title" text NOT NULL,
+  "sourceUrl" text NOT NULL,
+  "sourceId" text NOT NULL,
+  "duration" integer NOT NULL,
+  "thumbnailUrl" text NOT NULL,
+  "addedBy" text NOT NULL,
+  "nickname" text,
+  "artist" text,
+  "album" text,
+  "artwork" text,
+  "tags" text NOT NULL DEFAULT '[]',
+  "volumeBoost" integer,
+  "createdAt" integer NOT NULL
+);
+--> statement-breakpoint
+
+INSERT INTO "Song_new" SELECT
+  "id",
+  "title",
+  "youtubeUrl" AS "sourceUrl",
+  "youtubeId" AS "sourceId",
+  "duration",
+  "thumbnailUrl",
+  "addedBy",
+  "nickname",
+  "artist",
+  "album",
+  "artwork",
+  "tags",
+  "volumeBoost",
+  "createdAt"
+FROM "Song";
+--> statement-breakpoint
+
+DROP TABLE "Song";
+--> statement-breakpoint
+
+ALTER TABLE "Song_new" RENAME TO "Song";
+--> statement-breakpoint
+
+CREATE UNIQUE INDEX "Song_sourceUrl_unique" ON "Song" ("sourceUrl");
+--> statement-breakpoint
+
+CREATE UNIQUE INDEX "Song_sourceId_unique" ON "Song" ("sourceId");

--- a/packages/server/src/shared/db/schema.ts
+++ b/packages/server/src/shared/db/schema.ts
@@ -5,8 +5,8 @@ export const song = sqliteTable('Song', {
     .primaryKey()
     .$defaultFn(() => crypto.randomUUID()),
   title: text('title').notNull(),
-  youtubeUrl: text('youtubeUrl').notNull().unique(),
-  youtubeId: text('youtubeId').notNull().unique(),
+  sourceUrl: text('sourceUrl').notNull().unique(),
+  sourceId: text('sourceId').notNull().unique(),
   duration: integer('duration').notNull(),
   thumbnailUrl: text('thumbnailUrl').notNull(),
   addedBy: text('addedBy').notNull(),

--- a/packages/server/src/shared/format.ts
+++ b/packages/server/src/shared/format.ts
@@ -1,5 +1,6 @@
 export function formatDuration(seconds: number): string {
-  const m = Math.floor(seconds / 60);
-  const s = seconds % 60;
-  return `${m}:${s.toString().padStart(2, '0')}`;
+  const s = Math.round(seconds);
+  const m = Math.floor(s / 60);
+  const sec = s % 60;
+  return `${m}:${sec.toString().padStart(2, '0')}`;
 }

--- a/packages/server/src/shared/types.ts
+++ b/packages/server/src/shared/types.ts
@@ -15,8 +15,8 @@
 export interface Song {
   id: string;
   title: string;
-  youtubeUrl: string;
-  youtubeId: string;
+  sourceUrl: string;
+  sourceId: string;
   duration: number; // seconds
   thumbnailUrl: string;
   addedBy: string; // Discord user ID

--- a/packages/server/src/startDiscord.ts
+++ b/packages/server/src/startDiscord.ts
@@ -9,8 +9,8 @@ export { createPlayer, destroyAllPlayers, getPlayer } from './manager';
 export {
   getMetadata,
   getPlaylistMetadataWithVideos,
-  isValidYouTubeUrl,
-  isYouTubePlaylistUrl,
+  isPlaylistUrl,
+  isValidSourceUrl,
   type PlaylistMetadata,
 } from './utils/nodelink';
 

--- a/packages/server/src/utils/nodelink.ts
+++ b/packages/server/src/utils/nodelink.ts
@@ -133,7 +133,10 @@ export function isPlaylistUrl(url: string): boolean {
     // YouTube playlists
     if (parsed.searchParams.has('list')) return true;
     // SoundCloud sets
-    if (parsed.hostname.includes('soundcloud.com') && parsed.pathname.includes('/sets/'))
+    if (
+      (parsed.hostname === 'soundcloud.com' || parsed.hostname.endsWith('.soundcloud.com')) &&
+      parsed.pathname.includes('/sets/')
+    )
       return true;
     return false;
   } catch {

--- a/packages/server/src/utils/nodelink.ts
+++ b/packages/server/src/utils/nodelink.ts
@@ -1,15 +1,22 @@
 interface SongMetadata {
   title: string;
-  youtubeId: string;
+  sourceId: string;
   duration: number; // seconds
   thumbnailUrl: string;
+  sourceName?: string;
 }
 
 export interface PlaylistMetadata {
   title: string;
   playlistId: string;
   videoCount: number;
-  videos: { id: string; title: string; duration: number; thumbnailUrl: string }[];
+  videos: {
+    id: string;
+    title: string;
+    duration: number;
+    thumbnailUrl: string;
+    sourceName?: string;
+  }[];
 }
 
 const NODELINK_URL = 'http://127.0.0.1:2333';
@@ -61,6 +68,7 @@ interface LoadTrackResponse {
       position?: number;
       author?: string;
       artworkUrl?: string;
+      sourceName?: string;
       name?: string; // playlist name when loadType is "playlist"
       selectedTrack?: number;
     };
@@ -90,23 +98,63 @@ interface TrackInfo {
   pluginInfo?: Record<string, unknown>;
 }
 
-const YOUTUBE_HOSTS = ['youtube.com', 'www.youtube.com', 'youtu.be', 'music.youtube.com'];
+// ---------------------------------------------------------------------------
+// Supported sources — add new hostnames here to enable more sources.
+// NodeLink must also support the source for it to work end-to-end.
+// ---------------------------------------------------------------------------
 
-export function isValidYouTubeUrl(url: string): boolean {
+const SUPPORTED_HOSTS = [
+  // YouTube
+  'youtube.com',
+  'www.youtube.com',
+  'youtu.be',
+  'music.youtube.com',
+  // SoundCloud
+  'soundcloud.com',
+  'www.soundcloud.com',
+];
+
+export function isValidSourceUrl(url: string): boolean {
   try {
-    return YOUTUBE_HOSTS.includes(new URL(url).hostname);
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+    return SUPPORTED_HOSTS.some(
+      (host) => parsed.hostname === host || parsed.hostname.endsWith(`.${host}`)
+    );
   } catch {
     return false;
   }
 }
 
-export function isYouTubePlaylistUrl(url: string): boolean {
-  if (!isValidYouTubeUrl(url)) return false;
+export function isPlaylistUrl(url: string): boolean {
+  if (!isValidSourceUrl(url)) return false;
   try {
-    return new URL(url).searchParams.has('list');
+    const parsed = new URL(url);
+    // YouTube playlists
+    if (parsed.searchParams.has('list')) return true;
+    // SoundCloud sets
+    if (parsed.hostname.includes('soundcloud.com') && parsed.pathname.includes('/sets/'))
+      return true;
+    return false;
   } catch {
     return false;
   }
+}
+
+function resolveThumbnail(info: TrackInfo['info']): string {
+  const identifier = info?.identifier ?? '';
+  const artworkUrl = info?.artworkUrl;
+  const sourceName = info?.sourceName;
+
+  // Prefer artworkUrl from NodeLink when available (SoundCloud, Bandcamp, etc.)
+  if (artworkUrl) return artworkUrl;
+
+  // Fall back to YouTube thumbnail for YouTube identifiers
+  if (sourceName === 'youtube' && identifier) {
+    return `https://img.youtube.com/vi/${identifier}/hqdefault.jpg`;
+  }
+
+  return '';
 }
 
 async function loadTrack(url: string): Promise<LoadTrackResponse> {
@@ -129,8 +177,8 @@ async function loadTrack(url: string): Promise<LoadTrackResponse> {
   return data;
 }
 
-export async function getMetadata(youtubeUrl: string): Promise<SongMetadata> {
-  const response = await loadTrack(youtubeUrl);
+export async function getMetadata(url: string): Promise<SongMetadata> {
+  const response = await loadTrack(url);
 
   const data = response.data;
 
@@ -140,13 +188,14 @@ export async function getMetadata(youtubeUrl: string): Promise<SongMetadata> {
     const first = data.tracks[0];
     if (!first?.info) throw new Error('NodeLink returned no track data');
     const info = first.info;
-    const youtubeId = info.identifier ?? '';
+    const sourceId = info.identifier ?? '';
     const title = info.title ?? 'Unknown';
     return {
       title,
-      youtubeId,
-      duration: (info.length ?? 0) / 1000,
-      thumbnailUrl: `https://img.youtube.com/vi/${youtubeId}/hqdefault.jpg`,
+      sourceId,
+      duration: Math.round((info.length ?? 0) / 1000),
+      thumbnailUrl: resolveThumbnail(info),
+      sourceName: info.sourceName,
     };
   }
 
@@ -155,21 +204,22 @@ export async function getMetadata(youtubeUrl: string): Promise<SongMetadata> {
   }
 
   const info = data.info;
-  const youtubeId = info.identifier ?? '';
+  const sourceId = info.identifier ?? '';
   const title = info.title ?? 'Unknown';
 
   return {
     title,
-    youtubeId,
-    duration: (info.length ?? 0) / 1000,
-    thumbnailUrl: `https://img.youtube.com/vi/${youtubeId}/hqdefault.jpg`,
+    sourceId,
+    duration: Math.round((info.length ?? 0) / 1000),
+    thumbnailUrl: resolveThumbnail(info),
+    sourceName: info.sourceName,
   };
 }
 
 export async function getStreamFormat(
-  youtubeUrl: string
+  url: string
 ): Promise<{ track: string; isWebmOpus: boolean }> {
-  const response = await loadTrack(youtubeUrl);
+  const response = await loadTrack(url);
 
   const data = response.data;
 
@@ -193,7 +243,7 @@ export async function getPlaylistMetadataWithVideos(
   playlistUrl: string,
   maxVideos?: number
 ): Promise<PlaylistMetadata> {
-  // NodeLink v4 uses /v4/loadtracks with YouTube playlist URL.
+  // NodeLink v4 uses /v4/loadtracks with the playlist URL.
   // It returns a "playlist" loadType with track array.
   const response = await loadTrack(playlistUrl);
 
@@ -209,8 +259,9 @@ export async function getPlaylistMetadataWithVideos(
     return {
       id,
       title: t.info?.title ?? 'Unknown',
-      duration: (t.info?.length ?? 0) / 1000,
-      thumbnailUrl: `https://img.youtube.com/vi/${id}/hqdefault.jpg`,
+      duration: Math.round((t.info?.length ?? 0) / 1000),
+      thumbnailUrl: resolveThumbnail(t.info),
+      sourceName: t.info?.sourceName,
     };
   });
 
@@ -222,14 +273,10 @@ export async function getPlaylistMetadataWithVideos(
   };
 }
 
-export async function preloadTrack(
-  guildId: string,
-  sessionId: string,
-  youtubeUrl: string
-): Promise<void> {
+export async function preloadTrack(guildId: string, sessionId: string, url: string): Promise<void> {
   // Resolve the track via NodeLink's loadtracks endpoint.
   const loadUrl = new URL('/v4/loadtracks', NODELINK_URL);
-  loadUrl.searchParams.set('identifier', youtubeUrl);
+  loadUrl.searchParams.set('identifier', url);
 
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (NODELINK_AUTH) headers.Authorization = NODELINK_AUTH;
@@ -264,7 +311,7 @@ export async function preloadTrack(
     throw new Error(`NodeLink preload PATCH returned ${patchResp.status}`);
   }
 
-  logger.debug({ guildId, youtubeUrl }, 'Gapless preload succeeded');
+  logger.debug({ guildId, url }, 'Gapless preload succeeded');
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/components/AddSongModal.tsx
+++ b/packages/web/src/components/AddSongModal.tsx
@@ -1,19 +1,9 @@
 import type { Song } from '@alfira-bot/server/shared';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { addSong, importPlaylist } from '../api/api';
 import { apiErrorMessage } from '../utils/api';
 import { Backdrop } from './Backdrop';
 import { Button } from './ui/Button';
-
-const YOUTUBE_HOSTS = ['youtube.com', 'www.youtube.com', 'youtu.be', 'music.youtube.com'] as const;
-
-function isValidYouTubeUrl(url: string): boolean {
-  try {
-    return YOUTUBE_HOSTS.includes(new URL(url).hostname as (typeof YOUTUBE_HOSTS)[number]);
-  } catch {
-    return false;
-  }
-}
 
 export default function AddSongModal({
   onClose,
@@ -30,9 +20,6 @@ export default function AddSongModal({
   const isPlaylist = url.includes('list=');
   const [importFullPlaylist, setImportFullPlaylist] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
-
-  const trimmedUrl = url.trim();
-  const urlIsValid = useMemo(() => isValidYouTubeUrl(trimmedUrl), [trimmedUrl]);
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -80,12 +67,14 @@ export default function AddSongModal({
     <Backdrop onClose={onClose}>
       <div className="bg-surface rounded-xl p-5 md:p-6 w-full max-w-md mx-4 modal-clay animate-fade-up">
         <h2 className="font-display text-2xl md:text-3xl text-fg tracking-wider mb-1">Add Song</h2>
-        <p className="font-mono text-xs text-muted mb-4 md:mb-6">paste a youtube url</p>
+        <p className="font-mono text-xs text-muted mb-4 md:mb-6">
+          paste a YouTube or SoundCloud url
+        </p>
 
         <input
           ref={inputRef}
           className="input mb-3"
-          placeholder="https://youtube.com/watch?v=..."
+          placeholder="https://..."
           value={url}
           onChange={(e) => {
             setUrl(e.target.value);
@@ -109,9 +98,9 @@ export default function AddSongModal({
           </label>
         )}
 
-        {urlIsValid && !importFullPlaylist && (
+        {!importFullPlaylist && (
           <input
-            className="input mb-3 animate-fade-up"
+            className="input mb-3"
             placeholder="Nickname (optional)"
             value={nickname}
             onChange={(e) => setNickname(e.target.value)}
@@ -134,13 +123,7 @@ export default function AddSongModal({
           <Button variant="inherit" onClick={onClose} disabled={loading} surface="surface">
             Cancel
           </Button>
-          <Button
-            variant="primary"
-            onClick={handleSubmit}
-            disabled={
-              loading || (!importFullPlaylist && !urlIsValid) || (importFullPlaylist && !url.trim())
-            }
-          >
+          <Button variant="primary" onClick={handleSubmit} disabled={loading || !url.trim()}>
             {importFullPlaylist ? 'Import' : 'Add'}
           </Button>
         </div>

--- a/packages/web/src/components/QueuePanel.tsx
+++ b/packages/web/src/components/QueuePanel.tsx
@@ -521,7 +521,7 @@ const NowPlayingCard = memo(function NowPlayingCard({
         </div>
         <div className="flex-1 flex flex-col justify-center min-w-0">
           <a
-            href={song.youtubeUrl}
+            href={song.sourceUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="font-body text-sm text-fg hover:text-accent line-clamp-2"

--- a/packages/web/src/components/queue/OverrideModal.tsx
+++ b/packages/web/src/components/queue/OverrideModal.tsx
@@ -12,16 +12,16 @@ export default function OverrideModal({
   onClose: () => void;
   onOverride: () => void;
 }) {
-  const [youtubeUrl, setYoutubeUrl] = useState('');
+  const [sourceUrl, setSourceUrl] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
 
   const handleSubmit = async () => {
-    if (!youtubeUrl.trim()) return;
+    if (!sourceUrl.trim()) return;
     setSubmitting(true);
     setError('');
     try {
-      await overridePlay(youtubeUrl.trim());
+      await overridePlay(sourceUrl.trim());
       onOverride();
     } catch (err: unknown) {
       setError(apiErrorMessage(err, 'Could not override playback. Is the bot in a voice channel?'));
@@ -41,20 +41,20 @@ export default function OverrideModal({
         <div className="space-y-4 mb-6">
           <div>
             <p className="font-mono text-xs text-muted mb-2 uppercase tracking-widest">
-              YouTube URL
+              Source URL
             </p>
             <input
               type="text"
-              value={youtubeUrl}
+              value={sourceUrl}
               onChange={(e) => {
-                setYoutubeUrl(e.target.value);
+                setSourceUrl(e.target.value);
                 setError('');
               }}
-              placeholder="https://youtube.com/watch?v=..."
+              placeholder="https://..."
               className="input w-full"
               disabled={submitting}
               onKeyDown={(e) => {
-                if (e.key === 'Enter' && youtubeUrl.trim()) {
+                if (e.key === 'Enter' && sourceUrl.trim()) {
                   handleSubmit();
                 }
               }}
@@ -85,7 +85,7 @@ export default function OverrideModal({
             variant="danger"
             type="button"
             onClick={handleSubmit}
-            disabled={submitting || !youtubeUrl.trim()}
+            disabled={submitting || !sourceUrl.trim()}
           >
             {submitting ? 'Overriding...' : 'Override & Play'}
           </Button>

--- a/packages/web/src/components/queue/QuickAddModal.tsx
+++ b/packages/web/src/components/queue/QuickAddModal.tsx
@@ -11,27 +11,27 @@ export default function QuickAddModal({
   onClose: () => void;
   onAdded: () => void;
 }) {
-  const [youtubeUrl, setYoutubeUrl] = useState('');
+  const [sourceUrl, setSourceUrl] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
   const [successMsg, setSuccessMsg] = useState('');
-  const isPlaylist = youtubeUrl.includes('list=');
+  const isPlaylist = sourceUrl.includes('list=');
   const [importFullPlaylist, setImportFullPlaylist] = useState(false);
 
   const handleSubmit = async () => {
-    if (!youtubeUrl.trim()) return;
+    if (!sourceUrl.trim()) return;
     setSubmitting(true);
     setError('');
     setSuccessMsg('');
     try {
       if (importFullPlaylist) {
-        const result = await quickAddPlaylistToQueue(youtubeUrl.trim());
+        const result = await quickAddPlaylistToQueue(sourceUrl.trim());
         setSuccessMsg(result.message);
         setTimeout(() => {
           onAdded();
         }, 1500);
       } else {
-        await quickAddToQueue(youtubeUrl.trim());
+        await quickAddToQueue(sourceUrl.trim());
         onAdded();
       }
     } catch (err: unknown) {
@@ -45,27 +45,27 @@ export default function QuickAddModal({
       <div className="p-5 md:p-6 w-full max-w-sm mx-4 modal-clay animate-fade-up">
         <h2 className="font-display text-2xl md:text-3xl text-fg tracking-wider mb-1">Quick Add</h2>
         <p className="font-mono text-xs text-muted mb-4 md:mb-6">
-          add a song to Up Next without saving to library
+          add a YouTube or SoundCloud url to Up Next without saving to library
         </p>
 
         <div className="space-y-4 mb-6">
           <div>
             <p className="font-mono text-xs text-muted mb-2 uppercase tracking-widest">
-              YouTube URL
+              Source URL
             </p>
             <input
               type="text"
-              value={youtubeUrl}
+              value={sourceUrl}
               onChange={(e) => {
-                setYoutubeUrl(e.target.value);
+                setSourceUrl(e.target.value);
                 setError('');
                 setSuccessMsg('');
               }}
-              placeholder="https://youtube.com/watch?v=..."
+              placeholder="https://..."
               className="input w-full"
               disabled={submitting}
               onKeyDown={(e) => {
-                if (e.key === 'Enter' && youtubeUrl.trim()) {
+                if (e.key === 'Enter' && sourceUrl.trim()) {
                   handleSubmit();
                 }
               }}
@@ -109,7 +109,7 @@ export default function QuickAddModal({
             variant="primary"
             type="button"
             onClick={handleSubmit}
-            disabled={submitting || !youtubeUrl.trim()}
+            disabled={submitting || !sourceUrl.trim()}
           >
             {submitting ? 'Adding...' : importFullPlaylist ? 'Add Playlist' : 'Add to Up Next'}
           </Button>

--- a/packages/web/src/hooks/useSongActions.tsx
+++ b/packages/web/src/hooks/useSongActions.tsx
@@ -99,7 +99,7 @@ export function useSongActions({
               id: 'open-link',
               label: 'Open Link',
               icon: <ArrowSquareOutIcon size={14} weight="duotone" />,
-              onClick: () => window.open(song.youtubeUrl, '_blank'),
+              onClick: () => window.open(song.sourceUrl, '_blank'),
             },
             // Delete + Requested By (library context, admin only)
             ...(isAdmin && onDelete
@@ -127,7 +127,7 @@ export function useSongActions({
     ],
     [
       onAddToQueue,
-      song.youtubeUrl,
+      song.sourceUrl,
       song.addedByDisplayName,
       song.addedBy,
       onRemove,


### PR DESCRIPTION
## Summary

Enables SoundCloud as a supported audio source and renames the YouTube-specific database fields to generic source fields, laying the groundwork for future sources like Spotify.

## Changes

- **DB schema**: rename `youtubeUrl` → `sourceUrl`, `youtubeId` → `sourceId` with migration
- **NodeLink config**: enable SoundCloud source plugin
- **Validation**: replace YouTube-only URL validation with allowlist-based validation (YouTube + SoundCloud); add explicit error messages listing supported sources
- **Thumbnails**: use NodeLink's `artworkUrl` when available (SoundCloud), fall back to YouTube thumbnails for YouTube sources
- **Duration**: fix floating-point precision by rounding to whole seconds
- **API**: rename all `youtubeUrl` params and request body fields to `url`
- **Frontend**: update all field references, input labels, placeholders, and descriptions