### PR TITLE
feat(web): replace sidebar logout button with user menu popover

### DIFF
--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { CaretLeftIcon, CraneTowerIcon, GuitarIcon, StairsIcon } from '@phosphor-icons/react';
+import { CaretLeftIcon, CraneTowerIcon, GuitarIcon } from '@phosphor-icons/react';
 import { useEffect, useState } from 'react';
 import { NavLink, Outlet, useNavigate } from 'react-router-dom';
 import { ADMIN_NAV_ITEMS, NAV_ITEMS } from '../constants';
@@ -10,7 +10,7 @@ import MobileNav from './MobileNav';
 import { NowPlayingBar } from './NowPlayingBar';
 import QueuePanel from './QueuePanel';
 import SettingsMenu from './SettingsMenu';
-import { Button } from './ui/Button';
+import UserMenu from './UserMenu';
 
 export default function Layout() {
   return (
@@ -230,68 +230,11 @@ function LayoutContent() {
         )}
 
         {/* User section */}
-        <div className="p-3">
-          {collapsed ? (
-            <div className="flex flex-col items-center gap-4">
-              <div
-                className="w-7 h-7 rounded-full bg-elevated flex items-center justify-center overflow-hidden"
-                title={user?.username}
-              >
-                {user?.avatar ? (
-                  <img
-                    src={user.avatar}
-                    alt={user.username}
-                    className="w-full h-full object-cover"
-                    decoding="async"
-                  />
-                ) : (
-                  <span className="font-mono text-sm text-muted">
-                    {user?.username?.[0]?.toUpperCase()}
-                  </span>
-                )}
-              </div>
-              <div className="flex justify-center px-2 pt-1">
-                <Button
-                  variant="danger"
-                  size="default"
-                  className="w-full! flex justify-center py-2.5! rounded-xl! min-h-0!"
-                  onClick={handleLogout}
-                  title="Log out"
-                >
-                  <StairsIcon size={16} weight="duotone" />
-                </Button>
-              </div>
-            </div>
-          ) : (
-            <>
-              <div className="flex items-center gap-3 px-2 py-2 mb-3">
-                {user?.avatar ? (
-                  <img
-                    src={user.avatar}
-                    alt={user.username}
-                    className="w-7 h-7 rounded-full"
-                    decoding="async"
-                  />
-                ) : (
-                  <div className="w-7 h-7 rounded-full bg-elevated flex items-center justify-center">
-                    <span className="font-mono text-sm text-muted">
-                      {user?.username?.[0]?.toUpperCase()}
-                    </span>
-                  </div>
-                )}
-                <span className="text-fg font-body truncate flex-1">{user?.username}</span>
-              </div>
-              <Button
-                variant="danger"
-                onClick={handleLogout}
-                className="flex items-center px-3 py-2 w-full"
-              >
-                <span className="mr-auto text-sm">log out</span>
-                <StairsIcon size={18} weight="duotone" />
-              </Button>
-            </>
-          )}
-        </div>
+        {user && (
+          <div className={collapsed ? 'px-2 py-3' : 'p-3'}>
+            <UserMenu user={user} collapsed={collapsed} onLogout={handleLogout} />
+          </div>
+        )}
       </aside>
 
       {/* ------------------------------------------------------------------ */}

--- a/packages/web/src/components/UserMenu.tsx
+++ b/packages/web/src/components/UserMenu.tsx
@@ -125,7 +125,11 @@ export default function UserMenu({ user, collapsed, onLogout }: UserMenuProps) {
         } ${open ? 'pressed text-accent' : ''}`}
         style={triggerSurfaceVar}
       >
-        {!collapsed && <span className="text-fg truncate mr-auto">{user.username}</span>}
+        {!collapsed && (
+          <span className={`truncate mr-auto ${open ? 'text-accent' : 'text-fg'}`}>
+            {user.username}
+          </span>
+        )}
         {avatar}
       </button>
 

--- a/packages/web/src/components/UserMenu.tsx
+++ b/packages/web/src/components/UserMenu.tsx
@@ -1,0 +1,167 @@
+import type { User } from '@alfira-bot/server/shared';
+import { SignOutIcon, UserIcon } from '@phosphor-icons/react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+interface UserMenuProps {
+  user: User;
+  collapsed: boolean;
+  onLogout: () => void;
+}
+
+export default function UserMenu({ user, collapsed, onLogout }: UserMenuProps) {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState({ top: 0, left: 0 });
+
+  // Position the popover above the trigger, falling back to below if needed
+  const updatePosition = useCallback(() => {
+    if (!triggerRef.current || !menuRef.current) return;
+    const trigger = triggerRef.current.getBoundingClientRect();
+    const menu = menuRef.current.getBoundingClientRect();
+    const gap = 8;
+
+    // Try above first
+    let top = trigger.top - menu.height - gap;
+    // Fall back to below the trigger if there isn't enough room above
+    if (top < gap) {
+      top = trigger.bottom + gap;
+    }
+    // Clamp to viewport
+    if (top + menu.height > window.innerHeight - gap) {
+      top = window.innerHeight - menu.height - gap;
+    }
+
+    let left = trigger.left + trigger.width / 2 - menu.width / 2;
+    if (left < gap) left = gap;
+    if (left + menu.width > window.innerWidth - gap) {
+      left = window.innerWidth - menu.width - gap;
+    }
+
+    setPosition({ top, left });
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    // Wait for the portal content to be in the DOM before measuring
+    requestAnimationFrame(() => {
+      updatePosition();
+      window.addEventListener('resize', updatePosition);
+      window.addEventListener('scroll', updatePosition, true);
+    });
+    return () => {
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+    };
+  }, [open, updatePosition]);
+
+  // Close on click outside
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent | TouchEvent) => {
+      const target = e.target as Node;
+      if (menuRef.current?.contains(target) || triggerRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    document.addEventListener('touchstart', handler);
+    return () => {
+      document.removeEventListener('mousedown', handler);
+      document.removeEventListener('touchstart', handler);
+    };
+  }, [open]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [open]);
+
+  const handleLogout = () => {
+    setOpen(false);
+    onLogout();
+  };
+
+  const avatarSize = collapsed ? 'size-[22px]' : 'w-7 h-7';
+  const avatarFallbackSize = collapsed ? 'text-[11px]' : 'text-sm';
+
+  const avatar = user.avatar ? (
+    <img
+      src={user.avatar}
+      alt={user.username}
+      className={`${avatarSize} rounded-full object-cover shrink-0`}
+      decoding="async"
+    />
+  ) : (
+    <div
+      className={`${avatarSize} rounded-full bg-elevated flex items-center justify-center shrink-0`}
+    >
+      <span className={`font-mono ${avatarFallbackSize} text-muted`}>
+        {user.username?.[0]?.toUpperCase()}
+      </span>
+    </div>
+  );
+
+  const triggerSurfaceVar = { '--btn-surface': 'var(--color-elevated)' } as React.CSSProperties;
+
+  return (
+    <>
+      {/* Trigger */}
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        title={user.username}
+        className={`flex items-center rounded-xl font-body transition-all duration-150 cursor-pointer w-full btn-inherit ${
+          collapsed ? 'justify-center px-0 py-3' : 'gap-3 px-3 py-2.5'
+        } ${open ? 'pressed text-accent' : ''}`}
+        style={triggerSurfaceVar}
+      >
+        {!collapsed && <span className="text-fg truncate mr-auto">{user.username}</span>}
+        {avatar}
+      </button>
+
+      {/* Popover — mirrors ContextMenu styling: bg-base, clay-floating, animate-fade-up */}
+      {open &&
+        createPortal(
+          <div
+            ref={menuRef}
+            role="menu"
+            style={{ position: 'fixed', top: position.top, left: position.left }}
+            className="z-9999 min-w-40"
+            onKeyDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="bg-base rounded-2xl clay-floating overflow-hidden animate-fade-up">
+              {/* Username header — mirrors ContextMenu InfoRow */}
+              <div className="px-3 py-1.5 text-xs font-mono text-muted flex items-center gap-2">
+                <UserIcon size={14} weight="duotone" className="shrink-0" />
+                <span className="truncate">{user.username}</span>
+              </div>
+              {/* Separator — mirrors ContextMenu separators */}
+              <div className="border-b border-muted/50" />
+              {/* Logout — mirrors ContextMenu MenuItemButton danger styling */}
+              <button
+                type="button"
+                role="menuitem"
+                onClick={handleLogout}
+                className="w-full text-left px-3 py-1.5 text-xs font-mono text-danger hover:bg-danger/10 flex items-center gap-2 transition-colors duration-100"
+              >
+                <SignOutIcon size={14} weight="duotone" className="shrink-0" />
+                <span>Log out</span>
+              </button>
+            </div>
+          </div>,
+          document.body
+        )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Replaces the always-visible danger-styled logout button in the sidebar user area with a clickable user menu popover. The avatar/username row is now a `btn-inherit` trigger that opens a compact dropdown with the username and a subtle logout option, matching the ContextMenu styling patterns.

## Changes

- New `UserMenu` component with trigger (avatar ± username) and popover menu
- Popover mirrors ContextMenu styling: `bg-base rounded-2xl clay-floating animate-fade-up`
- Trigger matches sidebar nav item styling in both collapsed and expanded modes
- Collapsed avatar sized to exactly 22px (matching sidebar icons) for pixel-perfect alignment
- Removed unused `StairsIcon` and `Button` imports from Layout