### PR TITLE
feat(pi): add /smell prompt and guardrails to all prompts

### DIFF
--- a/.pi/prompts/cleanup.md
+++ b/.pi/prompts/cleanup.md
@@ -24,6 +24,10 @@ Follow these principles:
 
 The goal is a clean, legible codebase that's easy to reason about and extend. Every removal or simplification should raise the bar, not just churn the code.
 
+## Boundaries
+
+Structural design issues — long functions, god objects, feature envy, inconsistent patterns — aren't cleanup. Use `/smell` for those.
+
 ## Honesty
 
 If you don't find anything worth acting on, say so. It's better to be honest than to manufacture a problem that doesn't exist. No cleanup is still a valid result.

--- a/.pi/prompts/plan.md
+++ b/.pi/prompts/plan.md
@@ -5,6 +5,12 @@ argument-hint: "<task description>"
 
 Before writing any code, produce a plan. If the user provided a task description ($@), use it as the starting point. Otherwise, ask what we're building.
 
+## Guardrails
+
+**Don't plan too much at once.** If the task naturally breaks into 8+ steps touching 10+ files, it's too big for one plan. Say so and suggest splitting it into smaller pieces.
+
+**Re-plan when necessary.** If implementation reveals the plan was wrong — a step doesn't work, a dependency was missed, the architecture doesn't support the approach — stop and update the plan. Don't bulldoze through a broken plan.
+
 ## Plan format
 
 Output a plan with these sections:

--- a/.pi/prompts/release.md
+++ b/.pi/prompts/release.md
@@ -5,6 +5,8 @@ argument-hint: "[version or semver bump: major|minor|patch]"
 
 Follow these steps exactly, reporting progress as you go.
 
+> ⚠️ **Releases touch `main`, trigger CI/CD, and publish artifacts. This is the riskiest operation in the workflow. Double-check everything before pushing.**
+
 ## 1. Check what's pending
 
 ```bash
@@ -56,6 +58,8 @@ Compute: `v<major>.<minor>.<patch>`.
 Tell the user what you determined and why (e.g., "Bumping minor because there are feat commits: v0.1.0 → v0.2.0"). If they disagree, they can provide a different version.
 
 ## 4. Update the changelog
+
+Check that `CHANGELOG.md` exists. If it doesn't, stop and ask: "No CHANGELOG.md found. Want me to create one?"
 
 Read `CHANGELOG.md`. Replace the `## [Unreleased]` section with:
 

--- a/.pi/prompts/smell.md
+++ b/.pi/prompts/smell.md
@@ -1,0 +1,46 @@
+---
+description: Find and evaluate code smells — structural design issues worth refactoring
+argument-hint: "[area to focus on]"
+---
+
+Search for code smells in the repo. $1
+
+Follow these principles:
+
+## Approach
+
+**Understand first.** Before flagging anything, build a holistic understanding of the project — not just individual files, but how they fit together. Read related files, trace call paths, and grasp the architecture. A pattern that looks like a smell in isolation may be a deliberate tradeoff when you see the full picture.
+
+**Evaluate cost vs. benefit.** Not every smell is worth fixing. Ask: does this actually cause bugs or slow down development? A long function that never changes and is well-tested may not be worth the churn. Be honest about when the juice isn't worth the squeeze.
+
+**Focus on one smell at a time.** If you find multiple candidates, pick the most impactful one and stay with it.
+
+**Behavior must be preserved.** A refactor changes structure, not behavior. If tests exist, they must still pass. If they don't, be explicit about what you're relying on for safety.
+
+## What to look for
+
+Smells relevant to this TypeScript + React codebase:
+
+- **Long functions** — functions over ~40 lines that juggle multiple responsibilities. Especially common in route handlers and Discord event callbacks.
+- **God objects** — classes or modules that know and do too much. GuildPlayer, large React components with many hooks, or utility modules that have become grab-bags.
+- **Primitive obsession** — strings and numbers used where a small typed wrapper would prevent bugs (e.g., raw strings for IDs, magic numbers for durations, untyped config dictionaries).
+- **Feature envy** — a function that spends more time accessing another module's data than its own. Often a sign that the logic belongs somewhere else.
+- **Too many parameters** — functions with 4+ positional parameters, especially when several are always passed together (data clump).
+- **Commented-out explanations** — comments that narrate *what* the code does rather than *why*. The code should be self-documenting; comments should explain intent.
+- **Inconsistent patterns** — the same problem solved differently in different places (error handling, validation, async patterns, state management).
+- **Shotgun surgery** — a single conceptual change requiring edits across many files. Often a sign of poor cohesion.
+- **Speculative generality** — hooks, abstractions, or configuration built for a future that never arrived.
+
+## Standards
+
+The goal is code that's easy to reason about and cheap to change. Every refactor should make the codebase clearly better, not just different. If the improvement is marginal, say so — it might not be worth the risk.
+
+## If you find a smell worth fixing
+
+1. Describe the smell: what it is, where it lives, why it hurts
+2. Propose the fix at a high level (not a line-by-line plan — that's what `/plan` is for)
+3. Offer to proceed: "Want me to `/plan` this and implement it?"
+
+## Honesty
+
+If you don't find anything worth acting on, say so. A clean bill of health is a good result. Don't invent problems.

--- a/.pi/prompts/submit.md
+++ b/.pi/prompts/submit.md
@@ -27,6 +27,8 @@ If lint or format issues are found, fix them before proceeding. If fixes produce
 
 ## 3. Create a feature branch
 
+Validate the branch name: `<type>/<short-description>`. `type` must be one of `feat`, `fix`, `chore`, `refactor`, `docs`, `ci`, `style`, `test`, `perf`, `security`, `revert`, `ui`, `cleanup`. Reject anything else.
+
 If currently on `main` or `dev`, create a new branch from `dev` that is up to date:
 
 ```bash

--- a/.pi/prompts/verify.md
+++ b/.pi/prompts/verify.md
@@ -4,6 +4,16 @@ description: Run quality checks and review the diff before submitting — the ga
 
 Run the verification gate. Do not proceed to `/submit` until this passes.
 
+## 0. Scope check
+
+```bash
+git diff --stat
+```
+
+If only non-code files changed (`.pi/prompts/`, `docs/`, `README.md`, `*.md`, `.gitignore`, etc.), skip TypeScript compilation (step 2). Linting and diff review still apply.
+
+If the diff is large (200+ lines), flag it: "Large diff — review carefully."
+
 ## 1. Lint and format
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a new `/smell` prompt for identifying and evaluating code smells, and improves all existing prompts with guardrails, boundaries, and safety checks.

## Changes

- **New: `/smell` prompt** — finds structural design issues (long functions, god objects, feature envy, etc.), evaluates cost/benefit, and hands off to `/plan` for fixes worth doing
- **`/cleanup`** — added Boundaries section pointing structural issues to `/smell`
- **`/plan`** — added Guardrails: don't plan too much at once, re-plan when the plan breaks
- **`/verify`** — added step 0 scope check: skips TypeScript compilation for non-code changes, flags large diffs
- **`/submit`** — added branch type validation to step 3
- **`/release`** — added danger-zone warning and missing-CHANGELOG.md guard