### PR TITLE
ui(web): unify tags page and setup wizard with clay design system

### DIFF
--- a/packages/web/src/pages/SetupWizard.tsx
+++ b/packages/web/src/pages/SetupWizard.tsx
@@ -22,6 +22,7 @@ import {
   type SetupRole,
 } from '../api/api';
 import { SourceIcon } from '../components/SourceIcons';
+import { Button } from '../components/ui/Button';
 import Checkbox from '../components/ui/Checkbox';
 import { ErrorBanner } from '../components/ui/ErrorBanner';
 import { Spinner } from '../components/ui/Spinner';
@@ -254,7 +255,7 @@ export default function SetupWizard() {
         {error && <ErrorBanner message={error} className="mb-6" />}
 
         {/* Step content */}
-        <div className="bg-elevated border border-border rounded-xl p-6 md:p-8">
+        <div className="modal-clay p-6 md:p-8">
           {step === 'welcome' && (
             <div className="text-center space-y-6">
               <div className="flex justify-center">
@@ -271,13 +272,9 @@ export default function SetupWizard() {
                   admin roles, and set a few preferences.
                 </p>
               </div>
-              <button
-                type="button"
-                onClick={loadGuilds}
-                className="btn-primary px-6 py-2.5 rounded-xl font-body text-sm cursor-pointer"
-              >
+              <Button variant="primary" onClick={loadGuilds}>
                 Get Started
-              </button>
+              </Button>
             </div>
           )}
 
@@ -336,18 +333,13 @@ export default function SetupWizard() {
                   <CaretLeftIcon size={14} />
                   Back
                 </button>
-                <button
-                  type="button"
+                <Button
+                  variant="primary"
                   onClick={() => setStep('sources')}
                   disabled={!selectedGuildId}
-                  className={`px-5 py-2 rounded-xl font-body text-sm transition-colors ${
-                    selectedGuildId
-                      ? 'btn-primary cursor-pointer'
-                      : 'bg-elevated text-muted cursor-not-allowed'
-                  }`}
                 >
                   Next
-                </button>
+                </Button>
               </div>
             </div>
           )}
@@ -416,18 +408,13 @@ export default function SetupWizard() {
                   <CaretLeftIcon size={14} />
                   Back
                 </button>
-                <button
-                  type="button"
+                <Button
+                  variant="primary"
                   onClick={loadRoles}
                   disabled={selectedSourceKeys.size === 0}
-                  className={`px-5 py-2 rounded-xl font-body text-sm transition-colors ${
-                    selectedSourceKeys.size > 0
-                      ? 'btn-primary cursor-pointer'
-                      : 'bg-elevated text-muted cursor-not-allowed'
-                  }`}
                 >
                   Next
-                </button>
+                </Button>
               </div>
             </div>
           )}
@@ -479,18 +466,13 @@ export default function SetupWizard() {
                   <CaretLeftIcon size={14} />
                   Back
                 </button>
-                <button
-                  type="button"
+                <Button
+                  variant="primary"
                   onClick={loadChannels}
                   disabled={selectedRoleIds.size === 0}
-                  className={`px-5 py-2 rounded-xl font-body text-sm transition-colors ${
-                    selectedRoleIds.size > 0
-                      ? 'btn-primary cursor-pointer'
-                      : 'bg-elevated text-muted cursor-not-allowed'
-                  }`}
                 >
                   Next
-                </button>
+                </Button>
               </div>
             </div>
           )}
@@ -541,23 +523,19 @@ export default function SetupWizard() {
                   Back
                 </button>
                 <div className="flex gap-2">
-                  <button
-                    type="button"
+                  <Button
+                    variant="inherit"
                     onClick={() => {
                       setSelectedChannelId('');
                       setStep('timeout');
                     }}
-                    className="px-4 py-2 rounded-xl font-body text-sm text-muted hover:text-fg transition-colors cursor-pointer"
+                    surface="surface"
                   >
                     Skip
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setStep('timeout')}
-                    className="px-5 py-2 rounded-xl btn-primary font-body text-sm cursor-pointer"
-                  >
+                  </Button>
+                  <Button variant="primary" onClick={() => setStep('timeout')}>
                     Next
-                  </button>
+                  </Button>
                 </div>
               </div>
             </div>
@@ -599,13 +577,9 @@ export default function SetupWizard() {
                   <CaretLeftIcon size={14} />
                   Back
                 </button>
-                <button
-                  type="button"
-                  onClick={() => setStep('publicUrl')}
-                  className="px-5 py-2 rounded-xl btn-primary font-body text-sm cursor-pointer"
-                >
+                <Button variant="primary" onClick={() => setStep('publicUrl')}>
                   Next
-                </button>
+                </Button>
               </div>
             </div>
           )}
