### PR TITLE
feat: add playlist cover art grid from song artwork

### DIFF
--- a/packages/server/src/routes/playlists.ts
+++ b/packages/server/src/routes/playlists.ts
@@ -108,11 +108,37 @@ async function handleGetPlaylists(ctx: RouteContext, request: Request): Promise<
     (pl) => canAccessPlaylist(pl, user, adminView).ok
   );
 
+  // Batch-fetch cover artwork URLs (up to 4 per playlist)
+  const playlistIds = filteredPlaylists.map((pl) => pl.id);
+  const coverMap = new Map<string, string[]>();
+  if (playlistIds.length > 0) {
+    const songRows = await db
+      .select({
+        playlistId: playlistSongTable.playlistId,
+        artwork: tables.song.artwork,
+        thumbnailUrl: tables.song.thumbnailUrl,
+      })
+      .from(playlistSongTable)
+      .innerJoin(tables.song, eq(playlistSongTable.songId, tables.song.id))
+      .where(inArray(playlistSongTable.playlistId, playlistIds))
+      .orderBy(playlistSongTable.playlistId, playlistSongTable.position);
+
+    for (const row of songRows) {
+      const urls = coverMap.get(row.playlistId);
+      if (!urls) {
+        coverMap.set(row.playlistId, [row.artwork ?? row.thumbnailUrl]);
+      } else if (urls.length < 4) {
+        urls.push(row.artwork ?? row.thumbnailUrl);
+      }
+    }
+  }
+
   // Fetch creator display names for each playlist
   const playlistsWithCreator = await Promise.all(
     filteredPlaylists.map(async (pl) => ({
       ...pl,
       createdByDisplayName: await getUserDisplayName(pl.createdBy),
+      coverUrls: coverMap.get(pl.id),
     }))
   );
 

--- a/packages/server/src/shared/types.ts
+++ b/packages/server/src/shared/types.ts
@@ -179,6 +179,8 @@ export interface Playlist {
   createdAt: string; // ISO 8601 string (JSON wire format)
   songs?: { id: string; playlistId: string; songId: string; position: number; song?: Song }[];
   _count?: { songs: number };
+  /** Up to 4 artwork URLs from the playlist's songs, for the cover grid. Only present in list responses. */
+  coverUrls?: string[];
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/components/PlaylistRow.tsx
+++ b/packages/web/src/components/PlaylistRow.tsx
@@ -10,9 +10,23 @@ interface PlaylistRowProps {
   'data-playlist-id'?: string;
 }
 
+/** Fill an array of artwork URLs to exactly 4 slots, repeating as needed. */
+function spreadUrls(urls: string[]): (string | null)[] {
+  if (urls.length === 0) return [null, null, null, null];
+  const result: (string | null)[] = [];
+  for (let i = 0; i < 4; i++) {
+    result.push(urls[i % urls.length] ?? null);
+  }
+  return result;
+}
+
 export const PlaylistRow = memo(
   ({ playlist, animationDelay, onClick, 'data-playlist-id': dataPlaylistId }: PlaylistRowProps) => {
     const count = playlist._count?.songs ?? 0;
+    const coverUrls = playlist.coverUrls ?? [];
+    const cells = spreadUrls(coverUrls);
+    const hasArtwork = coverUrls.length > 0;
+
     return (
       <Card
         hoverable
@@ -30,10 +44,30 @@ export const PlaylistRow = memo(
         role="button"
         tabIndex={0}
       >
-        {/* Icon */}
-        <div className="w-11 h-11 md:w-10 md:h-10 rounded-xl bg-accent/10 border border-accent/20 shrink-0 flex items-center justify-center">
-          <PlaylistIcon size={18} weight="duotone" className="text-accent md:w-4 md:h-4" />
+        {/* Cover art grid or fallback icon */}
+        <div className="w-16 h-16 md:w-20 md:h-20 rounded-xl overflow-hidden clay-flat shrink-0">
+          {hasArtwork ? (
+            <div className="grid grid-cols-2 grid-rows-2 w-full h-full">
+              {cells.map((url, i) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: cells are always exactly 4, never reorder
+                <div key={i} className="overflow-hidden bg-elevated">
+                  <img
+                    src={url ?? undefined}
+                    alt=""
+                    className="w-full h-full object-cover"
+                    loading="lazy"
+                    decoding="async"
+                  />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="w-full h-full bg-elevated flex items-center justify-center">
+              <PlaylistIcon size={32} weight="duotone" className="text-accent" />
+            </div>
+          )}
         </div>
+
         {/* Info */}
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

Playlist cards on the /playlists page now display a 2×2 grid of album artwork from the playlist's songs, replacing the static PlaylistIcon. Empty playlists fall back to the icon. The container styling matches the grid SongCard thumbnails (rounded-xl, clay-flat).

## Changes

- **server:** Add `coverUrls` field to `Playlist` type (up to 4 artwork URLs, list responses only)
- **server:** Batch-query artwork URLs per playlist in `handleGetPlaylists` via a single JOIN
- **web:** Replace static `PlaylistIcon` with 2×2 CSS grid of `object-cover` images, sized 64–80px and `rounded-xl clay-flat` to match song card thumbnails