### PR TITLE
feat: add tag-associated smart playlists

### DIFF
--- a/packages/server/src/lib/syncPlaylistToTag.ts
+++ b/packages/server/src/lib/syncPlaylistToTag.ts
@@ -1,0 +1,46 @@
+import { eq, sql } from 'drizzle-orm';
+import { db, tables } from '../shared/db';
+
+const { playlistSong: playlistSongTable, playlist: playlistTable, song: songTable } = tables;
+
+/**
+ * Replaces all songs in a smart playlist with the current set of songs
+ * matching the playlist's tracked tag. Runs in a transaction.
+ *
+ * Returns the playlist with updated song count for socket emission.
+ */
+export async function syncPlaylistToTag(
+  playlistId: string
+): Promise<typeof playlistTable.$inferSelect | null> {
+  const [playlist] = await db
+    .select()
+    .from(playlistTable)
+    .where(eq(playlistTable.id, playlistId))
+    .limit(1);
+
+  if (!playlist?.tagNameLower) return null;
+
+  await db.transaction(async (tx) => {
+    // Remove all existing playlist-song entries
+    await tx.delete(playlistSongTable).where(eq(playlistSongTable.playlistId, playlistId));
+
+    // Find all songs matching the tag and insert them
+    const songs = await tx
+      .select()
+      .from(songTable)
+      .where(sql`lower(${songTable.tags}) LIKE lower(${`%${playlist.tagNameLower}%`})`)
+      .orderBy(songTable.title);
+
+    if (songs.length === 0) return;
+
+    await tx.insert(playlistSongTable).values(
+      songs.map((song, index) => ({
+        playlistId,
+        songId: song.id,
+        position: index,
+      }))
+    );
+  });
+
+  return playlist;
+}

--- a/packages/server/src/routes/playlists.ts
+++ b/packages/server/src/routes/playlists.ts
@@ -8,6 +8,7 @@ import { checkRateLimit, getClientIp, rateLimitResponse } from '../lib/rateLimit
 import { checkGuards } from '../lib/routeGuards';
 import { buildSongSearchClause } from '../lib/search';
 import { emitPlaylistUpdated } from '../lib/socket';
+import { syncPlaylistToTag } from '../lib/syncPlaylistToTag';
 import { validatePlaylistName } from '../lib/validation';
 import { db, tables } from '../shared/db';
 
@@ -26,6 +27,7 @@ type PlaylistRow = {
   name: string;
   createdBy: string;
   isPrivate: boolean;
+  tagNameLower: string | null;
   createdAt: Date;
   _count?: { songs: number };
 };
@@ -37,6 +39,7 @@ async function findPlaylistOr404(id: string, withCount = false): Promise<Playlis
       name: playlistTable.name,
       createdBy: playlistTable.createdBy,
       isPrivate: playlistTable.isPrivate,
+      tagNameLower: playlistTable.tagNameLower,
       createdAt: playlistTable.createdAt,
     })
     .from(playlistTable)
@@ -132,7 +135,7 @@ async function handlePostPlaylist(ctx: RouteContext, request: Request): Promise<
   if (guards instanceof Response) return guards;
   const { user } = guards;
 
-  let body: { name?: unknown };
+  let body: { name?: unknown; tagNameLower?: unknown };
   try {
     body = (await request.json()) as typeof body;
   } catch {
@@ -143,11 +146,17 @@ async function handlePostPlaylist(ctx: RouteContext, request: Request): Promise<
   if (!nameResult.ok) return nameResult.response;
   const trimmedName = nameResult.value;
 
+  const tagNameLower =
+    typeof body.tagNameLower === 'string' && body.tagNameLower.trim().length > 0
+      ? body.tagNameLower.trim().toLowerCase()
+      : null;
+
   const [playlist] = await db
     .insert(playlistTable)
     .values({
       name: trimmedName,
       createdBy: user.discordId,
+      tagNameLower,
     })
     .returning();
 
@@ -155,7 +164,13 @@ async function handlePostPlaylist(ctx: RouteContext, request: Request): Promise<
     return json({ error: 'Failed to create playlist.' }, 500);
   }
 
-  emitPlaylistUpdated(formatPlaylist(playlist, 0));
+  // If smart playlist, populate with matching songs
+  if (tagNameLower) {
+    await syncPlaylistToTag(playlist.id);
+  }
+
+  const songCount = await getPlaylistSongCount(playlist.id);
+  emitPlaylistUpdated(formatPlaylist(playlist, songCount));
   return json(playlist, 201);
 }
 
