### PR TITLE
fix(web): fix scrubber thumb stuck at start during playback

### DIFF
--- a/packages/web/src/components/NowPlayingBar.tsx
+++ b/packages/web/src/components/NowPlayingBar.tsx
@@ -211,13 +211,6 @@ const Scrubber = memo(function Scrubber({
   // Last known slider value during drag (used to commit seek on pointer up)
   const lastDragValueRef = useRef<number>(0);
 
-  // Register the thumb div with the rAF loop so it glides at display-native rate.
-  useEffect(() => {
-    if (thumbRef.current) {
-      registerThumb(thumbRef.current);
-    }
-  }, [registerThumb]);
-
   // Position both fill bar and thumb directly in the DOM during drag.
   // Bypasses React + rAF entirely — immediate, jank-free visual feedback.
   const seekElements = useCallback((trackPct: number) => {
@@ -298,7 +291,10 @@ const Scrubber = memo(function Scrubber({
       {/* Fill & thumb — positioned entirely by useProgressBar (rAF + effect).
            No React style props. */}
       <div
-        ref={thumbRef}
+        ref={(ref) => {
+          thumbRef.current = ref;
+          if (ref) registerThumb(ref);
+        }}
         className="scrubber-thumb absolute top-1/2 -translate-y-1/2 w-3.5 h-3.5 rounded-full bg-surface border-2 border-accent opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity"
       />
       {/* Invisible hit area for hovering */}


### PR DESCRIPTION
## Summary

The scrubber thumb icon was not tracking with the fill progress bar during playback — it remained stuck at the start of the track while the bar filled normally.

## Root Cause

The thumb used a `useRef` + `useEffect([registerThumb])` pattern to register with the rAF progress loop, which only fired on initial mount. On page load there's no song, so `isSeekable` is `false` and the thumb div doesn't exist yet. When playback starts and `isSeekable` becomes `true`, the thumb DOM element mounts, but the effect doesn't re-fire because its dependency (`registerThumb`) hasn't changed. The thumb never gets added to the progress tracking Set.

## Changes

- Convert thumb registration from `useRef` + `useEffect` to a ref callback (matching the fill bar pattern), ensuring the thumb is registered every time it mounts