### PR TITLE
ci: add paths-ignore to skip non-code changes in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,23 @@ permissions:
 on:
   push:
     branches: [main, dev]
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - ".zed/**"
+      - ".pi/**"
+      - "LICENSE"
+      - ".git-commit-template"
+      - ".env.example"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - ".zed/**"
+      - ".pi/**"
+      - "LICENSE"
+      - ".git-commit-template"
+      - ".env.example"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,24 @@ name: CodeQL
 on:
   push:
     branches: [main, dev]
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - ".zed/**"
+      - ".pi/**"
+      - "LICENSE"
+      - ".git-commit-template"
+      - ".env.example"
   pull_request:
     branches: [main, dev]
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - ".zed/**"
+      - ".pi/**"
+      - "LICENSE"
+      - ".git-commit-template"
+      - ".env.example"
   schedule:
     - cron: "0 6 * * 1" # every Monday at 06:00 UTC
   workflow_dispatch:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,11 +7,21 @@ on:
       - dev
     paths-ignore:
       - "docs/**"
-      - "README.md"
+      - "**.md"
+      - ".zed/**"
+      - ".pi/**"
+      - "LICENSE"
+      - ".git-commit-template"
+      - ".env.example"
   pull_request:
     paths-ignore:
       - "docs/**"
-      - "README.md"
+      - "**.md"
+      - ".zed/**"
+      - ".pi/**"
+      - "LICENSE"
+      - ".git-commit-template"
+      - ".env.example"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

Add consistent `paths-ignore` blocks to CI, CodeQL, and Docker Build workflows so pushes that only touch non-code files don't waste CI minutes.

## Changes

- **CI** — Added `paths-ignore` (was missing entirely)
- **CodeQL** — Added `paths-ignore` (was missing entirely)
- **Docker Build** — Expanded existing ignore list from `docs/**` + `README.md` to full set

## Ignored paths

```yaml
paths-ignore:
  - "docs/**"
  - "**.md"
  - ".zed/**"
  - ".pi/**"
  - "LICENSE"
  - ".git-commit-template"
  - ".env.example"
```