@@ -326,16 +341,12 @@ async function handlePatchPlaylist(
   if (guards instanceof Response) return guards;
   const { user } = guards;
 
-  let body: { name?: unknown };
+  let body: { name?: unknown; tagNameLower?: unknown };
   try {
     body = (await request.json()) as typeof body;
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
-
-  const nameResult = validatePlaylistName(body.name);
-  if (!nameResult.ok) return nameResult.response;
-  const trimmedName = nameResult.value;
 
   const existing = await findPlaylistOr404(id);
   if (!existing) {
@@ -347,14 +358,39 @@ async function handlePatchPlaylist(
     return json({ error: `Only the playlist owner or admins can rename this playlist.` }, 403);
   }
 
+  const data: Record<string, unknown> = {};
+
+  if (body.name !== undefined) {
+    const nameResult = validatePlaylistName(body.name);
+    if (!nameResult.ok) return nameResult.response;
+    data.name = nameResult.value;
+  }
+
+  if (body.tagNameLower !== undefined) {
+    if (body.tagNameLower === null || body.tagNameLower === '') {
+      data.tagNameLower = null;
+    } else if (typeof body.tagNameLower === 'string' && body.tagNameLower.trim().length > 0) {
+      data.tagNameLower = body.tagNameLower.trim().toLowerCase();
+    }
+  }
+
+  if (Object.keys(data).length === 0) {
+    return json({ error: 'No valid fields to update.' }, 400);
+  }
+
   const [updatedPlaylist] = await db
     .update(playlistTable)
-    .set({ name: trimmedName })
+    .set(data)
     .where(eq(playlistTable.id, id))
     .returning();
 
   if (!updatedPlaylist) {
     return json({ error: 'Failed to update playlist.' }, 500);
+  }
+
+  // If tag was set or changed, sync songs to tag
+  if ('tagNameLower' in data) {
+    await syncPlaylistToTag(updatedPlaylist.id);
   }
 
   const value = await getPlaylistSongCount(updatedPlaylist.id);
@@ -412,6 +448,19 @@ async function handleAddSong(ctx: RouteContext, request: Request, id: string): P
   const playlist = await findPlaylistOr404(id);
   if (!playlist) {
     return json({ error: 'Playlist not found.' }, 404);
+  }
+
+  // Smart playlists are auto-managed — reject manual adds
+  if (playlist.tagNameLower) {
+    return json(
+      {
+        error:
+          'This playlist automatically tracks the "' +
+          playlist.tagNameLower +
+          '" tag. Songs are added when tagged and cannot be added manually.',
+      },
+      409
+    );
   }
 
   const accessResult = canAccessPlaylist(playlist, user, undefined);

--- a/packages/server/src/routes/songs.ts
+++ b/packages/server/src/routes/songs.ts
@@ -1,4 +1,4 @@
-import { eq, inArray, or, sql } from 'drizzle-orm';
+import { and, eq, inArray, or, sql } from 'drizzle-orm';
 import type { RouteContext } from '../index';
 import { getGuildId } from '../lib/config';
 import { getUserDisplayName, resolveDisplayNames } from '../lib/displayName';
@@ -8,7 +8,13 @@ import { checkRateLimit, getClientIp, rateLimitResponse } from '../lib/rateLimit
 import { checkGuards } from '../lib/routeGuards';
 import { buildSongSearchClause } from '../lib/search';
 import { formatSong } from '../lib/serialization';
-import { emitSongAdded, emitSongDeleted, emitSongUpdated } from '../lib/socket';
+import {
+  emitPlaylistUpdated,
+  emitSongAdded,
+  emitSongDeleted,
+  emitSongUpdated,
+} from '../lib/socket';
+import { syncPlaylistToTag } from '../lib/syncPlaylistToTag';
 import { canonicalizeTags } from '../lib/tagCanonicalization';
 import {
   clampMaxVideos,
@@ -26,7 +32,7 @@ import {
 import { db, tables } from '../shared/db';
 import { getPlayer } from '../startDiscord';
 
-const { song: songTable } = tables;
+const { song: songTable, playlist: playlistTable, playlistSong: playlistSongTable } = tables;
 
 // ---------------------------------------------------------------------------
 // GET /api/songs — paginated list of songs, newest first.
@@ -337,6 +343,9 @@ async function handlePatchSong(ctx: RouteContext, request: Request, id: string):
   }
 
   // Tags
+  // Track old tags for smart playlist re-sync
+  const oldTagsLower = new Set((existing.tags ?? []).map((t: string) => t.toLowerCase()));
+
   if ('tags' in body) {
     const tagsResult = validateTags(body.tags);
     if (!tagsResult.ok) return tagsResult.response;
@@ -361,6 +370,50 @@ async function handlePatchSong(ctx: RouteContext, request: Request, id: string):
   }
 
   emitSongUpdated(formatSong(updatedSong));
+
+  // If tags changed, re-sync any smart playlists tracking affected tags
+  if ('tags' in data) {
+    const newTagsLower = new Set(
+      ((data.tags as string[]) ?? []).map((t: string) => t.toLowerCase())
+    );
+
+    // Find all smart playlists whose tagNameLower is in the old or new tag set
+    const affectedTags = new Set([...oldTagsLower, ...newTagsLower]);
+    if (affectedTags.size > 0) {
+      const affectedPlaylists = await db
+        .select({ id: playlistTable.id, tagNameLower: playlistTable.tagNameLower })
+        .from(playlistTable)
+        .where(
+          and(
+            sql`${playlistTable.tagNameLower} IS NOT NULL`,
+            inArray(playlistTable.tagNameLower, [...affectedTags])
+          )
+        );
+
+      for (const pl of affectedPlaylists) {
+        if (pl.tagNameLower) {
+          await syncPlaylistToTag(pl.id);
+          const [updatedPl] = await db
+            .select()
+            .from(playlistTable)
+            .where(eq(playlistTable.id, pl.id))
+            .limit(1);
+          if (updatedPl) {
+            const songCountResult = await db
+              .select({ count: sql<number>`count(*)` })
+              .from(playlistSongTable)
+              .where(eq(playlistSongTable.playlistId, pl.id));
+            const count = songCountResult[0]?.count ?? 0;
+            emitPlaylistUpdated({
+              ...updatedPl,
+              createdAt: updatedPl.createdAt.toISOString(),
+              _count: { songs: count },
+            });
+          }
+        }
+      }
+    }
+  }
 
   // If this song is currently playing, update volume live without restarting
   const player = getPlayer(getGuildId());

--- a/packages/server/src/routes/tags.ts
+++ b/packages/server/src/routes/tags.ts
@@ -2,9 +2,10 @@ import { eq, sql } from 'drizzle-orm';
 import type { RouteContext } from '../index';
 import { json } from '../lib/json';
 import { checkGuards } from '../lib/routeGuards';
+import { emitPlaylistUpdated } from '../lib/socket';
 import { db, tables } from '../shared/db';
 
-const { tag: tagTable, song: songTable } = tables;
+const { tag: tagTable, song: songTable, playlist: playlistTable } = tables;
 
 const TAG_COLORS = ['orange', 'sky', 'emerald', 'amber', 'violet'] as const;
 type TagColor = (typeof TAG_COLORS)[number];
@@ -101,6 +102,30 @@ async function handleDeleteTag(ctx: RouteContext, nameLower: string): Promise<Re
         .set({ tags: updatedTags })
         .where(eq(songTable.id, song.id))
         .returning();
+    }
+  }
+
+  // Convert any smart playlists tracking this tag to regular playlists
+  const smartPlaylists = await db
+    .select()
+    .from(playlistTable)
+    .where(eq(playlistTable.tagNameLower, nameLower))
+    .all();
+
+  for (const pl of smartPlaylists) {
+    await db.update(playlistTable).set({ tagNameLower: null }).where(eq(playlistTable.id, pl.id));
+
+    // Emit update for each affected playlist
+    const [updatedPl] = await db
+      .select()
+      .from(playlistTable)
+      .where(eq(playlistTable.id, pl.id))
+      .limit(1);
+    if (updatedPl) {
+      emitPlaylistUpdated({
+        ...updatedPl,
+        createdAt: updatedPl.createdAt.toISOString(),
+      });
     }
   }
 

--- a/packages/server/src/shared/api.ts
+++ b/packages/server/src/shared/api.ts
@@ -188,8 +188,8 @@ export function fetchPlaylists(adminView = false): Promise<Playlist[]> {
   );
 }
 
-export function createPlaylist(name: string): Promise<Playlist> {
-  return post('/api/playlists', { name });
+export function createPlaylist(name: string, tagNameLower?: string): Promise<Playlist> {
+  return post('/api/playlists', { name, ...(tagNameLower && { tagNameLower }) });
 }
 
 export function fetchPlaylistsPage(
@@ -217,6 +217,10 @@ export function fetchPlaylistPage(
 
 export function renamePlaylist(id: string, name: string): Promise<Playlist> {
   return patch(`/api/playlists/${id}`, { name });
+}
+
+export function updatePlaylistTag(id: string, tagNameLower: string | null): Promise<Playlist> {
+  return patch(`/api/playlists/${id}`, { tagNameLower });
 }
 
 export function deletePlaylist(id: string): Promise<void> {

--- a/packages/server/src/shared/db/migrations/0057_add_playlist_tag.sql
+++ b/packages/server/src/shared/db/migrations/0057_add_playlist_tag.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `Playlist` ADD `tagNameLower` text;

--- a/packages/server/src/shared/db/schema.ts
+++ b/packages/server/src/shared/db/schema.ts
@@ -36,6 +36,7 @@ export const playlist = sqliteTable('Playlist', {
   name: text('name').notNull(),
   createdBy: text('createdBy').notNull(),
   isPrivate: integer('isPrivate', { mode: 'boolean' }).default(false).notNull(),
+  tagNameLower: text('tagNameLower'),
   createdAt: integer('createdAt', { mode: 'timestamp_ms' })
     .notNull()
     .$defaultFn(() => new Date()),

--- a/packages/server/src/shared/types.ts
+++ b/packages/server/src/shared/types.ts
@@ -172,6 +172,7 @@ export interface Playlist {
   createdBy: string;
   createdByDisplayName?: string;
   isPrivate: boolean;
+  tagNameLower?: string | null;
   createdAt: string; // ISO 8601 string (JSON wire format)
   songs?: { id: string; playlistId: string; songId: string; position: number; song?: Song }[];
   _count?: { songs: number };

--- a/packages/web/src/components/PlaylistRow.tsx
+++ b/packages/web/src/components/PlaylistRow.tsx
@@ -1,5 +1,5 @@
 import type { Playlist } from '@alfira-bot/server/shared';
-import { CaretRightIcon, GhostIcon, PlaylistIcon } from '@phosphor-icons/react';
+import { CaretRightIcon, GhostIcon, PlaylistIcon, TagIcon } from '@phosphor-icons/react';
 import { memo } from 'react';
 
 interface PlaylistRowProps {
@@ -40,6 +40,14 @@ export const PlaylistRow = memo(
             {playlist.isPrivate && (
               <span className="text-muted" title="Private playlist">
                 <GhostIcon size={14} weight="duotone" />
+              </span>
+            )}
+            {playlist.tagNameLower && (
+              <span
+                className="text-accent"
+                title={`Smart playlist — tracks "${playlist.tagNameLower}" tag`}
+              >
+                <TagIcon size={14} weight="duotone" />
               </span>
             )}
           </div>

--- a/packages/web/src/hooks/useCreatePlaylist.tsx
+++ b/packages/web/src/hooks/useCreatePlaylist.tsx
@@ -11,8 +11,9 @@ async function createPlaylistAction(
   if (!name?.trim()) {
     return { error: 'Playlist name is required' };
   }
+  const tagNameLower = (formData.get('tagNameLower') as string)?.trim() || undefined;
   try {
-    await createPlaylist(name.trim());
+    await createPlaylist(name.trim(), tagNameLower);
     return { error: null };
   } catch {
     return { error: 'Could not create playlist. Try again.' };

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -1,4 +1,5 @@
-import type { Playlist, PlaylistDetail, Song } from '@alfira-bot/server/shared';
+import type { Playlist, PlaylistDetail, Song, TagItem } from '@alfira-bot/server/shared';
+import { fetchTags, updatePlaylistTag } from '@alfira-bot/server/shared/api';
 import {
   BombIcon,
   CaretLeftIcon,
@@ -10,6 +11,7 @@ import {
   PlayCircleIcon,
   PlayIcon,
   PlusCircleIcon,
+  TagIcon,
 } from '@phosphor-icons/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -40,6 +42,21 @@ import { apiErrorMessage } from '../utils/api';
 
 const ITEMS_PER_PAGE = 24;
 
+const TAG_COLORS: Record<string, { bg: string; text: string }> = {
+  orange: { bg: 'bg-orange-500/15', text: 'text-orange-300' },
+  sky: { bg: 'bg-sky-500/15', text: 'text-sky-300' },
+  emerald: { bg: 'bg-emerald-500/15', text: 'text-emerald-300' },
+  amber: { bg: 'bg-amber-500/15', text: 'text-amber-300' },
+  violet: { bg: 'bg-violet-500/15', text: 'text-violet-300' },
+};
+
+function hashTagColor(tag: string): { bg: string; text: string } {
+  let hash = 5381;
+  for (let i = 0; i < tag.length; i++) hash = (hash * 33) ^ tag.charCodeAt(i);
+  const colors = Object.values(TAG_COLORS);
+  return colors[((hash >>> 0) * 31) % colors.length];
+}
+
 export default function PlaylistDetailPage() {
   const { id } = useParams<{ id: string }>();
   const { isAdminView } = useAdminView();
@@ -54,13 +71,27 @@ export default function PlaylistDetailPage() {
   const [removeId, setRemoveId] = useState<string | null>(null);
   const [deleteConfirm, setDeleteConfirm] = useState(false);
   const [playingSongId, setPlayingSongId] = useState<string | null>(null);
+  const [tagSmartConfirm, setTagSmartConfirm] = useState<string | null>(null);
+  const [tags, setTags] = useState<TagItem[]>([]);
   const { handleAddToQueue, notification } = useAddToQueue();
   const { notify } = useNotification();
 
   const isOwner = user?.discordId === playlistDetail?.createdBy;
   const canEdit = isAdminView || isOwner;
+  const isSmart = !!playlistDetail?.tagNameLower;
   const menuTriggerRef = useRef<HTMLButtonElement>(null);
   const [menuOpen, setMenuOpen] = useState(false);
+
+  // Fetch tags for tag change submenu
+  useEffect(() => {
+    if (canEdit) {
+      fetchTags()
+        .then(setTags)
+        .catch(() => {
+          // Tags are non-critical — fail silently
+        });
+    }
+  }, [canEdit]);
 
   const { state: queueState } = usePlayerState();
 
@@ -256,6 +287,49 @@ export default function PlaylistDetailPage() {
     [playlistDetail, queueState.loopMode, notify]
   );
 
+  const handleConvertToRegular = useCallback(async () => {
+    if (!playlistDetail) return;
+    try {
+      await updatePlaylistTag(playlistDetail.id, null);
+      setPlaylistDetail((p) => (p ? { ...p, tagNameLower: null } : p));
+      void loadPage(currentPage, false, true);
+      notify('Playlist converted to regular playlist', 'success');
+    } catch (err: unknown) {
+      notify(apiErrorMessage(err, 'Could not convert playlist.'), 'error', 5000);
+    }
+  }, [playlistDetail, currentPage, loadPage, notify]);
+
+  const handleChangeTag = useCallback(
+    async (tagNameLower: string) => {
+      if (!playlistDetail) return;
+      try {
+        const updated = await updatePlaylistTag(playlistDetail.id, tagNameLower);
+        setPlaylistDetail((p) => (p ? { ...p, tagNameLower: updated.tagNameLower ?? null } : p));
+        void loadPage(currentPage, false, true);
+        notify('Playlist tag updated', 'success');
+      } catch (err: unknown) {
+        notify(apiErrorMessage(err, 'Could not update playlist tag.'), 'error', 5000);
+      }
+    },
+    [playlistDetail, currentPage, loadPage, notify]
+  );
+
+  const handleMakeSmart = useCallback(
+    async (tagNameLower: string) => {
+      if (!playlistDetail) return;
+      setTagSmartConfirm(null);
+      try {
+        const updated = await updatePlaylistTag(playlistDetail.id, tagNameLower);
+        setPlaylistDetail((p) => (p ? { ...p, tagNameLower: updated.tagNameLower ?? null } : p));
+        void loadPage(currentPage, false, true);
+        notify('Playlist now tracking tag', 'success');
+      } catch (err: unknown) {
+        notify(apiErrorMessage(err, 'Could not update playlist tag.'), 'error', 5000);
+      }
+    },
+    [playlistDetail, currentPage, loadPage, notify]
+  );
+
   const handleAddPlaylistToQueue = useCallback(async () => {
     if (!playlistDetail) return;
     try {
@@ -269,6 +343,11 @@ export default function PlaylistDetailPage() {
       notify(apiErrorMessage(err, 'Could not add to queue.'), 'error', 5000);
     }
   }, [playlistDetail, queueState.loopMode, notify]);
+
+  const tagSubmenuItems = tags.map((tag) => ({
+    id: tag.nameLower,
+    label: tag.canonicalName,
+  }));
 
   const menuItems: MenuItem[] = [
     {
@@ -304,12 +383,45 @@ export default function PlaylistDetailPage() {
             ),
             onClick: handleToggleVisibility,
           } as MenuItem,
-          {
-            id: 'add-songs',
-            label: 'Add Songs',
-            icon: <PlayCircleIcon size={14} weight="duotone" />,
-            onClick: () => setShowAddSongs(true),
-          } as MenuItem,
+          ...(isSmart
+            ? [
+                {
+                  id: 'change-tag',
+                  label: 'Change Tracked Tag',
+                  icon: <TagIcon size={14} weight="duotone" />,
+                  submenu: {
+                    title: 'Track Tag',
+                    items: tagSubmenuItems,
+                    onSelect: (tagId: string) => handleChangeTag(tagId),
+                    emptyMessage: 'No tags available',
+                  },
+                } as MenuItem,
+                {
+                  id: 'convert-regular',
+                  label: 'Convert to Regular Playlist',
+                  icon: <PlayCircleIcon size={14} weight="duotone" />,
+                  onClick: handleConvertToRegular,
+                } as MenuItem,
+              ]
+            : [
+                {
+                  id: 'add-songs',
+                  label: 'Add Songs',
+                  icon: <PlayCircleIcon size={14} weight="duotone" />,
+                  onClick: () => setShowAddSongs(true),
+                } as MenuItem,
+                {
+                  id: 'make-smart',
+                  label: 'Track a Tag',
+                  icon: <TagIcon size={14} weight="duotone" />,
+                  submenu: {
+                    title: 'Track Tag',
+                    items: tagSubmenuItems,
+                    onSelect: (tagId: string) => setTagSmartConfirm(tagId),
+                    emptyMessage: 'No tags available',
+                  },
+                } as MenuItem,
+              ]),
           {
             id: 'delete',
             label: 'Delete',
@@ -384,7 +496,7 @@ export default function PlaylistDetailPage() {
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-start justify-between mb-6 md:mb-8 gap-4">
         <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 flex-wrap">
             <h1 className="font-display text-3xl md:text-4xl text-fg tracking-wider">
               {playlistDetail.name}
             </h1>
@@ -394,13 +506,34 @@ export default function PlaylistDetailPage() {
                 private
               </span>
             )}
+            {playlistDetail.tagNameLower &&
+              (() => {
+                const tag = tags.find((t) => t.nameLower === playlistDetail.tagNameLower);
+                const displayName = tag?.canonicalName ?? playlistDetail.tagNameLower;
+                const colors = hashTagColor(displayName);
+                return (
+                  <span
+                    className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium ${colors.bg} ${colors.text}`}
+                    title={`Auto-tracking all songs tagged "${displayName}"`}
+                  >
+                    <TagIcon size={12} weight="duotone" />
+                    {displayName}
+                  </span>
+                );
+              })()}
           </div>
           <p className="font-mono text-xs text-muted mt-1">
             {songItems.length} {songItems.length === 1 ? 'track' : 'tracks'}
-            {' • '}
-            {isOwner
-              ? 'Created by you'
-              : `Created by ${playlistDetail.createdByDisplayName || playlistDetail.createdBy}`}
+            {playlistDetail.tagNameLower ? (
+              <span className="text-accent"> • auto-tracked</span>
+            ) : (
+              <>
+                {' • '}
+                {isOwner
+                  ? 'Created by you'
+                  : `Created by ${playlistDetail.createdByDisplayName || playlistDetail.createdBy}`}
+              </>
+            )}
           </p>
         </div>
 
@@ -455,12 +588,24 @@ export default function PlaylistDetailPage() {
 
       {/* Song list */}
       {songItems.length === 0 && !isLoading ? (
-        <EmptyState
-          title="Empty Playlist"
-          isAdmin={canEdit}
-          onAdd={() => setShowAddSongs(true)}
-          addLabel="add some songs"
-        />
+        isSmart ? (
+          <div className="text-center py-24">
+            <p className="font-display text-4xl text-faint tracking-wider mb-2">No Songs Yet</p>
+            <p className="font-mono text-xs text-faint">
+              This playlist tracks the "
+              {tags.find((t) => t.nameLower === playlistDetail.tagNameLower)?.canonicalName ??
+                playlistDetail.tagNameLower}
+              " tag. Tag some songs to populate it.
+            </p>
+          </div>
+        ) : (
+          <EmptyState
+            title="Empty Playlist"
+            isAdmin={canEdit}
+            onAdd={() => setShowAddSongs(true)}
+            addLabel="add some songs"
+          />
+        )
       ) : (
         <VirtualSongList
           items={songItems}
@@ -531,6 +676,24 @@ export default function PlaylistDetailPage() {
             handleDeletePlaylist();
           }}
           onCancel={() => setDeleteConfirm(false)}
+        />
+      )}
+      {tagSmartConfirm && (
+        <ConfirmModal
+          title="Track a Tag"
+          message={
+            <>
+              This will convert the playlist to auto-track the "
+              <span className="text-fg font-semibold">
+                {tags.find((t) => t.nameLower === tagSmartConfirm)?.canonicalName ??
+                  tagSmartConfirm}
+              </span>
+              " tag. All current songs not matching this tag will be removed.
+            </>
+          }
+          confirmLabel="Convert"
+          onConfirm={() => handleMakeSmart(tagSmartConfirm)}
+          onCancel={() => setTagSmartConfirm(null)}
         />
       )}
     </div>

--- a/packages/web/src/pages/PlaylistsPage.tsx
+++ b/packages/web/src/pages/PlaylistsPage.tsx
@@ -1,4 +1,5 @@
-import type { Playlist } from '@alfira-bot/server/shared';
+import type { Playlist, TagItem } from '@alfira-bot/server/shared';
+import { fetchTags } from '@alfira-bot/server/shared/api';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getPlaylistsPage } from '../api/api';
@@ -106,6 +107,16 @@ export default function PlaylistsPage() {
 function CreatePlaylistModal({ onClose }: { onClose: () => void }) {
   const [state, formAction] = useCreatePlaylist();
   const [name, setName] = useState('');
+  const [tags, setTags] = useState<TagItem[]>([]);
+  const [selectedTag, setSelectedTag] = useState('');
+
+  useEffect(() => {
+    fetchTags()
+      .then(setTags)
+      .catch(() => {
+        // Tags are non-critical — fail silently
+      });
+  }, []);
 
   // Close modal on success (error === null means success)
   useEffect(() => {
@@ -137,6 +148,22 @@ function CreatePlaylistModal({ onClose }: { onClose: () => void }) {
           }}
           required
         />
+        <div className="mb-3">
+          <p className="font-mono text-xs text-muted mb-1.5">track a tag (optional)</p>
+          <select
+            name="tagNameLower"
+            className="input w-full"
+            value={selectedTag}
+            onChange={(e) => setSelectedTag(e.target.value)}
+          >
+            <option value="">None (manual playlist)</option>
+            {tags.map((tag) => (
+              <option key={tag.nameLower} value={tag.nameLower}>
+                {tag.canonicalName}
+              </option>
+            ))}
+          </select>
+        </div>
         {state?.error && <p className="font-mono text-xs text-danger mb-3">{state.error}</p>}
         <div className="flex gap-2 justify-end">
           <Button variant="inherit" type="button" onClick={onClose} surface="surface">


### PR DESCRIPTION
## Summary

Playlists can now be associated with a tag, making them "smart" — they automatically track all songs with that tag. When a song's tags change, affected smart playlists re-sync automatically.

## Changes

- **Schema**: Added `tagNameLower` column to `Playlist` table (migration `0057_add_playlist_tag.sql`)
- **Server**: New `syncPlaylistToTag` utility replaces playlist songs with tag-matching set in a transaction
- **Server**: `POST /api/playlists` accepts optional `tagNameLower` and auto-populates matching songs
- **Server**: `PATCH /api/playlists/:id` accepts `tagNameLower` to convert between smart/regular
- **Server**: `POST /api/playlists/:id/songs` rejects 409 for smart playlists
- **Server**: Song tag changes trigger re-sync of any smart playlists tracking affected tags
- **Server**: Tag deletion converts associated smart playlists to regular
- **Web**: Create playlist modal has optional tag selector
- **Web**: Playlist list shows tag icon indicator for smart playlists
- **Web**: Playlist detail shows tracked tag pill, disables manual add for smart playlists, and adds context menu options to change tag or convert to regular

Closes #13