### PR TITLE
ui(web): overhaul now playing bar layout and metadata display

### DIFF
--- a/packages/web/src/components/BarButton.tsx
+++ b/packages/web/src/components/BarButton.tsx
@@ -33,10 +33,10 @@ export function BarButton({
         busy
           ? 'text-black/50 dark:text-white/50'
           : `${pulse ? 'pressed text-accent' : 'text-black dark:text-white'} ${hoverColor} cursor-pointer`
-      } disabled:cursor-not-allowed disabled:opacity-50 ${className}`}
+      } disabled:cursor-not-allowed disabled:opacity-50 md:w-12 md:h-12 ${className}`}
     >
       {busy ? (
-        <CircleNotchIcon size={18} weight="bold" className="animate-spin md:w-3.5 md:h-3.5" />
+        <CircleNotchIcon size={22} weight="bold" className="animate-spin md:w-5 md:h-5" />
       ) : (
         children
       )}

--- a/packages/web/src/components/NowPlayingBar.tsx
+++ b/packages/web/src/components/NowPlayingBar.tsx
@@ -11,14 +11,17 @@ import {
   RepeatOnceIcon,
   ShuffleIcon,
   SkipForwardIcon,
-  SparkleIcon,
 } from '@phosphor-icons/react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { usePlayer } from '../context/PlayerContext';
 import { useQueuePanel } from '../context/QueuePanelContext';
+import { getSourceKey } from '../utils/source';
 import { BarButton } from './BarButton';
 import QueuePanel from './QueuePanel';
+import { SourceIcon } from './SourceIcons';
+import TagTicker from './TagTicker';
 import { Button } from './ui/Button';
