### PR TITLE
fix(permissions): un-gate UI actions for non-admin users with granular permissions

### DIFF
--- a/packages/server/src/routes/permissions.ts
+++ b/packages/server/src/routes/permissions.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm';
 import type { RouteContext } from '../index';
 import { getGuildId } from '../lib/config';
 import { json } from '../lib/json';
@@ -137,9 +137,40 @@ async function handlePatchPermissions(ctx: RouteContext, request: Request): Prom
 }
 
 // ---------------------------------------------------------------------------
+// GET /api/permissions/me — returns permissions for the current user
+// ---------------------------------------------------------------------------
+async function handleGetMyPermissions(ctx: RouteContext): Promise<Response> {
+  const user = ctx.user;
+  if (!user) {
+    return json({ error: 'Not authenticated.' }, 401);
+  }
+
+  const userRoles = user.roles ?? [];
+  if (userRoles.length === 0) {
+    return json({ permissions: [] });
+  }
+
+  const rows = await db
+    .select({ action: tables.rolePermission.action })
+    .from(tables.rolePermission)
+    .where(inArray(tables.rolePermission.roleId, userRoles));
+
+  const permissions = [...new Set(rows.map((r) => r.action))];
+  return json({ permissions });
+}
+
+// ---------------------------------------------------------------------------
 // Dispatcher
 // ---------------------------------------------------------------------------
 export async function handlePermissions(ctx: RouteContext, request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  const pathname = url.pathname;
+
+  // GET /api/permissions/me
+  if (request.method === 'GET' && pathname === '/api/permissions/me') {
+    return await handleGetMyPermissions(ctx);
+  }
+
   if (request.method === 'GET') return await handleGetPermissions(ctx);
   if (request.method === 'PATCH') return await handlePatchPermissions(ctx, request);
   return json({ error: 'Not Found' }, 404);

--- a/packages/server/src/shared/api.ts
+++ b/packages/server/src/shared/api.ts
@@ -424,3 +424,11 @@ export function updatePermission(
 ): Promise<{ action: string; roleIds: string[] }> {
   return patch('/api/permissions', { action, roleIds });
 }
+
+export interface MyPermissionsResponse {
+  permissions: string[];
+}
+
+export function fetchMyPermissions(): Promise<MyPermissionsResponse> {
+  return get('/api/permissions/me');
+}

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -5,6 +5,7 @@ import SettingsPage from './components/settings/SettingsPage';
 import { AdminViewProvider } from './context/AdminViewContext';
 import { AuthProvider } from './context/AuthContext';
 import { NotificationProvider } from './context/NotificationContext';
+import { PermissionsProvider } from './context/PermissionsContext';
 import { PlayerProvider } from './context/PlayerContext';
 import { SongEditProvider } from './context/SongEditContext';
 import { TagsProvider } from './context/TagsContext';
@@ -24,42 +25,44 @@ export default function App() {
       <TagsProvider>
         <AuthProvider>
           <AdminViewProvider>
-            <NotificationProvider>
-              <SongEditProvider>
-                <Routes>
-                  <Route path="/login" element={<LoginPage />} />
-                  <Route
-                    path="/setup"
-                    element={
-                      <ProtectedRoute>
-                        <SetupWizard />
-                      </ProtectedRoute>
-                    }
-                  />
-                  <Route
-                    path="/"
-                    element={
-                      <ProtectedRoute>
-                        {/* PlayerProvider lives inside ProtectedRoute so it only polls while a user is authenticated. */}
-                        <PlayerProvider>
-                          <Layout />
-                        </PlayerProvider>
-                      </ProtectedRoute>
-                    }
-                  >
-                    <Route index element={<Navigate to="/songs" replace />} />
-                    <Route path="songs" element={<SongsPage />} />
-                    <Route path="playlists" element={<PlaylistsPage />} />
-                    <Route path="playlists/:id" element={<PlaylistDetailPage />} />
-                    <Route path="settings" element={<SettingsPage />} />
-                    <Route path="audio" element={<AudioPage />} />
-                    <Route path="tags" element={<TagsPage />} />
-                    <Route path="permissions" element={<PermissionsPage />} />
-                  </Route>
-                  <Route path="*" element={<Navigate to="/" replace />} />
-                </Routes>
-              </SongEditProvider>
-            </NotificationProvider>
+            <PermissionsProvider>
+              <NotificationProvider>
+                <SongEditProvider>
+                  <Routes>
+                    <Route path="/login" element={<LoginPage />} />
+                    <Route
+                      path="/setup"
+                      element={
+                        <ProtectedRoute>
+                          <SetupWizard />
+                        </ProtectedRoute>
+                      }
+                    />
+                    <Route
+                      path="/"
+                      element={
+                        <ProtectedRoute>
+                          {/* PlayerProvider lives inside ProtectedRoute so it only polls while a user is authenticated. */}
+                          <PlayerProvider>
+                            <Layout />
+                          </PlayerProvider>
+                        </ProtectedRoute>
+                      }
+                    >
+                      <Route index element={<Navigate to="/songs" replace />} />
+                      <Route path="songs" element={<SongsPage />} />
+                      <Route path="playlists" element={<PlaylistsPage />} />
+                      <Route path="playlists/:id" element={<PlaylistDetailPage />} />
+                      <Route path="settings" element={<SettingsPage />} />
+                      <Route path="audio" element={<AudioPage />} />
+                      <Route path="tags" element={<TagsPage />} />
+                      <Route path="permissions" element={<PermissionsPage />} />
+                    </Route>
+                    <Route path="*" element={<Navigate to="/" replace />} />
+                  </Routes>
+                </SongEditProvider>
+              </NotificationProvider>
+            </PermissionsProvider>
           </AdminViewProvider>
         </AuthProvider>
       </TagsProvider>

--- a/packages/web/src/api/api.ts
+++ b/packages/web/src/api/api.ts
@@ -11,7 +11,7 @@ export type {
   SetupRole,
 } from '@alfira-bot/server/shared';
 
-export type { PermissionsResponse } from '@alfira-bot/server/shared/api';
+export type { MyPermissionsResponse, PermissionsResponse } from '@alfira-bot/server/shared/api';
 // ---------------------------------------------------------------------------
 // Re-export everything from shared API with web-compatible names
 // ---------------------------------------------------------------------------
@@ -27,6 +27,7 @@ export {
   fetchLogout as logout,
   // Auth
   fetchMe as getMe,
+  fetchMyPermissions,
   fetchPermissions,
   fetchPlaylistPage as getPlaylistPage,
   // Playlists

--- a/packages/web/src/components/AddSongModal.tsx
+++ b/packages/web/src/components/AddSongModal.tsx
@@ -1,6 +1,8 @@
 import type { Song } from '@alfira-bot/server/shared';
 import { useEffect, useRef, useState } from 'react';
 import { addSong, importPlaylist } from '../api/api';
+import { useAdminView } from '../context/AdminViewContext';
+import { usePermissions } from '../context/PermissionsContext';
 import { apiErrorMessage } from '../utils/api';
 import { Backdrop } from './Backdrop';
 import { Button } from './ui/Button';
@@ -12,12 +14,15 @@ export default function AddSongModal({
   onClose: () => void;
   onAdded: (song: Song) => void;
 }) {
+  const { isAdminView } = useAdminView();
+  const { hasPermission } = usePermissions();
   const [url, setUrl] = useState('');
   const [nickname, setNickname] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [successMsg, setSuccessMsg] = useState('');
   const isPlaylist = url.includes('list=');
+  const canImport = isAdminView || hasPermission('songs.import');
   const [importFullPlaylist, setImportFullPlaylist] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -83,7 +88,7 @@ export default function AddSongModal({
           disabled={loading}
         />
 
-        {isPlaylist && (
+        {isPlaylist && canImport && (
           <label className="flex items-center gap-2 mb-3 cursor-pointer">
             <input
               type="checkbox"

--- a/packages/web/src/components/QueuePanel.tsx
+++ b/packages/web/src/components/QueuePanel.tsx
@@ -39,6 +39,7 @@ import LoadPlaylistModal from '../components/queue/LoadPlaylistModal';
 import OverrideModal from '../components/queue/OverrideModal';
 import QuickAddModal from '../components/queue/QuickAddModal';
 import { useAdminView } from '../context/AdminViewContext';
+import { usePermissions } from '../context/PermissionsContext';
 import { usePlayer } from '../context/PlayerContext';
 import { Button } from './ui/Button';
 
@@ -71,6 +72,7 @@ export default function QueuePanel({
 }) {
   const { state, loading, elapsed, registerProgress, clear } = usePlayer();
   const { isAdminView } = useAdminView();
+  const { hasPermission } = usePermissions();
   const [showQuickAdd, setShowQuickAdd] = useState(false);
   const [showLoadPlaylist, setShowLoadPlaylist] = useState(false);
   const [showOverride, setShowOverride] = useState(false);
@@ -136,14 +138,16 @@ export default function QueuePanel({
         icon: <ListIcon size={14} weight="duotone" />,
         onClick: () => setShowLoadPlaylist(true),
       },
-      {
+    ];
+    if (isAdminView || hasPermission('queue.quickadd')) {
+      items.push({
         id: 'quick-add',
         label: 'Quick Add',
         icon: <PlusCircleIcon size={14} weight="duotone" />,
         onClick: () => setShowQuickAdd(true),
-      },
-    ];
-    if (isAdminView) {
+      });
+    }
+    if (isAdminView || hasPermission('queue.manage')) {
       items.push({
         id: 'override',
         label: 'Override',
@@ -151,6 +155,8 @@ export default function QueuePanel({
         danger: true,
         onClick: () => setShowOverride(true),
       });
+    }
+    if (isAdminView || hasPermission('queue.clear')) {
       items.push({
         id: 'clear-queue',
         label: 'Clear Queue',
@@ -161,7 +167,7 @@ export default function QueuePanel({
       });
     }
     return items;
-  }, [isAdminView, clearBusy, isQueueEmpty]);
+  }, [isAdminView, hasPermission, clearBusy, isQueueEmpty]);
 
   if (loading) {
     return (

--- a/packages/web/src/components/SongCard.tsx
+++ b/packages/web/src/components/SongCard.tsx
@@ -2,6 +2,7 @@ import type { Playlist, Song } from '@alfira-bot/server/shared';
 import { formatDuration } from '@alfira-bot/server/shared';
 import { CircleNotchIcon, HeadphonesIcon, PlayIcon } from '@phosphor-icons/react';
 import React, { useCallback, useMemo } from 'react';
+import { usePermissions } from '../context/PermissionsContext';
 import { useSongEdit } from '../context/SongEditContext';
 import { useSongActions } from '../hooks/useSongActions';
 import { ContextMenu, ContextMenuTrigger } from './ContextMenu';
@@ -10,7 +11,6 @@ import { Button } from './ui/Button';
 
 interface SongCardProps {
   song: Song;
-  isAdmin: boolean;
   playlists: Playlist[];
   delay?: number;
   isAdminView?: boolean;
@@ -22,7 +22,6 @@ interface SongCardProps {
 
 const SongCardInner = ({
   song,
-  isAdmin,
   playlists,
   delay,
   isAdminView,
@@ -32,6 +31,7 @@ const SongCardInner = ({
   onAddToQueue,
 }: SongCardProps) => {
   const { openSongId, setOpenSongId } = useSongEdit();
+  const { hasPermission } = usePermissions();
   const isOpen = openSongId === song.id;
   const style = useMemo(
     () => ({ animationDelay: `${Math.min((delay ?? 0) * 30, 300)}ms` }),
@@ -41,6 +41,9 @@ const SongCardInner = ({
   const handlePlay = useCallback(() => onPlay(song.id), [onPlay, song.id]);
   const handleAddToQueue = useCallback(() => onAddToQueue(song.id), [onAddToQueue, song.id]);
 
+  const canEdit = isAdminView || hasPermission('songs.edit');
+  const canDelete = isAdminView || hasPermission('songs.delete');
+
   const actionHandlers = useMemo(
     () => ({ onAddToQueue: handleAddToQueue, onDelete: handleDelete }),
     [handleAddToQueue, handleDelete]
@@ -48,7 +51,8 @@ const SongCardInner = ({
 
   const { menuOpen, setMenuOpen, triggerRef, menuItems } = useSongActions({
     song,
-    isAdmin,
+    canEdit,
+    canDelete,
     playlists,
     ...actionHandlers,
   });
@@ -58,7 +62,7 @@ const SongCardInner = ({
       className={`animate-fade-up opacity-0 flex flex-col bg-elevated rounded-xl clay-resting transition-all duration-100${isAdminView ? ' hover:clay-raised hover:-translate-y-px active:clay-flat active:translate-y-0 group cursor-pointer' : ''}`}
       style={style}
       data-song-edit-container
-      onClick={() => isAdmin && setOpenSongId(isOpen ? null : song.id)}
+      onClick={() => canEdit && setOpenSongId(isOpen ? null : song.id)}
     >
       {/* Thumbnail with play overlay */}
       <div

--- a/packages/web/src/components/SongRow.tsx
+++ b/packages/web/src/components/SongRow.tsx
@@ -11,6 +11,7 @@ import {
   UserIcon,
 } from '@phosphor-icons/react';
 import { memo, useMemo, useState } from 'react';
+import { usePermissions } from '../context/PermissionsContext';
 import { useSongEdit } from '../context/SongEditContext';
 import { useSongActions } from '../hooks/useSongActions';
 import { getSourceKey } from '../utils/source';
@@ -61,7 +62,6 @@ function MetaInfo({ song, isHovered, sourceKey }: MetaInfoProps) {
 
 interface SongRowProps {
   song: Song;
-  isAdmin: boolean;
   isAdminView?: boolean;
   playlists?: Playlist[];
   onDelete?: (id: string) => void;
@@ -77,7 +77,6 @@ interface SongRowProps {
 export const SongRow = memo(
   ({
     song,
-    isAdmin,
     isAdminView,
     playlists,
     onDelete,
@@ -88,12 +87,18 @@ export const SongRow = memo(
     onAddToQueue,
   }: SongRowProps) => {
     const { openSongId, setOpenSongId } = useSongEdit();
+    const { hasPermission } = usePermissions();
     const [isRowHovered, setIsRowHovered] = useState(false);
     const isOpen = openSongId === song.id;
     const sourceKey = useMemo(() => getSourceKey(song.sourceUrl), [song.sourceUrl]);
+
+    const canEdit = isAdminView || hasPermission('songs.edit');
+    const canDelete = isAdminView || hasPermission('songs.delete');
+
     const { menuOpen, setMenuOpen, triggerRef, menuItems } = useSongActions({
       song,
-      isAdmin,
+      canEdit,
+      canDelete,
       playlists: playlists ?? [],
       onAddToQueue,
       ...(onDelete ? { onDelete: () => onDelete(song.id) } : {}),
@@ -109,16 +114,16 @@ export const SongRow = memo(
       >
         <div
           className="flex items-center gap-1.5 md:gap-2 px-3 md:px-4 py-3"
-          onClick={() => isAdmin && setOpenSongId(isOpen ? null : song.id)}
+          onClick={() => canEdit && setOpenSongId(isOpen ? null : song.id)}
           onKeyDown={(e) => {
-            if (isAdmin && (e.key === 'Enter' || e.key === ' ')) {
+            if (canEdit && (e.key === 'Enter' || e.key === ' ')) {
               e.preventDefault();
               setOpenSongId(isOpen ? null : song.id);
             }
           }}
           role="button"
           tabIndex={0}
-          style={isAdmin ? { cursor: 'pointer' } : undefined}
+          style={canEdit ? { cursor: 'pointer' } : undefined}
           onMouseEnter={() => setIsRowHovered(true)}
           onMouseLeave={() => setIsRowHovered(false)}
         >

--- a/packages/web/src/components/VirtualSongList.tsx
+++ b/packages/web/src/components/VirtualSongList.tsx
@@ -6,7 +6,6 @@ import SongRow from './SongRow';
 interface VirtualSongListProps {
   items: Song[];
   viewMode: 'grid' | 'list';
-  isAdmin: boolean;
   isAdminView: boolean;
   playlists: Playlist[];
   isLoading: boolean;
@@ -68,7 +67,6 @@ function SkeletonList() {
 export const VirtualSongList = memo(function VirtualSongList({
   items,
   viewMode,
-  isAdmin,
   isAdminView,
   playlists,
   isLoading,
@@ -98,7 +96,6 @@ export const VirtualSongList = memo(function VirtualSongList({
             <SongCard
               key={song.id}
               song={song}
-              isAdmin={isAdmin}
               isAdminView={isAdminView}
               playlists={playlists}
               onDelete={onDelete}
@@ -146,7 +143,6 @@ export const VirtualSongList = memo(function VirtualSongList({
           <SongRow
             key={song.id}
             song={song}
-            isAdmin={isAdmin}
             isAdminView={isAdminView}
             playlists={playlists}
             onDelete={onDelete}

--- a/packages/web/src/components/settings/CompressorSection.tsx
+++ b/packages/web/src/components/settings/CompressorSection.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useAdminView } from '../../context/AdminViewContext';
+import { usePermissions } from '../../context/PermissionsContext';
 import SettingsToggle from './SettingsToggle';
 
 const DEFAULTS = { enabled: false, threshold: -6, ratio: 4.0, attack: 5, release: 50, gain: 3 };
@@ -25,6 +26,9 @@ interface CompressorValues {
 
 export default function CompressorSection() {
   const { isAdminView } = useAdminView();
+  const { hasPermission } = usePermissions();
+
+  const canManage = isAdminView || hasPermission('audio.manage');
   const [values, setValues] = useState<CompressorValues>(DEFAULTS);
   const [savedValues, setSavedValues] = useState<CompressorValues>(DEFAULTS);
   const [saving, setSaving] = useState(false);
@@ -42,8 +46,8 @@ export default function CompressorSection() {
         // silently fail
       }
     }
-    if (isAdminView) load();
-  }, [isAdminView]);
+    if (canManage) load();
+  }, [canManage]);
 
   const hasChanges = JSON.stringify(values) !== JSON.stringify(savedValues);
 
@@ -73,7 +77,7 @@ export default function CompressorSection() {
     setValues((v) => ({ ...v, [key]: value }));
   }
 
-  const dimmed = !isAdminView;
+  const dimmed = !canManage;
 
   return (
     <div className={`space-y-3 ${dimmed ? 'opacity-40 pointer-events-none' : ''}`}>

--- a/packages/web/src/components/settings/EqualizerSection.tsx
+++ b/packages/web/src/components/settings/EqualizerSection.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useAdminView } from '../../context/AdminViewContext';
+import { usePermissions } from '../../context/PermissionsContext';
 
 const FREQ_LABELS = [
   '25',
@@ -22,6 +23,9 @@ const DEFAULT_BANDS = Array(15).fill(50);
 
 export default function EqualizerSection() {
   const { isAdminView } = useAdminView();
+  const { hasPermission } = usePermissions();
+
+  const canManage = isAdminView || hasPermission('audio.manage');
   const [bands, setBands] = useState<number[]>(DEFAULT_BANDS);
   const [savedBands, setSavedBands] = useState<number[]>(DEFAULT_BANDS);
   const [saving, setSaving] = useState(false);
@@ -39,8 +43,8 @@ export default function EqualizerSection() {
         // silently fail
       }
     }
-    if (isAdminView) load();
-  }, [isAdminView]);
+    if (canManage) load();
+  }, [canManage]);
 
   const hasChanges = JSON.stringify(bands) !== JSON.stringify(savedBands);
 
@@ -79,7 +83,7 @@ export default function EqualizerSection() {
   }
 
   return (
-    <div className={`space-y-3 ${!isAdminView ? 'opacity-40 pointer-events-none' : ''}`}>
+    <div className={`space-y-3 ${!canManage ? 'opacity-40 pointer-events-none' : ''}`}>
       <h4 className="font-mono text-[11px] text-muted uppercase tracking-wider">Equalizer</h4>
       <div className="flex flex-wrap justify-center gap-2 md:flex-nowrap">
         {bands.map((value, i) => (

--- a/packages/web/src/context/PermissionsContext.tsx
+++ b/packages/web/src/context/PermissionsContext.tsx
@@ -1,0 +1,70 @@
+import type { PermissionAction } from '@alfira-bot/server/shared';
+import type React from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { fetchMyPermissions } from '../api/api';
+import { useAuth } from './AuthContext';
+
+interface PermissionsContextValue {
+  permissions: Set<string>;
+  hasPermission: (action: PermissionAction) => boolean;
+  refresh: () => Promise<void>;
+}
+
+const PermissionsContext = createContext<PermissionsContextValue | null>(null);
+
+export function PermissionsProvider({ children }: { children: React.ReactNode }) {
+  const { user } = useAuth();
+  const [permissions, setPermissions] = useState<Set<string>>(new Set());
+
+  const refresh = useCallback(async () => {
+    if (!user) {
+      setPermissions(new Set());
+      return;
+    }
+
+    try {
+      const result = await fetchMyPermissions();
+      setPermissions(new Set(result.permissions));
+    } catch {
+      // Silently ignore — the user just won't have any permissions.
+      setPermissions(new Set());
+    }
+  }, [user]);
+
+  // Fetch on mount and when user changes
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  // Re-fetch on tab focus so permission changes take effect without re-login
+  useEffect(() => {
+    const onFocus = () => refresh();
+    window.addEventListener('focus', onFocus);
+    return () => window.removeEventListener('focus', onFocus);
+  }, [refresh]);
+
+  const hasPermission = useCallback(
+    (action: PermissionAction): boolean => {
+      return permissions.has(action);
+    },
+    [permissions]
+  );
+
+  return (
+    <PermissionsContext
+      value={useMemo(
+        () => ({ permissions, hasPermission, refresh }),
+        [permissions, hasPermission, refresh]
+      )}
+    >
+      {children}
+    </PermissionsContext>
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function usePermissions(): PermissionsContextValue {
+  const ctx = useContext(PermissionsContext);
+  if (!ctx) throw new Error('usePermissions must be used inside PermissionsProvider');
+  return ctx;
+}

--- a/packages/web/src/hooks/useSongActions.tsx
+++ b/packages/web/src/hooks/useSongActions.tsx
@@ -13,7 +13,8 @@ import { useNotification } from './useNotification';
 
 interface UseSongActionsOptions {
   song: Song;
-  isAdmin: boolean;
+  canEdit: boolean;
+  canDelete: boolean;
   playlists: Playlist[];
   onAddToQueue: () => void;
   onDelete?: () => void;
@@ -23,7 +24,8 @@ interface UseSongActionsOptions {
 
 export function useSongActions({
   song,
-  isAdmin,
+  canEdit,
+  canDelete,
   playlists,
   onAddToQueue,
   onDelete,
@@ -76,7 +78,7 @@ export function useSongActions({
           ]
         : [
             // Full admin submenu (when onDelete is provided, library context)
-            ...(isAdmin && onDelete
+            ...(canEdit && onDelete
               ? [
                   {
                     id: 'add-to-playlist',
@@ -101,8 +103,8 @@ export function useSongActions({
               icon: <ArrowSquareOutIcon size={14} weight="duotone" />,
               onClick: () => window.open(song.sourceUrl, '_blank'),
             },
-            // Delete + Requested By (library context, admin only)
-            ...(isAdmin && onDelete
+            // Delete + Requested By (library context, can delete)
+            ...(canDelete && onDelete
               ? [
                   {
                     id: 'delete',
@@ -133,7 +135,8 @@ export function useSongActions({
       onRemove,
       removeLabel,
       onDelete,
-      isAdmin,
+      canEdit,
+      canDelete,
       playlists,
       optimisticAdded,
       handleAddToPlaylist,

--- a/packages/web/src/pages/AudioPage.tsx
+++ b/packages/web/src/pages/AudioPage.tsx
@@ -1,9 +1,13 @@
 import CompressorSection from '../components/settings/CompressorSection';
 import EqualizerSection from '../components/settings/EqualizerSection';
 import { useAdminView } from '../context/AdminViewContext';
+import { usePermissions } from '../context/PermissionsContext';
 
 export default function AudioPage() {
   const { isAdminView } = useAdminView();
+  const { hasPermission } = usePermissions();
+
+  const canManage = isAdminView || hasPermission('audio.manage');
 
   return (
     <div className="p-4 md:p-8">
@@ -13,8 +17,8 @@ export default function AudioPage() {
       </div>
 
       <div className="space-y-2">
-        {isAdminView && <EqualizerSection />}
-        {isAdminView && (
+        {canManage && <EqualizerSection />}
+        {canManage && (
           <>
             <div className="border-t border-muted/20 my-4" />
             <CompressorSection />

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -34,6 +34,7 @@ import { Button } from '../components/ui/Button';
 import { VirtualSongList } from '../components/VirtualSongList';
 import { useAdminView } from '../context/AdminViewContext';
 import { useAuth } from '../context/AuthContext';
+import { usePermissions } from '../context/PermissionsContext';
 import { usePlayerState } from '../context/PlayerContext';
 import { useAddToQueue } from '../hooks/useAddToQueue';
 import { useNotification } from '../hooks/useNotification';
@@ -60,6 +61,7 @@ function hashTagColor(tag: string): { bg: string; text: string } {
 export default function PlaylistDetailPage() {
   const { id } = useParams<{ id: string }>();
   const { isAdminView } = useAdminView();
+  const { hasPermission } = usePermissions();
   const { user } = useAuth();
   const navigate = useNavigate();
 
@@ -77,7 +79,7 @@ export default function PlaylistDetailPage() {
   const { notify } = useNotification();
 
   const isOwner = user?.discordId === playlistDetail?.createdBy;
-  const canEdit = isAdminView || isOwner;
+  const canEdit = isAdminView || isOwner || hasPermission('songs.edit');
   const isSmart = !!playlistDetail?.tagNameLower;
   const menuTriggerRef = useRef<HTMLButtonElement>(null);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -610,7 +612,6 @@ export default function PlaylistDetailPage() {
         <VirtualSongList
           items={songItems}
           viewMode="list"
-          isAdmin={canEdit}
           isAdminView={isAdminView}
           playlists={[]}
           isLoading={isLoading}

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -8,6 +8,7 @@ import NotificationToast from '../components/NotificationToast';
 import { Button } from '../components/ui/Button';
 import { VirtualSongList } from '../components/VirtualSongList';
 import { useAdminView } from '../context/AdminViewContext';
+import { usePermissions } from '../context/PermissionsContext';
 import { usePlayerState } from '../context/PlayerContext';
 import { useAddToQueue } from '../hooks/useAddToQueue';
 import { useNotification } from '../hooks/useNotification';
@@ -19,6 +20,7 @@ const ITEMS_PER_PAGE = 24;
 
 export default function SongsPage() {
   const { isAdminView } = useAdminView();
+  const { hasPermission } = usePermissions();
   const { state: queueState } = usePlayerState();
   const [search, setSearch] = useState('');
   const [viewMode, setViewMode] = useState<'grid' | 'list'>(() => {
@@ -139,7 +141,7 @@ export default function SongsPage() {
             {isLoading ? '—' : `${total} track${total !== 1 ? 's' : ''}`}
           </p>
         </div>
-        {isAdminView && (
+        {(isAdminView || hasPermission('songs.add')) && (
           <Button
             variant="primary"
             onClick={() => setShowAddModal(true)}
@@ -201,7 +203,6 @@ export default function SongsPage() {
       <VirtualSongList
         items={items}
         viewMode={viewMode}
-        isAdmin={isAdminView}
         isAdminView={isAdminView}
         playlists={playlists}
         isLoading={isLoading}


### PR DESCRIPTION
## Summary

The API already supported granular permissions (e.g. `songs.add`, `queue.manage`) via the `rolePermission` table and `checkGuards` middleware, but the web UI gated all write actions behind `isAdminView` (super-admin only). This meant non-admin users with granted permissions couldn't use them.

## Changes

- **New `GET /api/permissions/me` endpoint** — returns the current user's computed permissions from the `rolePermission` table
- **New `PermissionsContext` + `usePermissions` hook** — fetches permissions on mount and re-fetches on tab focus (no re-login needed after permission changes)
- **Un-gated 12 UI actions** across SongsPage, SongRow, SongCard, QueuePanel, AudioPage, PlaylistDetailPage, and AddSongModal — each now checks `isAdminView || hasPermission(...)`
- **Removed `isAdmin` prop** from VirtualSongList → SongRow/SongCard chain — leaf components now use `usePermissions()` directly