### PR TITLE
fix: prevent clearing all admin roles

### DIFF
--- a/packages/server/src/routes/generalSettings.ts
+++ b/packages/server/src/routes/generalSettings.ts
@@ -85,6 +85,9 @@ async function handlePatchGeneral(ctx: RouteContext, request: Request): Promise<
     if (typeof body.adminRoleIds !== 'string') {
       return json({ error: 'adminRoleIds must be a string' }, 400);
     }
+    if (body.adminRoleIds.trim().length === 0) {
+      return json({ error: 'adminRoleIds must not be empty' }, 400);
+    }
     updates.adminRoleIds = body.adminRoleIds;
   }
 

--- a/packages/web/src/components/settings/AdminTab.tsx
+++ b/packages/web/src/components/settings/AdminTab.tsx
@@ -106,8 +106,12 @@ export default function AdminTab() {
       .map((s) => s.trim())
       .filter(Boolean);
     const set = new Set(current);
-    if (set.has(id)) set.delete(id);
-    else set.add(id);
+    if (set.has(id)) {
+      if (set.size === 1) return; // Last one — can't remove.
+      set.delete(id);
+    } else {
+      set.add(id);
+    }
     setAdminRoleIds([...set].join(','));
   }
 
@@ -179,6 +183,9 @@ export default function AdminTab() {
                   }}
                 />
                 <span className="text-sm text-fg">{r.name}</span>
+                {selectedRoleIdSet.size === 1 && selectedRoleIdSet.has(r.id) && (
+                  <span className="text-xs text-muted ml-auto">(must keep at least one)</span>
+                )}
               </label>
             ))}
           </div>


### PR DESCRIPTION
## Summary

Block users from removing all admin roles via the settings page, which would cause a permanent lockout from admin settings.

## Changes

- **Web** — Added last-role guard in `AdminTab.tsx` toggleRole: deselecting the only remaining role is now a no-op, matching the existing pattern in toggleSource
- **Server** — Added validation in PATCH `/api/settings/general` to reject empty `adminRoleIds` with a 400 error