+import { VolumeBoostBadge } from './ui/VolumeBoostBadge';
 
 /* ---------------------------------------------------------------------------
  * Memoized sub-components — these bail out of re-rendering when their props
@@ -61,9 +64,9 @@ const PlaybackControls = memo(function PlaybackControls({
         pulse={isPlaying && !isPaused}
       >
         {isPaused || isStopped ? (
-          <PlayIcon size={20} weight="duotone" className="md:w-4.5 md:h-4.5" />
+          <PlayIcon size={24} weight="duotone" className="md:w-5 md:h-5" />
         ) : (
-          <PauseIcon size={20} weight="duotone" className="md:w-4.5 md:h-4.5" />
+          <PauseIcon size={24} weight="duotone" className="md:w-5 md:h-5" />
         )}
       </BarButton>
       <BarButton
@@ -74,7 +77,7 @@ const PlaybackControls = memo(function PlaybackControls({
         hoverColor="hover:text-fg"
         className="hidden md:flex"
       >
-        <SkipForwardIcon size={20} weight="duotone" className="md:w-4.5 md:h-4.5" />
+        <SkipForwardIcon size={24} weight="duotone" className="md:w-5 md:h-5" />
       </BarButton>
 
       <Button
@@ -84,24 +87,11 @@ const PlaybackControls = memo(function PlaybackControls({
         onClick={onStop}
         disabled={!isConnectedToVoice}
         title="Stop playback"
-        className="text-black dark:text-white hover:text-danger"
+        className="text-black dark:text-white hover:text-danger md:w-12 md:h-12"
       >
-        <DoorOpenIcon size={20} weight="duotone" className="md:w-4.5 md:h-4.5" />
+        <DoorOpenIcon size={24} weight="duotone" className="md:w-5 md:h-5" />
       </Button>
     </div>
-  );
-});
-
-interface TimingDisplayProps {
-  elapsed: number;
-  duration: number;
-}
-
-const TimingDisplay = memo(function TimingDisplay({ elapsed, duration }: TimingDisplayProps) {
-  return (
-    <p className="font-mono text-xs text-muted">
-      {formatDuration(elapsed)} / {formatDuration(duration)}
-    </p>
   );
 });
 
@@ -127,12 +117,12 @@ const LoopShuffleControls = memo(function LoopShuffleControls({
   const isLoopActive = loopMode !== 'off';
   const loopIcon = isLoopActive ? (
     loopMode === 'song' ? (
-      <RepeatOnceIcon size={18} weight="fill" className="md:w-4 md:h-4" />
+      <RepeatOnceIcon size={22} weight="fill" className="md:w-5 md:h-5" />
     ) : (
-      <RepeatIcon size={18} weight="fill" className="md:w-4 md:h-4" />
+      <RepeatIcon size={22} weight="fill" className="md:w-5 md:h-5" />
     )
   ) : (
-    <RepeatIcon size={18} weight="duotone" className="md:w-4 md:h-4" />
+    <RepeatIcon size={22} weight="duotone" className="md:w-5 md:h-5" />
   );
 
   return (
@@ -144,14 +134,14 @@ const LoopShuffleControls = memo(function LoopShuffleControls({
         onClick={onCycleLoop}
         disabled={!currentSong || loopBusy}
         title={`Loop: ${loopMode}`}
-        className={`shrink-0 disabled:opacity-50 ${
+        className={`shrink-0 disabled:opacity-50 md:w-12 md:h-12 ${
           isLoopActive
             ? 'pressed text-accent hover:text-accent-muted'
             : 'text-black dark:text-white hover:text-fg'
         }`}
       >
         {loopBusy ? (
-          <CircleNotchIcon size={18} weight="bold" className="animate-spin md:w-4 md:h-4" />
+          <CircleNotchIcon size={22} weight="bold" className="animate-spin md:w-5 md:h-5" />
         ) : (
           loopIcon
         )}
@@ -163,19 +153,19 @@ const LoopShuffleControls = memo(function LoopShuffleControls({
         onClick={onShuffleToggle}
         disabled={!currentSong || shuffleBusy}
         title={isShuffled ? 'Unshuffle queue' : 'Shuffle queue'}
-        className={`shrink-0 disabled:opacity-50 ${
+        className={`shrink-0 disabled:opacity-50 md:w-12 md:h-12 ${
           isShuffled
             ? 'pressed text-accent hover:text-accent-muted'
             : 'text-black dark:text-white hover:text-fg'
         }`}
       >
         {shuffleBusy ? (
-          <CircleNotchIcon size={18} weight="bold" className="animate-spin md:w-4 md:h-4" />
+          <CircleNotchIcon size={22} weight="bold" className="animate-spin md:w-5 md:h-5" />
         ) : (
           <ShuffleIcon
-            size={20}
+            size={24}
             weight={isShuffled ? 'fill' : 'duotone'}
-            className="md:w-4 md:h-4"
+            className="md:w-5 md:h-5"
           />
         )}
       </Button>
@@ -315,7 +305,6 @@ interface ProgressBarProps {
 
 const ProgressBar = memo(function ProgressBar({
   currentSong,
-  elapsed,
   registerProgress,
   registerThumb,
   onSeek,
@@ -338,24 +327,8 @@ const ProgressBar = memo(function ProgressBar({
     );
   }
 
-  const displayName = currentSong ? currentSong.nickname || currentSong.title : '';
-  const artist = currentSong?.artist || null;
-
   return (
-    <div className="hidden md:flex flex-col flex-1 items-center xl:items-end self-stretch px-4 min-h-0 gap-1 relative">
-      {currentSong ? (
-        <div className="text-center w-full truncate xl:text-right h-12 flex flex-col justify-center min-h-12">
-          <p className="font-body text-sm font-semibold text-fg truncate">{displayName}</p>
-          {artist && <p className="font-body text-xs text-muted truncate">{artist}</p>}
-        </div>
-      ) : (
-        <div className="h-12 shrink-0 flex items-center xl:justify-end justify-center">
-          <p className="font-body text-sm text-muted">Nothing playing</p>
-        </div>
-      )}
-      <div className="absolute top-1/2 -translate-y-1/2 left-4">
-        <TimingDisplay elapsed={elapsed} duration={currentSong?.duration ?? 0} />
-      </div>
+    <div className="hidden md:flex items-center flex-1 min-h-0">
       <Scrubber
         isSeekable={currentSong?.isSeekable ?? false}
         duration={currentSong?.duration ?? 0}
@@ -370,18 +343,11 @@ const ProgressBar = memo(function ProgressBar({
 
 interface AlbumArtProps {
   currentSong: QueuedSong | null;
-  isPlaying: boolean;
-  isPaused: boolean;
 }
 
-const AlbumArt = memo(function AlbumArt({ currentSong, isPlaying, isPaused }: AlbumArtProps) {
+const AlbumArt = memo(function AlbumArt({ currentSong }: AlbumArtProps) {
   return (
-    <div className="w-12 h-12 md:w-14 md:h-14 rounded-2xl clay-inset shrink-0 overflow-hidden relative">
-      {currentSong && isPlaying && !isPaused && (
-        <div className="absolute -top-1.5 -right-1.5 z-10">
-          <SparkleIcon size={12} weight="duotone" className="text-accent animate-pulse-gentle" />
-        </div>
-      )}
+    <div className="w-12 h-12 md:w-14 md:h-14 rounded border border-border shrink-0 overflow-hidden relative">
       {currentSong ? (
         <img
           src={currentSong.artwork ?? currentSong.thumbnailUrl}
@@ -394,6 +360,50 @@ const AlbumArt = memo(function AlbumArt({ currentSong, isPlaying, isPaused }: Al
           <GuitarIcon size={18} weight="duotone" className="text-faint" />
         </div>
       )}
+    </div>
+  );
+});
+
+interface MetadataSectionProps {
+  currentSong: QueuedSong | null;
+  elapsed: number;
+}
+
+const MetadataSection = memo(function MetadataSection({
+  currentSong,
+  elapsed,
+}: MetadataSectionProps) {
+  if (!currentSong) {
+    return (
+      <div className="flex items-center h-6">
+        <p className="font-body text-sm text-muted">Nothing playing</p>
+      </div>
+    );
+  }
+
+  const displayName = currentSong.nickname || currentSong.title;
+  const sourceKey = getSourceKey(currentSong.sourceUrl);
+
+  return (
+    <div className="flex flex-col min-w-0 gap-0.5">
+      <div className="flex items-center gap-2 min-w-0">
+        <p className="font-body text-sm font-medium text-fg truncate">{displayName}</p>
+        {currentSong.artist && (
+          <p className="font-body text-xs text-muted shrink-0">· {currentSong.artist}</p>
+        )}
+        <TagTicker tags={currentSong.tags ?? []} />
+      </div>
+      <div className="flex items-center gap-2">
+        <p className="font-mono text-xs text-muted">
+          {formatDuration(elapsed)} / {formatDuration(currentSong.duration)}
+        </p>
+        {sourceKey && (
+          <span className="flex items-center shrink-0 [&_svg]:w-3 [&_svg]:h-3">
+            <SourceIcon sourceKey={sourceKey} />
+          </span>
+        )}
+        <VolumeBoostBadge volumeBoost={currentSong.volumeBoost} />
+      </div>
     </div>
   );
 });
@@ -502,9 +512,7 @@ export function NowPlayingBar() {
         variant="mobile"
       />
 
-      <div
-        className={`h-22 md:h-20 flex flex-row items-center px-3 md:px-5 gap-1 md:gap-1.5 ${!currentSong ? 'justify-end md:justify-start' : ''}`}
-      >
+      <div className="h-22 md:h-20 flex flex-row items-center px-3 md:px-8 gap-1">
         {/* Playback controls: Play/Pause (desktop: also Skip, Leave) */}
         <PlaybackControls
           currentSong={currentSong}
