### PR TITLE
ui(web): unify sidebar page subtitle pattern

### DIFF
--- a/packages/web/src/pages/AudioPage.tsx
+++ b/packages/web/src/pages/AudioPage.tsx
@@ -14,6 +14,7 @@ export default function AudioPage() {
       {/* Page header */}
       <div className="mb-6 md:mb-8">
         <h1 className="font-display text-3xl md:text-4xl text-fg tracking-wider">Audio</h1>
+        <p className="font-mono text-xs text-muted mt-2">Equalizer and compressor settings</p>
       </div>
 
       <div className="space-y-2">

--- a/packages/web/src/pages/PermissionsPage.tsx
+++ b/packages/web/src/pages/PermissionsPage.tsx
@@ -71,7 +71,7 @@ export default function PermissionsPage() {
       {/* Page header */}
       <div className="mb-6 md:mb-8">
         <h1 className="font-display text-3xl md:text-4xl text-fg tracking-wider">Permissions</h1>
-        <p className="text-xs text-muted mt-1">
+        <p className="font-mono text-xs text-muted mt-2">
           Grant specific abilities to non-admin roles. Super-admins always have full access.
         </p>
       </div>

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -524,7 +524,7 @@ export default function PlaylistDetailPage() {
                 );
               })()}
           </div>
-          <p className="font-mono text-xs text-muted mt-1">
+          <p className="font-mono text-xs text-muted mt-2">
             {songItems.length} {songItems.length === 1 ? 'track' : 'tracks'}
             {playlistDetail.tagNameLower ? (
               <span className="text-accent"> • auto-tracked</span>

--- a/packages/web/src/pages/PlaylistsPage.tsx
+++ b/packages/web/src/pages/PlaylistsPage.tsx
@@ -71,8 +71,9 @@ export default function PlaylistsPage() {
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-6 md:mb-8">
         <div>
           <h1 className="font-display text-3xl md:text-4xl text-fg tracking-wider">Playlists</h1>
-          <p className="font-mono text-xs text-muted mt-1">
-            {isLoading ? '—' : `${items.length} playlist${items.length !== 1 ? 's' : ''}`}
+          <p className="font-mono text-xs text-muted mt-2">
+            Browse & manage playlists
+            {isLoading ? '' : ` • ${items.length} playlist${items.length !== 1 ? 's' : ''}`}
           </p>
         </div>
         <Button

--- a/packages/web/src/pages/RequestsPage.tsx
+++ b/packages/web/src/pages/RequestsPage.tsx
@@ -82,7 +82,9 @@ export default function RequestsPage() {
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-6 md:mb-8">
         <div>
           <h1 className="font-display text-3xl md:text-4xl text-fg tracking-wider">Requests</h1>
-          <p className="font-mono text-xs text-muted mt-1">{countLabel}</p>
+          <p className="font-mono text-xs text-muted mt-2">
+            Submit & review requests{isLoading ? '' : ` • ${countLabel}`}
+          </p>
         </div>
         <Button
           variant="primary"

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -138,8 +138,8 @@ export default function SongsPage() {
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-6 md:mb-8">
         <div>
           <h1 className="font-display text-3xl md:text-4xl text-fg tracking-wider">Songs</h1>
-          <p className="font-mono text-xs text-muted mt-1">
-            {isLoading ? '—' : `${total} track${total !== 1 ? 's' : ''}`}
+          <p className="font-mono text-xs text-muted mt-2">
+            Music library{isLoading ? '' : ` • ${total} track${total !== 1 ? 's' : ''}`}
           </p>
         </div>
         <span className="relative group">

--- a/packages/web/src/pages/TagsPage.tsx
+++ b/packages/web/src/pages/TagsPage.tsx
@@ -142,7 +142,11 @@ export default function TagsPage() {
     <div className="p-4 md:p-8">
       {/* Page header */}
       <div className="mb-6 md:mb-8">
-        <h1 className="font-display text-3xl md:text-4xl text-fg tracking-wider">Tag Editor</h1>
+        <h1 className="font-display text-3xl md:text-4xl text-fg tracking-wider">Tags</h1>
+        <p className="font-mono text-xs text-muted mt-2">
+          Manage tags & colors
+          {loadingTags ? '' : ` • ${allTags.length} tag${allTags.length !== 1 ? 's' : ''}`}
+        </p>
       </div>
 
       <div className="flex gap-4 h-105">


### PR DESCRIPTION
Add uniform `[Description] • [Count]` subtitles under each page heading across all sidebar pages (Songs, Playlists, Tags, Requests, Audio, Permissions), plus the Playlist Detail page. Also increases title–subtitle spacing to `mt-2` for better visual breathing room.

**Changes:**
- Songs: `"Music library • X tracks"`
- Playlists: `"Browse & manage playlists • X playlists"`
- Tags: `"Manage tags & colors • X tags"` (also renamed h1 from "Tag Editor" → "Tags")
- Requests: `"Submit & review requests • X requests"`
- Audio: `"Equalizer and compressor settings"`
- Permissions: updated font to `font-mono` for consistency, kept existing description
- Playlist Detail: already matched the pattern, only spacing update applied