### PR TITLE
refactor(server): deduplicate getClientIp in auth route

### DIFF
--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -4,6 +4,7 @@ import jwt from 'jsonwebtoken';
 import type { RouteContext } from '../index';
 import { getGuildId } from '../lib/config';
 import { json } from '../lib/json';
+import { getClientIp } from '../lib/rateLimit';
 import { db, tables } from '../shared/db';
 import { logger } from '../shared/logger';
 
@@ -339,14 +340,6 @@ async function generateAndStoreTokens(
 // ---------------------------------------------------------------------------
 // Route handlers
 // ---------------------------------------------------------------------------
-
-function getClientIp(request: Request): string {
-  return (
-    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
-    request.headers.get('x-real-ip') ??
-    'unknown'
-  );
-}
 
 export async function handleAuth(ctx: RouteContext, request: Request): Promise<Response> {
   const url = new URL(request.url);


### PR DESCRIPTION
## Summary

Remove a duplicated `getClientIp` function in the auth route and replace it with an import from the canonical shared implementation in `lib/rateLimit.ts`.

## Changes

- Removed 7-line duplicate `getClientIp` from `routes/auth.ts`
- Added import of `getClientIp` from `lib/rateLimit.ts` — the same function already used by `routes/player.ts`, `routes/songs.ts`, and `routes/playlists.ts`