### PR TITLE
ui(web): replace accent-accent with theme-aware custom range inputs

### DIFF
--- a/packages/web/src/components/settings/AdminTab.tsx
+++ b/packages/web/src/components/settings/AdminTab.tsx
@@ -376,7 +376,12 @@ export default function AdminTab() {
             max={120}
             value={timeoutMinutes}
             onChange={(e) => setTimeoutMinutes(Number(e.target.value))}
-            className="flex-1 accent-accent"
+            className="flex-1 range-input range-input-h"
+            style={
+              {
+                ['--range-pct' as string]: `${((timeoutMinutes - 1) / (120 - 1)) * 100}%`,
+              } as React.CSSProperties
+            }
           />
           <span className="font-mono text-sm text-fg w-20 text-right whitespace-nowrap">
             {timeoutMinutes} min

--- a/packages/web/src/components/settings/CompressorSection.tsx
+++ b/packages/web/src/components/settings/CompressorSection.tsx
@@ -108,7 +108,12 @@ export default function CompressorSection() {
               step={step}
               value={values[key]}
               onChange={(e) => updateValue(key, parseFloat(e.target.value))}
-              className="flex-1 accent-accent"
+              className="flex-1 range-input range-input-h"
+              style={
+                {
+                  ['--range-pct' as string]: `${((values[key] - min) / (max - min)) * 100}%`,
+                } as React.CSSProperties
+              }
             />
           </div>
         ))}

--- a/packages/web/src/components/settings/EqualizerSection.tsx
+++ b/packages/web/src/components/settings/EqualizerSection.tsx
@@ -97,8 +97,17 @@ export default function EqualizerSection() {
               step={1}
               value={value}
               onChange={(e) => updateBand(i, parseInt(e.target.value, 10))}
-              className="accent-accent"
-              style={{ writingMode: 'vertical-lr', direction: 'rtl', height: '120px' }}
+              className="range-input"
+              style={
+                {
+                  writingMode: 'vertical-lr',
+                  direction: 'rtl',
+                  width: '8px',
+                  height: '120px',
+                  borderRadius: '4px',
+                  background: `linear-gradient(to top, var(--color-accent) 0%, var(--color-accent) ${(value / 100) * 100}%, var(--color-border) ${(value / 100) * 100}%, var(--color-border) 100%)`,
+                } as React.CSSProperties
+              }
             />
             <span className="font-mono text-[10px] text-fg min-w-[2em] text-right">
               {gainDisplay(value)}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1092,6 +1092,43 @@
     cursor: pointer;
 }
 
+/* Range input — base: strips native appearance, custom thumb */
+.range-input {
+    appearance: none;
+    -webkit-appearance: none;
+    cursor: pointer;
+}
+.range-input::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--color-accent);
+    border: 2px solid var(--color-surface);
+    cursor: pointer;
+}
+.range-input::-moz-range-thumb {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--color-accent);
+    border: 2px solid var(--color-surface);
+    cursor: pointer;
+}
+
+/* Horizontal range input — accent fill up to thumb, theme border for rest */
+.range-input-h {
+    height: 6px;
+    border-radius: 3px;
+    background: linear-gradient(
+        to right,
+        var(--color-accent) 0%,
+        var(--color-accent) var(--range-pct, 50%),
+        var(--color-border) var(--range-pct, 50%),
+        var(--color-border) 100%
+    );
+}
+
 .scrubber-range-input {
     appearance: none;
     -webkit-appearance: none;

--- a/packages/web/src/pages/SetupWizard.tsx
+++ b/packages/web/src/pages/SetupWizard.tsx
@@ -579,7 +579,12 @@ export default function SetupWizard() {
                   max={120}
                   value={timeoutMinutes}
                   onChange={(e) => setTimeoutMinutes(Number(e.target.value))}
-                  className="flex-1 accent-accent"
+                  className="flex-1 range-input range-input-h"
+                  style={
+                    {
+                      ['--range-pct' as string]: `${((timeoutMinutes - 1) / (120 - 1)) * 100}%`,
+                    } as React.CSSProperties
+                  }
                 />
                 <span className="font-mono text-lg text-fg w-20 text-right whitespace-nowrap">
                   {timeoutMinutes} min


### PR DESCRIPTION
## Summary

Replace the Tailwind `accent-accent` utility (browser-default track styling) with custom `.range-input` / `.range-input-h` CSS classes that use theme colors for both the filled and unfilled track portions. Fixes the jarring light-gray unfilled track appearance on dark themes.

## Changes

- Add `.range-input` base class (appearance reset + custom accent thumb) and `.range-input-h` horizontal variant (accent-to-border fill gradient) in `index.css`
- Update equalizer vertical sliders with explicit 8×120px dimensions, `to top` gradient, and theme border-radius
- Update compressor, admin timeout, and setup wizard horizontal sliders to use `.range-input range-input-h` with computed `--range-pct` fill position