### PR TITLE
feat: add song request system

### DIFF
--- a/.pi/skills/alfira-api/SKILL.md
+++ b/.pi/skills/alfira-api/SKILL.md
@@ -18,7 +18,8 @@ Bun native HTTP server on port 3001. Serves three concerns:
 | Prefix | Handler file | Purpose |
 |--------|-------------|---------|
 | `/api/tags` | `routes/tags.ts` | CRUD for tags |
-| `/api/songs` | `routes/songs.ts` | Song library, search, import |
+| `/api/songs` | `routes/songs.ts` | Song library, search, edit, delete |
+| `/api/requests` | `routes/requests.ts` | Song request CRUD, preview, approve/deny |
 | `/api/playlists` | `routes/playlists.ts` | Playlist CRUD, reorder, import |
 | `/api/player` | `routes/player.ts` | Playback control (play, pause, skip, seek, volume, queue) |
 | `/api/settings/compressor` | `routes/compressor.ts` | Compressor settings |

--- a/.pi/skills/alfira-architecture/SKILL.md
+++ b/.pi/skills/alfira-architecture/SKILL.md
@@ -17,7 +17,7 @@ packages/
 │       ├── PlaybackCursor.ts # Queue cursor logic
 │       ├── lib/              # Utilities (socket, voice, lavalink, config, etc.)
 │       ├── middleware/        # Auth middleware
-│       ├── routes/           # API route handlers (10 files)
+│       ├── routes/           # API route handlers (11 files)
 │       ├── shared/           # Types, DB schema, logger, format, API service
 │       └── utils/            # NodeLink subprocess helpers
 └── web/        # React 19 + Tailwind CSS 4 web UI
@@ -79,7 +79,7 @@ Guild ID, admin roles, idle timeout, and notification channel are configured via
 **Utilities:** `formatDuration(seconds)`, `fisherYatesShuffle(array)`
 **DB:** Schema in `packages/server/src/shared/db/schema.ts`
 **Logger:** `logger` from `@alfira-bot/server/shared/logger`
-**API Service:** `@alfira-bot/server/shared/api` — centralized API functions (`fetchSongs`, `createSong`, `importPlaylist`, etc.)
+**API Service:** `@alfira-bot/server/shared/api` — centralized API functions (`fetchSongs`, `createRequest`, `fetchRequests`, etc.)
 
 Always use the shared API service for API calls rather than raw `fetch`.
 

--- a/.pi/skills/alfira-database/SKILL.md
+++ b/.pi/skills/alfira-database/SKILL.md
@@ -53,7 +53,16 @@ Single-row table (always `id = 1`). Holds:
 - **Equalizer:** 15 columns (`eqBand0` through `eqBand14`, range 0-100)
 - **Admin:** `guildId`, `adminRoleIds` (comma-separated string), `setupCompleted`, `voiceIdleTimeoutMinutes`
 - **Sources:** `enabledSources` (comma-separated string, default `"youtube,soundcloud"`)
-- **Misc:** `notificationChannelId`, `publicUrl`
+- **Misc:** `afkNotificationChannelId`, `requestNotificationChannelId`, `publicUrl`
+
+### `songRequest` table
+Tracks pending/approved/denied song requests. Key columns:
+- `sourceUrl` + `sourceId` — identifies the source track
+- `type` — `'track'` or `'playlist'`
+- `playlistData` — JSON blob with playlist metadata and embedded track list
+- `status` — `'pending'`, `'approved'`, or `'denied'`
+- `notifyDm` — whether to DM the requester on review
+- `requestedBy` / `reviewedBy` — Discord IDs
 
 ### `RefreshToken` table
 OAuth2 refresh tokens: `tokenHash` (unique), `discordId`, `expiresAt`. Index on `discordId`.

--- a/.pi/skills/alfira-troubleshooting/SKILL.md
+++ b/.pi/skills/alfira-troubleshooting/SKILL.md
@@ -39,9 +39,17 @@ description: Common issues and solutions for Alfira — bot problems, authentica
    - Your `.env` file
 2. Ensure you're using `https://` in production.
 
-### "Add Song" button not visible / Admin features missing
+### "Request Song" button not visible
 
-**Symptoms:** Logged in but no "Add Song" button, can't use quick-add, can't manage playlists.
+**Symptoms:** Logged in but the "+ Request Song" button is missing from the Songs page.
+
+**Solutions:**
+1. **Re-login** — The button is visible to all authenticated users. If you can't see it, your session may be expired. Log out and back in.
+2. **Check WebSocket connection** — The UI relies on real-time updates. Verify the WebSocket indicator in the sidebar shows "Connected".
+
+### Admin features missing (approve/deny requests, manage playlists)
+
+**Symptoms:** Logged in but can't approve/deny requests, can't edit/delete songs, can't access admin settings.
 
 **Solutions:**
 1. **Check admin role configuration** — Go to **Settings → Admin** and verify the correct roles are selected under "Admin Roles". Save changes if needed.

--- a/.pi/skills/alfira-web/SKILL.md
+++ b/.pi/skills/alfira-web/SKILL.md
@@ -30,6 +30,7 @@ description: React 19 + Tailwind CSS 4 web UI, component and page structure, API
 | `TagsPage.tsx` | `/tags` | Tag management |
 | `AudioPage.tsx` | `/audio` | Compressor + equalizer settings |
 | `PermissionsPage.tsx` | `/permissions` | Role-based permission config |
+| `RequestsPage.tsx` | `/requests` | Song request queue (pending/history, approve/deny) |
 
 ## Component Map
 
@@ -64,8 +65,9 @@ description: React 19 + Tailwind CSS 4 web UI, component and page structure, API
 ## API Client (`packages/web/src/utils/api.ts`)
 
 Centralized API client. All frontend API calls go through this file. Provides typed functions for:
-- Song CRUD: `fetchSongs()`, `createSong()`, `updateSong()`, `deleteSong()`
-- Playlist operations: `fetchPlaylists()`, `createPlaylist()`, `updatePlaylist()`, `importPlaylist()`, etc.
+- Song CRUD: `fetchSongs()`, `updateSong()`, `deleteSong()`
+- Song requests: `createRequest()`, `previewRequest()`, `fetchRequests()`, `approveRequest()`, `denyRequest()`, `cancelRequest()`
+- Playlist operations: `fetchPlaylists()`, `createPlaylist()`, `updatePlaylist()`, etc.
 - Player control: `play()`, `pause()`, `skip()`, `seek()`, `setVolume()`, etc.
 - Settings: compressor, equalizer, general, permissions
 - Authentication: login, logout, session check

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -36,9 +36,17 @@ Common issues and solutions for Alfira.
    - Your `.env` file
 2. Ensure you're using `https://` in production.
 
-### "Add Song" button not visible / Admin features missing
+### "Request Song" button not visible
 
-**Symptoms:** Logged in but no "Add Song" button, can't use quick-add, can't manage playlists.
+**Symptoms:** Logged in but the "+ Request Song" button is missing from the Songs page.
+
+**Solutions:**
+1. **Re-login** — The button is visible to all authenticated users. If you can't see it, your session may be expired. Log out and back in.
+2. **Check your internet connection** — The UI relies on the API being reachable.
+
+### Admin features missing (approve/deny requests, manage playlists)
+
+**Symptoms:** Logged in but can't approve/deny requests, can't edit/delete songs, can't access admin settings.
 
 **Solutions:**
 1. **Check admin role configuration** — Go to **Settings → Admin** and verify the correct roles are selected under "Admin Roles". Save changes if needed.

--- a/packages/server/src/GuildPlayer.ts
+++ b/packages/server/src/GuildPlayer.ts
@@ -115,7 +115,7 @@ export class GuildPlayer {
     // Send notification to the configured channel, if any.
     try {
       const row = await db
-        .select({ channelId: tables.guildSettings.notificationChannelId })
+        .select({ channelId: tables.guildSettings.afkNotificationChannelId })
         .from(tables.guildSettings)
         .where(eq(tables.guildSettings.id, 1))
         .get();

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -34,6 +34,7 @@ import { handleGeneralSettings } from './routes/generalSettings';
 import { handlePermissions } from './routes/permissions';
 import { handlePlayer } from './routes/player';
 import { handlePlaylists } from './routes/playlists';
+import { handleRequests } from './routes/requests';
 import { handleSetup } from './routes/setup';
 import { handleSongs } from './routes/songs';
 import { handleTags } from './routes/tags';
@@ -235,6 +236,9 @@ function startServer(): void {
       if (url.pathname.startsWith('/api/tags')) {
         return setSecurityHeaders(await handleTags(ctx, request));
       }
+      if (url.pathname.startsWith('/api/requests')) {
+        return setSecurityHeaders(await handleRequests(ctx, request));
+      }
       if (url.pathname.startsWith('/api/songs')) {
         return setSecurityHeaders(await handleSongs(ctx, request));
       }
@@ -329,11 +333,16 @@ function runMigrations(): void {
       try {
         $client.run(trimmed);
       } catch (err) {
-        // Skip "already exists" errors — the table/index is already there
-        if ((err as Error).message.includes('already exists')) {
+        // Skip errors that indicate the schema change was already applied
+        // in a previous partial run (RENAME, ADD COLUMN, CREATE TABLE retries).
+        if (
+          (err as Error).message.includes('already exists') ||
+          (err as Error).message.includes('no such column') ||
+          (err as Error).message.includes('duplicate column name')
+        ) {
           logger.info(
             { file, stmt: trimmed.substring(0, 50) },
-            'Skipping already-exists statement'
+            'Skipping already-applied statement'
           );
           continue;
         }

--- a/packages/server/src/lib/notifications.ts
+++ b/packages/server/src/lib/notifications.ts
@@ -1,0 +1,103 @@
+import { eq } from 'drizzle-orm';
+import type { RouteContext } from '../index';
+import { db, tables } from '../shared/db';
+import { logger } from '../shared/logger';
+import type { SongRequest } from '../shared/types';
+
+const DISCORD_API = 'https://discord.com/api/v10';
+
+function botHeaders(): Record<string, string> {
+  const token = process.env.DISCORD_BOT_TOKEN;
+  if (!token) throw new Error('DISCORD_BOT_TOKEN not set');
+  return { Authorization: `Bot ${token}` };
+}
+
+/**
+ * Send a notification to the configured request notification channel.
+ */
+export async function sendRequestNotification(
+  event: 'new' | 'approved' | 'denied',
+  req: SongRequest,
+  user: { discordId: string; username: string },
+  _ctx: RouteContext
+): Promise<void> {
+  try {
+    const row = await db
+      .select({
+        channelId: tables.guildSettings.requestNotificationChannelId,
+        notifyOnApproved: tables.guildSettings.notifyOnApproved,
+        notifyOnDenied: tables.guildSettings.notifyOnDenied,
+      })
+      .from(tables.guildSettings)
+      .where(eq(tables.guildSettings.id, 1))
+      .get();
+
+    if (!row?.channelId) return;
+
+    // Respect per-event toggles ("new" always sends if channel is set)
+    if (event === 'approved' && !row.notifyOnApproved) return;
+    if (event === 'denied' && !row.notifyOnDenied) return;
+
+    const messages: Record<string, string> = {
+      new: `🎵 **New song request** from **${user.username}**: **${req.title}**`,
+      approved: `✅ Request approved: **${req.title}**`,
+      denied: `❌ Request denied: **${req.title}**`,
+    };
+
+    const content = messages[event] ?? `Request update: **${req.title}**`;
+
+    await fetch(`${DISCORD_API}/channels/${row.channelId}/messages`, {
+      method: 'POST',
+      headers: {
+        ...botHeaders(),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ content }),
+    });
+  } catch (err) {
+    logger.warn({ err }, 'Failed to send request notification');
+  }
+}
+
+/**
+ * Send a DM to a user about their request status.
+ */
+export async function sendRequestDm(
+  discordId: string,
+  status: 'approved' | 'denied',
+  title: string
+): Promise<void> {
+  try {
+    // Create a DM channel with the user
+    const dmRes = await fetch(`${DISCORD_API}/users/@me/channels`, {
+      method: 'POST',
+      headers: {
+        ...botHeaders(),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ recipient_id: discordId }),
+    });
+
+    if (!dmRes.ok) {
+      logger.warn({ discordId, status: dmRes.status }, 'Failed to create DM channel');
+      return;
+    }
+
+    const dmChannel = (await dmRes.json()) as { id: string };
+    const messages: Record<string, string> = {
+      approved: `✅ Your song request for **${title}** has been approved and added to the library!`,
+      denied: `❌ Your song request for **${title}** has been denied.`,
+    };
+
+    await fetch(`${DISCORD_API}/channels/${dmChannel.id}/messages`, {
+      method: 'POST',
+      headers: {
+        ...botHeaders(),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ content: messages[status] }),
+    });
+  } catch (err) {
+    logger.warn({ err, discordId }, 'Failed to send request DM');
+  }
+}

--- a/packages/server/src/lib/tagCanonicalization.ts
+++ b/packages/server/src/lib/tagCanonicalization.ts
@@ -57,6 +57,9 @@ export async function canonicalizeTags(rawTags: string[]): Promise<string[]> {
           .execute();
       }
     });
+
+    // Include the newly created tags in the return value
+    canonicalNames.push(...missingTags);
   }
 
   return canonicalNames;

--- a/packages/server/src/routes/generalSettings.ts
+++ b/packages/server/src/routes/generalSettings.ts
@@ -22,7 +22,10 @@ const SETTINGS_COLUMNS = {
   setupCompleted: tables.guildSettings.setupCompleted,
   adminRoleIds: tables.guildSettings.adminRoleIds,
   voiceIdleTimeoutMinutes: tables.guildSettings.voiceIdleTimeoutMinutes,
-  notificationChannelId: tables.guildSettings.notificationChannelId,
+  afkNotificationChannelId: tables.guildSettings.afkNotificationChannelId,
+  requestNotificationChannelId: tables.guildSettings.requestNotificationChannelId,
+  notifyOnApproved: tables.guildSettings.notifyOnApproved,
+  notifyOnDenied: tables.guildSettings.notifyOnDenied,
   publicUrl: tables.guildSettings.publicUrl,
   enabledSources: tables.guildSettings.enabledSources,
 };
@@ -47,7 +50,10 @@ async function handleGetGeneral(ctx: RouteContext): Promise<Response> {
         setupCompleted: false,
         adminRoleIds: '',
         voiceIdleTimeoutMinutes: 5,
-        notificationChannelId: null,
+        afkNotificationChannelId: null,
+        requestNotificationChannelId: null,
+        notifyOnApproved: true,
+        notifyOnDenied: true,
         publicUrl: null,
         enabledSources: 'youtube,soundcloud',
       })