@@ -625,7 +599,7 @@ export default function SetupWizard() {
                 value={publicUrl}
                 onChange={(e) => setPublicUrl(e.target.value)}
                 placeholder="https://music.yourserver.com"
-                className="w-full px-4 py-2.5 rounded-lg bg-base border border-border text-fg text-sm font-mono placeholder:text-muted/50 focus:outline-none focus:border-accent transition-colors"
+                className="input font-mono"
               />
               <div className="flex justify-between pt-2">
                 <button
@@ -636,13 +610,9 @@ export default function SetupWizard() {
                   <CaretLeftIcon size={14} />
                   Back
                 </button>
-                <button
-                  type="button"
-                  onClick={() => setStep('confirm')}
-                  className="px-5 py-2 rounded-xl btn-primary font-body text-sm cursor-pointer"
-                >
+                <Button variant="primary" onClick={() => setStep('confirm')}>
                   Review
-                </button>
+                </Button>
               </div>
             </div>
           )}
@@ -706,19 +676,10 @@ export default function SetupWizard() {
                   <CaretLeftIcon size={14} />
                   Back
                 </button>
-                <button
-                  type="button"
-                  onClick={handleSubmit}
-                  disabled={saving}
-                  className={`flex items-center gap-2 px-5 py-2 rounded-xl font-body text-sm transition-colors ${
-                    saving
-                      ? 'bg-elevated text-muted cursor-not-allowed'
-                      : 'btn-primary cursor-pointer'
-                  }`}
-                >
+                <Button variant="primary" onClick={handleSubmit} disabled={saving}>
                   <CheckIcon size={16} weight="bold" />
                   {saving ? 'Saving…' : 'Finish Setup'}
-                </button>
+                </Button>
               </div>
             </div>
           )}

--- a/packages/web/src/pages/TagsPage.tsx
+++ b/packages/web/src/pages/TagsPage.tsx
@@ -1,7 +1,9 @@
 import { deleteTag, fetchTagSongs, fetchTags, updateTag } from '@alfira-bot/server/shared/api';
 import type { Song } from '@alfira-bot/server/shared/types';