@@ -519,22 +527,54 @@ export function NowPlayingBar() {
           onStop={handleStop}
         />
 
-        {/* Desktop: centered progress bar */}
-        <ProgressBar
-          currentSong={currentSong}
-          registerProgress={registerProgress}
-          registerThumb={registerThumb}
-          elapsed={elapsed}
-          onSeek={handleSeek}
-          setOverrideElapsed={setOverrideElapsed}
-          variant="desktop"
-        />
+        {/* Desktop: spacer → art → metadata+progress → spacer → loop/shuffle+queue */}
+        <div className="hidden md:flex flex-1" />
+        <div className="hidden md:block shrink-0">
+          <AlbumArt currentSong={currentSong} />
+        </div>
+        <div className="hidden md:flex flex-col flex-8 min-w-0 px-3 h-14 justify-between">
+          <MetadataSection currentSong={currentSong} elapsed={elapsed} />
+          <ProgressBar
+            currentSong={currentSong}
+            registerProgress={registerProgress}
+            registerThumb={registerThumb}
+            elapsed={elapsed}
+            onSeek={handleSeek}
+            setOverrideElapsed={setOverrideElapsed}
+            variant="desktop"
+          />
+        </div>
+        <div className="hidden md:flex flex-1" />
+        <div className="hidden md:flex items-center gap-1.5 shrink-0">
+          <LoopShuffleControls
+            currentSong={currentSong}
+            loopMode={loopMode}
+            isShuffled={isShuffled}
+            loopBusy={loopBusy}
+            shuffleBusy={shuffleBusy}
+            onCycleLoop={handleCycleLoop}
+            onShuffleToggle={handleShuffleToggle}
+          />
+          <Button
+            variant="inherit"
+            surface="base"
+            size="icon"
+            onClick={() => setQueueOpen(!queueOpen)}
+            title="Queue"
+            className={`shrink-0 md:w-12 md:h-12 ${
+              queueOpen
+                ? 'pressed text-accent hover:text-accent-muted'
+                : 'text-black dark:text-white hover:text-fg'
+            }`}
+          >
+            <QueueIcon size={24} weight="duotone" className="md:w-5 md:h-5" />
+          </Button>
+        </div>
 
-        {/* Right-aligned group: metadata, art, queue */}
-        <div className="flex items-center ms-auto shrink-0">
-          {/* Mobile: metadata (left of art, right-aligned text) */}
+        {/* Mobile: metadata + art + queue */}
+        <div className="md:hidden flex items-center ms-auto shrink-0">
           {currentSong ? (
-            <div className="md:hidden max-w-32 min-w-0 mr-2">
+            <div className="max-w-32 min-w-0 mr-2">
               <p className="font-body text-sm font-semibold text-fg truncate text-right">
                 {currentSong.nickname || currentSong.title}
               </p>
@@ -545,44 +585,26 @@ export function NowPlayingBar() {
               )}
             </div>
           ) : (
-            <div className="md:hidden min-w-0 mr-2">
+            <div className="min-w-0 mr-2">
               <p className="font-body text-sm text-muted text-right">Nothing playing</p>
             </div>
           )}
