### PR TITLE
feat(dx): add pi skills for alfira domain knowledge

### DIFF
--- a/.pi/prompts/plan.md
+++ b/.pi/prompts/plan.md
@@ -35,6 +35,15 @@ Example:
 ### Risks / edge cases
 Anything that could go wrong or needs special attention.
 
+### Skills
+Which Pi skills are relevant for this task? Load them via `read` before writing the plan if you haven't already:
+- `alfira-architecture` — server startup, WebSocket pipeline, build cycle
+- `alfira-audio` — audio pipeline, GuildPlayer, voice connections
+- `alfira-database` — schema, migrations, query patterns
+- `alfira-api` — routes, auth, middleware
+- `alfira-web` — components, pages, API client
+- `alfira-troubleshooting` — debugging common issues
+
 ### Verification
 What to check after implementation:
 - [ ] `bun run check` passes

--- a/.pi/skills/alfira-api/SKILL.md
+++ b/.pi/skills/alfira-api/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: alfira-api
+description: API route structure, authentication flow, middleware, security headers, WebSocket auth, and response helpers. Use when working on routes/*.ts, middleware/requireAuth.ts, index.ts route wiring, or adding new API endpoints.
+---
+
+# Alfira API
+
+## Server
+
+Bun native HTTP server on port 3001. Serves three concerns:
+
+1. **REST API** — All `/api/*` routes
+2. **WebSocket** — `/ws` endpoint for real-time player state
+3. **Static assets** — Built web UI from `packages/web/dist/` with SPA fallback
+
+## Route Map (defined in `index.ts` fetch handler)
+
+| Prefix | Handler file | Purpose |
+|--------|-------------|---------|
+| `/api/tags` | `routes/tags.ts` | CRUD for tags |
+| `/api/songs` | `routes/songs.ts` | Song library, search, import |
+| `/api/playlists` | `routes/playlists.ts` | Playlist CRUD, reorder, import |
+| `/api/player` | `routes/player.ts` | Playback control (play, pause, skip, seek, volume, queue) |
+| `/api/settings/compressor` | `routes/compressor.ts` | Compressor settings |
+| `/api/settings/equalizer` | `routes/equalizer.ts` | Equalizer settings |
+| `/api/permissions` | `routes/permissions.ts` | Role-based permission management |
+| `/api/settings/general` | `routes/generalSettings.ts` | General guild settings |
+| `/api/setup` | `routes/setup.ts` | Initial setup wizard |
+| `/auth` | `routes/auth.ts` | OAuth2 Discord login flow |
+
+Special routes (no `/api` prefix):
+- `/health` — Returns service health with component status (database, nodelink, discord)
+- `/api/version` — Returns version, public (no auth)
+- `/ws` — WebSocket upgrade
+
+## Route Context
+
+Every route handler receives `RouteContext`:
+
+```typescript
+type RouteContext = {
+  user: ReturnType<typeof verifySessionToken>; // null if unauthenticated
+  isAdmin: boolean;
+  cookies: Record<string, string>;
+};
+```
+
+Created by `createContext(request)` which parses cookies and validates session token. Routes are responsible for their own auth checks — check `ctx.user` and `ctx.isAdmin`.
+
+## Authentication Flow
+
+### Discord OAuth2 (`routes/auth.ts`)
+
+1. User clicks "Login with Discord" → redirects to Discord OAuth2 authorize URL
+2. Discord redirects back to `DISCORD_REDIRECT_URI` with auth code
+3. Server exchanges code for access token, fetches user info + guild member
+4. Issues JWT session token, sets `session` cookie (httpOnly, secure, sameSite=lax)
+5. User info (discordId, username, avatar, isAdmin) encoded in JWT
+
+### Session validation (`middleware/requireAuth.ts`)
+
+- `verifySessionToken(token)` — verifies JWT, returns `{ discordId, username, avatar, isAdmin } | null`
+- Cookie-based: reads `session` cookie from request
+- Admin status is cached in JWT — user must re-login after role changes
+
+### JWT secret
+
+Must be set in `.env` as `JWT_SECRET`. Used for signing and verifying session tokens.
+
+## Security Headers
+
+All API responses get security headers applied by `setSecurityHeaders()`:
+
+```
+Content-Security-Policy: default-src 'none'
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+X-XSS-Protection: 1; mode=block
+Referrer-Policy: strict-origin-when-cross-origin
+```
+
+`Set-Cookie` headers are preserved (not overwritten).
+
+## WebSocket (`/ws` endpoint)
+
+- Auth happens **before** upgrade — `getSessionUser()` validates session cookie
+- On 401: returns 401 response, no upgrade
+- On success: `server.upgrade(request, { data: { user } })`
+- Client data: never sends messages (receive-only)
+- Registration: `registerClient(ws, user)` assigns a UUID socket ID
+- Cleanup: `unregisterClient(ws)` on close
+
+## Response Helpers
+
+### `json(data, status)` — `lib/json.ts`
+```typescript
+import { json } from './lib/json';
+return json({ error: 'Not found' }, 404);
+```
+
+### Player guards — `lib/player.ts`
+```typescript
+import { requirePlayer, requirePlaying } from './lib/player';
+
+const result = requirePlaying();
+if (!result.ok) return result.response; // 409 with error message
+// result.player is typed GuildPlayer
+```
+
+## Adding a new route
+
+1. Create handler in `packages/server/src/routes/yourRoute.ts`
+2. Export a `handleYourRoute(ctx: RouteContext, request: Request): Promise<Response>` function
+3. Add route matching in `index.ts` fetch handler:
+```typescript
+if (url.pathname.startsWith('/api/yourRoute')) {
+  return setSecurityHeaders(await handleYourRoute(ctx, request));
+}
+```
+
+## Rate Limiting
+
+`lib/rateLimit.ts` — in-memory store, pruned every 5 minutes. Apply via middleware pattern in route handlers as needed.
+
+## Enabled Sources
+
+Cached from `guildSettings.enabledSources` (comma-separated string). Initialized at startup via `initEnabledSources()` from `startDiscord.ts`. Used by player routes to validate source URLs.

--- a/.pi/skills/alfira-architecture/SKILL.md
+++ b/.pi/skills/alfira-architecture/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: alfira-architecture
+description: Server architecture, startup sequence, WebSocket pipeline, build/deploy cycle, shared package exports, and monorepo layout. Use when working on packages/server/src/index.ts, lib/socket.ts, startDiscord.ts, server config, or understanding how components connect.
+---
+
+# Alfira Architecture
+
+## Monorepo Layout
+
+```
+packages/
+├── server/     # Bun API + Discord bot (GuildPlayer, NodeLink audio, Seyfert v4)
+│   └── src/
+│       ├── index.ts          # Entry point — startup sequence + HTTP server
+│       ├── startDiscord.ts   # Seyfert Discord client + NodeLink init
+│       ├── GuildPlayer.ts    # Per-guild audio player state machine
+│       ├── PlaybackCursor.ts # Queue cursor logic
+│       ├── lib/              # Utilities (socket, voice, lavalink, config, etc.)
+│       ├── middleware/        # Auth middleware
+│       ├── routes/           # API route handlers (10 files)
+│       ├── shared/           # Types, DB schema, logger, format, API service
+│       └── utils/            # NodeLink subprocess helpers
+└── web/        # React 19 + Tailwind CSS 4 web UI
+```
+
+The bot and API run in a **single Bun process**. They share memory for player state, enabling real-time WebSocket broadcasts directly from playback events.
+
+## Startup Sequence (`packages/server/src/index.ts::main()`)
+
+1. **Run database migrations** — Homegrown runner reads `.sql` files from `packages/server/src/shared/db/migrations/`, hashes them, tracks applied migrations in `__drizzle_migrations` table
+2. **Migrate existing tags** — `ensureTagsMigrated()` transfers inline `song.tags` JSON arrays to the normalized `Tag` table
+3. **Verify database connectivity** — `db.all(sql\`SELECT 1\`)`
+4. **Initialize guild ID cache** — `initGuildId()` reads the single `guildSettings` row (id=1)
+5. **Initialize enabled sources cache** — `initEnabledSources()` from `startDiscord.ts`
+6. **Start NodeLink subprocess** — Spawns NodeLink as a child process (`/usr/local/bin/bun src/index.ts` inside `/usr/local/nodelink`), polls `http://127.0.0.1:2333/v4/info` until ready
+7. **Start the Discord bot** — `startDiscord()` initializes Seyfert client + connects to NodeLink WebSocket
+8. **Start HTTP server** — `Bun.serve()` on port 3001
+
+### Graceful shutdown
+
+On SIGTERM/SIGINT: kill NodeLink subprocess → stop HTTP server + close all WebSocket clients → destroy all players (FFmpeg + voice) → close database.
+
+## WebSocket Pipeline
+
+Real-time player state broadcast to the web UI:
+
+```
+GuildPlayer (player state change)
+  → emitPlayerUpdate(state)         [packages/server/src/lib/socket.ts]
+    → fetch compressor settings
+    → serialize state
+    → send to all registered WsClient connections
+```
+
+Key facts:
+- The bot never directly holds WebSocket connections — all goes through `lib/socket.ts`
+- Clients authenticate via session cookie on WebSocket upgrade (`/ws` endpoint in `index.ts`)
+- The client never sends messages — it's receive-only
+- Socket registration: `registerClient(ws, user)` / `unregisterClient(ws)` / `closeAllClients()`
+
+## Server Build/Deploy Cycle
+
+- Server source compiles to `packages/server/dist/` during Docker image build
+- `bun run dev` rebuilds local `dist/` then starts Docker with a fresh image
+- API source is live-mounted via Docker volume — `docker compose restart alfira` picks up changes without a full rebuild
+- Web UI changes: run `bun run web:build` then `docker compose restart alfira`
+
+## Environment Configuration
+
+Single `.env` file at project root. Required: `DISCORD_BOT_TOKEN`, `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET`, `DISCORD_REDIRECT_URI`, `JWT_SECRET`, `DATABASE_URL`.
+
+Guild ID, admin roles, idle timeout, and notification channel are configured via the in-app setup wizard. Can optionally pre-configure via `GUILD_ID` / `ADMIN_ROLE_IDS` env vars.
+
+## Shared Package Exports
+
+`@alfira-bot/server/shared` (imported by `packages/web`):
+
+**Types:** `Song`, `QueuedSong`, `LoopMode`, `QueueState`, `Playlist`, `PlaylistDetail`, `User`
+**Utilities:** `formatDuration(seconds)`, `fisherYatesShuffle(array)`
+**DB:** Schema in `packages/server/src/shared/db/schema.ts`
+**Logger:** `logger` from `@alfira-bot/server/shared/logger`
+**API Service:** `@alfira-bot/server/shared/api` — centralized API functions (`fetchSongs`, `createSong`, `importPlaylist`, etc.)
+
+Always use the shared API service for API calls rather than raw `fetch`.
+
+## Security Headers
+
+Defined in `index.ts` as `SECURITY_HEADERS` constant, applied to all API responses via `setSecurityHeaders()`:
+- `Content-Security-Policy: default-src 'none'`
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: DENY`
+- `X-XSS-Protection: 1; mode=block`
+- `Referrer-Policy: strict-origin-when-cross-origin`

--- a/.pi/skills/alfira-audio/SKILL.md
+++ b/.pi/skills/alfira-audio/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: alfira-audio
+description: NodeLink/Lavalink audio pipeline, GuildPlayer state machine, voice connection flow, track lifecycle events, and REST commands for player control. Use when working on lib/lavalink.ts, GuildPlayer.ts, lib/voice.ts, PlaybackCursor.ts, lib/applyNodeLinkFilter.ts, or any audio/playback feature.
+---
+
+# Alfira Audio Pipeline
+
+## NodeLink
+
+NodeLink is a Lavalink v4-compatible audio server. It runs as a child process, not a separate Docker container — spawned from `index.ts::startNodeLink()`.
+
+- **Internal URL:** `http://127.0.0.1:2333`
+- **Auth header:** `Authorization: nodelink-internal`
+- **Ready check:** Polls `GET /v4/info` every 500ms until 200
+
+## LavalinkSocket (`packages/server/src/lib/lavalink.ts`)
+
+A singleton EventEmitter class managing the WebSocket connection to NodeLink.
+
+### Connection lifecycle
+
+```
+connect(url, auth, userId)
+  → _doConnect()
+    → new WebSocket(url, { headers: { Authorization, User-Id, Client-Name: "Alfira" } })
+    → on 'ready' opcode → resolves connect promise, stores sessionId
+    → on close → schedule exponential backoff reconnect (1s base, 30s max)
+    → disconnect() → sets intentionalClose flag, clears timers
+```
+
+### WebSocket opcodes
+
+| Opcode | Handler |
+|--------|---------|
+| `ready` | Stores `sessionId`, resolves connect promise |
+| `playerUpdate` | Updates per-guild `connected` state |
+| `event: TrackStartEvent` | Sets guild `playing = true` |
+| `event: TrackEndEvent` | Sets guild `playing = false`, emits `trackEnd` event with reason |
+| `event: TrackExceptionEvent` | Sets guild `playing = false`, emits `trackError` event |
+| `event: WebSocketClosedEvent` | Sets guild `connected = false`, `playing = false`, emits `socketClosed` |
+
+### TrackEnd reasons
+
+`'finished' | 'loadFailed' | 'stopped' | 'replaced' | 'cleanup' | 'gapless'`
+
+### Guild state tracking
+
+Each guild tracks `{ connected: boolean, playing: boolean }`. Available via:
+- `lavalink.isGuildConnected(guildId)`
+- `lavalink.isGuildPlaying(guildId)`
+- `lavalink.markConnected(guildId, connected)`
+- `lavalink.markPlaying(guildId, playing)`
+
+### Event subscription pattern
+
+```typescript
+// Subscribe to track end for a specific guild
+const unsubscribe = lavalink.onTrackEnd(guildId, (reason) => {
+  // reason is typed TrackEndReason
+});
+// Later: unsubscribe();
+```
+
+Similarly: `onTrackError(guildId, handler)`, `onSocketClosed(guildId, handler)`.
+
+## GuildPlayer (`packages/server/src/GuildPlayer.ts`)
+
+Per-guild audio player state machine. Manages:
+- Queue (array of `QueuedSong`)
+- Current song + playback position
+- Loop mode (`off` | `song` | `queue`)
+- Volume control
+- Play/pause/stop/skip/seek
+- Filter application (equalizer, compressor)
+
+### Key patterns
+
+- **Player lookup:** `getPlayer(guildId)` from `startDiscord.ts`, returns `GuildPlayer | undefined`
+- **Guard helpers:** `requirePlayer()` and `requirePlaying()` from `lib/player.ts` — return `{ ok, player }` or `{ ok, response }` for route handlers
+- **State broadcast:** GuildPlayer calls `emitPlayerUpdate(state)` directly, not through the WebSocket
+
+## Voice Connection Flow
+
+Voice connections use Discord's gateway forwarded to NodeLink's REST API:
+
+1. Discord sends `VOICE_STATE_UPDATE` → bot joins channel
+2. Discord sends `VOICE_SERVER_UPDATE` → provides voice server endpoint + token
+3. Forward both to NodeLink REST: `PATCH /v4/sessions/{sessionId}/players/{guildId}` with `voice` payload
+
+See `lib/voice.ts` for the voice connection helpers.
+
+## NodeLink REST Commands
+
+Player control is done via NodeLink's REST API (not WebSocket):
+
+- **Play:** `PUT /v4/sessions/{sessionId}/players/{guildId}?noReplace=true` with track data
+- **Stop:** `DELETE /v4/sessions/{sessionId}/players/{guildId}`
+- **Pause:** `PATCH /v4/sessions/{sessionId}/players/{guildId}` with `paused: true`
+- **Resume:** `PATCH ...` with `paused: false`
+- **Seek:** `PATCH ...` with `position: ms`
+- **Volume:** `PATCH ...` with `volume: 0-1000`
+- **Filters:** `PATCH ...` with `filters` object
+
+## Filters
+
+Filter application is in `lib/applyNodeLinkFilter.ts`. Supports:
+- **Equalizer:** 15-band (0-14), each band 0-100 (midpoint 50), mapped to NodeLink's ±0.25 range
+- **Compressor:** Threshold (-60 to 0 dB), ratio (1-20), attack (0-100ms), release (10-1000ms), gain (0-24 dB)
+
+Filters are applied by building the filter object and sending `PATCH /v4/sessions/{sessionId}/players/{guildId}`.
+
+## PlaybackCursor (`packages/server/src/PlaybackCursor.ts`)
+
+Manages queue position tracking for loop modes and shuffle. Handles forward/backward navigation through the queue with loop wrapping.

--- a/.pi/skills/alfira-database/SKILL.md
+++ b/.pi/skills/alfira-database/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: alfira-database
+description: SQLite + Drizzle ORM schema, homegrown migration runner, query patterns, tag system, and guild settings. Use when working on shared/db/schema.ts, migrations, lib/ensureTagsMigrated.ts, lib/tagCanonicalization.ts, or any database query.
+---
+
+# Alfira Database
+
+## Tech
+
+- **Database:** SQLite via `bun:sqlite` (libsql)
+- **ORM:** Drizzle ORM (`drizzle-orm/sqlite-core`)
+- **Migration runner:** Homegrown (not Drizzle Kit), reads `.sql` files from `packages/server/src/shared/db/migrations/`
+
+## Two database clients
+
+There are **two** database handles — know which to use:
+
+| Client | Import | Type | Use case |
+|--------|--------|------|----------|
+| `$client` | `shared/db` | Raw `bun:sqlite` Database | Migration runner (`$client.run()`, `$client.query()`), synchronous |
+| `db` | `shared/db` | Drizzle instance | All application queries (`db.select()`, `db.insert()`, etc.), async |
+
+Never mix them — use `db` for application code, `$client` only for migrations and schema introspection.
+
+## Schema (`packages/server/src/shared/db/schema.ts`)
+
+### `Song` table
+Primary music entity. Key columns:
+- `id` — UUID primary key (auto-generated via `$defaultFn`)
+- `sourceUrl` + `sourceId` — both unique, identify the source track
+- `tags` — JSON array of tag name strings (being migrated to `Tag` table)
+- `volumeBoost` — optional per-song volume boost (dB)
+- `createdAt` — timestamp_ms, auto-set to `new Date()`
+
+### `Playlist` table
+- `name`, `createdBy`, `isPrivate` (boolean, default false)
+- `tagNameLower` — links to `Tag.nameLower` for auto-generated playlists
+
+### `PlaylistSong` join table
+- Links songs to playlists at a specific `position`
+- Compound unique constraint on `(playlistId, songId)`
+- Index on `(playlistId, position)` for ordered retrieval
+
+### `Tag` table
+Normalized tag storage (migrated from `Song.tags` JSON). Key columns:
+- `nameLower` — unique, lowercase tag name (used for lookups)
+- `canonicalName` — display name with original casing
+- `color` — optional hex color
+
+### `guildSettings` table
+Single-row table (always `id = 1`). Holds:
+- **Compressor:** 5 columns (enabled, threshold, ratio, attack, release, gain)
+- **Equalizer:** 15 columns (`eqBand0` through `eqBand14`, range 0-100)
+- **Admin:** `guildId`, `adminRoleIds` (comma-separated string), `setupCompleted`, `voiceIdleTimeoutMinutes`
+- **Sources:** `enabledSources` (comma-separated string, default `"youtube,soundcloud"`)
+- **Misc:** `notificationChannelId`, `publicUrl`
+
+### `RefreshToken` table
+OAuth2 refresh tokens: `tokenHash` (unique), `discordId`, `expiresAt`. Index on `discordId`.
+
+### `rolePermission` table
+Composite primary key `(action, roleId)`.
+
+## Migration Runner (`index.ts::runMigrations()`)
+
+Custom, not Drizzle Kit:
+
+1. Ensures `__drizzle_migrations` tracking table exists
+2. Reads `.sql` files from `migrations/` directory, sorted by filename
+3. For each file: compute SHA-256 hash, check if already applied, split on `-->\s*statement-breakpoint`, run each statement
+4. Skips "already exists" errors (idempotent)
+5. Records applied hash + timestamp
+
+### Creating new migrations
+
+```bash
+bun run db:generate    # Generate .sql migration files
+bun run db:migrate     # Run them (standalone, not via the server)
+```
+
+## Tag Migration (`lib/ensureTagsMigrated.ts`)
+
+Migrates from the old `Song.tags` JSON array pattern to the normalized `Tag` table:
+1. Reads all songs with non-empty `tags`
+2. For each unique tag name: creates a `Tag` row if it doesn't exist
+3. Does NOT remove `Song.tags` column (backward compatible)
+
+## Tag Canonicalization (`lib/tagCanonicalization.ts`)
+
+Ensures consistent tag casing: the first encounter of a tag name (case-insensitive) becomes the canonical casing. Subsequent different casings are normalized to the canonical form.
+
+## Query Patterns
+
+**Drizzle queries (use `db`):**
+```typescript
+import { db } from './shared/db';
+import { song, eq } from './shared/db/schema'; // hypothetical
+
+const songs = await db.select().from(song).where(eq(song.id, id));
+```
+
+**Raw queries (only for migrations, use `$client`):**
+```typescript
+$client.run('CREATE TABLE IF NOT EXISTS ...');
+$client.query('SELECT hash FROM "__drizzle_migrations" WHERE hash = ?').get(hash);
+```
+
+**Singleton guild settings pattern:**
+```typescript
+// Always id = 1
+const settings = await db.select().from(guildSettings).where(eq(guildSettings.id, 1)).get();
+if (!settings) {
+  await db.insert(guildSettings).values({ id: 1 });
+}
+```
+
+## Rate Limiting
+
+`lib/rateLimit.ts` provides in-memory rate limiting with periodic pruning (every 5 minutes via `setInterval` in `index.ts`).

--- a/.pi/skills/alfira-troubleshooting/SKILL.md
+++ b/.pi/skills/alfira-troubleshooting/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: alfira-troubleshooting
+description: Common issues and solutions for Alfira — bot problems, authentication failures, music source errors, database issues, and reset procedures. Use when debugging any Alfira problem or investigating error reports.
+---
+
+# Alfira Troubleshooting
+
+## Bot Issues
+
+### Bot not joining voice channels
+
+**Symptoms:** Bot doesn't appear in voice channel when using the Play button.
+
+**Solutions:**
+1. Ensure the bot has the required permissions (Connect, Speak).
+2. Check that the voice channel allows bot access.
+3. Verify `DISCORD_BOT_TOKEN` is correct.
+4. Check API logs: `docker compose logs alfira`
+
+### Audio not playing
+
+**Symptoms:** Bot joins but no audio is heard.
+
+**Solutions:**
+1. Ensure the NodeLink service is running (it starts automatically inside the alfira container).
+2. Check API logs for NodeLink connection errors: `docker compose logs alfira`
+3. Look for `[NodeLink]` prefix in logs to see NodeLink startup status.
+4. Try a different video/URL to isolate the issue.
+
+## Authentication Issues
+
+### OAuth2 login fails
+
+**Symptoms:** "Invalid redirect_uri" error during Discord login.
+
+**Solutions:**
+1. Verify `DISCORD_REDIRECT_URI` matches exactly in:
+   - Discord Developer Portal → OAuth2 → Redirects
+   - Your `.env` file
+2. Ensure you're using `https://` in production.
+
+### "Add Song" button not visible / Admin features missing
+
+**Symptoms:** Logged in but no "Add Song" button, can't use quick-add, can't manage playlists.
+
+**Solutions:**
+1. **Check admin role configuration** — Go to **Settings → Admin** and verify the correct roles are selected under "Admin Roles". Save changes if needed.
+2. **Enable Server Members Intent** — Go to Discord Developer Portal → Bot → Privileged Gateway Intents → enable **Server Members Intent** → Save Changes.
+3. **Re-login** — Admin status is cached in the JWT token. Log out and log back in after fixing the above.
+4. **Check logs** — Run `docker compose logs alfira | grep -i admin` to verify the bot detects your admin status.
+
+### Slash commands not working
+
+**Symptoms:** `/play`, `/skip`, etc. give "The application did not respond" errors.
+
+**Cause:** Alfira removed Discord slash commands in April 2026 — all playback control is exclusively through the web UI. Discord may still have old commands cached.
+
+**Solutions:**
+1. **Use the web UI instead** — Play/pause/skip/seek via the Now Playing bar, Play buttons, or queue management.
+2. **Restart the container** — Stale commands are automatically unregistered on every server startup:
+   ```bash
+   docker compose restart alfira
+   ```
+3. **Manual unregister (if needed):**
+   ```bash
+   bun run discord:unregister-commands
+   ```
+   (Requires `.env` with `DISCORD_BOT_TOKEN`, `DISCORD_CLIENT_ID`, `GUILD_ID`)
+4. **Wait for Discord cache** — After unregistering, guild commands disappear immediately (global commands can take up to 1 hour).
+
+## Music Source Issues
+
+### Spotify / Apple Music / Tidal tracks won't load
+
+**Symptoms:** Pasting a URL from these sources returns "Could not fetch track info" or similar error.
+
+**Cause:** These sources require API credentials that aren't configured.
+
+**Solutions:**
+1. Add the required credentials to your `.env` file (see Installation Guide).
+2. Restart Alfira after adding credentials: `docker compose restart alfira`
+3. Verify the source is enabled in **Settings → Admin → Music Sources**.
+
+### "That URL doesn't look right" error
+
+**Symptoms:** Pasting a valid URL from a supported source but getting a validation error.
+
+**Solutions:**
+1. Check that the source is enabled in **Settings → Admin → Music Sources**.
+2. The error message lists which sources are currently enabled — check those match what you expect.
+3. Ensure the URL is a direct track/playlist link (not a search results page).
+
+## Database Issues
+
+### Connection errors
+
+**Symptoms:** API crashes with "database not found" or permission errors.
+
+**Solutions:**
+1. Ensure the alfira container is running: `docker compose ps`
+2. Check API logs: `docker compose logs alfira`
+3. Verify the `/data` volume is properly mounted and writable.
+4. For fresh database, delete the volume: `docker compose down -v` then `docker compose up --build`
+
+## Resetting Everything
+
+**Warning:** This will delete all your data (playlists, songs, etc.).
+
+```bash
+# Stop and remove everything, including database
+docker compose down -v
+
+# Rebuild from scratch
+docker compose up --build
+```
+
+## Getting Help
+
+1. Check the logs: `docker compose logs -f alfira`
+2. Search existing [GitHub Issues](https://github.com/ebears/alfira/issues).
+3. Open a new issue with:
+   - Docker version
+   - Relevant log output
+   - Steps to reproduce

--- a/.pi/skills/alfira-web/SKILL.md
+++ b/.pi/skills/alfira-web/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: alfira-web
+description: React 19 + Tailwind CSS 4 web UI, component and page structure, API client, WebSocket client, virtual list pattern, and settings sections. Use when working on packages/web/src/, UI components, or frontend features.
+---
+
+# Alfira Web UI
+
+## Tech
+
+- **Framework:** React 19
+- **Styling:** Tailwind CSS 4
+- **Bundler:** Bun (builds to `packages/web/dist/`)
+- **Build command:** `bun run web:build`
+
+## Entry Point & Routing
+
+- **Entry:** `packages/web/src/main.tsx` — mounts `<App />`
+- **Router:** `App.tsx` — client-side SPA routing (no react-router, likely custom/hash-based)
+- **Auth guard:** Routes check auth state, redirect to `/login` if unauthenticated
+
+## Page Map
+
+| Page file | Route | Purpose |
+|-----------|-------|---------|
+| `LoginPage.tsx` | `/login` | Discord OAuth2 login |
+| `SetupWizard.tsx` | `/setup` | Initial guild setup (first run) |
+| `SongsPage.tsx` | `/songs` | Song library with search, filter, add |
+| `PlaylistsPage.tsx` | `/playlists` | Playlist list with create/delete |
+| `PlaylistDetailPage.tsx` | `/playlists/:id` | Single playlist with songs + reorder |
+| `TagsPage.tsx` | `/tags` | Tag management |
+| `AudioPage.tsx` | `/audio` | Compressor + equalizer settings |
+| `PermissionsPage.tsx` | `/permissions` | Role-based permission config |
+
+## Component Map
+
+### Core UI Components
+| Component | Purpose |
+|-----------|---------|
+| `Backdrop.tsx` | Modal backdrop overlay |
+| `ConfirmModal.tsx` | Confirmation dialog |
+| `PlayModal.tsx` | Play action modal (play now, play next, add to queue) |
+| `MobileNav.tsx` | Mobile navigation bar |
+| `SettingsMenu.tsx` | Settings navigation menu |
+
+### Player Components
+| Component | Purpose |
+|-----------|---------|
+| `QueuePanel.tsx` | Now playing + upcoming queue |
+| `SongRow.tsx` | Single song display row (thumbnail, title, actions) |
+| `SongEditPanel.tsx` | Song metadata editor (tags, volume boost, etc.) |
+| `VirtualSongList.tsx` | Virtualized song list for performance |
+| `SourceIcons.tsx` | Source platform icons (YouTube, SoundCloud, etc.) |
+
+### Settings Components
+| Component | Purpose |
+|-----------|---------|
+| `SettingsPage.tsx` | Settings page shell with tabs |
+| `SettingsToggle.tsx` | Toggle switch component |
+| `AdminTab.tsx` | Admin settings (roles, idle timeout, sources) |
+| `AppearanceTab.tsx` | Theme/appearance settings |
+| `CompressorSection.tsx` | Compressor controls (threshold, ratio, etc.) |
+| `EqualizerSection.tsx` | 15-band equalizer sliders |
+
+## API Client (`packages/web/src/utils/api.ts`)
+
+Centralized API client. All frontend API calls go through this file. Provides typed functions for:
+- Song CRUD: `fetchSongs()`, `createSong()`, `updateSong()`, `deleteSong()`
+- Playlist operations: `fetchPlaylists()`, `createPlaylist()`, `updatePlaylist()`, `importPlaylist()`, etc.
+- Player control: `play()`, `pause()`, `skip()`, `seek()`, `setVolume()`, etc.
+- Settings: compressor, equalizer, general, permissions
+- Authentication: login, logout, session check
+
+Uses the shared API service from `@alfira-bot/server/shared/api` for type consistency. Always use this client — never raw `fetch` in components.
+
+## WebSocket Client
+
+Connects to `/ws` for real-time player state updates. Used primarily by the now-playing bar and queue panel. The client is receive-only (never sends messages).
+
+## Constants (`packages/web/src/constants.ts`)
+
+Shared constants used across the web UI. Common values like API base URLs, default settings, etc.
+
+## Tailwind CSS 4 Conventions
+
+- Use Tailwind utility classes for all styling
+- Custom components use Tailwind's `@apply` sparingly
+- Dark theme is the default
+- Responsive design: mobile-first with breakpoint utilities
+
+## Build & Serve
+
+- `bun run web:build` — Builds to `packages/web/dist/`
+- Served by the Bun server as static files with SPA fallback (`index.html` for non-asset paths)
+- Static extensions mapped in `index.ts`: `.html`, `.js`, `.css`, `.png`, `.jpg`, `.svg`, `.ico`, `.webmanifest`, `.woff2`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,18 +7,20 @@ Alfira is a self-hosted Discord music bot with a web UI as the primary interface
 - `packages/server` — Bun API server + Discord bot (`GuildPlayer`, NodeLink audio, Seyfert v4), plus shared types, utilities, DB schema, and logger
 - `packages/web` — React 19 + Tailwind CSS 4 web UI
 
-The bot and API run in a **single Bun process** started from `packages/server/src/index.ts`. They share memory for player state, enabling real-time WebSocket broadcasts directly from playback events.
+The bot and API run in a **single Bun process**. For detailed architecture (startup sequence, WebSocket pipeline, build cycle, shared exports), load the `alfira-architecture` skill.
 
 ## Tech Stack
 
-- **Runtime:** Bun
-- **Language:** TypeScript
-- **Discord:** Seyfert v4
-- **Audio:** NodeLink (Lavalink v4-compatible) with a thin WebSocket client + REST commands
-- **API:** Bun native HTTP + WebSocket
-- **Database:** SQLite + Drizzle ORM
-- **Frontend:** React 19 + Tailwind CSS 4
-- **Linting:** Biome
+| Component | Technology |
+|-----------|------------|
+| Runtime | Bun |
+| Language | TypeScript |
+| Discord | Seyfert v4 |
+| Audio | NodeLink (Lavalink v4) |
+| API | Bun native HTTP + WebSocket |
+| Database | SQLite + Drizzle ORM |
+| Frontend | React 19 + Tailwind CSS 4 |
+| Linting | Biome |
 
 ## Development Commands
 
@@ -45,56 +47,15 @@ bun run lint:fix
 bun run format
 ```
 
-## Key Architecture Notes
-
-### Single-Process Startup Sequence (packages/server/src/index.ts)
-
-1. Run database migrations (homegrown, reads `packages/shared/dist/db/migrations/*.sql`)
-2. Verify database connectivity
-3. Start NodeLink subprocess
-4. Call `startDiscord()` — initializes Seyfert Discord client + NodeLink connection
-5. Start Bun HTTP server on port 3001 (serves API routes, WebSocket at `/ws`, and static web assets from `packages/web/dist/`)
-
-### Real-Time Updates (WebSocket Pipeline)
-
-The bot never directly holds WebSocket connections. Instead:
-
-1. `GuildPlayer` calls `emitPlayerUpdate(state)` directly (packages/server/src/lib/socket.ts)
-2. `emitPlayerUpdate` fetches compressor settings, serializes the state, and sends to all registered WebSocket clients
-
-WebSocket clients authenticate via session cookie on connection. The client never sends messages — it's receive-only.
-
-### Server Changes Require Rebuild
-
-The server is compiled to `packages/server/dist/` during Docker image build. If you change `packages/server/src/**`, run `bun run dev` again — it rebuilds the local `dist/` and then starts Docker with a fresh image. API source is live-mounted via Docker volume so `docker compose restart alfira` picks up changes without a rebuild.
-
-### Environment Configuration
-
-A single `.env` file at the project root is used for all configuration. Copy `.env.example` to `.env` and fill in all values before running. Required: `DISCORD_BOT_TOKEN`, `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET`, `DISCORD_REDIRECT_URI`, `JWT_SECRET`. Guild ID, admin roles, idle timeout, and notification channel are configured via the in-app setup wizard (or optionally via `GUILD_ID` / `ADMIN_ROLE_IDS` env vars for existing deployments).
-
-### NodeLink Audio Service
-
-The bot streams audio from NodeLink (a Lavalink v4-compatible server). The `nodelink` service runs in Docker (docker-compose.yml) on port 2333. Player control uses NodeLink's REST API directly; events (TrackEnd, etc.) are received over a WebSocket connection managed by `lib/lavalink.ts`. Voice connections use Discord's gateway (VOICE_STATE_UPDATE / VOICE_SERVER_UPDATE) forwarded to NodeLink's REST endpoint.
-
 ## Code Style
 
 - Biome for linting and formatting
 - Run `bun run check` before committing
 - CI runs `bun run lint` — code must pass before merging
 
-## Shared Package Exports
+## Domain Knowledge
 
-`@alfira-bot/server/shared` provides:
-
-**Types:** `Song`, `QueuedSong`, `LoopMode`, `QueueState`, `Playlist`, `PlaylistDetail`, `User`
-
-**Utilities:** `formatDuration(seconds)`, `fisherYatesShuffle(array)`
-
-**DB:** Schema defined in `packages/server/src/shared/db/schema.ts`
-
-**Logger:** `logger` export from `@alfira-bot/server/shared/logger`
-
-**API Service:** `@alfira-bot/server/shared/api` provides centralized API functions (`fetchSongs`, `createSong`, `importPlaylist`, etc.) that should be used by all consumers.
+Detailed architecture, audio pipeline, database schema, API routes, and web UI patterns live in **Pi skills** (`.pi/skills/`). The agent loads them on-demand when relevant. Force-load with `/skill:name` if needed.
 
 ## Git Workflow
 
@@ -195,4 +156,4 @@ Always run `bun run check` and resolve any lint/format issues before committing.
 - [Installation Guide](docs/installation.md) — Setup, environment variables, Docker commands
 - [Philosophy](docs/philosophy.md) — Design principles guiding the project
 - [Tech Stack](docs/tech-stack.md) — Detailed architecture
-- [Troubleshooting](docs/troubleshooting.md) — Common issues and solutions
+- [Troubleshooting](docs/troubleshooting.md) — Common issues and solutions (also available as the `alfira-troubleshooting` skill)


### PR DESCRIPTION
## Summary

Move deep architectural and domain knowledge from `AGENTS.md` (always in context) into on-demand Pi skills. Reduces per-turn context by ~2.3KB while providing richer, subsystem-specific guidance.

## Changes

- **6 new Pi skills** in `.pi/skills/`:
  - `alfira-architecture` — server startup, WebSocket pipeline, build cycle, shared exports
  - `alfira-audio` — NodeLink/Lavalink protocol, GuildPlayer, voice connections, track events, filters
  - `alfira-database` — Drizzle schema, migration runner, query patterns, tag system
  - `alfira-api` — route map, auth flow, middleware, WebSocket auth
  - `alfira-web` — component/page map, API client, WebSocket client, Tailwind conventions
  - `alfira-troubleshooting` — common issues and solutions (migrated from docs/troubleshooting.md)
- **Trimmed `AGENTS.md`** — removed deep architecture sections (startup sequence, WebSocket pipeline, NodeLink details, shared exports). Replaced with compact tech stack table and pointer to skills.
- **Updated `/plan` template** — now prompts the agent to load relevant skills before writing implementation plans.