### PR TITLE
refactor(server): deduplicate SerializedSong type

### DIFF
--- a/packages/server/src/lib/serialization.ts
+++ b/packages/server/src/lib/serialization.ts
@@ -2,7 +2,7 @@ import type { Song } from '../shared';
 
 // Accept both Date and string createdAt — Drizzle uses Date at the DB level,
 // but we serialize to ISO string for JSON serialization.
-type SerializedSong = Omit<Song, 'createdAt'> & { createdAt: string | Date };
+export type SerializedSong = Omit<Song, 'createdAt'> & { createdAt: string | Date };
 
 // ---------------------------------------------------------------------------
 // Serialization helpers

--- a/packages/server/src/lib/socket.ts
+++ b/packages/server/src/lib/socket.ts
@@ -1,13 +1,12 @@
 import { eq } from 'drizzle-orm';
-import type { CompressorSettings, Playlist, QueueState, Song, User } from '../shared';
+import type { CompressorSettings, Playlist, QueueState, User } from '../shared';
 import { db, tables } from '../shared/db';
 import { logger } from '../shared/logger';
 
-import { formatSong } from './serialization';
+import { formatSong, type SerializedSong } from './serialization';
 
 // Accept both Date and string createdAt — Drizzle uses Date at the DB level,
 // but we serialize to ISO string for JSON serialization.
-type SerializedSong = Omit<Song, 'createdAt'> & { createdAt: string | Date };
 type SerializedPlaylist = Omit<Playlist, 'createdAt'> & { createdAt: string | Date };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Remove a duplicated type definition — `SerializedSong` was defined identically in both `serialization.ts` and `socket.ts`.

## Changes

- Export `SerializedSong` from `serialization.ts` so it can be shared
- Import it in `socket.ts` instead of redefining it locally
- Drop the now-unused `Song` import from `socket.ts`