### PR TITLE
feat(web): add custom Checkbox component with animated check icon

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -127,6 +127,23 @@
       }
     },
     {
+      "includes": [
+        "packages/web/src/components/AddSongModal.tsx",
+        "packages/web/src/components/queue/QuickAddModal.tsx",
+        "packages/web/src/pages/RequestsPage.tsx",
+        "packages/web/src/components/settings/AdminTab.tsx",
+        "packages/web/src/pages/SetupWizard.tsx",
+        "packages/web/src/pages/PermissionsPage.tsx"
+      ],
+      "linter": {
+        "rules": {
+          "a11y": {
+            "noLabelWithoutControl": "off"
+          }
+        }
+      }
+    },
+    {
       "includes": ["packages/server/src/middleware/requireAuth.ts"],
       "linter": {
         "rules": {

--- a/packages/web/src/components/AddSongModal.tsx
+++ b/packages/web/src/components/AddSongModal.tsx
@@ -6,6 +6,7 @@ import { apiErrorMessage } from '../utils/api';
 import { getTagColorClasses } from '../utils/tagColors';
 import { Backdrop } from './Backdrop';
 import { Button } from './ui/Button';
+import Checkbox from './ui/Checkbox';
 import { Spinner } from './ui/Spinner';
 
 type Step = 'url' | 'metadata';
@@ -412,12 +413,7 @@ export default function AddSongModal({
 
             {/* Notify DM */}
             <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={notifyDm}
-                onChange={(e) => setNotifyDm(e.target.checked)}
-                className="w-4 h-4 rounded border-border bg-surface accent-accent"
-              />
+              <Checkbox checked={notifyDm} onChange={setNotifyDm} />
               <span className="font-mono text-xs text-fg">DM me when this request is reviewed</span>
             </label>
 

--- a/packages/web/src/components/queue/QuickAddModal.tsx
+++ b/packages/web/src/components/queue/QuickAddModal.tsx
@@ -3,6 +3,7 @@ import { quickAddPlaylistToQueue, quickAddToQueue } from '../../api/api';
 import { apiErrorMessage } from '../../utils/api';
 import { Backdrop } from '../Backdrop';
 import { Button } from '../ui/Button';
+import Checkbox from '../ui/Checkbox';
 import { Spinner } from '../ui/Spinner';
 
 export default function QuickAddModal({
@@ -73,12 +74,10 @@ export default function QuickAddModal({
             />
             {isPlaylist && (
               <label className="flex items-center gap-2 cursor-pointer mt-2">
-                <input
-                  type="checkbox"
+                <Checkbox
                   checked={importFullPlaylist}
-                  onChange={(e) => setImportFullPlaylist(e.target.checked)}
+                  onChange={setImportFullPlaylist}
                   disabled={submitting}
-                  className="w-4 h-4 rounded border-border bg-surface accent-accent"
                 />
                 <span className="font-mono text-xs text-fg">Add all songs from playlist</span>
               </label>

--- a/packages/web/src/components/settings/AdminTab.tsx
+++ b/packages/web/src/components/settings/AdminTab.tsx
@@ -16,6 +16,7 @@ import {
   updateGeneralSettings,
 } from '../../api/api';
 import { SourceIcon } from '../SourceIcons';
+import Checkbox from '../ui/Checkbox';
 import { ErrorBanner } from '../ui/ErrorBanner';
 import SettingsToggle from './SettingsToggle';
 
@@ -180,12 +181,7 @@ export default function AdminTab() {
                     : 'border-border hover:border-muted'
                 }`}
               >
-                <input
-                  type="checkbox"
-                  checked={selectedRoleIdSet.has(r.id)}
-                  onChange={() => toggleRole(r.id)}
-                  className="accent-accent"
-                />
+                <Checkbox checked={selectedRoleIdSet.has(r.id)} onChange={() => toggleRole(r.id)} />
                 <span
                   className="w-2.5 h-2.5 rounded-full shrink-0"
                   style={{
@@ -231,11 +227,9 @@ export default function AdminTab() {
                       : 'border-border hover:border-muted'
                   }`}
                 >
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={selectedSourceKeySet.has(source.key)}
                     onChange={() => toggleSource(source.key)}
-                    className="accent-accent"
                   />
                   <SourceIcon sourceKey={source.key} className="shrink-0" />
                   <span className="text-sm text-fg">{source.displayName}</span>

--- a/packages/web/src/components/ui/Checkbox.tsx
+++ b/packages/web/src/components/ui/Checkbox.tsx
@@ -1,0 +1,69 @@
+import { Check } from '@phosphor-icons/react';
+
+interface CheckboxProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  disabled?: boolean;
+  size?: 'sm' | 'md';
+  variant?: 'accent' | 'danger' | 'muted';
+}
+
+const sizeConfig = {
+  sm: { box: 'w-4 h-4', icon: 12, border: 'border-[1.5px]', rounded: 'rounded' },
+  md: { box: 'w-5 h-5', icon: 16, border: 'border-2', rounded: 'rounded-md' },
+} as const;
+
+const variantChecked = {
+  accent: 'bg-accent border-accent',
+  danger: 'bg-danger border-danger',
+  muted: 'bg-muted border-muted',
+} as const;
+
+const variantIcon = {
+  accent: 'text-white',
+  danger: 'text-white',
+  muted: 'text-surface',
+} as const;
+
+export default function Checkbox({
+  checked,
+  onChange,
+  disabled = false,
+  size = 'sm',
+  variant = 'accent',
+}: CheckboxProps) {
+  const s = sizeConfig[size];
+
+  return (
+    <span
+      className={`group relative inline-flex shrink-0 ${disabled ? 'opacity-50 pointer-events-none' : ''}`}
+    >
+      {/* Hidden native input fills the entire box, capturing clicks even inside parent labels */}
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.checked)}
+        className={`opacity-0 absolute inset-0 z-10 ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'}`}
+      />
+      <span
+        aria-hidden
+        className={`
+          ${s.box} ${s.rounded} ${s.border}
+          flex items-center justify-center shrink-0
+          transition-colors duration-150
+          group-focus-within:ring-2 group-focus-within:ring-accent/50 group-focus-within:ring-offset-2 group-focus-within:ring-offset-surface
+          ${checked ? variantChecked[variant] : 'border-border bg-surface'}
+        `}
+      >
+        <Check
+          size={s.icon}
+          weight="bold"
+          className={`transition-all duration-150 ease-out ${
+            checked ? `scale-100 opacity-100 ${variantIcon[variant]}` : 'scale-0 opacity-0'
+          }`}
+        />
+      </span>
+    </span>
+  );
+}

--- a/packages/web/src/pages/PermissionsPage.tsx
+++ b/packages/web/src/pages/PermissionsPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { fetchPermissions, type PermissionsResponse, updatePermission } from '../api/api';
+import Checkbox from '../components/ui/Checkbox';
 import { ErrorBanner } from '../components/ui/ErrorBanner';
 
 export default function PermissionsPage() {
@@ -109,11 +110,9 @@ export default function PermissionsPage() {
                                 : 'border-border hover:border-muted'
                             }`}
                           >
-                            <input
-                              type="checkbox"
+                            <Checkbox
                               checked={isSelected}
                               onChange={() => toggleRole(action, role.id)}
-                              className="accent-accent"
                             />
                             <span
                               className="w-2 h-2 rounded-full shrink-0"

--- a/packages/web/src/pages/RequestsPage.tsx
+++ b/packages/web/src/pages/RequestsPage.tsx
@@ -3,6 +3,7 @@ import { useCallback, useState } from 'react';
 import { approveRequest, cancelRequest, denyRequest, fetchRequests } from '../api/api';
 import AddSongModal from '../components/AddSongModal';
 import { Button } from '../components/ui/Button';
+import Checkbox from '../components/ui/Checkbox';
 import { ErrorBanner } from '../components/ui/ErrorBanner';
 import VirtualRequestList from '../components/VirtualRequestList';
 import { useAdminView } from '../context/AdminViewContext';
@@ -125,12 +126,7 @@ export default function RequestsPage() {
 
         {tab === 'pending' && (
           <label className="flex items-center gap-2 cursor-pointer ml-auto">
-            <input
-              type="checkbox"
-              checked={mineOnly}
-              onChange={(e) => setMineOnly(e.target.checked)}
-              className="w-4 h-4 rounded border-border bg-surface accent-accent"
-            />
+            <Checkbox checked={mineOnly} onChange={setMineOnly} />
             <span className="font-mono text-xs text-muted">Only show my requests</span>
           </label>
         )}

--- a/packages/web/src/pages/SetupWizard.tsx
+++ b/packages/web/src/pages/SetupWizard.tsx
@@ -22,6 +22,7 @@ import {
   type SetupRole,
 } from '../api/api';
 import { SourceIcon } from '../components/SourceIcons';
+import Checkbox from '../components/ui/Checkbox';
 import { ErrorBanner } from '../components/ui/ErrorBanner';
 import { Spinner } from '../components/ui/Spinner';
 import { useAuth } from '../context/AuthContext';
@@ -372,11 +373,9 @@ export default function SetupWizard() {
                           : 'border-border hover:border-muted'
                       }`}
                     >
-                      <input
-                        type="checkbox"
+                      <Checkbox
                         checked={selectedSourceKeys.has(source.key)}
                         onChange={() => toggleSource(source.key)}
-                        className="accent-accent"
                       />
                       <SourceIcon sourceKey={source.key} className="shrink-0" />
                       <span className="text-sm text-fg">{source.displayName}</span>
@@ -454,11 +453,9 @@ export default function SetupWizard() {
                           : 'border-border hover:border-muted'
                       }`}
                     >
-                      <input
-                        type="checkbox"
+                      <Checkbox
                         checked={selectedRoleIds.has(r.id)}
                         onChange={() => toggleRole(r.id)}
-                        className="accent-accent"
                       />
                       <span
                         className="w-3 h-3 rounded-full shrink-0"


### PR DESCRIPTION
## Summary

Replaces all native `<input type="checkbox">` elements with a reusable `<Checkbox>` component featuring animated check icon, size variants, and color variants.

## Changes

- **New**: `packages/web/src/components/ui/Checkbox.tsx` — custom checkbox with hidden native input, Phosphor `Check` icon, animated scale+opacity transition, `sm`/`md` sizes, `accent`/`danger`/`muted` variants, focus ring, and disabled state
- **Replaced**: 8 native checkbox instances across 6 files (`AddSongModal`, `QuickAddModal`, `RequestsPage`, `AdminTab`, `SetupWizard`, `PermissionsPage`)
- **Config**: `biome.json` override disabling `noLabelWithoutControl` for affected files (Biome can't see through the component boundary)