+import { MagnifyingGlassIcon, TrashIcon } from '@phosphor-icons/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import ConfirmModal from '../components/ConfirmModal';
+import { Button } from '../components/ui/Button';
 import { useTagColors } from '../context/TagsContext';
 
 const TAG_COLORS = [
@@ -139,9 +141,9 @@ export default function TagsPage() {
   }, [selected, refreshTags]);
 
   return (
-    <div className="p-4 md:p-8">
+    <div className="p-4 md:p-8 flex flex-col h-full">
       {/* Page header */}
-      <div className="mb-6 md:mb-8">
+      <div className="mb-6 md:mb-8 shrink-0">
         <h1 className="font-display text-3xl md:text-4xl text-fg tracking-wider">Tags</h1>
         <p className="font-mono text-xs text-muted mt-2">
           Manage tags & colors
@@ -149,17 +151,23 @@ export default function TagsPage() {
         </p>
       </div>
 
-      <div className="flex gap-4 h-105">
+      <div className="flex gap-4 flex-1 min-h-0">
         {/* Left pane: tag list */}
-        <div className="flex-1 flex flex-col min-w-0 border border-border rounded-md overflow-hidden bg-elevated">
-          <div className="px-3 py-2 border-b border-border">
-            <input
-              type="text"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search tags..."
-              className="w-full bg-transparent text-sm text-fg placeholder:text-muted outline-none caret-current"
-            />
+        <div className="flex-1 flex flex-col min-w-0 bg-elevated clay-resting rounded-lg overflow-hidden">
+          <div className="px-3 pt-3 pb-2">
+            <div className="relative">
+              <MagnifyingGlassIcon
+                className="absolute left-3 top-1/2 -translate-y-1/2 text-faint w-3.5 h-3.5"
+                weight="duotone"
+              />
+              <input
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search tags..."
+                className="input text-sm pl-9"
+              />
+            </div>
           </div>
 
           <div className="flex-1 overflow-y-auto">
@@ -180,14 +188,14 @@ export default function TagsPage() {
                     type="button"
                     key={tag.nameLower}
                     onClick={() => selectTag(tag)}
-                    className={`w-full flex items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${
+                    className={`w-full flex items-center gap-2 px-3 py-2 text-left text-sm rounded transition-colors cursor-pointer ${
                       isActive
                         ? 'bg-accent/25 text-accent-foreground'
-                        : 'hover:bg-secondary text-foreground'
+                        : 'hover:bg-accent/10 text-fg'
                     }`}
                   >
                     <span
-                      className={`inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium whitespace-nowrap ${colors.bg} ${colors.text}`}
+                      className={`inline-flex items-center px-1.5 py-0.5 rounded text-[13px] font-medium whitespace-nowrap ${colors.bg} ${colors.text}`}
                     >
                       {tag.canonicalName}
                     </span>
@@ -199,7 +207,7 @@ export default function TagsPage() {
         </div>
 
         {/* Right pane: tag detail */}
-        <div className="flex-1 flex flex-col min-w-0 border border-border rounded-md overflow-hidden bg-elevated">
+        <div className="flex-1 flex flex-col min-w-0 bg-elevated clay-resting rounded-lg overflow-hidden">
           {!selected ? (
             <div className="flex-1 flex items-center justify-center text-muted text-sm">
               Select a tag to view and edit its details.
@@ -207,22 +215,33 @@ export default function TagsPage() {
           ) : (
             <>
               {/* Header */}
-              <div className="px-4 py-3 border-b border-border space-y-1">
-                <p className="text-xs font-medium text-fg uppercase tracking-wider">
-                  Canonical Name
-                </p>
-                <input
-                  type="text"
-                  value={editingName}
-                  onChange={(e) => setEditingName(e.target.value)}
-                  onBlur={() => editingName !== selected.canonicalName && saveName(editingName)}
-                  onKeyDown={(e) =>
-                    e.key === 'Enter' &&
-                    editingName !== selected.canonicalName &&
-                    saveName(editingName)
-                  }
-                  className="w-full px-2 py-1 text-sm text-fg bg-secondary rounded border border-border outline-none focus:border-accent transition-colors"
-                />
+              <div className="px-4 py-3 border-b border-border">
+                <div className="flex items-center gap-2">
+                  <p className="text-xs font-medium text-fg uppercase tracking-wider shrink-0">
+                    Tag Name
+                  </p>
+                  <input
+                    type="text"
+                    value={editingName}
+                    onChange={(e) => setEditingName(e.target.value)}
+                    onBlur={() => editingName !== selected.canonicalName && saveName(editingName)}
+                    onKeyDown={(e) =>
+                      e.key === 'Enter' &&
+                      editingName !== selected.canonicalName &&
+                      saveName(editingName)
+                    }
+                    className="input text-sm flex-1"
+                  />
+                  <Button
+                    variant="danger"
+                    size="icon"
+                    onClick={() => setShowDeleteConfirm(true)}
+                    title={`Delete "${selected.canonicalName}"`}
+                    className="shrink-0 -mr-1"
+                  >
+                    <TrashIcon size={16} weight="duotone" />
+                  </Button>
+                </div>
               </div>
 
               {/* Color picker */}
@@ -239,9 +258,9 @@ export default function TagsPage() {
                         key={colorName}
                         onClick={() => pickColor(colorName)}
                         title={colorName}
-                        className={`w-6 h-6 rounded-full flex items-center justify-center transition-opacity ${
+                        className={`w-6 h-6 rounded-full flex items-center justify-center transition-opacity cursor-pointer ${
                           isSelected
-                            ? 'opacity-100 ring-2 ring-offset-1 ring-offset-background ring-foreground'
+                            ? 'opacity-100 ring-2 ring-offset-1 ring-offset-surface ring-fg'
                             : 'opacity-60 hover:opacity-80'
                         } ${colorClasses.bg} ${colorClasses.text}`}
                       >
@@ -262,49 +281,99 @@ export default function TagsPage() {
               </div>
 
               {/* Song list */}
-              <div className="flex-1 overflow-y-auto px-4 py-3 space-y-2">
-                <p className="text-xs font-medium text-fg uppercase tracking-wider">
+              <div className="flex-1 overflow-y-auto px-4 py-3">
+                <p className="text-xs font-medium text-fg uppercase tracking-wider mb-3">
                   {loadingSongs
                     ? 'Loading…'
                     : `${tagSongs.length} song${tagSongs.length !== 1 ? 's' : ''}`}
                 </p>
-                <div className="space-y-2">
-                  {tagSongs.map((song) => (
-                    <div
-                      key={song.id}
-                      className="flex items-center gap-2 py-1 px-2 rounded bg-secondary hover:bg-tertiary transition-colors"
-                    >
-                      <span className="flex-1 truncate text-sm text-fg">{song.title}</span>
-                      <button
-                        type="button"
-                        onClick={() => removeSong(song)}
-                        className="text-muted hover:text-destructive transition-colors"
-                        title="Remove from this tag"
-                        aria-label="Remove from this tag"
-                      >
-                        <svg className="w-4 h-4" fill="none" viewBox="0 0 16 16" aria-hidden="true">
-                          <path
-                            d="M4 4l8 8M12 4l-8 8"
-                            stroke="currentColor"
-                            strokeWidth="1.5"
-                            strokeLinecap="round"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              {/* Delete */}
-              <div className="px-4 py-3 border-t border-border">
-                <button
-                  type="button"
-                  onClick={() => setShowDeleteConfirm(true)}
-                  className="w-full py-1.5 text-sm rounded text-red-500 hover:text-fg hover:bg-red-500 transition-colors"
-                >
-                  Delete "{selected.canonicalName}"
-                </button>
+                {tagSongs.length === 0 && !loadingSongs ? (
+                  <p className="text-sm text-muted text-center py-8">No songs with this tag yet.</p>
+                ) : (
+                  <div className="space-y-1">
+                    {tagSongs.map((song) => {
+                      const allTags = song.tags ?? [];
+                      return (
+                        <div
+                          key={song.id}
+                          className="flex items-center gap-3 py-2 px-2 rounded-lg hover:bg-surface/80 transition-colors group"
+                        >
+                          <div className="w-12 h-12 rounded border border-border shrink-0 overflow-hidden bg-base">
+                            {(song.artwork ?? song.thumbnailUrl) ? (
+                              <img
+                                src={song.artwork ?? song.thumbnailUrl}
+                                alt=""
+                                className="w-full h-full object-cover"
+                                loading="lazy"
+                              />
+                            ) : (
+                              <div className="w-full h-full flex items-center justify-center text-faint text-[10px]" />
+                            )}
+                          </div>
+                          <div className="flex-1 min-w-0">
+                            <p className="font-body text-sm text-fg truncate leading-snug">
+                              {song.nickname || song.title}
+                            </p>
+                            <div className="flex items-center gap-2 flex-wrap">
+                              {song.artist && (
+                                <span className="font-mono text-[11px] text-muted truncate">
+                                  {song.artist}
+                                </span>
+                              )}
+                              {song.album && (
+                                <span className="font-mono text-[11px] text-faint truncate">
+                                  {song.album}
+                                </span>
+                              )}
+                            </div>
+                            {allTags.length > 0 && (
+                              <div className="flex items-center gap-1 mt-0.5 flex-wrap">
+                                {allTags.slice(0, 3).map((tag) => {
+                                  const c = getTagColor(tag);
+                                  return (
+                                    <span
+                                      key={tag}
+                                      className={`inline-flex items-center px-1 py-px rounded text-[10px] font-mono ${c.bg} ${c.text}`}
+                                    >
+                                      {tag}
+                                    </span>
+                                  );
+                                })}
+                                {allTags.length > 3 && (
+                                  <span className="text-[10px] text-faint font-mono">
+                                    +{allTags.length - 3}
+                                  </span>
+                                )}
+                              </div>
+                            )}
+                          </div>
+                          <Button
+                            variant="inherit"
+                            size="icon"
+                            surface="base"
+                            onClick={() => removeSong(song)}
+                            title="Remove from this tag"
+                            className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
+                          >
+                            <svg
+                              className="w-3.5 h-3.5"
+                              fill="none"
+                              viewBox="0 0 16 16"
+                              aria-hidden="true"
+                            >
+                              <path
+                                d="M4 4l8 8M12 4l-8 8"
+                                stroke="currentColor"
+                                strokeWidth="1.5"
+                                strokeLinecap="round"
+                              />
+                            </svg>
+                          </Button>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
               </div>
             </>
           )}


### PR DESCRIPTION
## Summary

Brings TagsPage and SetupWizard in line with the clay design system established by recent PRs. Fixes broken theme token references and redesigns the tag detail view with richer song cards, consistent inputs, and proper clay surfaces.

## Changes

### TagsPage
- Redesigned two-pane layout with clay-resting elevated surfaces, filling available vertical space
- Search input now matches Songs/Playlists pattern (MagnifyingGlassIcon + standalone .input)
- Fixed broken class references (`bg-secondary`, `bg-tertiary`, `text-foreground`, `ring-offset-background`, `text-destructive`) → valid theme tokens
- Tag list badges resized and given cursor pointers
- Song detail cards redesigned with artwork thumbnails, artist, album, and tag badges
- Delete button moved to header row as danger icon button; renamed heading to "Tag Name"
- Color picker rings fixed to use valid theme tokens

### SetupWizard
- Step container switched from raw border styling to `modal-clay`
- Public URL input switched to `.input` class
- All action buttons replaced raw `<button>` elements with the `Button` component using proper `variant`/`disabled` props