### PR TITLE
fix(web): prevent inherited pointer cursor on modal cards

### DIFF
--- a/packages/web/src/components/Backdrop.tsx
+++ b/packages/web/src/components/Backdrop.tsx
@@ -9,7 +9,7 @@ export function Backdrop({
 }) {
   return (
     <div
-      className="fixed inset-0 z-50 bg-black/70 backdrop-blur-sm flex items-center justify-center p-4 cursor-pointer"
+      className="fixed inset-0 z-50 bg-black/70 backdrop-blur-sm flex items-center justify-center p-4 cursor-default"
       onMouseDown={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}


### PR DESCRIPTION
## Summary

The Backdrop component had `cursor-pointer` on its root div, which CSS inherited into all child elements — including modal cards. This made every empty/blank area inside modals appear clickable (showing a grab hand cursor) even though clicking there did nothing.

## Changes

- Changed `cursor-pointer` to `cursor-default` on the Backdrop root div in `packages/web/src/components/Backdrop.tsx`