@@ -63,7 +69,10 @@ async function handleGetGeneral(ctx: RouteContext): Promise<Response> {
 interface GeneralSettingsPatch {
   adminRoleIds?: string;
   voiceIdleTimeoutMinutes?: number;
-  notificationChannelId?: string | null;
+  afkNotificationChannelId?: string | null;
+  requestNotificationChannelId?: string | null;
+  notifyOnApproved?: boolean;
+  notifyOnDenied?: boolean;
   publicUrl?: string | null;
   enabledSources?: string;
 }
@@ -99,11 +108,38 @@ async function handlePatchGeneral(ctx: RouteContext, request: Request): Promise<
     updates.voiceIdleTimeoutMinutes = v;
   }
 
-  if (body.notificationChannelId !== undefined) {
-    if (body.notificationChannelId !== null && typeof body.notificationChannelId !== 'string') {
-      return json({ error: 'notificationChannelId must be a string or null' }, 400);
+  if (body.afkNotificationChannelId !== undefined) {
+    if (
+      body.afkNotificationChannelId !== null &&
+      typeof body.afkNotificationChannelId !== 'string'
+    ) {
+      return json({ error: 'afkNotificationChannelId must be a string or null' }, 400);
     }
-    updates.notificationChannelId = body.notificationChannelId;
+    updates.afkNotificationChannelId = body.afkNotificationChannelId;
+  }
+
+  if (body.requestNotificationChannelId !== undefined) {
+    if (
+      body.requestNotificationChannelId !== null &&
+      typeof body.requestNotificationChannelId !== 'string'
+    ) {
+      return json({ error: 'requestNotificationChannelId must be a string or null' }, 400);
+    }
+    updates.requestNotificationChannelId = body.requestNotificationChannelId;
+  }
+
+  if (body.notifyOnApproved !== undefined) {
+    if (typeof body.notifyOnApproved !== 'boolean') {
+      return json({ error: 'notifyOnApproved must be a boolean' }, 400);
+    }
+    updates.notifyOnApproved = body.notifyOnApproved;
+  }
+
+  if (body.notifyOnDenied !== undefined) {
+    if (typeof body.notifyOnDenied !== 'boolean') {
+      return json({ error: 'notifyOnDenied must be a boolean' }, 400);
+    }
+    updates.notifyOnDenied = body.notifyOnDenied;
   }
 
   if (body.publicUrl !== undefined) {

--- a/packages/server/src/routes/requests.ts
+++ b/packages/server/src/routes/requests.ts
@@ -1,0 +1,839 @@
+import { and, eq, inArray, or, sql } from 'drizzle-orm';
+import type { RouteContext } from '../index';
+import { getUserDisplayName, resolveDisplayNames } from '../lib/displayName';
+import { json } from '../lib/json';
+import { sendRequestDm, sendRequestNotification } from '../lib/notifications';
+import { parsePagination } from '../lib/pagination';
+import { checkGuards } from '../lib/routeGuards';
+import { formatSong } from '../lib/serialization';
+import { emitSongAdded } from '../lib/socket';
+import { canonicalizeTags } from '../lib/tagCanonicalization';
+import {
+  fetchPlaylistMetadata,
+  fetchSourceMetadata,
+  validateArtworkUrl,
+  validateNickname,
+  validateOptionalString,
+  validateSourceUrl,
+  validateTags,
+  validateVolumeBoost,
+  youTubeUrl,
+} from '../lib/validation';
+import { db, tables } from '../shared/db';
+import { logger } from '../shared/logger';
+import type { SongRequest } from '../shared/types';
+import { isPlaylistUrl } from '../startDiscord';
+
+const { song: songTable, songRequest: requestTable } = tables;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatRequest(row: typeof requestTable.$inferSelect): SongRequest {
+  const base = {
+    ...row,
+    createdAt: new Date(row.createdAt).toISOString(),
+    closedAt: row.closedAt ? new Date(row.closedAt).toISOString() : null,
+    playlistData: row.playlistData as SongRequest['playlistData'],
+    type: row.type as 'track' | 'playlist',
+  };
+  return base as SongRequest;
+}
+
+async function userCanAutoApprove(ctx: RouteContext): Promise<boolean> {
+  if (ctx.isAdmin) return true;
+  if (!ctx.user) return false;
+  const userRoles = ctx.user.roles ?? [];
+  if (userRoles.length === 0) return false;
+
+  const rows = await db
+    .select({ roleId: tables.rolePermission.roleId })
+    .from(tables.rolePermission)
+    .where(
+      and(
+        eq(tables.rolePermission.action, 'requests.autoapprove'),
+        inArray(tables.rolePermission.roleId, userRoles)
+      )
+    );
+  return rows.length > 0;
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/requests/preview — resolve URL metadata without creating.
+// ---------------------------------------------------------------------------
+async function handlePreviewRequest(ctx: RouteContext, request: Request): Promise<Response> {
+  const guards = await checkGuards(ctx);
+  if (guards instanceof Response) return guards;
+
+  let body: { url?: unknown };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return json({ error: 'Invalid JSON body.' }, 400);
+  }
+
+  const urlResult = validateSourceUrl(body.url);
+  if (!urlResult.ok) return urlResult.response;
+  let url = urlResult.value;
+
+  // Strip any ?list=... query param for single-track preview
+  try {
+    const parsed = new URL(url);
+    parsed.searchParams.delete('list');
+    url = parsed.toString();
+  } catch {
+    // leave URL unchanged
+  }
+
+  const isPlaylist = isPlaylistUrl(url);
+
+  if (isPlaylist) {
+    const playlistResult = await fetchPlaylistMetadata(url, 100);
+    if (!playlistResult.ok) return playlistResult.response;
+    const pm = playlistResult.value;
+
+    const playlistThumb = pm.videos[0]?.thumbnailUrl ?? '';
+    return json({
+      title: pm.title,
+      sourceId: `playlist-${Date.now()}`, // placeholder; real sourceId on approval
+      duration: pm.videos.reduce((sum, v) => sum + (v.duration || 0), 0),
+      thumbnailUrl: playlistThumb,
+      sourceName: 'playlist',
+      artist: null,
+      artworkUrl: null,
+      alreadyExists: false,
+      isPlaylist: true,
+      playlistMeta: {
+        name: pm.title,
+        videoCount: pm.videoCount,
+        thumbnailUrl: playlistThumb,
+      },
+    });
+  }
+
+  const metadataResult = await fetchSourceMetadata(url);
+  if (!metadataResult.ok) return metadataResult.response;
+  const metadata = metadataResult.value;
+
+  const [existing] = await db
+    .select()
+    .from(songTable)
+    .where(eq(songTable.sourceId, metadata.sourceId))
+    .limit(1);
+
+  const [existingReq] = await db
+    .select()
+    .from(requestTable)
+    .where(eq(requestTable.sourceId, metadata.sourceId))
+    .limit(1);
+
+  return json({
+    title: metadata.title,
+    sourceId: metadata.sourceId,
+    duration: metadata.duration,
+    thumbnailUrl: metadata.thumbnailUrl ?? '',
+    sourceName: metadata.sourceName ?? null,
+    artist: metadata.artist ?? null,
+    artworkUrl: metadata.artworkUrl ?? null,
+    alreadyExists: !!existing || !!existingReq,
+    isPlaylist: false,
+    playlistMeta: undefined,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/requests — create a song or playlist request.
+// ---------------------------------------------------------------------------
+async function handleCreateRequest(ctx: RouteContext, request: Request): Promise<Response> {
+  const guards = await checkGuards(ctx);
+  if (guards instanceof Response) return guards;
+  const { user } = guards;
+
+  let body: {
+    sourceUrl?: unknown;
+    notifyDm?: unknown;
+    nickname?: unknown;
+    artist?: unknown;
+    album?: unknown;
+    artwork?: unknown;
+    tags?: unknown;
+    volumeBoost?: unknown;
+  };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return json({ error: 'Invalid JSON body.' }, 400);
+  }
+
+  const notifyDm = body.notifyDm === true;
+
+  const nicknameResult = validateNickname(body.nickname);
+  if (!nicknameResult.ok) return nicknameResult.response;
+
+  const artist = validateOptionalString(body.artist);
+  const album = validateOptionalString(body.album);
+
+  const artworkResult = validateArtworkUrl(body.artwork);
+  if (!artworkResult.ok) return artworkResult.response;
+
+  const tagsResult = validateTags(body.tags);
+  if (!tagsResult.ok) return tagsResult.response;
+
+  const volumeBoostResult = validateVolumeBoost(body.volumeBoost);
+  if (!volumeBoostResult.ok) return volumeBoostResult.response;
+  const volumeBoost = volumeBoostResult.value !== undefined ? volumeBoostResult.value : null;
+
+  const urlResult = validateSourceUrl(body.sourceUrl);
+  if (!urlResult.ok) return urlResult.response;
+  const originalUrl = urlResult.value;
+
+  const autoApprove = await userCanAutoApprove(ctx);
+  const isPlaylist = isPlaylistUrl(originalUrl);
+
+  // Strip ?list= for single-track URLs only
+  let url = originalUrl;
+  if (!isPlaylist) {
+    try {
+      const parsed = new URL(url);
+      parsed.searchParams.delete('list');
+      url = parsed.toString();
+    } catch {
+      // leave URL unchanged
+    }
+  }
+
+  // --- Playlist request ---
+  if (isPlaylist) {
+    const playlistResult = await fetchPlaylistMetadata(url, 100);
+    if (!playlistResult.ok) return playlistResult.response;
+    const pm = playlistResult.value;
+
+    if (autoApprove) {
+      // Auto-approve: import all tracks as songs directly
+      const videosWithUrls = pm.videos.map((v) => ({
+        ...v,
+        canonicalUrl: youTubeUrl(v.id),
+      }));
+
+      // Deduplicate against existing songs
+      const sourceIds = videosWithUrls.map((v) => v.id);
+      const sourceUrls = videosWithUrls.map((v) => v.canonicalUrl);
+      const existingSourceIds = await db
+        .select({ sourceId: songTable.sourceId })
+        .from(songTable)
+        .where(
+          or(
+            sourceIds.length > 0 ? inArray(songTable.sourceId, sourceIds) : undefined,
+            sourceUrls.length > 0 ? inArray(songTable.sourceUrl, sourceUrls) : undefined
+          )
+        );
+
+      const existingIdSet = new Set(existingSourceIds.map((s) => s.sourceId));
+      const newVideos = videosWithUrls.filter((v) => !existingIdSet.has(v.id));
+
+      if (newVideos.length === 0) {
+        return json({ error: 'All songs from this playlist are already in your library.' }, 409);
+      }
+
+      const createdSongs = await db.transaction((tx) => {
+        return tx
+          .insert(songTable)
+          .values(
+            newVideos.map((video) => ({
+              title: video.title,
+              sourceUrl: video.canonicalUrl,
+              sourceId: video.id,
+              duration: video.duration,
+              thumbnailUrl: video.thumbnailUrl ?? '',
+              addedBy: user.discordId,
+              artist: video.artist ?? null,
+              artwork: video.artworkUrl ?? null,
+            }))
+          )
+          .returning();
+      });
+
+      // Emit socket events
+      const nameMap = await resolveDisplayNames(createdSongs);
+      for (const song of createdSongs) {
+        emitSongAdded({
+          ...formatSong(song),
+          addedByDisplayName: nameMap.get(song.addedBy) ?? song.addedBy,
+        });
+      }
+
+      // Record the auto-approved playlist request for history
+      const playlistThumb = pm.videos[0]?.thumbnailUrl ?? '';
+      const now = new Date();
+      const [reqRow] = await db
+        .insert(requestTable)
+        .values({
+          sourceUrl: url,
+          sourceId: `playlist-${Date.now()}`,
+          title: pm.title,
+          duration: pm.videos.reduce((sum, v) => sum + (v.duration || 0), 0),
+          thumbnailUrl: playlistThumb,
+          artist: null,
+          artworkUrl: null,
+          sourceName: 'playlist',
+          requestedBy: user.discordId,
+          notifyDm: false,
+          type: 'playlist',
+          playlistData: {
+            name: pm.title,
+            videoCount: pm.videoCount,
+            thumbnailUrl: playlistThumb || null,
+            videos: pm.videos.map((v) => ({
+              id: v.id,
+              title: v.title,
+              duration: v.duration,
+              thumbnailUrl: v.thumbnailUrl ?? null,
+              artist: v.artist ?? null,
+              artworkUrl: v.artworkUrl ?? null,
+            })),
+          },
+          status: 'approved',
+          reviewedBy: user.discordId,
+          createdAt: now,
+          closedAt: now,
+        })
+        .returning();
+
+      // Notify the request channel
+      if (reqRow) {
+        sendRequestNotification('approved', formatRequest(reqRow), user, ctx).catch((err) =>
+          logger.warn({ err }, 'Failed to send playlist auto-approve notification')
+        );
+      }
+
+      return json(
+        {
+          autoApproved: true,
+          songs: createdSongs.map(formatSong),
+          importedCount: createdSongs.length,
+          skippedCount: pm.videos.length - newVideos.length,
+          playlistTitle: pm.title,
+        },
+        201
+      );
+    }
+
+    // Pending playlist request
+    const playlistThumb2 = pm.videos[0]?.thumbnailUrl ?? '';
+    const playlistData = {
+      name: pm.title,
+      videoCount: pm.videoCount,
+      thumbnailUrl: playlistThumb2 || null,
+      videos: pm.videos.map((v) => ({
+        id: v.id,
+        title: v.title,
+        duration: v.duration,
+        thumbnailUrl: v.thumbnailUrl ?? null,
+        artist: v.artist ?? null,
+        artworkUrl: v.artworkUrl ?? null,
+      })),
+    };
+
+    const [created] = await db
+      .insert(requestTable)
+      .values({
+        sourceUrl: url,
+        sourceId: `playlist-${Date.now()}`,
+        title: pm.title,
+        duration: pm.videos.reduce((sum, v) => sum + (v.duration || 0), 0),
+        thumbnailUrl: playlistThumb2,
+        artist: null,
+        artworkUrl: null,
+        sourceName: 'playlist',
+        requestedBy: user.discordId,
+        notifyDm,
+        type: 'playlist',
+        playlistData,
+        status: 'pending',
+      })
+      .returning();
+
+    if (!created) {
+      return json({ error: 'Failed to create request.' }, 500);
+    }
+
+    const formatted = formatRequest(created);
+    await sendRequestNotification('new', formatted, user, ctx);
+
+    return json({ request: formatted, autoApproved: false }, 201);
+  }
+
+  // --- Track request ---
+  const metadataResult = await fetchSourceMetadata(url);
+  if (!metadataResult.ok) return metadataResult.response;
+  const metadata = metadataResult.value;
+
+  // Check duplicates: Song table
+  const [existingSong] = await db
+    .select()
+    .from(songTable)
+    .where(eq(songTable.sourceId, metadata.sourceId))
+    .limit(1);
+
+  if (existingSong) {
+    return json(
+      { error: 'This song is already in your library.', song: formatSong(existingSong) },
+      409
+    );
+  }
+
+  // Check duplicates: existing requests (any status)
+  const [existingReq] = await db
+    .select()
+    .from(requestTable)
+    .where(eq(requestTable.sourceId, metadata.sourceId))
+    .limit(1);
+
+  if (existingReq) {
+    return json({ error: 'This song has already been requested.' }, 409);
+  }
+
+  if (autoApprove) {
+    // Auto-approve: create Song directly
+    const tagValues = tagsResult.value.length > 0 ? await canonicalizeTags(tagsResult.value) : [];
+
+    const [song] = await db
+      .insert(songTable)
+      .values({
+        title: metadata.title,
+        sourceUrl: url,
+        sourceId: metadata.sourceId,
+        duration: metadata.duration,
+        thumbnailUrl: metadata.thumbnailUrl ?? '',
+        addedBy: user.discordId,
+        nickname: nicknameResult.value,
+        artist: artist ?? metadata.artist ?? null,
+        album: album ?? null,
+        artwork: artworkResult.value ?? metadata.artworkUrl ?? null,
+        tags: tagValues,
+        volumeBoost,
+      })
+      .returning();
+
+    if (!song) {
+      return json({ error: 'Failed to create song.' }, 500);
+    }
+
+    const formatted = formatSong(song);
+    const displayName = await getUserDisplayName(user.discordId);
+    const enriched = { ...formatted, addedByDisplayName: displayName };
+    emitSongAdded(enriched);
+
+    // Record the auto-approved request for history
+    const now = new Date();
+    const [reqRow] = await db
+      .insert(requestTable)
+      .values({
+        sourceUrl: url,
+        sourceId: metadata.sourceId,
+        title: metadata.title,
+        duration: metadata.duration,
+        thumbnailUrl: metadata.thumbnailUrl ?? '',
+        artist: metadata.artist ?? null,
+        artworkUrl: metadata.artworkUrl ?? null,
+        sourceName: metadata.sourceName ?? null,
+        requestedBy: user.discordId,
+        notifyDm,
+        type: 'track',
+        status: 'approved',
+        reviewedBy: user.discordId,
+        createdAt: now,
+        closedAt: now,
+      })
+      .returning();
+
+    // Notify the request channel
+    if (reqRow) {
+      sendRequestNotification('approved', formatRequest(reqRow), user, ctx).catch((err) =>
+        logger.warn({ err }, 'Failed to send auto-approve notification')
+      );
+    }
+
+    // Send DM if requested
+    if (notifyDm) {
+      try {
+        await sendRequestDm(user.discordId, 'approved', metadata.title);
+      } catch (err) {
+        logger.warn({ err }, 'Failed to send auto-approve DM');
+      }
+    }
+
+    return json({ song: enriched, autoApproved: true }, 201);
+  }
+
+  // Pending track request
+  const [created] = await db
+    .insert(requestTable)
+    .values({
+      sourceUrl: url,
+      sourceId: metadata.sourceId,
+      title: metadata.title,
+      duration: metadata.duration,
+      thumbnailUrl: metadata.thumbnailUrl ?? '',
+      artist: metadata.artist ?? null,
+      artworkUrl: metadata.artworkUrl ?? null,
+      sourceName: metadata.sourceName ?? null,
+      requestedBy: user.discordId,
+      notifyDm,
+      type: 'track',
+      status: 'pending',
+    })
+    .returning();
+
+  if (!created) {
+    return json({ error: 'Failed to create request.' }, 500);
+  }
+
+  const formatted = formatRequest(created);
+  await sendRequestNotification('new', formatted, user, ctx);
+
+  return json({ request: formatted, autoApproved: false }, 201);
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/requests — list requests.
+// ?status=pending|approved|denied|all  (defaults to 'pending')
+// ?mine=true (filter to own requests)
+// ---------------------------------------------------------------------------
+async function handleGetRequests(ctx: RouteContext, request: Request): Promise<Response> {
+  const guards = await checkGuards(ctx);
+  if (guards instanceof Response) return guards;
+  const { user } = guards;
+
+  const url = new URL(request.url);
+  const { page, limit, skip } = parsePagination(url);
+  const status = url.searchParams.get('status') ?? 'pending';
+  const mine = url.searchParams.get('mine') === 'true';
+
+  const conditions = [];
+
+  if (status !== 'all') {
+    conditions.push(eq(requestTable.status, status));
+  }
+
+  if (mine) {
+    conditions.push(eq(requestTable.requestedBy, user.discordId));
+  } else if (!ctx.isAdmin && status !== 'pending') {
+    // Non-admin users can only see their own closed (approved/denied) requests
+    conditions.push(eq(requestTable.requestedBy, user.discordId));
+  }
+
+  const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+  const [requests, countResult] = await Promise.all([
+    db
+      .select()
+      .from(requestTable)
+      .where(where)
+      .orderBy(sql`"createdAt" DESC`)
+      .offset(skip)
+      .limit(limit),
+    db.select({ count: sql<number>`count(*)` }).from(requestTable).where(where),
+  ]);
+
+  const total = parseInt(String(countResult[0]?.count ?? 0), 10);
+
+  // Resolve display names for requesters
+  const nameMap = await resolveDisplayNames(
+    requests.map((r) => ({ addedBy: r.requestedBy }) as { addedBy: string })
+  );
+
+  const formattedRequests = requests.map((r) => ({
+    ...formatRequest(r),
+    requestedByDisplayName: nameMap.get(r.requestedBy) ?? r.requestedBy,
+  }));
+
+  return json({
+    items: formattedRequests,
+    pagination: {
+      page,
+      limit,
+      total,
+      totalPages: Math.ceil(total / limit),
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// PATCH /api/requests/:id — approve or deny a request. Admin only.
+// ---------------------------------------------------------------------------
+async function handlePatchRequest(
+  ctx: RouteContext,
+  request: Request,
+  id: string
+): Promise<Response> {
+  const guards = await checkGuards(ctx, { admin: true });
+  if (guards instanceof Response) return guards;
+  const { user } = guards;
+
+  let body: { status?: unknown };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return json({ error: 'Invalid JSON body.' }, 400);
+  }
+
+  if (body.status !== 'approved' && body.status !== 'denied') {
+    return json({ error: 'status must be "approved" or "denied".' }, 400);
+  }
+
+  const [existing] = await db.select().from(requestTable).where(eq(requestTable.id, id)).limit(1);
+
+  if (!existing) {
+    return json({ error: 'Request not found.' }, 404);
+  }
+
+  if (existing.status !== 'pending') {
+    return json({ error: 'This request has already been processed.' }, 409);
+  }
+
+  const newStatus = body.status as 'approved' | 'denied';
+  const closedAt = new Date();
+
+  if (newStatus === 'denied') {
+    // Deny: update status
+    await db
+      .update(requestTable)
+      .set({ status: 'denied', reviewedBy: user.discordId, closedAt })
+      .where(eq(requestTable.id, id));
+
+    const formatted = formatRequest({
+      ...existing,
+      status: 'denied',
+      reviewedBy: user.discordId,
+      closedAt,
+    });
+
+    // Notify the request channel
+    sendRequestNotification('denied', formatted, user, ctx).catch((err) =>
+      logger.warn({ err }, 'Failed to send denied notification')
+    );
+
+    // Send DM if requested
+    if (existing.notifyDm) {
+      try {
+        await sendRequestDm(existing.requestedBy, 'denied', existing.title);
+      } catch (err) {
+        logger.warn({ err }, 'Failed to send denied DM');
+      }
+    }
+
+    return json({ request: formatted });
+  }
+
+  // Approve
+  if (existing.type === 'playlist' && existing.playlistData) {
+    const pd = existing.playlistData as NonNullable<typeof existing.playlistData>;
+    const videos = pd.videos ?? [];
+
+    if (videos.length === 0) {
+      return json({ error: 'Playlist request has no videos.' }, 400);
+    }
+
+    // Deduplicate against existing songs
+    const videoIds = videos.map((v) => v.id);
+    const existingSourceIds = await db
+      .select({ sourceId: songTable.sourceId })
+      .from(songTable)
+      .where(videoIds.length > 0 ? inArray(songTable.sourceId, videoIds) : undefined);
+
+    const existingIdSet = new Set(existingSourceIds.map((s) => s.sourceId));
+    const newVideos = videos.filter((v) => !existingIdSet.has(v.id));
+
+    let createdSongs: (typeof songTable.$inferSelect)[] = [];
+    if (newVideos.length > 0) {
+      createdSongs = await db.transaction((tx) => {
+        return tx
+          .insert(songTable)
+          .values(
+            newVideos.map((v) => ({
+              title: v.title,
+              sourceUrl: youTubeUrl(v.id),
+              sourceId: v.id,
+              duration: v.duration,
+              thumbnailUrl: v.thumbnailUrl ?? '',
+              addedBy: existing.requestedBy,
+              artist: v.artist ?? null,
+              artwork: v.artworkUrl ?? null,
+            }))
+          )
+          .returning();
+      });
+    }
+
+    // Mark request approved
+    await db
+      .update(requestTable)
+      .set({ status: 'approved', reviewedBy: user.discordId, closedAt })
+      .where(eq(requestTable.id, id));
+
+    // Emit socket events
+    const nameMap = await resolveDisplayNames(createdSongs);
+    for (const song of createdSongs) {
+      emitSongAdded({
+        ...formatSong(song),
+        addedByDisplayName: nameMap.get(song.addedBy) ?? song.addedBy,
+      });
+    }
+
+    // Send DM if requested
+    if (existing.notifyDm) {
+      try {
+        await sendRequestDm(existing.requestedBy, 'approved', existing.title);
+      } catch (err) {
+        logger.warn({ err }, 'Failed to send approved DM');
+      }
+    }
+
+    const formatted = formatRequest({
+      ...existing,
+      status: 'approved',
+      reviewedBy: user.discordId,
+      closedAt,
+    });
+
+    // Notify the request channel
+    sendRequestNotification('approved', formatted, user, ctx).catch((err) =>
+      logger.warn({ err }, 'Failed to send playlist approved notification')
+    );
+
+    return json({
+      request: formatted,
+      songs: createdSongs.map(formatSong),
+      importedCount: createdSongs.length,
+      skippedCount: videos.length - newVideos.length,
+    });
+  }
+
+  // Track approval: create Song from request
+  const [newSong] = await db
+    .insert(songTable)
+    .values({
+      title: existing.title,
+      sourceUrl: existing.sourceUrl,
+      sourceId: existing.sourceId,
+      duration: existing.duration,
+      thumbnailUrl: existing.thumbnailUrl,
+      addedBy: existing.requestedBy,
+      artist: existing.artist ?? null,
+      artwork: existing.artworkUrl ?? null,
+    })
+    .returning();
+
+  if (!newSong) {
+    return json({ error: 'Failed to create song from request.' }, 500);
+  }
+
+  // Mark request approved
+  await db
+    .update(requestTable)
+    .set({ status: 'approved', reviewedBy: user.discordId, closedAt })
+    .where(eq(requestTable.id, id));
+
+  // Emit socket event
+  const displayName = await getUserDisplayName(existing.requestedBy);
+  emitSongAdded({
+    ...formatSong(newSong),
+    addedByDisplayName: displayName,
+  });
+
+  // Send DM if requested
+  if (existing.notifyDm) {
+    try {
+      await sendRequestDm(existing.requestedBy, 'approved', existing.title);
+    } catch (err) {
+      logger.warn({ err }, 'Failed to send approved DM');
+    }
+  }
+
+  const formatted = formatRequest({
+    ...existing,
+    status: 'approved',
+    reviewedBy: user.discordId,
+    closedAt,
+  });
+
+  // Notify the request channel
+  sendRequestNotification('approved', formatted, user, ctx).catch((err) =>
+    logger.warn({ err }, 'Failed to send approved notification')
+  );
+
+  return json({
+    request: formatted,
+    song: formatSong(newSong),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /api/requests/:id — cancel own pending request.
+// ---------------------------------------------------------------------------
+async function handleDeleteRequest(
+  ctx: RouteContext,
+  _request: Request,
+  id: string
+): Promise<Response> {
+  const guards = await checkGuards(ctx);
+  if (guards instanceof Response) return guards;
+  const { user } = guards;
+
+  const [existing] = await db.select().from(requestTable).where(eq(requestTable.id, id)).limit(1);
+
+  if (!existing) {
+    return json({ error: 'Request not found.' }, 404);
+  }
+
+  if (existing.status !== 'pending') {
+    return json({ error: 'Only pending requests can be cancelled.' }, 409);
+  }
+
+  if (existing.requestedBy !== user.discordId && !ctx.isAdmin) {
+    return json({ error: 'You can only cancel your own requests.' }, 403);
+  }
+
+  await db.delete(requestTable).where(eq(requestTable.id, id));
+
+  return new Response(null, { status: 204 });
+}
+
+// ---------------------------------------------------------------------------
+// Dispatcher
+// ---------------------------------------------------------------------------
+export async function handleRequests(ctx: RouteContext, request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  const pathname = url.pathname;
+
+  // POST /api/requests/preview
+  if (request.method === 'POST' && pathname === '/api/requests/preview') {
+    return await handlePreviewRequest(ctx, request);
+  }
+
+  // GET /api/requests
+  if (request.method === 'GET' && pathname === '/api/requests') {
+    return await handleGetRequests(ctx, request);
+  }
+
+  // POST /api/requests
+  if (request.method === 'POST' && pathname === '/api/requests') {
+    return await handleCreateRequest(ctx, request);
+  }
+
+  // PATCH /api/requests/:id
+  if (request.method === 'PATCH' && pathname.startsWith('/api/requests/')) {
+    const id = pathname.slice('/api/requests/'.length);
+    return await handlePatchRequest(ctx, request, id);
+  }
+
+  // DELETE /api/requests/:id
+  if (request.method === 'DELETE' && pathname.startsWith('/api/requests/')) {
+    const id = pathname.slice('/api/requests/'.length);
+    return await handleDeleteRequest(ctx, request, id);
+  }
+
+  return json({ error: 'Not Found' }, 404);
+}

--- a/packages/server/src/routes/setup.ts
+++ b/packages/server/src/routes/setup.ts
@@ -206,7 +206,8 @@ async function handlePostComplete(ctx: RouteContext, request: Request): Promise<
     guildId?: unknown;
     adminRoleIds?: unknown;
     voiceIdleTimeoutMinutes?: unknown;
-    notificationChannelId?: unknown;
+    afkNotificationChannelId?: unknown;
+    requestNotificationChannelId?: unknown;
     publicUrl?: unknown;
     enabledSources?: unknown;
   };
@@ -238,10 +239,16 @@ async function handlePostComplete(ctx: RouteContext, request: Request): Promise<
     return json({ error: 'voiceIdleTimeoutMinutes must be an integer between 1 and 120.' }, 400);
   }
 
-  // Validate notificationChannelId (optional)
-  const notificationChannelId =
-    body.notificationChannelId && typeof body.notificationChannelId === 'string'
-      ? body.notificationChannelId
+  // Validate afkNotificationChannelId (optional)
+  const afkNotificationChannelId =
+    body.afkNotificationChannelId && typeof body.afkNotificationChannelId === 'string'
+      ? body.afkNotificationChannelId
+      : null;
+
+  // Validate requestNotificationChannelId (optional)
+  const requestNotificationChannelId =
+    body.requestNotificationChannelId && typeof body.requestNotificationChannelId === 'string'
+      ? body.requestNotificationChannelId
       : null;
 
   // Validate publicUrl (optional)
@@ -263,7 +270,8 @@ async function handlePostComplete(ctx: RouteContext, request: Request): Promise<
         setupCompleted: true,
         adminRoleIds: body.adminRoleIds,
         voiceIdleTimeoutMinutes: timeout,
-        notificationChannelId,
+        afkNotificationChannelId,
+        requestNotificationChannelId,
         publicUrl,
         enabledSources,
       })
@@ -274,7 +282,8 @@ async function handlePostComplete(ctx: RouteContext, request: Request): Promise<
           setupCompleted: true,
           adminRoleIds: body.adminRoleIds,
           voiceIdleTimeoutMinutes: timeout,
-          notificationChannelId,
+          afkNotificationChannelId,
+          requestNotificationChannelId,
           publicUrl,
           enabledSources,
         },

--- a/packages/server/src/routes/songs.ts
+++ b/packages/server/src/routes/songs.ts
@@ -1,33 +1,22 @@
-import { and, eq, inArray, or, sql } from 'drizzle-orm';
+import { and, eq, inArray, sql } from 'drizzle-orm';
 import type { RouteContext } from '../index';
 import { getGuildId } from '../lib/config';
-import { getUserDisplayName, resolveDisplayNames } from '../lib/displayName';
+import { resolveDisplayNames } from '../lib/displayName';
 import { json } from '../lib/json';
 import { parsePagination } from '../lib/pagination';
 import { checkRateLimit, getClientIp, rateLimitResponse } from '../lib/rateLimit';
 import { checkGuards } from '../lib/routeGuards';
 import { buildSongSearchClause } from '../lib/search';
 import { formatSong } from '../lib/serialization';
-import {
-  emitPlaylistUpdated,
-  emitSongAdded,
-  emitSongDeleted,
-  emitSongUpdated,
-} from '../lib/socket';
+import { emitPlaylistUpdated, emitSongDeleted, emitSongUpdated } from '../lib/socket';
 import { syncPlaylistToTag } from '../lib/syncPlaylistToTag';
 import { canonicalizeTags } from '../lib/tagCanonicalization';
 import {
-  clampMaxVideos,
-  fetchPlaylistMetadata,
-  fetchSourceMetadata,
   validateArtworkUrl,
   validateNickname,
   validateOptionalString,
-  validatePlaylistUrl,
-  validateSourceUrl,
   validateTags,
   validateVolumeBoost,
-  youTubeUrl,
 } from '../lib/validation';
 import { db, tables } from '../shared/db';
 import { getPlayer } from '../startDiscord';
@@ -76,276 +65,6 @@ async function handleGetSongs(ctx: RouteContext, request: Request): Promise<Resp
       totalPages: Math.ceil(total / limit),
     },
   });
-}
-
-// ---------------------------------------------------------------------------
-// POST /api/songs — add a song by source URL. Admin only.
-// ---------------------------------------------------------------------------
-async function handlePostSong(ctx: RouteContext, request: Request): Promise<Response> {
-  const guards = await checkGuards(ctx, { admin: true, permission: 'songs.add' });
-  if (guards instanceof Response) return guards;
-  const { user } = guards;
-
-  let body: {
-    url?: unknown;
-    nickname?: unknown;
-    artist?: unknown;
-    album?: unknown;
-    artwork?: unknown;
-    tags?: unknown;
-    volumeBoost?: unknown;
-  };
-  try {
-    body = (await request.json()) as typeof body;
-  } catch {
-    return json({ error: 'Invalid JSON body.' }, 400);
-  }
-
-  const nicknameResult = validateNickname(body.nickname);
-  if (!nicknameResult.ok) return nicknameResult.response;
-
-  const artist = validateOptionalString(body.artist);
-  const album = validateOptionalString(body.album);
-
-  const artworkResult = validateArtworkUrl(body.artwork);
-  if (!artworkResult.ok) return artworkResult.response;
-
-  const tagsResult = validateTags(body.tags);
-  if (!tagsResult.ok) return tagsResult.response;
-
-  const volumeBoostResult = validateVolumeBoost(body.volumeBoost);
-  if (!volumeBoostResult.ok) return volumeBoostResult.response;
-  // Only use the user-supplied volume boost if explicitly provided (not undefined).
-  // undefined means "don't set", null means "clear to 0".
-  const volumeBoost = volumeBoostResult.value !== undefined ? volumeBoostResult.value : null;
-
-  const urlResult = validateSourceUrl(body.url);
-  if (!urlResult.ok) return urlResult.response;
-  let url = urlResult.value;
-
-  // Strip any ?list=... query param so a plain song URL always adds a single track.
-  try {
-    const parsed = new URL(url);
-    parsed.searchParams.delete('list');
-    url = parsed.toString();
-  } catch {
-    // leave URL unchanged
-  }
-
-  const metadataResult = await fetchSourceMetadata(url);
-  if (!metadataResult.ok) return metadataResult.response;
-  const metadata = metadataResult.value;
-
-  // Check for duplicate by sourceId.
-  const [existing] = await db
-    .select()
-    .from(songTable)
-    .where(eq(songTable.sourceId, metadata.sourceId))
-    .limit(1);
-
-  if (existing) {
-    return json(
-      {
-        error: 'This song is already in your library.',
-        song: formatSong(existing),
-      },
-      409
-    );
-  }
-
-  const [song] = await db
-    .insert(songTable)
-    .values({
-      title: metadata.title,
-      sourceUrl: url,
-      sourceId: metadata.sourceId,
-      duration: metadata.duration,
-      thumbnailUrl: metadata.thumbnailUrl ?? '',
-      addedBy: user.discordId,
-      nickname: nicknameResult.value,
-      artist: artist ?? metadata.artist ?? null,
-      album: album ?? null,
-      artwork: artworkResult.value ?? metadata.artworkUrl ?? null,
-      tags: tagsResult.value.length > 0 ? await canonicalizeTags(tagsResult.value) : [],
-      volumeBoost,
-    })
-    .returning();
-
-  if (!song) {
-    return json({ error: 'Failed to create song.' }, 500);
-  }
-
-  const formatted = formatSong(song);
-  const displayName = await getUserDisplayName(user.discordId);
-  const enriched = { ...formatted, addedByDisplayName: displayName };
-  emitSongAdded(enriched);
-
-  return json(enriched, 201);
-}
-
-// ---------------------------------------------------------------------------
-// POST /api/songs/preview — resolve URL metadata without creating a song.
-// Admin only (same guard as adding).
-// ---------------------------------------------------------------------------
-async function handlePreviewSong(ctx: RouteContext, request: Request): Promise<Response> {
-  const guards = await checkGuards(ctx, { admin: true, permission: 'songs.add' });
-  if (guards instanceof Response) return guards;
-
-  let body: { url?: unknown };
-  try {
-    body = (await request.json()) as typeof body;
-  } catch {
-    return json({ error: 'Invalid JSON body.' }, 400);
-  }
-
-  const urlResult = validateSourceUrl(body.url);
-  if (!urlResult.ok) return urlResult.response;
-  let url = urlResult.value;
-
-  // Strip any ?list=... query param so a playlist-tagged URL can still
-  // be previewed as a single track.
-  try {
-    const parsed = new URL(url);
-    parsed.searchParams.delete('list');
-    url = parsed.toString();
-  } catch {
-    // leave URL unchanged
-  }
-
-  const metadataResult = await fetchSourceMetadata(url);
-  if (!metadataResult.ok) return metadataResult.response;
-  const metadata = metadataResult.value;
-
-  // Check for duplicate by sourceId.
-  const [existing] = await db
-    .select()
-    .from(songTable)
-    .where(eq(songTable.sourceId, metadata.sourceId))
-    .limit(1);
-
-  return json({
-    title: metadata.title,
-    sourceId: metadata.sourceId,
-    duration: metadata.duration,
-    thumbnailUrl: metadata.thumbnailUrl ?? '',
-    sourceName: metadata.sourceName ?? null,
-    artist: metadata.artist ?? null,
-    artworkUrl: metadata.artworkUrl ?? null,
-    alreadyExists: !!existing,
-    existingSong: existing ? formatSong(existing) : null,
-  });
-}
-
-// ---------------------------------------------------------------------------
-// POST /api/songs/import-playlist — import playlist. Admin only.
-// ---------------------------------------------------------------------------
-async function handleImportPlaylist(ctx: RouteContext, request: Request): Promise<Response> {
-  const guards = await checkGuards(ctx, { admin: true, permission: 'songs.import' });
-  if (guards instanceof Response) return guards;
-  const { user } = guards;
-
-  let body: { url?: unknown; maxVideos?: number };
-  try {
-    body = (await request.json()) as typeof body;
-  } catch {
-    return json({ error: 'Invalid JSON body.' }, 400);
-  }
-
-  const maxVideos = clampMaxVideos(body.maxVideos);
-  const urlResult = validatePlaylistUrl(body.url);
-  if (!urlResult.ok) return urlResult.response;
-  const url = urlResult.value;
-
-  const playlistResult = await fetchPlaylistMetadata(url, maxVideos);
-  if (!playlistResult.ok) return playlistResult.response;
-  const playlistMetadata = playlistResult.value;
-
-  // Build the canonical URL format for each video
-  const videosWithUrls = playlistMetadata.videos.map((v) => ({
-    ...v,
-    canonicalUrl: youTubeUrl(v.id),
-  }));
-
-  let existingSongs: { sourceId: string; sourceUrl: string }[] = [];
-  if (videosWithUrls.length > 0) {
-    existingSongs = await db
-      .select({ sourceId: songTable.sourceId, sourceUrl: songTable.sourceUrl })
-      .from(songTable)
-      .where(
-        or(
-          inArray(
-            songTable.sourceId,
-            videosWithUrls.map((v) => v.id)
-          ),
-          inArray(
-            songTable.sourceUrl,
-            videosWithUrls.map((v) => v.canonicalUrl)
-          )
-        )
-      );
-  }
-
-  // Create sets for quick lookup
-  const existingSourceIds = new Set(existingSongs.map((s) => s.sourceId));
-  const existingSourceUrls = new Set(existingSongs.map((s) => s.sourceUrl));
-
-  // Filter out duplicates (check both sourceId and sourceUrl)
-  const newVideos = videosWithUrls.filter(
-    (v) => !existingSourceIds.has(v.id) && !existingSourceUrls.has(v.canonicalUrl)
-  );
-
-  if (newVideos.length === 0) {
-    return json({
-      message: 'All songs from this playlist are already in your library.',
-      playlistTitle: playlistMetadata.title,
-      totalVideos: playlistMetadata.videoCount,
-      importedCount: 0,
-      skippedCount: playlistMetadata.videos.length,
-    });
-  }
-
-  const addedByDiscordId = user.discordId;
-
-  // Create songs in a transaction
-  const createdSongs = await db.transaction((tx) => {
-    return tx
-      .insert(songTable)
-      .values(
-        newVideos.map((video) => ({
-          title: video.title,
-          sourceUrl: video.canonicalUrl,
-          sourceId: video.id,
-          duration: video.duration,
-          thumbnailUrl: video.thumbnailUrl ?? '',
-          addedBy: addedByDiscordId,
-          artist: video.artist ?? null,
-          artwork: video.artworkUrl ?? null,
-        }))
-      )
-      .returning();
-  });
-
-  // Emit socket events for each new song
-  const nameMap = await resolveDisplayNames(createdSongs);
-  for (const song of createdSongs) {
-    const formatted = formatSong(song);
-    emitSongAdded({
-      ...formatted,
-      addedByDisplayName: nameMap.get(song.addedBy) ?? song.addedBy,
-    });
-  }
-
-  return json(
-    {
-      message: `Successfully imported ${createdSongs.length} song(s) from "${playlistMetadata.title}".`,
-      playlistTitle: playlistMetadata.title,
-      totalVideos: playlistMetadata.videoCount,
-      importedCount: createdSongs.length,
-      skippedCount: playlistMetadata.videos.length - newVideos.length,
-      songs: createdSongs.map(formatSong),
-    },
-    201
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -519,24 +238,9 @@ export async function handleSongs(ctx: RouteContext, request: Request): Promise<
     }
   }
 
-  // POST /api/songs/preview
-  if (request.method === 'POST' && pathname === '/api/songs/preview') {
-    return await handlePreviewSong(ctx, request);
-  }
-
-  // POST /api/songs/import-playlist
-  if (request.method === 'POST' && pathname === '/api/songs/import-playlist') {
-    return await handleImportPlaylist(ctx, request);
-  }
-
   // GET /api/songs
   if (request.method === 'GET' && pathname === '/api/songs') {
     return await handleGetSongs(ctx, request);
-  }
-
-  // POST /api/songs
-  if (request.method === 'POST' && pathname === '/api/songs') {
-    return await handlePostSong(ctx, request);
   }
 
   // DELETE /api/songs/:id

--- a/packages/server/src/shared/api.ts
+++ b/packages/server/src/shared/api.ts
@@ -6,11 +6,13 @@ import type {
   Playlist,
   PlaylistDetail,
   QueueState,
+  RequestPreview,
   SetupChannel,
   SetupGuild,
   SetupRole,
   SetupStatus,
   Song,
+  SongRequest,
   User,
 } from './types';
 
@@ -121,8 +123,13 @@ export function fetchSongsPage(
   return get(`/api/songs?${params}`);
 }
 
-export interface SongCreateData {
-  url: string;
+// ---------------------------------------------------------------------------
+// Requests API Functions
+// ---------------------------------------------------------------------------
+
+export interface RequestCreateData {
+  sourceUrl: string;
+  notifyDm?: boolean;
   nickname?: string | null;
   artist?: string | null;
   album?: string | null;
@@ -131,9 +138,20 @@ export interface SongCreateData {
   volumeBoost?: number | null;
 }
 
-export function createSong(data: SongCreateData): Promise<Song> {
-  return post('/api/songs', {
-    url: data.url,
+export interface CreateRequestResult {
+  request?: SongRequest;
+  song?: Song;
+  songs?: Song[];
+  autoApproved: boolean;
+  importedCount?: number;
+  skippedCount?: number;
+  playlistTitle?: string;
+}
+
+export function createRequest(data: RequestCreateData): Promise<CreateRequestResult> {
+  return post('/api/requests', {
+    sourceUrl: data.sourceUrl,
+    notifyDm: data.notifyDm ?? false,
     ...(data.nickname != null && { nickname: data.nickname }),
     ...(data.artist != null && { artist: data.artist }),
     ...(data.album != null && { album: data.album }),
@@ -141,6 +159,38 @@ export function createSong(data: SongCreateData): Promise<Song> {
     ...(data.tags != null && { tags: data.tags }),
     ...(data.volumeBoost !== undefined && { volumeBoost: data.volumeBoost }),
   });
+}
+
+export function previewRequest(url: string): Promise<RequestPreview> {
+  return post('/api/requests/preview', { url });
+}
+
+export interface FetchRequestsResult {
+  items: SongRequest[];
+  pagination: PaginationMeta;
+}
+
+export function fetchRequests(
+  page: number,
+  limit = 30,
+  opts?: { status?: string; mine?: boolean }
+): Promise<FetchRequestsResult> {
+  const params = new URLSearchParams({ page: String(page), limit: String(limit) });
+  if (opts?.status) params.set('status', opts.status);
+  if (opts?.mine) params.set('mine', 'true');
+  return get(`/api/requests?${params}`);
+}
+
+export function approveRequest(id: string): Promise<{ request: SongRequest; songs?: Song[] }> {
+  return patch(`/api/requests/${id}`, { status: 'approved' });
+}
+
+export function denyRequest(id: string): Promise<{ request: SongRequest }> {
+  return patch(`/api/requests/${id}`, { status: 'denied' });
+}
+
+export function cancelRequest(id: string): Promise<void> {
+  return remove(`/api/requests/${id}`);
 }
 
 export function deleteSong(id: string): Promise<void> {
@@ -345,39 +395,6 @@ export function overridePlay(url: string): Promise<{
 }
 
 // ---------------------------------------------------------------------------
-// Import Playlist API Functions
-// ---------------------------------------------------------------------------
-
-export interface SongPreview {
-  title: string;
-  sourceId: string;
-  duration: number;
-  thumbnailUrl: string;
-  sourceName: string | null;
-  artist: string | null;
-  artworkUrl: string | null;
-  alreadyExists: boolean;
-  existingSong: Song | null;
-}
-
-export function previewSong(url: string): Promise<SongPreview> {
-  return post('/api/songs/preview', { url });
-}
-
-export interface ImportPlaylistResult {
-  message: string;
-  playlistTitle: string;
-  totalVideos: number;
-  importedCount: number;
-  skippedCount: number;
-  songs: Song[];
-}
-
-export function importPlaylist(url: string, maxVideos?: number): Promise<ImportPlaylistResult> {
-  return post('/api/songs/import-playlist', { url, ...(maxVideos && { maxVideos }) });
-}
-
-// ---------------------------------------------------------------------------
 // Setup API Functions
 // ---------------------------------------------------------------------------
 
@@ -401,7 +418,8 @@ export interface CompleteSetupPayload {
   guildId: string;
   adminRoleIds: string;
   voiceIdleTimeoutMinutes: number;
-  notificationChannelId?: string | null;
+  afkNotificationChannelId?: string | null;
+  requestNotificationChannelId?: string | null;
   publicUrl?: string | null;
   enabledSources?: string;
 }
@@ -423,7 +441,10 @@ export type GeneralSettingsUpdate = Partial<
     GeneralSettings,
     | 'adminRoleIds'
     | 'voiceIdleTimeoutMinutes'
-    | 'notificationChannelId'
+    | 'afkNotificationChannelId'
+    | 'requestNotificationChannelId'
+    | 'notifyOnApproved'
+    | 'notifyOnDenied'
     | 'publicUrl'
     | 'enabledSources'
   >

--- a/packages/server/src/shared/db/index.ts
+++ b/packages/server/src/shared/db/index.ts
@@ -34,6 +34,7 @@ export const tables = {
   tag: schema.tag,
   guildSettings: schema.guildSettings,
   rolePermission: schema.rolePermission,
+  songRequest: schema.songRequest,
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/shared/db/migrations/0058_song_requests.sql
+++ b/packages/server/src/shared/db/migrations/0058_song_requests.sql
@@ -1,0 +1,30 @@
+--> statement-breakpoint
+ALTER TABLE "guildSettings" RENAME COLUMN "notificationChannelId" TO "afkNotificationChannelId";
+--> statement-breakpoint
+ALTER TABLE "guildSettings" ADD COLUMN "requestNotificationChannelId" text;
+--> statement-breakpoint
+ALTER TABLE "guildSettings" ADD COLUMN "notifyOnApproved" integer NOT NULL DEFAULT 1;
+--> statement-breakpoint
+ALTER TABLE "guildSettings" ADD COLUMN "notifyOnDenied" integer NOT NULL DEFAULT 1;
+--> statement-breakpoint
+CREATE TABLE "SongRequest" (
+  "id" text PRIMARY KEY NOT NULL,
+  "sourceUrl" text NOT NULL,
+  "sourceId" text NOT NULL,
+  "title" text NOT NULL,
+  "duration" integer NOT NULL,
+  "thumbnailUrl" text NOT NULL,
+  "artist" text,
+  "artworkUrl" text,
+  "sourceName" text,
+  "requestedBy" text NOT NULL,
+  "notifyDm" integer NOT NULL DEFAULT 0,
+  "type" text NOT NULL DEFAULT 'track',
+  "playlistData" text,
+  "status" text NOT NULL DEFAULT 'pending',
+  "reviewedBy" text,
+  "createdAt" integer NOT NULL,
+  "closedAt" integer
+);
+--> statement-breakpoint
+UPDATE "rolePermission" SET "action" = 'requests.autoapprove' WHERE "action" = 'songs.add';

--- a/packages/server/src/shared/db/schema.ts
+++ b/packages/server/src/shared/db/schema.ts
@@ -115,7 +115,10 @@ export const guildSettings = sqliteTable('guildSettings', {
   setupCompleted: integer('setupCompleted', { mode: 'boolean' }).notNull().default(false),
   adminRoleIds: text('adminRoleIds').notNull().default(''),
   voiceIdleTimeoutMinutes: integer('voiceIdleTimeoutMinutes').notNull().default(5),
-  notificationChannelId: text('notificationChannelId'),
+  afkNotificationChannelId: text('afkNotificationChannelId'),
+  requestNotificationChannelId: text('requestNotificationChannelId'),
+  notifyOnApproved: integer('notifyOnApproved', { mode: 'boolean' }).notNull().default(true),
+  notifyOnDenied: integer('notifyOnDenied', { mode: 'boolean' }).notNull().default(true),
   publicUrl: text('publicUrl'),
   enabledSources: text('enabledSources').notNull().default('youtube,soundcloud'),
 });
@@ -128,3 +131,39 @@ export const rolePermission = sqliteTable(
   },
   (t) => [primaryKey({ columns: [t.action, t.roleId] })]
 );
+
+export const songRequest = sqliteTable('SongRequest', {
+  id: text('id')
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  sourceUrl: text('sourceUrl').notNull(),
+  sourceId: text('sourceId').notNull(),
+  title: text('title').notNull(),
+  duration: integer('duration').notNull(),
+  thumbnailUrl: text('thumbnailUrl').notNull(),
+  artist: text('artist'),
+  artworkUrl: text('artworkUrl'),
+  sourceName: text('sourceName'),
+  requestedBy: text('requestedBy').notNull(),
+  notifyDm: integer('notifyDm', { mode: 'boolean' }).notNull().default(false),
+  type: text('type').notNull().default('track'), // 'track' | 'playlist'
+  playlistData: text('playlistData', { mode: 'json' }).$type<{
+    name: string;
+    videoCount: number;
+    thumbnailUrl?: string | null;
+    videos?: Array<{
+      id: string;
+      title: string;
+      duration: number;
+      thumbnailUrl?: string | null;
+      artist?: string | null;
+      artworkUrl?: string | null;
+    }>;
+  }>(),
+  status: text('status').notNull().default('pending'), // 'pending' | 'approved' | 'denied'
+  reviewedBy: text('reviewedBy'),
+  createdAt: integer('createdAt', { mode: 'timestamp_ms' })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  closedAt: integer('closedAt', { mode: 'timestamp_ms' }),
+});

--- a/packages/server/src/shared/index.ts
+++ b/packages/server/src/shared/index.ts
@@ -13,11 +13,15 @@ export type {
   PlaylistDetail,
   QueuedSong,
   QueueState,
+  RequestPreview,
   SetupChannel,
   SetupGuild,
   SetupRole,
   SetupStatus,
   Song,
+  SongRequest,
+  SongRequestPlaylist,
+  SongRequestTrack,
   User,
 } from './types';
 export {

--- a/packages/server/src/shared/types.ts
+++ b/packages/server/src/shared/types.ts
@@ -85,7 +85,10 @@ export interface GeneralSettings {
   setupCompleted: boolean;
   adminRoleIds: string;
   voiceIdleTimeoutMinutes: number;
-  notificationChannelId: string | null;
+  afkNotificationChannelId: string | null;
+  requestNotificationChannelId: string | null;
+  notifyOnApproved: boolean;
+  notifyOnDenied: boolean;
   publicUrl: string | null;
   enabledSources: string;
   availableSources: {
@@ -224,10 +227,10 @@ export interface User {
 
 /** Granular permission actions that can be delegated to non-admin roles. */
 export type PermissionAction =
-  | 'songs.add'
   | 'songs.edit'
   | 'songs.delete'
   | 'songs.import'
+  | 'requests.autoapprove'
   | 'queue.clear'
   | 'queue.shuffle'
   | 'queue.quickadd'
@@ -237,10 +240,10 @@ export type PermissionAction =
 
 /** Human-readable labels for each permission action. */
 export const PERMISSION_LABELS: Record<PermissionAction, string> = {
-  'songs.add': 'Add songs to library',
   'songs.edit': 'Edit song metadata',
   'songs.delete': 'Delete songs',
   'songs.import': 'Import external playlists',
+  'requests.autoapprove': 'Auto-approved song requests',
   'queue.clear': 'Clear the queue',
   'queue.shuffle': 'Shuffle / unshuffle queue',
   'queue.quickadd': 'Quick-add external URLs',
@@ -253,7 +256,7 @@ export const PERMISSION_LABELS: Record<PermissionAction, string> = {
 export const PERMISSION_CATEGORIES: { label: string; actions: PermissionAction[] }[] = [
   {
     label: 'Library',
-    actions: ['songs.add', 'songs.edit', 'songs.delete', 'songs.import'],
+    actions: ['songs.edit', 'songs.delete', 'songs.import', 'requests.autoapprove'],
   },
   {
     label: 'Playback',
@@ -264,3 +267,81 @@ export const PERMISSION_CATEGORIES: { label: string; actions: PermissionAction[]
     actions: ['tags.manage', 'audio.manage'],
   },
 ];
+
+// ---------------------------------------------------------------------------
+// Song Requests
+// ---------------------------------------------------------------------------
+
+export interface SongRequestTrack {
+  id: string;
+  sourceUrl: string;
+  sourceId: string;
+  title: string;
+  duration: number;
+  thumbnailUrl: string;
+  artist: string | null;
+  artworkUrl: string | null;
+  sourceName: string | null;
+  requestedBy: string;
+  requestedByDisplayName?: string;
+  notifyDm: boolean;
+  type: 'track';
+  playlistData: null;
+  status: 'pending' | 'approved' | 'denied';
+  reviewedBy: string | null;
+  createdAt: string;
+  closedAt: string | null;
+}
+
+export interface SongRequestPlaylist {
+  id: string;
+  sourceUrl: string;
+  sourceId: string;
+  title: string;
+  duration: number;
+  thumbnailUrl: string;
+  artist: string | null;
+  artworkUrl: string | null;
+  sourceName: string | null;
+  requestedBy: string;
+  requestedByDisplayName?: string;
+  notifyDm: boolean;
+  type: 'playlist';
+  playlistData: {
+    name: string;
+    videoCount: number;
+    thumbnailUrl?: string | null;
+    videos?: Array<{
+      id: string;
+      title: string;
+      duration: number;
+      thumbnailUrl?: string | null;
+      artist?: string | null;
+      artworkUrl?: string | null;
+    }>;
+  } | null;
+  status: 'pending' | 'approved' | 'denied';
+  reviewedBy: string | null;
+  createdAt: string;
+  closedAt: string | null;
+}
+
+export type SongRequest = SongRequestTrack | SongRequestPlaylist;
+
+export interface RequestPreview {
+  title: string;
+  sourceId: string;
+  duration: number;
+  thumbnailUrl: string;
+  sourceName: string | null;
+  artist: string | null;
+  artworkUrl: string | null;
+  alreadyExists: boolean;
+  existingSong?: unknown;
+  isPlaylist: boolean;
+  playlistMeta?: {
+    name: string;
+    videoCount: number;
+    thumbnailUrl?: string | null;
+  };
+}

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -15,6 +15,7 @@ import LoginPage from './pages/LoginPage';
 import PermissionsPage from './pages/PermissionsPage';
 import PlaylistDetailPage from './pages/PlaylistDetailPage';
 import PlaylistsPage from './pages/PlaylistsPage';
+import RequestsPage from './pages/RequestsPage';
 import SetupWizard from './pages/SetupWizard';
 import SongsPage from './pages/SongsPage';
 import TagsPage from './pages/TagsPage';
@@ -57,6 +58,7 @@ export default function App() {
                       <Route path="audio" element={<AudioPage />} />
                       <Route path="tags" element={<TagsPage />} />
                       <Route path="permissions" element={<PermissionsPage />} />
+                      <Route path="requests" element={<RequestsPage />} />
                     </Route>
                     <Route path="*" element={<Navigate to="/" replace />} />
                   </Routes>

--- a/packages/web/src/api/api.ts
+++ b/packages/web/src/api/api.ts
@@ -18,11 +18,16 @@ export type { MyPermissionsResponse, PermissionsResponse } from '@alfira-bot/ser
 export {
   addSongToPlaylist,
   addToPriorityQueue,
+  approveRequest,
+  type CreateRequestResult,
+  cancelRequest,
   completeSetup,
   createPlaylist,
-  createSong as addSong,
+  createRequest,
   deletePlaylist,
   deleteSong,
+  denyRequest,
+  type FetchRequestsResult,
   fetchGeneralSettings,
   fetchLogout as logout,
   // Auth
@@ -33,6 +38,8 @@ export {
   // Playlists
   fetchPlaylists as getPlaylists,
   fetchPlaylistsPage as getPlaylistsPage,
+  // Requests
+  fetchRequests,
   // Setup
   fetchSetupChannels,
   fetchSetupGuilds,
@@ -42,15 +49,13 @@ export {
   fetchSongsPage as getSongsPage,
   // Version
   fetchVersion,
-  importPlaylist,
   overridePlay,
-  previewSong,
+  previewRequest,
   quickAddPlaylistToQueue,
   quickAddToQueue,
+  type RequestCreateData,
   removeSongFromPlaylist,
   renamePlaylist,
-  type SongCreateData,
-  type SongPreview,
   startPlayback,
   togglePlaylistVisibility,
   updateGeneralSettings,

--- a/packages/web/src/components/AddSongModal.tsx
+++ b/packages/web/src/components/AddSongModal.tsx
@@ -231,16 +231,14 @@ export default function AddSongModal({
                 Cancel
               </Button>
               {isPlaylist && (
-                <Button
-                  variant="primary"
+                <button
+                  type="button"
+                  className="btn-primary-secondary"
                   onClick={handleImportPlaylist}
                   disabled={loading || !url.trim()}
-                  style={{
-                    background: `linear-gradient(180deg, color-mix(in srgb, var(--color-accent) 65%, white) 0%, color-mix(in srgb, var(--color-accent) 90%, black) 100%)`,
-                  }}
                 >
                   Import Playlist
-                </Button>
+                </button>
               )}
               <Button variant="primary" onClick={handleFetch} disabled={loading || !url.trim()}>
                 Fetch

--- a/packages/web/src/components/AddSongModal.tsx
+++ b/packages/web/src/components/AddSongModal.tsx
@@ -1,8 +1,6 @@
-import type { Song, SongPreview } from '@alfira-bot/server/shared';
+import type { RequestPreview, Song } from '@alfira-bot/server/shared';
 import { useEffect, useRef, useState } from 'react';
-import { addSong, importPlaylist, previewSong } from '../api/api';
-import { useAdminView } from '../context/AdminViewContext';
-import { usePermissions } from '../context/PermissionsContext';
+import { createRequest, previewRequest } from '../api/api';
 import { useTagColors } from '../context/TagsContext';
 import { apiErrorMessage } from '../utils/api';
 import { getTagColorClasses } from '../utils/tagColors';
@@ -18,8 +16,6 @@ export default function AddSongModal({
   onClose: () => void;
   onAdded: (song: Song) => void;
 }) {
-  const { isAdminView } = useAdminView();
-  const { hasPermission } = usePermissions();
   const { tagColorMap } = useTagColors();
 
   const [step, setStep] = useState<Step>('url');
@@ -28,13 +24,11 @@ export default function AddSongModal({
   const [error, setError] = useState('');
   const [successMsg, setSuccessMsg] = useState('');
 
-  // Playlist import
+  // Playlist detection
   const isPlaylist = url.includes('list=');
-  const canImport = isAdminView || hasPermission('songs.import');
-  const [importFullPlaylist, setImportFullPlaylist] = useState(false);
 
   // Preview data from server
-  const [preview, setPreview] = useState<SongPreview | null>(null);
+  const [preview, setPreview] = useState<RequestPreview | null>(null);
 
   // Editable metadata fields
   const [nickname, setNickname] = useState('');
@@ -44,6 +38,7 @@ export default function AddSongModal({
   const [tags, setTags] = useState<string[]>([]);
   const [tagInput, setTagInput] = useState('');
   const [volumeBoost, setVolumeBoost] = useState('');
+  const [notifyDm, setNotifyDm] = useState(false);
 
   const urlInputRef = useRef<HTMLInputElement>(null);
 
@@ -51,7 +46,7 @@ export default function AddSongModal({
     urlInputRef.current?.focus();
   }, []);
 
-  // Auto-close after successful playlist import
+  // Auto-close after successful submission
   useEffect(() => {
     if (successMsg) {
       const id = setTimeout(() => onClose(), 1500);
@@ -65,10 +60,10 @@ export default function AddSongModal({
     setError('');
 
     try {
-      const result = await previewSong(url.trim());
+      const result = await previewRequest(url.trim());
       setPreview(result);
 
-      // Pre-fill fields from NodeLink metadata
+      // Pre-fill fields from metadata
       setNickname('');
       setArtist(result.artist ?? '');
       setAlbum('');
@@ -78,12 +73,37 @@ export default function AddSongModal({
       setVolumeBoost('0');
 
       if (result.alreadyExists) {
-        setError('This song is already in your library.');
+        setError('This song is already in your library or has been requested.');
       }
 
       setStep('metadata');
     } catch (err: unknown) {
       setError(apiErrorMessage(err, 'Could not fetch track info. Try again.'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleImportPlaylist = async () => {
+    if (!url.trim()) return;
+    setLoading(true);
+    setError('');
+    setSuccessMsg('');
+
+    try {
+      const result = await createRequest({
+        sourceUrl: url.trim(),
+      });
+
+      if (result.autoApproved) {
+        setSuccessMsg(
+          `Imported ${result.importedCount ?? result.songs?.length ?? 0} songs from "${result.playlistTitle ?? 'playlist'}".`
+        );
+      } else {
+        setSuccessMsg('Playlist request submitted! An admin will review it.');
+      }
+    } catch (err: unknown) {
+      setError(apiErrorMessage(err, 'Could not import playlist. Try again.'));
     } finally {
       setLoading(false);
     }
@@ -96,21 +116,28 @@ export default function AddSongModal({
     setSuccessMsg('');
 
     try {
-      if (importFullPlaylist) {
-        const result = await importPlaylist(url.trim());
-        setSuccessMsg(result.message);
+      const parsedBoost = volumeBoost.trim() === '' ? null : parseInt(volumeBoost.trim(), 10);
+
+      const result = await createRequest({
+        sourceUrl: url.trim(),
+        notifyDm,
+        nickname: nickname.trim() || null,
+        artist: artist.trim() || null,
+        album: album.trim() || null,
+        artwork: artwork.trim() || null,
+        tags: tags.length > 0 ? tags : undefined,
+        volumeBoost: parsedBoost != null && !Number.isNaN(parsedBoost) ? parsedBoost : null,
+      });
+
+      if (result.autoApproved) {
+        if (result.song) {
+          onAdded(result.song);
+        } else if (result.songs) {
+          // Playlist auto-import
+          setSuccessMsg(`Imported ${result.importedCount} songs from "${result.playlistTitle}".`);
+        }
       } else {
-        const parsedBoost = volumeBoost.trim() === '' ? null : parseInt(volumeBoost.trim(), 10);
-        const song = await addSong({
-          url: url.trim(),
-          nickname: nickname.trim() || null,
-          artist: artist.trim() || null,
-          album: album.trim() || null,
-          artwork: artwork.trim() || null,
-          tags: tags.length > 0 ? tags : undefined,
-          volumeBoost: parsedBoost != null && !Number.isNaN(parsedBoost) ? parsedBoost : null,
-        });
-        onAdded(song);
+        setSuccessMsg('Request submitted! An admin will review it.');
       }
     } catch (err: unknown) {
       setError(apiErrorMessage(err, 'Something went wrong. Try again.'));
@@ -121,11 +148,7 @@ export default function AddSongModal({
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && step === 'url') {
-      if (importFullPlaylist) {
-        handleSubmit();
-      } else {
-        handleFetch();
-      }
+      handleFetch();
     }
     if (e.key === 'Escape') {
       if (step === 'metadata') setStep('url');
@@ -159,14 +182,16 @@ export default function AddSongModal({
     setError('');
   };
 
-  const canAdd = (step === 'metadata' || importFullPlaylist) && !loading && !preview?.alreadyExists;
+  const canSubmit = step === 'metadata' && !loading && !preview?.alreadyExists;
 
   return (
     <Backdrop onClose={onClose}>
       <div className="bg-surface rounded-xl p-5 md:p-6 w-full max-w-md mx-4 modal-clay animate-fade-up">
-        <h2 className="font-display text-2xl md:text-3xl text-fg tracking-wider mb-1">Add Song</h2>
+        <h2 className="font-display text-2xl md:text-3xl text-fg tracking-wider mb-1">
+          Request Song
+        </h2>
         <p className="font-mono text-xs text-muted mb-4 md:mb-6">
-          {step === 'url' ? 'paste a url' : (preview?.title ?? 'edit metadata')}
+          {step === 'url' ? 'paste a url' : (preview?.title ?? 'review details')}
         </p>
 
         {/* Step 1: URL input */}
@@ -186,17 +211,10 @@ export default function AddSongModal({
               disabled={loading}
             />
 
-            {isPlaylist && canImport && (
-              <label className="flex items-center gap-2 mb-3 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={importFullPlaylist}
-                  onChange={(e) => setImportFullPlaylist(e.target.checked)}
-                  disabled={loading}
-                  className="w-4 h-4 rounded border-border bg-surface accent-accent"
-                />
-                <span className="font-mono text-xs text-fg">Import full playlist</span>
-              </label>
+            {isPlaylist && (
+              <p className="font-mono text-[10px] text-muted mb-3">
+                Playlist detected — Fetch to add a single track, or import the full playlist.
+              </p>
             )}
 
             {error && <p className="font-mono text-xs text-danger mb-3">{error}</p>}
@@ -204,7 +222,7 @@ export default function AddSongModal({
             {loading && (
               <p className="font-mono text-xs text-muted mb-3 flex items-center gap-2">
                 <span className="w-3 h-3 border border-accent border-t-transparent rounded-full animate-spin inline-block" />
-                fetching metadata...
+                loading...
               </p>
             )}
 
@@ -212,15 +230,21 @@ export default function AddSongModal({
               <Button variant="inherit" onClick={onClose} disabled={loading} surface="surface">
                 Cancel
               </Button>
-              {importFullPlaylist ? (
-                <Button variant="primary" onClick={handleSubmit} disabled={loading || !url.trim()}>
-                  Import
-                </Button>
-              ) : (
-                <Button variant="primary" onClick={handleFetch} disabled={loading || !url.trim()}>
-                  Fetch
+              {isPlaylist && (
+                <Button
+                  variant="primary"
+                  onClick={handleImportPlaylist}
+                  disabled={loading || !url.trim()}
+                  style={{
+                    background: `linear-gradient(180deg, color-mix(in srgb, var(--color-accent) 65%, white) 0%, color-mix(in srgb, var(--color-accent) 90%, black) 100%)`,
+                  }}
+                >
+                  Import Playlist
                 </Button>
               )}
+              <Button variant="primary" onClick={handleFetch} disabled={loading || !url.trim()}>
+                Fetch
+              </Button>
             </div>
           </>
         )}
@@ -228,7 +252,7 @@ export default function AddSongModal({
         {/* Step 2: Metadata fields */}
         {step === 'metadata' && preview && (
           <div className="flex flex-col gap-3">
-            {/* Thumbnail + title + duration + source (informational, above the fields) */}
+            {/* Thumbnail + title + duration + source */}
             <div className="flex items-center gap-3 -mb-1">
               {(preview.artworkUrl || preview.thumbnailUrl) && (
                 <img
@@ -248,11 +272,16 @@ export default function AddSongModal({
                       {preview.sourceName}
                     </span>
                   )}
+                  {preview.isPlaylist && (
+                    <span className="font-mono text-[10px] text-accent uppercase">
+                      Playlist ({preview.playlistMeta?.videoCount ?? '?'} tracks)
+                    </span>
+                  )}
                 </div>
               </div>
             </div>
 
-            {/* Title / Nickname — merged: shows NodeLink title as placeholder, editing sets nickname */}
+            {/* Title / Nickname */}
             <Field
               id="add-title"
               label="Title"
@@ -293,7 +322,7 @@ export default function AddSongModal({
               >
                 Tags
               </label>
-              {/* biome-ignore lint/a11y/useKeyWithClickEvents: container click focuses inner input; keyboard users tab directly to the input */}
+              {/* biome-ignore lint/a11y/useKeyWithClickEvents: container click focuses inner input */}
               {/* biome-ignore lint/a11y/noStaticElementInteractions: container click focuses inner input */}
               <div
                 className="input text-sm flex flex-wrap gap-1.5 items-center min-h-9.5 cursor-text"
@@ -382,12 +411,23 @@ export default function AddSongModal({
               </div>
             </div>
 
+            {/* Notify DM */}
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={notifyDm}
+                onChange={(e) => setNotifyDm(e.target.checked)}
+                className="w-4 h-4 rounded border-border bg-surface accent-accent"
+              />
+              <span className="font-mono text-xs text-fg">DM me when this request is reviewed</span>
+            </label>
+
             {error && <p className="font-mono text-xs text-danger">{error}</p>}
 
             {loading && (
               <p className="font-mono text-xs text-muted flex items-center gap-2">
                 <span className="w-3 h-3 border border-accent border-t-transparent rounded-full animate-spin inline-block" />
-                adding song...
+                submitting request...
               </p>
             )}
 
@@ -400,8 +440,8 @@ export default function AddSongModal({
               >
                 Back
               </Button>
-              <Button variant="primary" onClick={handleSubmit} disabled={!canAdd}>
-                Add
+              <Button variant="primary" onClick={handleSubmit} disabled={!canSubmit}>
+                Submit Request
               </Button>
             </div>
           </div>
@@ -419,14 +459,12 @@ function Field({
   value,
   onChange,
   placeholder,
-  readOnly,
 }: {
   id: string;
   label: string;
   value: string;
-  onChange?: (v: string) => void;
+  onChange: (v: string) => void;
   placeholder?: string;
-  readOnly?: boolean;
 }) {
   return (
     <div>
@@ -435,11 +473,10 @@ function Field({
       </label>
       <input
         id={id}
-        className={`input text-sm ${readOnly ? 'opacity-60 cursor-default' : ''}`}
+        className="input text-sm"
         value={value}
-        onChange={onChange ? (e) => onChange(e.target.value) : undefined}
+        onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
-        readOnly={readOnly}
       />
     </div>
   );

--- a/packages/web/src/components/settings/AdminTab.tsx
+++ b/packages/web/src/components/settings/AdminTab.tsx
@@ -16,12 +16,18 @@ import {
   updateGeneralSettings,
 } from '../../api/api';
 import { SourceIcon } from '../SourceIcons';
+import SettingsToggle from './SettingsToggle';
 
 export default function AdminTab() {
   const [saved, setSaved] = useState<GeneralSettings | null>(null);
   const [adminRoleIds, setAdminRoleIds] = useState('');
   const [timeoutMinutes, setTimeoutMinutes] = useState(5);
-  const [notificationChannelId, setNotificationChannelId] = useState<string | null>(null);
+  const [afkNotificationChannelId, setAfkNotificationChannelId] = useState<string | null>(null);
+  const [requestNotificationChannelId, setRequestNotificationChannelId] = useState<string | null>(
+    null
+  );
+  const [notifyOnApproved, setNotifyOnApproved] = useState(true);
+  const [notifyOnDenied, setNotifyOnDenied] = useState(true);
   const [publicUrl, setPublicUrl] = useState<string | null>(null);
   const [enabledSources, setEnabledSources] = useState('youtube,soundcloud');
   const [availableSources, setAvailableSources] = useState<
@@ -49,7 +55,10 @@ export default function AdminTab() {
         setSaved(settings);
         setAdminRoleIds(settings.adminRoleIds);
         setTimeoutMinutes(settings.voiceIdleTimeoutMinutes);
-        setNotificationChannelId(settings.notificationChannelId);
+        setAfkNotificationChannelId(settings.afkNotificationChannelId);
+        setRequestNotificationChannelId(settings.requestNotificationChannelId);
+        setNotifyOnApproved(settings.notifyOnApproved);
+        setNotifyOnDenied(settings.notifyOnDenied);
         setPublicUrl(settings.publicUrl);
         setEnabledSources(settings.enabledSources);
         setAvailableSources(settings.availableSources);
@@ -73,7 +82,10 @@ export default function AdminTab() {
   const hasChanges = saved
     ? adminRoleIds !== saved.adminRoleIds ||
       timeoutMinutes !== saved.voiceIdleTimeoutMinutes ||
-      notificationChannelId !== saved.notificationChannelId ||
+      afkNotificationChannelId !== saved.afkNotificationChannelId ||
+      requestNotificationChannelId !== saved.requestNotificationChannelId ||
+      notifyOnApproved !== saved.notifyOnApproved ||
+      notifyOnDenied !== saved.notifyOnDenied ||
       publicUrl !== saved.publicUrl ||
       enabledSources !== saved.enabledSources
     : false;
@@ -86,7 +98,10 @@ export default function AdminTab() {
       const updated = await updateGeneralSettings({
         adminRoleIds,
         voiceIdleTimeoutMinutes: timeoutMinutes,
-        notificationChannelId,
+        afkNotificationChannelId,
+        requestNotificationChannelId,
+        notifyOnApproved,
+        notifyOnDenied,
         publicUrl,
         enabledSources,
       });
@@ -253,12 +268,12 @@ export default function AdminTab() {
 
       <div className="border-t border-muted/20" />
 
-      {/* Notification Channel */}
+      {/* AFK Notification Channel */}
       <div className="space-y-2">
         <div className="flex items-center gap-2">
           <MegaphoneIcon size={14} weight="duotone" className="text-muted" />
           <h3 className="font-mono text-[11px] text-muted uppercase tracking-wider">
-            Notification Channel
+            AFK Notification Channel
           </h3>
         </div>
         <p className="text-xs text-muted">
@@ -266,8 +281,8 @@ export default function AdminTab() {
         </p>
         {channels.length > 0 ? (
           <select
-            value={notificationChannelId ?? ''}
-            onChange={(e) => setNotificationChannelId(e.target.value || null)}
+            value={afkNotificationChannelId ?? ''}
+            onChange={(e) => setAfkNotificationChannelId(e.target.value || null)}
             className="w-full px-3 py-2 rounded-lg bg-base border border-border text-fg text-sm focus:outline-none focus:border-accent transition-colors"
           >
             <option value="">— Disabled —</option>
@@ -280,6 +295,77 @@ export default function AdminTab() {
         ) : (
           <p className="text-xs text-muted italic">No channels loaded.</p>
         )}
+      </div>
+
+      <div className="border-t border-muted/20" />
+
+      {/* Request Notification Channel */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <MegaphoneIcon size={14} weight="duotone" className="text-muted" />
+          <h3 className="font-mono text-[11px] text-muted uppercase tracking-wider">
+            Song Request Notifications
+          </h3>
+        </div>
+        <p className="text-xs text-muted">
+          Alfira posts here when new song requests are submitted.
+        </p>
+        {channels.length > 0 ? (
+          <select
+            value={requestNotificationChannelId ?? ''}
+            onChange={(e) => setRequestNotificationChannelId(e.target.value || null)}
+            className="w-full px-3 py-2 rounded-lg bg-base border border-border text-fg text-sm focus:outline-none focus:border-accent transition-colors"
+          >
+            <option value="">— Disabled —</option>
+            {channels.map((c) => (
+              <option key={c.id} value={c.id}>
+                # {c.name}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <p className="text-xs text-muted italic">No channels loaded.</p>
+        )}
+
+        <div className="mt-3 space-y-3">
+          <div className="flex items-start gap-4">
+            <div className="flex-1 min-w-0">
+              <p className="font-body text-sm font-medium text-fg flex items-center gap-1.5">
+                Notify on approved
+                <span className="relative group">
+                  <QuestionIcon size={14} weight="duotone" className="text-muted cursor-help" />
+                  <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-56 p-2 rounded-lg bg-elevated border border-border text-xs text-muted opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity z-10">
+                    Requesters can also opt into a personal DM when they submit a request.
+                  </span>
+                </span>
+              </p>
+              <p className="font-mono text-[11px] text-muted mt-0.5">
+                Post a message when a request is approved.
+              </p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={notifyOnApproved}
+              onClick={() => setNotifyOnApproved(!notifyOnApproved)}
+              className={`relative shrink-0 w-11 h-6 rounded-full transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface cursor-pointer ${
+                notifyOnApproved ? 'bg-accent' : 'bg-elevated'
+              }`}
+            >
+              <span
+                className={`absolute top-0.5 left-0.5 w-5 h-5 rounded-full transition-transform duration-200 ${
+                  notifyOnApproved ? 'translate-x-5 bg-elevated' : 'translate-x-0 bg-muted'
+                }`}
+              />
+            </button>
+          </div>
+          <SettingsToggle
+            label="Notify on denied"
+            description="Post a message when a request is denied."
+            checked={notifyOnDenied}
+            onChange={setNotifyOnDenied}
+          />
+        </div>
       </div>
 
       <div className="border-t border-muted/20" />

--- a/packages/web/src/constants.ts
+++ b/packages/web/src/constants.ts
@@ -4,11 +4,13 @@ import {
   ShieldCheckIcon,
   SlidersHorizontalIcon,
   TagIcon,
+  TrayIcon,
 } from '@phosphor-icons/react';
 
 export const NAV_ITEMS = [
   { to: '/songs', label: 'Songs', icon: MusicNotesIcon },
   { to: '/playlists', label: 'Playlists', icon: PlaylistIcon },
+  { to: '/requests', label: 'Requests', icon: TrayIcon },
 ];
 
 export const ADMIN_NAV_ITEMS = [

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -64,6 +64,7 @@
 
 [data-color-theme="artificer"] {
     --color-accent: #f97316;
+    --color-accent-secondary: #c2410c;
 
     &[data-mode="dark"] {
         --color-surface: #1e1e1e;
@@ -92,6 +93,7 @@
 
 [data-color-theme="barbarian"] {
     --color-accent: #dc2626;
+    --color-accent-secondary: #b91c1c;
 
     &[data-mode="dark"] {
         --color-surface: #1e1a1a;
@@ -120,6 +122,7 @@
 
 [data-color-theme="bard"] {
     --color-accent: #db2777;
+    --color-accent-secondary: #9d174d;
 
     &[data-mode="dark"] {
         --color-surface: #1e1618;
@@ -148,6 +151,7 @@
 
 [data-color-theme="cleric"] {
     --color-accent: #ca8a04;
+    --color-accent-secondary: #854d0e;
 
     &[data-mode="dark"] {
         --color-surface: #1e1a10;
@@ -176,6 +180,7 @@
 
 [data-color-theme="druid"] {
     --color-accent: #f43f5e;
+    --color-accent-secondary: #be123c;
 
     &[data-mode="dark"] {
         --color-surface: #181e18;
@@ -204,6 +209,7 @@
 
 [data-color-theme="fighter"] {
     --color-accent: #64748b;
+    --color-accent-secondary: #475569;
 
     &[data-mode="dark"] {
         --color-surface: #1a1a1e;
@@ -232,6 +238,7 @@
 
 [data-color-theme="monk"] {
     --color-accent: #14b8a6;
+    --color-accent-secondary: #0f766e;
 
     &[data-mode="dark"] {
         --color-surface: #161e1e;
@@ -260,6 +267,7 @@
 
 [data-color-theme="paladin"] {
     --color-accent: #94a3b8;
+    --color-accent-secondary: #64748b;
 
     &[data-mode="dark"] {
         --color-surface: #181c22;
@@ -288,6 +296,7 @@
 
 [data-color-theme="ranger"] {
     --color-accent: #15803d;
+    --color-accent-secondary: #166534;
 
     &[data-mode="dark"] {
         --color-surface: #161e14;
@@ -316,6 +325,7 @@
 
 [data-color-theme="rogue"] {
     --color-accent: #6366f1;
+    --color-accent-secondary: #4338ca;
 
     &[data-mode="dark"] {
         --color-surface: #18181e;
@@ -344,6 +354,7 @@
 
 [data-color-theme="sorcerer"] {
     --color-accent: #e11d48;
+    --color-accent-secondary: #9f1239;
 
     &[data-mode="dark"] {
         --color-surface: #1e1618;
@@ -372,6 +383,7 @@
 
 [data-color-theme="warlock"] {
     --color-accent: #9333ea;
+    --color-accent-secondary: #6b21a8;
 
     &[data-mode="dark"] {
         --color-surface: #1c1620;
@@ -400,6 +412,7 @@
 
 [data-color-theme="wizard"] {
     --color-accent: #3b82f6;
+    --color-accent-secondary: #1d4ed8;
 
     &[data-mode="dark"] {
         --color-surface: #161a22;
@@ -430,6 +443,7 @@
     /* Theme color tokens — values come from data-color-theme selectors above */
     --color-accent: var(--color-accent);
     --color-accent-muted: color-mix(in srgb, var(--color-accent) 55%, var(--color-muted));
+    --color-accent-secondary: var(--color-accent-secondary);
     --color-accent-foreground: color-mix(in srgb, var(--color-accent) 70%, var(--color-foreground));
     --color-danger: #ef4444;
     --color-warning: #f59e0b;
@@ -615,6 +629,47 @@
         box-shadow: var(--clay-shadow-flat);
     }
     .btn-primary.pressed {
+        transform: var(--btn-transform-active);
+        scale: var(--btn-scale-active);
+        box-shadow: inset 0 2px 4px 0 rgba(0, 0, 0, 0.25);
+    }
+
+    .btn-primary-secondary {
+        @apply font-body text-sm px-4 py-2.5 md:py-2
+           transition-all duration-150 cursor-pointer disabled:opacity-40
+           disabled:cursor-not-allowed min-h-11 md:min-h-0;
+        border-radius: var(--clay-radius-lg);
+        color: var(--color-fg);
+        background: linear-gradient(
+            180deg,
+            color-mix(in srgb, var(--color-accent-secondary) 75%, white) 0%,
+            var(--color-accent-secondary) 100%
+        );
+        box-shadow:
+            0 3px 0 0
+                color-mix(in srgb, var(--color-accent-secondary) 100%, black 35%),
+            0 4px 8px -2px rgba(0, 0, 0, 0.3),
+            inset 0 1px 1px 0 rgba(255, 255, 255, 0.08);
+    }
+    .btn-primary-secondary:hover {
+        transform: var(--btn-transform-hover);
+        background: linear-gradient(
+            180deg,
+            color-mix(in srgb, var(--color-accent-secondary) 65%, white) 0%,
+            var(--color-accent-secondary) 100%
+        );
+        box-shadow:
+            0 4px 0 0
+                color-mix(in srgb, var(--color-accent-secondary) 100%, black 35%),
+            0 6px 12px -2px rgba(0, 0, 0, 0.35),
+            inset 0 1px 1px 0 rgba(255, 255, 255, 0.08);
+    }
+    .btn-primary-secondary:active {
+        transform: var(--btn-transform-active);
+        scale: var(--btn-scale-active);
+        box-shadow: var(--clay-shadow-flat);
+    }
+    .btn-primary-secondary.pressed {
         transform: var(--btn-transform-active);
         scale: var(--btn-scale-active);
         box-shadow: inset 0 2px 4px 0 rgba(0, 0, 0, 0.25);

--- a/packages/web/src/pages/RequestsPage.tsx
+++ b/packages/web/src/pages/RequestsPage.tsx
@@ -1,0 +1,322 @@
+import type { SongRequest } from '@alfira-bot/server/shared';
+import { CheckCircleIcon, TrashIcon, XCircleIcon } from '@phosphor-icons/react';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  approveRequest,
+  cancelRequest,
+  denyRequest,
+  type FetchRequestsResult,
+  fetchRequests,
+} from '../api/api';
+import AddSongModal from '../components/AddSongModal';
+import { SourceIcon } from '../components/SourceIcons';
+import { Button } from '../components/ui/Button';
+import { useAdminView } from '../context/AdminViewContext';
+import { useAuth } from '../context/AuthContext';
+
+type Tab = 'pending' | 'closed';
+
+export default function RequestsPage() {
+  const { user } = useAuth();
+  const { isAdminView } = useAdminView();
+  const [tab, setTab] = useState<Tab>('pending');
+  const [mineOnly, setMineOnly] = useState(false);
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [data, setData] = useState<FetchRequestsResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const status = tab === 'pending' ? 'pending' : 'all';
+      const result = await fetchRequests(1, 50, {
+        status,
+        mine: mineOnly || undefined,
+      });
+      setData(result);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to load requests.');
+    } finally {
+      setLoading(false);
+    }
+  }, [tab, mineOnly]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleApprove = async (id: string) => {
+    setActionError(null);
+    try {
+      await approveRequest(id);
+      await load();
+    } catch (err: unknown) {
+      setActionError(err instanceof Error ? err.message : 'Failed to approve.');
+    }
+  };
+
+  const handleDeny = async (id: string) => {
+    setActionError(null);
+    try {
+      await denyRequest(id);
+      await load();
+    } catch (err: unknown) {
+      setActionError(err instanceof Error ? err.message : 'Failed to deny.');
+    }
+  };
+
+  const handleCancel = async (id: string) => {
+    setActionError(null);
+    try {
+      await cancelRequest(id);
+      await load();
+    } catch (err: unknown) {
+      setActionError(err instanceof Error ? err.message : 'Failed to cancel.');
+    }
+  };
+
+  const items = data?.items ?? [];
+  const countLabel = loading
+    ? '—'
+    : `${data?.pagination.total ?? 0} request${(data?.pagination.total ?? 0) !== 1 ? 's' : ''}`;
+
+  return (
+    <div className="p-4 md:p-8">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-6 md:mb-8">
+        <div>
+          <h1 className="font-display text-3xl md:text-4xl text-fg tracking-wider">Requests</h1>
+          <p className="font-mono text-xs text-muted mt-1">{countLabel}</p>
+        </div>
+        <Button
+          variant="primary"
+          onClick={() => setShowAddModal(true)}
+          className={showAddModal ? 'pressed' : ''}
+        >
+          + Request Song
+        </Button>
+      </div>
+
+      {/* Tabs + filter */}
+      <div className="flex items-center gap-3 mb-4 md:mb-6">
+        <div className="flex gap-1 bg-elevated rounded-lg p-1">
+          <button
+            type="button"
+            onClick={() => {
+              setTab('pending');
+            }}
+            className={`px-3 py-1.5 rounded-md text-sm font-body transition-colors cursor-pointer ${
+              tab === 'pending' ? 'bg-accent text-elevated' : 'text-muted hover:text-fg'
+            }`}
+          >
+            Pending
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setTab('closed');
+              setMineOnly(false);
+            }}
+            className={`px-3 py-1.5 rounded-md text-sm font-body transition-colors cursor-pointer ${
+              tab === 'closed' ? 'bg-accent text-elevated' : 'text-muted hover:text-fg'
+            }`}
+          >
+            History
+          </button>
+        </div>
+
+        {tab === 'pending' && (
+          <label className="flex items-center gap-2 cursor-pointer ml-auto">
+            <input
+              type="checkbox"
+              checked={mineOnly}
+              onChange={(e) => setMineOnly(e.target.checked)}
+              className="w-4 h-4 rounded border-border bg-surface accent-accent"
+            />
+            <span className="font-mono text-xs text-muted">Only show my requests</span>
+          </label>
+        )}
+      </div>
+
+      {/* Errors */}
+      {actionError && (
+        <div className="mb-4 p-3 rounded-lg bg-danger/10 border border-danger/20 text-danger text-sm font-mono">
+          {actionError}
+        </div>
+      )}
+      {error && (
+        <div className="mb-4 p-3 rounded-lg bg-danger/10 border border-danger/20 text-danger text-sm font-mono">
+          {error}
+        </div>
+      )}
+
+      {/* Loading */}
+      {loading && (
+        <div className="flex items-center gap-2 text-muted font-mono text-sm">
+          <span className="w-3 h-3 border border-accent border-t-transparent rounded-full animate-spin inline-block" />
+          Loading…
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!loading && items.length === 0 && (
+        <p className="text-sm text-muted">
+          {tab === 'pending' ? 'No pending requests.' : 'No request history.'}
+        </p>
+      )}
+
+      {/* Request cards */}
+      <div className="space-y-3">
+        {items.map((req) => (
+          <RequestCard
+            key={req.id}
+            req={req}
+            isOwn={req.requestedBy === user?.discordId}
+            isAdmin={isAdminView}
+            onApprove={handleApprove}
+            onDeny={handleDeny}
+            onCancel={handleCancel}
+          />
+        ))}
+      </div>
+
+      {/* Modals */}
+      {showAddModal && (
+        <AddSongModal
+          onClose={() => setShowAddModal(false)}
+          onAdded={() => {
+            setShowAddModal(false);
+            load();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function RequestCard({
+  req,
+  isOwn,
+  isAdmin,
+  onApprove,
+  onDeny,
+  onCancel,
+}: {
+  req: SongRequest;
+  isOwn: boolean;
+  isAdmin: boolean;
+  onApprove: (id: string) => void;
+  onDeny: (id: string) => void;
+  onCancel: (id: string) => void;
+}) {
+  const isPending = req.status === 'pending';
+  const isPlaylist = req.type === 'playlist';
+  const thumbnailUrl = isPlaylist
+    ? req.playlistData?.thumbnailUrl || req.thumbnailUrl
+    : req.artworkUrl || req.thumbnailUrl;
+
+  const statusColors: Record<string, string> = {
+    pending: 'bg-warning/10 text-warning border-warning/20',
+    approved: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20',
+    denied: 'bg-danger/10 text-danger border-danger/20',
+  };
+
+  const dateLabel = new Date(req.createdAt).toLocaleDateString();
+
+  return (
+    <div className="flex items-center gap-4 p-4 rounded-xl bg-elevated border border-border">
+      {/* Thumbnail */}
+      {thumbnailUrl ? (
+        <img
+          src={thumbnailUrl}
+          alt=""
+          className="w-14 h-14 rounded-lg object-cover shrink-0 border border-border"
+        />
+      ) : (
+        <div className="w-14 h-14 rounded-lg bg-muted/20 shrink-0 flex items-center justify-center">
+          <span className="text-muted text-xs font-mono">{isPlaylist ? 'PL' : 'TR'}</span>
+        </div>
+      )}
+
+      {/* Info */}
+      <div className="flex-1 min-w-0">
+        <p className="font-body text-sm text-fg truncate">{req.title}</p>
+        <div className="flex items-center gap-1.5 mt-0.5">
+          {req.sourceName && req.sourceName !== 'playlist' && (
+            <SourceIcon sourceKey={req.sourceName} />
+          )}
+          <span className="font-mono text-[10px] text-muted">{formatSeconds(req.duration)}</span>
+          {isPlaylist && req.playlistData && (
+            <span className="font-mono text-[10px] text-muted">
+              · {req.playlistData.videoCount} tracks
+            </span>
+          )}
+          <span className="font-mono text-[10px] text-muted">
+            · {req.requestedByDisplayName ?? req.requestedBy}
+          </span>
+          <span className="font-mono text-[10px] text-faint">· {dateLabel}</span>
+        </div>
+        {!isPending && req.reviewedBy && (
+          <p className="font-mono text-[10px] text-muted mt-0.5">
+            Reviewed {req.closedAt ? new Date(req.closedAt).toLocaleDateString() : ''}
+          </p>
+        )}
+      </div>
+
+      {/* Status badge */}
+      <span
+        className={`px-2 py-0.5 rounded-full text-[10px] font-mono uppercase border shrink-0 ${
+          statusColors[req.status] ?? 'bg-muted/10 text-muted border-muted/20'
+        }`}
+      >
+        {req.status}
+      </span>
+
+      {/* Actions */}
+      {isPending && (
+        <div className="flex items-center gap-2 shrink-0">
+          {isOwn && (
+            <Button
+              variant="inherit"
+              onClick={() => onCancel(req.id)}
+              surface="elevated"
+              title="Cancel request"
+            >
+              <TrashIcon size={16} weight="duotone" className="text-muted" />
+            </Button>
+          )}
+          {isAdmin && (
+            <>
+              <Button
+                variant="inherit"
+                onClick={() => onApprove(req.id)}
+                surface="elevated"
+                title="Approve"
+              >
+                <CheckCircleIcon size={16} weight="duotone" className="text-emerald-400" />
+              </Button>
+              <Button
+                variant="inherit"
+                onClick={() => onDeny(req.id)}
+                surface="elevated"
+                title="Deny"
+              >
+                <XCircleIcon size={16} weight="duotone" className="text-danger" />
+              </Button>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatSeconds(totalSeconds: number): string {
+  if (!Number.isFinite(totalSeconds) || totalSeconds < 0) return '0:00';
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = Math.floor(totalSeconds % 60);
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}

--- a/packages/web/src/pages/SetupWizard.tsx
+++ b/packages/web/src/pages/SetupWizard.tsx
@@ -192,7 +192,7 @@ export default function SetupWizard() {
         guildId: selectedGuildId,
         adminRoleIds: [...selectedRoleIds].join(','),
         voiceIdleTimeoutMinutes: timeoutMinutes,
-        notificationChannelId: selectedChannelId || null,
+        afkNotificationChannelId: selectedChannelId || null,
         publicUrl: publicUrl.trim() || null,
         enabledSources: [...selectedSourceKeys].join(','),
       });

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -1,14 +1,17 @@
 import type { Playlist, Song } from '@alfira-bot/server/shared';
-import { ListIcon, MagnifyingGlassIcon, SquaresFourIcon } from '@phosphor-icons/react';
+import {
+  ListIcon,
+  MagnifyingGlassIcon,
+  QuestionIcon,
+  SquaresFourIcon,
+} from '@phosphor-icons/react';
 import { useCallback, useEffect, useState } from 'react';
 import { deleteSong, getPlaylistsPage, getSongsPage, startPlayback } from '../api/api';
-import AddSongModal from '../components/AddSongModal';
 import ConfirmModal from '../components/ConfirmModal';
 import NotificationToast from '../components/NotificationToast';
 import { Button } from '../components/ui/Button';
 import { VirtualSongList } from '../components/VirtualSongList';
 import { useAdminView } from '../context/AdminViewContext';
-import { usePermissions } from '../context/PermissionsContext';
 import { usePlayerState } from '../context/PlayerContext';
 import { useAddToQueue } from '../hooks/useAddToQueue';
 import { useNotification } from '../hooks/useNotification';
@@ -20,14 +23,12 @@ const ITEMS_PER_PAGE = 24;
 
 export default function SongsPage() {
   const { isAdminView } = useAdminView();
-  const { hasPermission } = usePermissions();
   const { state: queueState } = usePlayerState();
   const [search, setSearch] = useState('');
   const [viewMode, setViewMode] = useState<'grid' | 'list'>(() => {
     const saved = localStorage.getItem('alfira-library-view');
     return saved === 'grid' ? 'grid' : 'list';
   });
-  const [showAddModal, setShowAddModal] = useState(false);
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [playingId, setPlayingId] = useState<string | null>(null);
   const { handleAddToQueue, notification } = useAddToQueue();
@@ -141,15 +142,14 @@ export default function SongsPage() {
             {isLoading ? '—' : `${total} track${total !== 1 ? 's' : ''}`}
           </p>
         </div>
-        {(isAdminView || hasPermission('songs.add')) && (
-          <Button
-            variant="primary"
-            onClick={() => setShowAddModal(true)}
-            className={showAddModal ? 'pressed' : ''}
-          >
-            + Add Song
-          </Button>
-        )}
+        <span className="relative group">
+          <QuestionIcon size={20} weight="duotone" className="text-muted cursor-help" />
+          <span className="absolute right-0 top-full mt-2 w-64 p-3 rounded-lg bg-elevated border border-border text-xs text-muted opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity z-10 leading-relaxed">
+            Songs are added through the <span className="text-accent">Requests</span> page. Submit a
+            URL there — admins review and approve it, or it&rsquo;s added instantly if you have
+            permission.
+          </span>
+        </span>
       </div>
 
       {/* Search and view toggle */}
@@ -218,15 +218,6 @@ export default function SongsPage() {
       />
 
       {/* Modals */}
-      {showAddModal && (
-        <AddSongModal
-          onClose={() => setShowAddModal(false)}
-          onAdded={(song) => {
-            prepend(song);
-            setShowAddModal(false);
-          }}
-        />
-      )}
 
       {deleteId && (
         <DeleteConfirmDialog


### PR DESCRIPTION
## Summary

Replaces the direct "Add Song" flow with a universal song request system. All songs enter the library through requests — users with the `requests.autoapprove` permission skip the review queue, while everyone else's submissions go into a pending queue for admin approval or denial.

## Changes

### New features
- **Song request flow** — new `POST /api/requests` endpoint replaces `POST /api/songs`. Auto-approves if the user has `requests.autoapprove` permission or is an admin. Auto-approved requests still create a history row so they appear in the requester's history.
- **Requests page** — new web UI page at `/requests` with pending/history tabs, "Only show my requests" filter (pending tab only), approve/deny/cancel actions.
- **Playlist requests** — entire playlists submitted as a single request entry. Approve imports all tracks; deny imports none. "Import Playlist" button appears alongside "Fetch" when a playlist URL is detected, using the new theme `accent-secondary` color.
- **Notifications** — configurable Discord channel for request alerts. Separate toggles for "notify on approved" and "notify on denied" events. Per-request DM opt-in for requesters (checkbox on submission form).
- **Source icons** on request cards matching the song card style.
- **Theme expansion** — new `--color-accent-secondary` CSS token on all 12 themes with a `btn-primary-secondary` button class, a darker complementary shade of each theme's primary accent.

### Bug fixes
- Fixed `canonicalizeTags()` dropping newly-created tags (tags were inserted into the Tag table but never included in the return value)
- Migration runner now handles `duplicate column name` and `no such column` errors for idempotent retries after partial runs
- Playlist URL detection now runs before `?list=` stripping, so playlist links resolve correctly

### Schema changes
- New `SongRequest` table with full request lifecycle tracking
- `notificationChannelId` renamed to `afkNotificationChannelId`
- New `requestNotificationChannelId`, `notifyOnApproved`, `notifyOnDenied` columns
- Permission `songs.add` migrated to `requests.autoapprove`

### UI changes
- "+ Request Song" button moved from Songs page to Requests page header
- Songs page header now has a `?` tooltip explaining the request flow
- Settings page: AFK and request notification channels split, approve/denied toggles added
- Permissions page: "Auto-approve song requests" → "Auto-approved song requests"

### Breaking changes
- **Permission rename**: existing `songs.add` grants are migrated to `requests.autoapprove` automatically
- **Column rename**: `notificationChannelId` → `afkNotificationChannelId` (migrated by 0058_song_requests.sql)