### PR TITLE
docs: fix incorrect logging entry in tech stack

### DIFF
--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -11,7 +11,7 @@
 | **API** | Bun native HTTP + WebSocket |
 | **Database** | SQLite + Drizzle ORM |
 | **Frontend** | React + Bun + Tailwind |
-| **Logging** | Pino |
+| **Logging** | Custom (shared/logger) |
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

Remove stale Pino reference from tech stack docs — replaced with the actual custom logger used by the project.

## Changes

- Replace `| **Logging** | Pino |` with `| **Logging** | Custom (shared/logger) |` in `docs/tech-stack.md`