### PR TITLE
feat(web): show monotone source icon on song rows

### DIFF
--- a/packages/web/src/components/SongRow.tsx
+++ b/packages/web/src/components/SongRow.tsx
@@ -10,23 +10,31 @@ import {
   TagIcon,
   UserIcon,
 } from '@phosphor-icons/react';
-import { memo, useState } from 'react';
+import { memo, useMemo, useState } from 'react';
 import { useSongEdit } from '../context/SongEditContext';
 import { useSongActions } from '../hooks/useSongActions';
+import { getSourceKey } from '../utils/source';
 import { ContextMenu, ContextMenuTrigger } from './ContextMenu';
 import SongEditPanel from './SongEditPanel';
+import { SourceIcon } from './SourceIcons';
 import TagTicker from './TagTicker';
 import { Button } from './ui/Button';
 
 interface MetaInfoProps {
   song: Song;
   isHovered?: boolean;
+  sourceKey: string | null;
 }
 
-function MetaInfo({ song, isHovered }: MetaInfoProps) {
+function MetaInfo({ song, isHovered, sourceKey }: MetaInfoProps) {
   const tags = song.tags ?? [];
   return (
     <>
+      {sourceKey && (
+        <span className="flex items-center shrink-0 grayscale opacity-50 [&_svg]:w-3 [&_svg]:h-3">
+          <SourceIcon sourceKey={sourceKey} />
+        </span>
+      )}
       <span className="flex items-center gap-1.5 font-mono text-xs text-muted">
         {formatDuration(song.duration)}
         <ClockIcon size={11} weight="fill" className="shrink-0" />
@@ -82,6 +90,7 @@ export const SongRow = memo(
     const { openSongId, setOpenSongId } = useSongEdit();
     const [isRowHovered, setIsRowHovered] = useState(false);
     const isOpen = openSongId === song.id;
+    const sourceKey = useMemo(() => getSourceKey(song.sourceUrl), [song.sourceUrl]);
     const { menuOpen, setMenuOpen, triggerRef, menuItems } = useSongActions({
       song,
       isAdmin,
@@ -162,7 +171,7 @@ export const SongRow = memo(
             })()}
           </div>
           <div className="hidden md:flex flex-col items-end gap-px shrink-0 mr-2">
-            <MetaInfo song={song} isHovered={isRowHovered} />
+            <MetaInfo song={song} isHovered={isRowHovered} sourceKey={sourceKey} />
           </div>
           <Button
             variant="primary"

--- a/packages/web/src/utils/source.ts
+++ b/packages/web/src/utils/source.ts
@@ -1,0 +1,33 @@
+/**
+ * Maps hostnames to source keys. Must mirror the server's SOURCE_DEFINITIONS
+ * in packages/server/src/utils/nodelink.ts.
+ */
+const HOST_TO_SOURCE: Record<string, string> = {
+  'youtube.com': 'youtube',
+  'www.youtube.com': 'youtube',
+  'youtu.be': 'youtube',
+  'music.youtube.com': 'youtube',
+  'soundcloud.com': 'soundcloud',
+  'www.soundcloud.com': 'soundcloud',
+  'open.spotify.com': 'spotify',
+  'spotify.com': 'spotify',
+  'www.spotify.com': 'spotify',
+  'music.apple.com': 'applemusic',
+  'tidal.com': 'tidal',
+  'www.tidal.com': 'tidal',
+  'listen.tidal.com': 'tidal',
+  'drive.google.com': 'googledrive',
+};
+
+/**
+ * Derive a source key from a song's sourceUrl.
+ * Returns the source key (e.g. "youtube", "spotify") or null if unparseable/unknown.
+ */
+export function getSourceKey(sourceUrl: string): string | null {
+  try {
+    const parsed = new URL(sourceUrl);
+    return HOST_TO_SOURCE[parsed.hostname] ?? null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Add a small monotone source icon to each song row in list view, so users can see at a glance which platform (YouTube, SoundCloud, Spotify, etc.) a song originated from.

## Changes

- New `packages/web/src/utils/source.ts` — `getSourceKey(sourceUrl)` utility that derives the source key from a URL's hostname, mirroring the server's `SOURCE_DEFINITIONS`
- Modified `packages/web/src/components/SongRow.tsx` — renders a 12×12 `SourceIcon` in the metadata column with `grayscale opacity-50` for a monotone look