### PR TITLE
feat(server): add role-based granular permissions with admin UI

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -31,6 +31,7 @@ import { handleAuth } from './routes/auth';
 import { handleCompressor } from './routes/compressor';
 import { handleEqualizer } from './routes/equalizer';
 import { handleGeneralSettings } from './routes/generalSettings';
+import { handlePermissions } from './routes/permissions';
 import { handlePlayer } from './routes/player';
 import { handlePlaylists } from './routes/playlists';
 import { handleSetup } from './routes/setup';
@@ -248,6 +249,9 @@ function startServer(): void {
       }
       if (url.pathname.startsWith('/api/settings/equalizer')) {
         return setSecurityHeaders(await handleEqualizer(ctx, request));
+      }
+      if (url.pathname.startsWith('/api/permissions')) {
+        return setSecurityHeaders(await handlePermissions(ctx, request));
       }
       if (url.pathname.startsWith('/api/settings/general')) {
         return setSecurityHeaders(await handleGeneralSettings(ctx, request));

--- a/packages/server/src/lib/routeGuards.ts
+++ b/packages/server/src/lib/routeGuards.ts
@@ -1,6 +1,9 @@
+import { and, eq, inArray } from 'drizzle-orm';
 import type { RouteContext } from '../index';
-import type { User } from '../shared';
+import type { PermissionAction, User } from '../shared';
+import { db, tables } from '../shared/db';
 import { requireAdmin, requireAuth } from './guards';
+import { json } from './json';
 import { requireUserInVoice } from './voice';
 
 interface GuardOptions {
@@ -13,6 +16,9 @@ interface GuardOptions {
   setupMode?: boolean;
   /** Require user is in a voice channel. Defaults to false. Requires auth. */
   voice?: boolean;
+  /** Granular permission action. When set with admin:true, super-admins bypass;
+   *  non-admin users are checked against the rolePermission table. */
+  permission?: PermissionAction;
 }
 
 interface GuardResult {
@@ -47,8 +53,20 @@ export async function checkGuards(
   }
 
   if (admin) {
-    const adminErr = requireAdmin(ctx);
-    if (adminErr) return adminErr;
+    // Super-admin bypass: users in adminRoleIds always pass.
+    if (ctx.isAdmin) {
+      // Fall through to voice check below.
+    } else if (options.permission) {
+      // Granular permission check for non-admin users.
+      const hasPermission = await checkRolePermission(user.roles ?? [], options.permission);
+      if (!hasPermission) {
+        return json({ error: 'You do not have permission to perform this action.' }, 403);
+      }
+    } else {
+      // No granular permission — super-admin only.
+      const adminErr = requireAdmin(ctx);
+      if (adminErr) return adminErr;
+    }
   }
 
   if (voice) {
@@ -57,4 +75,27 @@ export async function checkGuards(
   }
 
   return { user };
+}
+
+/**
+ * Check if any of the user's Discord roles have been granted a specific
+ * granular permission via the rolePermission table.
+ */
+async function checkRolePermission(
+  userRoles: string[],
+  action: PermissionAction
+): Promise<boolean> {
+  if (userRoles.length === 0) return false;
+
+  const rows = await db
+    .select({ roleId: tables.rolePermission.roleId })
+    .from(tables.rolePermission)
+    .where(
+      and(
+        eq(tables.rolePermission.action, action),
+        inArray(tables.rolePermission.roleId, userRoles)
+      )
+    );
+
+  return rows.length > 0;
 }

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -107,6 +107,8 @@ function generateAccessToken(payload: {
   username: string;
   avatar: string | null;
   isAdmin: boolean;
+  isSetupAdmin?: boolean;
+  roles?: string[];
 }): string {
   return jwt.sign(payload, JWT_SECRET_, {
     expiresIn: ACCESS_TOKEN_EXPIRES_IN,
@@ -219,7 +221,7 @@ async function fetchDiscordUserProfile(
 /** Returns null if the user is not in the guild or Discord is unreachable. */
 async function fetchUserAdminStatus(
   discordId: string
-): Promise<{ isAdmin: boolean; username: string; avatar: string | null } | null> {
+): Promise<{ isAdmin: boolean; username: string; avatar: string | null; roles: string[] } | null> {
   try {
     const userRes = await fetch(`https://discord.com/api/users/${discordId}`, {
       headers: { Authorization: `Bot ${DISCORD_BOT_TOKEN_}` },
@@ -237,6 +239,7 @@ async function fetchUserAdminStatus(
       isAdmin: await isAdminUser(roles),
       username,
       avatar: avatar ? `https://cdn.discordapp.com/avatars/${discordId}/${avatar}.png` : null,
+      roles,
     };
   } catch (err: unknown) {
     logger.error(
@@ -300,17 +303,25 @@ async function fetchDiscordIdentity(
 async function generateAndStoreTokens(
   discordUser: { id: string; username: string; avatar: string | null },
   isAdmin: boolean,
-  isSetupAdmin = false
+  opts: { isSetupAdmin?: boolean; roles?: string[] } = {}
 ): Promise<{ accessToken: string; refreshToken: string }> {
-  const payload = {
+  const payload: {
+    discordId: string;
+    username: string;
+    avatar: string | null;
+    isAdmin: boolean;
+    isSetupAdmin?: boolean;
+    roles?: string[];
+  } = {
     discordId: discordUser.id,
     username: discordUser.username,
     avatar: discordUser.avatar
       ? `https://cdn.discordapp.com/avatars/${discordUser.id}/${discordUser.avatar}.png`
       : null,
     isAdmin,
-    ...(isSetupAdmin ? { isSetupAdmin: true } : {}),
   };
+  if (opts.isSetupAdmin) payload.isSetupAdmin = true;
+  if (opts.roles) payload.roles = opts.roles;
   const accessToken = generateAccessToken(payload);
   const refreshToken = generateRefreshToken(discordUser.id);
 
@@ -436,7 +447,9 @@ async function handleCallback(request: Request, url: URL): Promise<Response> {
       // Fall through to normal auth flow below.
     } else {
       // Fresh install — redirect to setup wizard.
-      const { accessToken, refreshToken } = await generateAndStoreTokens(discordUser, true, true);
+      const { accessToken, refreshToken } = await generateAndStoreTokens(discordUser, true, {
+        isSetupAdmin: true,
+      });
 
       const headers = new Headers();
       headers.append(
@@ -463,7 +476,9 @@ async function handleCallback(request: Request, url: URL): Promise<Response> {
   const isAdmin = await isAdminUser(memberRoles);
 
   // 6. Generate and store tokens.
-  const { accessToken, refreshToken } = await generateAndStoreTokens(discordUser, isAdmin);
+  const { accessToken, refreshToken } = await generateAndStoreTokens(discordUser, isAdmin, {
+    roles: memberRoles,
+  });
 
   // 7. Set cookies and redirect.
   const headers = new Headers();
@@ -533,6 +548,7 @@ async function handleRefresh(ctx: RouteContext): Promise<Response> {
   let avatar: string | null;
   let isAdmin: boolean;
   let isSetupAdmin = false;
+  let roles: string[] | undefined;
 
   if (!setupDone) {
     // Setup not complete — fetch basic profile, grant admin.
@@ -555,16 +571,25 @@ async function handleRefresh(ctx: RouteContext): Promise<Response> {
     username = userInfo.username;
     avatar = userInfo.avatar;
     isAdmin = userInfo.isAdmin;
+    roles = userInfo.roles;
   }
 
   // 7. Generate new tokens.
-  const payload = {
+  const payload: {
+    discordId: string;
+    username: string;
+    avatar: string | null;
+    isAdmin: boolean;
+    isSetupAdmin?: boolean;
+    roles?: string[];
+  } = {
     discordId: decoded.discordId,
     username,
     avatar,
     isAdmin,
-    ...(isSetupAdmin ? { isSetupAdmin: true } : {}),
   };
+  if (isSetupAdmin) payload.isSetupAdmin = true;
+  if (roles) payload.roles = roles;
   const newAccessToken = generateAccessToken(payload);
   const newRefreshToken = generateRefreshToken(decoded.discordId);
 

--- a/packages/server/src/routes/compressor.ts
+++ b/packages/server/src/routes/compressor.ts
@@ -14,7 +14,7 @@ interface CompressorPayload {
 }
 
 export async function handleCompressor(ctx: RouteContext, request: Request): Promise<Response> {
-  const guards = await checkGuards(ctx, { admin: true });
+  const guards = await checkGuards(ctx, { admin: true, permission: 'audio.manage' });
   if (guards instanceof Response) return guards;
 
   let body: CompressorPayload;

--- a/packages/server/src/routes/equalizer.ts
+++ b/packages/server/src/routes/equalizer.ts
@@ -16,7 +16,7 @@ interface EqualizerPayload {
 }
 
 async function handleEqualizerGet(ctx: RouteContext): Promise<Response> {
-  const guards = await checkGuards(ctx, { admin: true });
+  const guards = await checkGuards(ctx, { admin: true, permission: 'audio.manage' });
   if (guards instanceof Response) return guards;
 
   const row = await db
@@ -31,7 +31,7 @@ async function handleEqualizerGet(ctx: RouteContext): Promise<Response> {
 }
 
 async function handleEqualizerPatch(ctx: RouteContext, request: Request): Promise<Response> {
-  const guards = await checkGuards(ctx, { admin: true });
+  const guards = await checkGuards(ctx, { admin: true, permission: 'audio.manage' });
   if (guards instanceof Response) return guards;
 
   let body: EqualizerPayload;

--- a/packages/server/src/routes/permissions.ts
+++ b/packages/server/src/routes/permissions.ts
@@ -1,0 +1,146 @@
+import { eq } from 'drizzle-orm';
+import type { RouteContext } from '../index';
+import { getGuildId } from '../lib/config';
+import { json } from '../lib/json';
+import { checkGuards } from '../lib/routeGuards';
+import { PERMISSION_CATEGORIES, PERMISSION_LABELS, type PermissionAction } from '../shared';
+import { db, tables } from '../shared/db';
+import { logger } from '../shared/logger';
+import type { SetupRole } from '../shared/types';
+
+const DISCORD_API = 'https://discord.com/api/v10';
+
+function botHeaders(): Record<string, string> {
+  const token = process.env.DISCORD_BOT_TOKEN;
+  if (!token) throw new Error('DISCORD_BOT_TOKEN not set');
+  return { Authorization: `Bot ${token}` };
+}
+
+async function fetchGuildRoles(): Promise<SetupRole[]> {
+  const guildId = getGuildId();
+  if (!guildId) return [];
+
+  try {
+    const res = await fetch(`${DISCORD_API}/guilds/${guildId}/roles`, {
+      headers: botHeaders(),
+    });
+
+    if (!res.ok) {
+      logger.error({ guildId, status: res.status }, 'Failed to fetch guild roles for permissions');
+      return [];
+    }
+
+    const roles = (await res.json()) as Array<{
+      id: string;
+      name: string;
+      color: number;
+      managed: boolean;
+    }>;
+
+    return roles
+      .filter((r) => r.id !== guildId && !r.managed)
+      .map((r) => ({
+        id: r.id,
+        name: r.name,
+        color: r.color,
+      }));
+  } catch (err) {
+    logger.error({ err }, 'Error fetching guild roles for permissions');
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/permissions
+// ---------------------------------------------------------------------------
+async function handleGetPermissions(ctx: RouteContext): Promise<Response> {
+  const guards = await checkGuards(ctx, { admin: true });
+  if (guards instanceof Response) return guards;
+
+  const [allRows, roles, settingsRow] = await Promise.all([
+    db.select().from(tables.rolePermission),
+    fetchGuildRoles(),
+    db
+      .select({ adminRoleIds: tables.guildSettings.adminRoleIds })
+      .from(tables.guildSettings)
+      .where(eq(tables.guildSettings.id, 1))
+      .get(),
+  ]);
+
+  // Filter out roles that are already super-admins (implied full access).
+  const adminRoleIdSet = new Set(
+    (settingsRow?.adminRoleIds ?? '')
+      .split(',')
+      .map((id) => id.trim())
+      .filter(Boolean)
+  );
+  const filteredRoles = roles.filter((r) => !adminRoleIdSet.has(r.id));
+
+  // Build mapping: action → roleIds
+  const mapping: Record<string, string[]> = {};
+  for (const row of allRows) {
+    if (!mapping[row.action]) mapping[row.action] = [];
+    mapping[row.action].push(row.roleId);
+  }
+
+  return json({
+    mapping,
+    roles: filteredRoles,
+    categories: PERMISSION_CATEGORIES,
+    labels: PERMISSION_LABELS,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// PATCH /api/permissions
+// Body: { action: PermissionAction; roleIds: string[] }
+// ---------------------------------------------------------------------------
+async function handlePatchPermissions(ctx: RouteContext, request: Request): Promise<Response> {
+  const guards = await checkGuards(ctx, { admin: true });
+  if (guards instanceof Response) return guards;
+
+  let body: { action?: unknown; roleIds?: unknown };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return json({ error: 'Invalid JSON body.' }, 400);
+  }
+
+  if (typeof body.action !== 'string') {
+    return json({ error: 'action (string) is required.' }, 400);
+  }
+
+  if (!Array.isArray(body.roleIds) || body.roleIds.some((id) => typeof id !== 'string')) {
+    return json({ error: 'roleIds must be an array of strings.' }, 400);
+  }
+
+  const action = body.action;
+  const roleIds = body.roleIds as string[];
+
+  // Validate the action is a known permission.
+  if (!PERMISSION_LABELS[action as PermissionAction]) {
+    return json({ error: `Unknown permission action: ${action}` }, 400);
+  }
+
+  // Replace the role set for this action in a transaction.
+  await db.transaction(async (tx) => {
+    // Delete existing entries for this action.
+    await tx.delete(tables.rolePermission).where(eq(tables.rolePermission.action, action));
+
+    // Insert new entries.
+    if (roleIds.length > 0) {
+      await tx.insert(tables.rolePermission).values(roleIds.map((roleId) => ({ action, roleId })));
+    }
+  });
+
+  return json({ action, roleIds });
+}
+
+// ---------------------------------------------------------------------------
+// Dispatcher
+// ---------------------------------------------------------------------------
+export async function handlePermissions(ctx: RouteContext, request: Request): Promise<Response> {
+  if (request.method === 'GET') return await handleGetPermissions(ctx);
+  if (request.method === 'PATCH') return await handlePatchPermissions(ctx, request);
+  return json({ error: 'Not Found' }, 404);
+}

--- a/packages/server/src/routes/player.ts
+++ b/packages/server/src/routes/player.ts
@@ -196,7 +196,7 @@ async function handleLoop(ctx: RouteContext, request: Request): Promise<Response
 // POST /api/player/shuffle — shuffle queue (admin only)
 // ---------------------------------------------------------------------------
 async function handleShuffle(ctx: RouteContext): Promise<Response> {
-  const guards = await checkGuards(ctx, { admin: true, voice: true });
+  const guards = await checkGuards(ctx, { admin: true, voice: true, permission: 'queue.shuffle' });
   if (guards instanceof Response) return guards;
 
   const player = getPlayer(getGuildId());
@@ -213,7 +213,7 @@ async function handleShuffle(ctx: RouteContext): Promise<Response> {
 // POST /api/player/unshuffle — restore original queue order (admin only)
 // ---------------------------------------------------------------------------
 async function handleUnshuffle(ctx: RouteContext): Promise<Response> {
-  const guards = await checkGuards(ctx, { admin: true, voice: true });
+  const guards = await checkGuards(ctx, { admin: true, voice: true, permission: 'queue.shuffle' });
   if (guards instanceof Response) return guards;
 
   const playerResult = requirePlayer();
@@ -231,8 +231,12 @@ type UrlTempSongResult =
   | { ok: true; player: GuildPlayer; queuedSong: QueuedSong; metadataTitle: string }
   | { ok: false; response: Response };
 
-async function resolveUrlTempSong(ctx: RouteContext, request: Request): Promise<UrlTempSongResult> {
-  const guards = await checkGuards(ctx, { admin: true, voice: true });
+async function resolveUrlTempSong(
+  ctx: RouteContext,
+  request: Request,
+  permission: 'queue.quickadd' | 'queue.manage'
+): Promise<UrlTempSongResult> {
+  const guards = await checkGuards(ctx, { admin: true, voice: true, permission });
   if (guards instanceof Response) return { ok: false, response: guards };
   const { user } = guards;
 
@@ -274,7 +278,7 @@ async function resolveUrlTempSong(ctx: RouteContext, request: Request): Promise<
 // POST /api/player/quick-add — add YouTube URL to priority queue (admin only)
 // ---------------------------------------------------------------------------
 async function handleQuickAdd(ctx: RouteContext, request: Request): Promise<Response> {
-  const result = await resolveUrlTempSong(ctx, request);
+  const result = await resolveUrlTempSong(ctx, request, 'queue.quickadd');
   if (!result.ok) return result.response;
   await result.player.addToPriorityQueue(result.queuedSong);
   return json({
@@ -287,7 +291,7 @@ async function handleQuickAdd(ctx: RouteContext, request: Request): Promise<Resp
 // POST /api/player/quick-add-playlist — add playlist to queue (admin only)
 // ---------------------------------------------------------------------------
 async function handleQuickAddPlaylist(ctx: RouteContext, request: Request): Promise<Response> {
-  const guards = await checkGuards(ctx, { admin: true, voice: true });
+  const guards = await checkGuards(ctx, { admin: true, voice: true, permission: 'queue.quickadd' });
   if (guards instanceof Response) return guards;
   const { user } = guards;
 
@@ -381,7 +385,7 @@ async function handleSeek(ctx: RouteContext, request: Request): Promise<Response
 // POST /api/player/clear — clear queue (admin only)
 // ---------------------------------------------------------------------------
 async function handleClear(ctx: RouteContext): Promise<Response> {
-  const guards = await checkGuards(ctx, { admin: true, voice: true });
+  const guards = await checkGuards(ctx, { admin: true, voice: true, permission: 'queue.clear' });
   if (guards instanceof Response) return guards;
 
   const playerResult = requirePlayer();
@@ -395,7 +399,7 @@ async function handleClear(ctx: RouteContext): Promise<Response> {
 // POST /api/player/add-to-priority — add library song to Up Next (admin only)
 // ---------------------------------------------------------------------------
 async function handleAddToPriority(ctx: RouteContext, request: Request): Promise<Response> {
-  const guards = await checkGuards(ctx, { admin: true, voice: true });
+  const guards = await checkGuards(ctx, { admin: true, voice: true, permission: 'queue.manage' });
   if (guards instanceof Response) return guards;
   const { user } = guards;
 
@@ -444,7 +448,7 @@ async function handleAddToPriority(ctx: RouteContext, request: Request): Promise
 // POST /api/player/override — immediately play YouTube URL (admin only)
 // ---------------------------------------------------------------------------
 async function handleOverride(ctx: RouteContext, request: Request): Promise<Response> {
-  const result = await resolveUrlTempSong(ctx, request);
+  const result = await resolveUrlTempSong(ctx, request, 'queue.manage');
   if (!result.ok) return result.response;
   await result.player.replaceQueueAndPlay([result.queuedSong]);
   return json({

--- a/packages/server/src/routes/songs.ts
+++ b/packages/server/src/routes/songs.ts
@@ -76,7 +76,7 @@ async function handleGetSongs(ctx: RouteContext, request: Request): Promise<Resp
 // POST /api/songs — add a song by source URL. Admin only.
 // ---------------------------------------------------------------------------
 async function handlePostSong(ctx: RouteContext, request: Request): Promise<Response> {
-  const guards = await checkGuards(ctx, { admin: true });
+  const guards = await checkGuards(ctx, { admin: true, permission: 'songs.add' });
   if (guards instanceof Response) return guards;
   const { user } = guards;
 
@@ -161,7 +161,7 @@ async function handlePostSong(ctx: RouteContext, request: Request): Promise<Resp
 // POST /api/songs/import-playlist — import playlist. Admin only.
 // ---------------------------------------------------------------------------
 async function handleImportPlaylist(ctx: RouteContext, request: Request): Promise<Response> {
-  const guards = await checkGuards(ctx, { admin: true });
+  const guards = await checkGuards(ctx, { admin: true, permission: 'songs.import' });
   if (guards instanceof Response) return guards;
   const { user } = guards;
 
@@ -275,7 +275,7 @@ async function handleDeleteSong(
   _request: Request,
   id: string
 ): Promise<Response> {
-  const guards = await checkGuards(ctx, { admin: true });
+  const guards = await checkGuards(ctx, { admin: true, permission: 'songs.delete' });
   if (guards instanceof Response) return guards;
 
   const [existing] = await db.select().from(songTable).where(eq(songTable.id, id)).limit(1);
@@ -295,7 +295,7 @@ async function handleDeleteSong(
 // PATCH /api/songs/:id — update song fields. Admin only.
 // ---------------------------------------------------------------------------
 async function handlePatchSong(ctx: RouteContext, request: Request, id: string): Promise<Response> {
-  const guards = await checkGuards(ctx, { admin: true });
+  const guards = await checkGuards(ctx, { admin: true, permission: 'songs.edit' });
   if (guards instanceof Response) return guards;
 
   let body: Record<string, unknown>;

--- a/packages/server/src/routes/tags.ts
+++ b/packages/server/src/routes/tags.ts
@@ -29,7 +29,7 @@ async function handlePatchTag(
   nameLower: string,
   body: Record<string, unknown>
 ): Promise<Response> {
-  const guards = await checkGuards(ctx, { admin: true });
+  const guards = await checkGuards(ctx, { admin: true, permission: 'tags.manage' });
   if (guards instanceof Response) return guards;
 
   const [existing] = await db
@@ -74,7 +74,7 @@ async function handlePatchTag(
 }
 
 async function handleDeleteTag(ctx: RouteContext, nameLower: string): Promise<Response> {
-  const guards = await checkGuards(ctx, { admin: true });
+  const guards = await checkGuards(ctx, { admin: true, permission: 'tags.manage' });
   if (guards instanceof Response) return guards;
 
   const [existing] = await db

--- a/packages/server/src/shared/api.ts
+++ b/packages/server/src/shared/api.ts
@@ -398,3 +398,25 @@ export type GeneralSettingsUpdate = Partial<
 export function updateGeneralSettings(data: GeneralSettingsUpdate): Promise<GeneralSettings> {
   return patch('/api/settings/general', data);
 }
+
+// ---------------------------------------------------------------------------
+// Permissions API Functions
+// ---------------------------------------------------------------------------
+
+export interface PermissionsResponse {
+  mapping: Record<string, string[]>;
+  roles: { id: string; name: string; color: number }[];
+  categories: { label: string; actions: string[] }[];
+  labels: Record<string, string>;
+}
+
+export function fetchPermissions(): Promise<PermissionsResponse> {
+  return get('/api/permissions');
+}
+
+export function updatePermission(
+  action: string,
+  roleIds: string[]
+): Promise<{ action: string; roleIds: string[] }> {
+  return patch('/api/permissions', { action, roleIds });
+}

--- a/packages/server/src/shared/db/index.ts
+++ b/packages/server/src/shared/db/index.ts
@@ -33,6 +33,7 @@ export const tables = {
   refreshToken: schema.refreshToken,
   tag: schema.tag,
   guildSettings: schema.guildSettings,
+  rolePermission: schema.rolePermission,
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/shared/db/migrations/0056_add_role_permissions.sql
+++ b/packages/server/src/shared/db/migrations/0056_add_role_permissions.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `rolePermission` (
+  `action` text NOT NULL,
+  `roleId` text NOT NULL,
+  PRIMARY KEY (`action`, `roleId`)
+);

--- a/packages/server/src/shared/db/schema.ts
+++ b/packages/server/src/shared/db/schema.ts
@@ -1,4 +1,12 @@
-import { index, integer, real, sqliteTable, text, unique } from 'drizzle-orm/sqlite-core';
+import {
+  index,
+  integer,
+  primaryKey,
+  real,
+  sqliteTable,
+  text,
+  unique,
+} from 'drizzle-orm/sqlite-core';
 
 export const song = sqliteTable('Song', {
   id: text('id')
@@ -110,3 +118,12 @@ export const guildSettings = sqliteTable('guildSettings', {
   publicUrl: text('publicUrl'),
   enabledSources: text('enabledSources').notNull().default('youtube,soundcloud'),
 });
+
+export const rolePermission = sqliteTable(
+  'rolePermission',
+  {
+    action: text('action').notNull(),
+    roleId: text('roleId').notNull(),
+  },
+  (t) => [primaryKey({ columns: [t.action, t.roleId] })]
+);

--- a/packages/server/src/shared/index.ts
+++ b/packages/server/src/shared/index.ts
@@ -8,6 +8,7 @@ export type {
   LoopMode,
   PaginatedResult,
   PaginationMeta,
+  PermissionAction,
   Playlist,
   PlaylistDetail,
   QueuedSong,
@@ -18,4 +19,8 @@ export type {
   SetupStatus,
   Song,
   User,
+} from './types';
+export {
+  PERMISSION_CATEGORIES,
+  PERMISSION_LABELS,
 } from './types';

--- a/packages/server/src/shared/types.ts
+++ b/packages/server/src/shared/types.ts
@@ -213,4 +213,53 @@ export interface User {
   isAdmin: boolean;
   /** Temporarily granted during first-run setup before admin roles are configured. */
   isSetupAdmin?: boolean;
+  /** Discord role IDs the user has in the guild. Used for granular permission checks. */
+  roles?: string[];
 }
+
+// ---------------------------------------------------------------------------
+// Permissions
+// ---------------------------------------------------------------------------
+
+/** Granular permission actions that can be delegated to non-admin roles. */
+export type PermissionAction =
+  | 'songs.add'
+  | 'songs.edit'
+  | 'songs.delete'
+  | 'songs.import'
+  | 'queue.clear'
+  | 'queue.shuffle'
+  | 'queue.quickadd'
+  | 'queue.manage'
+  | 'tags.manage'
+  | 'audio.manage';
+
+/** Human-readable labels for each permission action. */
+export const PERMISSION_LABELS: Record<PermissionAction, string> = {
+  'songs.add': 'Add songs to library',
+  'songs.edit': 'Edit song metadata',
+  'songs.delete': 'Delete songs',
+  'songs.import': 'Import external playlists',
+  'queue.clear': 'Clear the queue',
+  'queue.shuffle': 'Shuffle / unshuffle queue',
+  'queue.quickadd': 'Quick-add external URLs',
+  'queue.manage': 'Add to Up Next / override',
+  'tags.manage': 'Manage tags',
+  'audio.manage': 'Audio settings (EQ & compressor)',
+};
+
+/** Categories for grouping permissions in the UI. */
+export const PERMISSION_CATEGORIES: { label: string; actions: PermissionAction[] }[] = [
+  {
+    label: 'Library',
+    actions: ['songs.add', 'songs.edit', 'songs.delete', 'songs.import'],
+  },
+  {
+    label: 'Playback',
+    actions: ['queue.clear', 'queue.shuffle', 'queue.quickadd', 'queue.manage'],
+  },
+  {
+    label: 'Management',
+    actions: ['tags.manage', 'audio.manage'],
+  },
+];

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -11,6 +11,7 @@ import { TagsProvider } from './context/TagsContext';
 import { ThemeProvider } from './context/ThemeContext';
 import AudioPage from './pages/AudioPage';
 import LoginPage from './pages/LoginPage';
+import PermissionsPage from './pages/PermissionsPage';
 import PlaylistDetailPage from './pages/PlaylistDetailPage';
 import PlaylistsPage from './pages/PlaylistsPage';
 import SetupWizard from './pages/SetupWizard';
@@ -53,6 +54,7 @@ export default function App() {
                     <Route path="settings" element={<SettingsPage />} />
                     <Route path="audio" element={<AudioPage />} />
                     <Route path="tags" element={<TagsPage />} />
+                    <Route path="permissions" element={<PermissionsPage />} />
                   </Route>
                   <Route path="*" element={<Navigate to="/" replace />} />
                 </Routes>

--- a/packages/web/src/api/api.ts
+++ b/packages/web/src/api/api.ts
@@ -15,6 +15,7 @@ export type {
 export type {
   CompleteSetupPayload,
   GeneralSettingsUpdate,
+  PermissionsResponse,
 } from '@alfira-bot/server/shared/api';
 // ---------------------------------------------------------------------------
 // Re-export everything from shared API with web-compatible names
@@ -32,6 +33,7 @@ export {
   fetchLogout as logout,
   // Auth
   fetchMe as getMe,
+  fetchPermissions,
   fetchPlaylistPage as getPlaylistPage,
   // Playlists
   fetchPlaylists as getPlaylists,
@@ -62,4 +64,5 @@ export {
   togglePlaylistVisibility,
   unshuffleQueue,
   updateGeneralSettings,
+  updatePermission,
 } from '@alfira-bot/server/shared/api';

--- a/packages/web/src/constants.ts
+++ b/packages/web/src/constants.ts
@@ -1,6 +1,7 @@
 import {
   MusicNotesIcon,
   PlaylistIcon,
+  ShieldCheckIcon,
   SlidersHorizontalIcon,
   TagIcon,
 } from '@phosphor-icons/react';
@@ -13,4 +14,5 @@ export const NAV_ITEMS = [
 export const ADMIN_NAV_ITEMS = [
   { to: '/audio', label: 'Audio', icon: SlidersHorizontalIcon },
   { to: '/tags', label: 'Tags', icon: TagIcon },
+  { to: '/permissions', label: 'Permissions', icon: ShieldCheckIcon },
 ];

--- a/packages/web/src/pages/PermissionsPage.tsx
+++ b/packages/web/src/pages/PermissionsPage.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useState } from 'react';
+import { fetchPermissions, type PermissionsResponse, updatePermission } from '../api/api';
+
+export default function PermissionsPage() {
+  const [data, setData] = useState<PermissionsResponse | null>(null);
+  const [mapping, setMapping] = useState<Record<string, string[]>>({});
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const result = await fetchPermissions();
+        setData(result);
+        setMapping(result.mapping);
+      } catch {
+        setError('Could not load permissions.');
+      }
+    }
+    load();
+  }, []);
+
+  function toggleRole(action: string, roleId: string) {
+    setMapping((prev) => {
+      const current = new Set(prev[action] ?? []);
+      if (current.has(roleId)) {
+        current.delete(roleId);
+      } else {
+        current.add(roleId);
+      }
+      return { ...prev, [action]: [...current] };
+    });
+  }
+
+  async function handleSave() {
+    if (!data) return;
+    setSaving(true);
+    setError(null);
+    setSuccessMsg(null);
+
+    try {
+      // Save each action's role assignments
+      const actions = data.categories.flatMap((c) => c.actions);
+      await Promise.all(actions.map((action) => updatePermission(action, mapping[action] ?? [])));
+      setSuccessMsg('Permissions saved.');
+      setTimeout(() => setSuccessMsg(null), 3000);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to save permissions.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!data) {
+    return (
+      <div className="p-4 md:p-8">
+        <div className="mb-6 md:mb-8">
+          <h1 className="font-display text-3xl md:text-4xl text-fg tracking-wider">Permissions</h1>
+        </div>
+        {error ? (
+          <div className="p-3 rounded-lg bg-danger/10 border border-danger/20 text-danger text-sm">
+            {error}
+          </div>
+        ) : (
+          <p className="text-sm text-muted">Loading…</p>
+        )}
+      </div>
+    );
+  }
+
+  const { roles, categories, labels } = data;
+
+  return (
+    <div className="p-4 md:p-8">
+      {/* Page header */}
+      <div className="mb-6 md:mb-8">
+        <h1 className="font-display text-3xl md:text-4xl text-fg tracking-wider">Permissions</h1>
+        <p className="text-xs text-muted mt-1">
+          Grant specific abilities to non-admin roles. Super-admins always have full access.
+        </p>
+      </div>
+
+      {error && (
+        <div className="mb-4 p-3 rounded-lg bg-danger/10 border border-danger/20 text-danger text-sm">
+          {error}
+        </div>
+      )}
+
+      {successMsg && (
+        <div className="mb-4 p-3 rounded-lg bg-accent/10 border border-accent/20 text-accent text-sm">
+          {successMsg}
+        </div>
+      )}
+
+      <div className="space-y-6">
+        {categories.map((category) => (
+          <section key={category.label}>
+            <h2 className="font-mono text-xs text-muted uppercase tracking-wider mb-3">
+              {category.label}
+            </h2>
+            <div className="bg-elevated border border-border rounded-xl p-5 space-y-4">
+              {category.actions.map((action) => (
+                <div key={action} className="space-y-2">
+                  <h3 className="text-sm text-fg font-medium">{labels[action] ?? action}</h3>
+                  {roles.length === 0 ? (
+                    <p className="text-xs text-muted italic">No roles available.</p>
+                  ) : (
+                    <div className="flex flex-wrap gap-2">
+                      {roles.map((role) => {
+                        const isSelected = (mapping[action] ?? []).includes(role.id);
+                        return (
+                          <label
+                            key={role.id}
+                            className={`flex items-center gap-2 px-3 py-1.5 rounded-lg border cursor-pointer transition-colors text-sm ${
+                              isSelected
+                                ? 'border-accent bg-accent/5'
+                                : 'border-border hover:border-muted'
+                            }`}
+                          >
+                            <input
+                              type="checkbox"
+                              checked={isSelected}
+                              onChange={() => toggleRole(action, role.id)}
+                              className="accent-accent"
+                            />
+                            <span
+                              className="w-2 h-2 rounded-full shrink-0"
+                              style={{
+                                backgroundColor: role.color
+                                  ? `#${role.color.toString(16).padStart(6, '0')}`
+                                  : 'var(--color-muted)',
+                              }}
+                            />
+                            <span>{role.name}</span>
+                          </label>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+
+      {/* Save */}
+      <div className="flex gap-3 pt-6 justify-end">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saving}
+          className={`font-body text-sm px-4 py-1.5 rounded transition-colors ${
+            !saving
+              ? 'bg-accent text-elevated cursor-pointer'
+              : 'bg-elevated text-muted cursor-not-allowed'
+          }`}
+        >
+          {saving ? 'Saving…' : 'Save Changes'}
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a role-based permissions system that lets super-admins delegate specific abilities (add songs, clear queue, manage tags, etc.) to non-admin Discord roles via a new Permissions page in the web UI.

Super-admins (roles in adminRoleIds) retain full access and bypass all granular checks. The existing admin role configuration in setup/settings is unchanged.

## Changes

### Database
- New `rolePermission` table with composite PK (action, roleId)
- Migration `0056_add_role_permissions.sql`

### Server
- 10 granular `PermissionAction` types grouped into 3 categories (Library, Playback, Management)
- JWT now carries `roles: string[]` from Discord for permission lookups
- `checkGuards` accepts optional `permission` parameter — super-admins bypass, non-admins checked against `rolePermission` table
- New `GET/PATCH /api/permissions` endpoints (super-admin only)
- 8 existing route guards updated from binary admin to granular permission checks
- Super-admin roles filtered out of permissions page role picker

### Web
- New `/permissions` page in admin sidebar (ShieldCheck icon)
- Grouped by category with per-action role checkboxes
- Single save button

### Intentionally not covered
- Playlist endpoints use ownership model, not admin guards
- Skip/pause/loop/seek are available to all authenticated users