-
-          {/* Album art */}
-          <AlbumArt currentSong={currentSong} isPlaying={isPlaying} isPaused={isPaused} />
-
-          {/* Separator */}
-          <div className="hidden md:block w-px h-8 md:h-10 bg-border shrink-0 mx-3 md:mx-5" />
-          <div className="md:hidden w-px h-8 bg-border shrink-0 mx-1" />
-
-          {/* Queue button (with desktop-only loop/shuffle) */}
-          <div className="flex items-center gap-1 md:gap-1.5 shrink-0">
-            <LoopShuffleControls
-              currentSong={currentSong}
-              loopMode={loopMode}
-              isShuffled={isShuffled}
-              loopBusy={loopBusy}
-              shuffleBusy={shuffleBusy}
-              onCycleLoop={handleCycleLoop}
-              onShuffleToggle={handleShuffleToggle}
-            />
-            <Button
-              variant="inherit"
-              surface="base"
-              size="icon"
-              onClick={() => setQueueOpen(!queueOpen)}
-              title="Queue"
-              className={`shrink-0 ${
-                queueOpen
-                  ? 'pressed text-accent hover:text-accent-muted'
-                  : 'text-black dark:text-white hover:text-fg'
-              }`}
-            >
-              <QueueIcon size={20} weight="duotone" className="md:w-4 md:h-4" />
-            </Button>
-          </div>
+          <AlbumArt currentSong={currentSong} />
+          <div className="w-px h-8 bg-border shrink-0 mx-1" />
+          <Button
+            variant="inherit"
+            surface="base"
+            size="icon"
+            onClick={() => setQueueOpen(!queueOpen)}
+            title="Queue"
+            className={`shrink-0 md:w-12 md:h-12 ${
+              queueOpen
+                ? 'pressed text-accent hover:text-accent-muted'
+                : 'text-black dark:text-white hover:text-fg'
+            }`}
+          >
+            <QueueIcon size={24} weight="duotone" className="md:w-5 md:h-5" />
+          </Button>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Visual overhaul of the bottom now-playing bar to bring metadata display up to song card standards, improve layout symmetry, and increase control button sizes.

## Changes

- **Layout restructured**: album art moved next to controls, metadata+progress centered with balanced flex spacers, loop/shuffle/queue pinned right
- **MetadataSection**: new memoized component showing source icon (colored), title, artist, volume boost, tags, and elapsed/duration time row
- **Album art**: matched song card list-row style (`rounded border`), removed sparkle overlay
- **Progress bar**: simplified to scrubber-only, time moved to metadata section
- **Control buttons**: bumped from 40×40 to 48×48px with proportionally larger icons
- **Spacing**: increased edge padding, unified loop/shuffle/queue button gaps