### PR TITLE
chore(server): remove unused getEnabledSourceKeys function

### DIFF
--- a/packages/server/src/startDiscord.ts
+++ b/packages/server/src/startDiscord.ts
@@ -8,7 +8,6 @@ export type { GuildPlayer } from './GuildPlayer';
 export { createPlayer, destroyAllPlayers, getPlayer } from './manager';
 export {
   getEnabledSourceDisplayNames,
-  getEnabledSourceKeys,
   getMetadata,
   getPlaylistMetadataWithVideos,
   initEnabledSources,

--- a/packages/server/src/utils/nodelink.ts
+++ b/packages/server/src/utils/nodelink.ts
@@ -177,10 +177,6 @@ function getEnabledSourcesSync(): string[] {
   return ALL_SOURCE_KEYS;
 }
 
-export function getEnabledSourceKeys(): string[] {
-  return getEnabledSourcesSync();
-}
-
 export function getEnabledSourceDisplayNames(): string[] {
   return getEnabledSourcesSync()
     .map((key) => SOURCE_DEFINITIONS[key]?.displayName)


### PR DESCRIPTION
## Summary

Remove the dead `getEnabledSourceKeys` function — it was defined, exported, and re-exported but never imported or called anywhere in the codebase.

## Changes

- Remove `getEnabledSourceKeys` definition from `packages/server/src/utils/nodelink.ts`
- Remove `getEnabledSourceKeys` from the re-export block in `packages/server/src/startDiscord.ts`