### PR TITLE
fix(auth): prevent forced logout on transient discord api failures

### DIFF
--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -487,6 +487,22 @@ async function handleCallback(request: Request, url: URL): Promise<Response> {
   return new Response(null, { status: 302, headers });
 }
 
+/** Retry an async operation up to `attempts` times with exponential backoff. */
+async function withRetry<T>(fn: () => Promise<T>, attempts = 3, baseDelayMs = 500): Promise<T> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (i < attempts - 1) {
+        await new Promise((r) => setTimeout(r, baseDelayMs * 2 ** i));
+      }
+    }
+  }
+  throw lastErr;
+}
+
 async function handleRefresh(ctx: RouteContext): Promise<Response> {
   const refreshToken = ctx.cookies[REFRESH_COOKIE_NAME];
   if (!refreshToken) {
@@ -521,10 +537,7 @@ async function handleRefresh(ctx: RouteContext): Promise<Response> {
     return json({ error: 'Refresh token has expired.' }, 401);
   }
 
-  // 4. Delete the used refresh token (single-use for security).
-  await db.delete(refreshTokenTable).where(eq(refreshTokenTable.id, storedToken.id));
-
-  // 5. Clean up expired tokens for this user (lazy cleanup).
+  // 4. Clean up expired tokens for this user (lazy cleanup).
   await db
     .delete(refreshTokenTable)
     .where(
@@ -534,7 +547,9 @@ async function handleRefresh(ctx: RouteContext): Promise<Response> {
       )
     );
 
-  // 6. Re-fetch user info from Discord (including admin status).
+  // 5. Re-fetch user info from Discord (including admin status).
+  //    This runs BEFORE we burn the old refresh token — if Discord is
+  //    unreachable, the client can retry with the same token.
   //    During setup mode, skip guild membership check.
   const setupDone = await isSetupCompleted();
   let username: string;
@@ -545,27 +560,36 @@ async function handleRefresh(ctx: RouteContext): Promise<Response> {
 
   if (!setupDone) {
     // Setup not complete — fetch basic profile, grant admin.
-    const profile = await fetchDiscordUserProfile(decoded.discordId);
-    if (!profile) {
-      await db.delete(refreshTokenTable).where(eq(refreshTokenTable.discordId, decoded.discordId));
-      return json({ error: 'Unable to verify user identity. Please log in again.' }, 401);
+    try {
+      const profile = await withRetry(() => fetchDiscordUserProfile(decoded.discordId));
+      if (!profile) {
+        return json({ error: 'Unable to verify user identity. Please try again.' }, 503);
+      }
+      username = profile.username;
+      avatar = profile.avatar;
+      isAdmin = true;
+      isSetupAdmin = true;
+    } catch {
+      return json({ error: 'Discord is temporarily unreachable. Please try again.' }, 503);
     }
-    username = profile.username;
-    avatar = profile.avatar;
-    isAdmin = true;
-    isSetupAdmin = true;
   } else {
     // Normal flow — verify guild membership and roles.
-    const userInfo = await fetchUserAdminStatus(decoded.discordId);
-    if (!userInfo) {
-      await db.delete(refreshTokenTable).where(eq(refreshTokenTable.discordId, decoded.discordId));
-      return json({ error: 'Unable to verify user membership. Please log in again.' }, 401);
+    try {
+      const userInfo = await withRetry(() => fetchUserAdminStatus(decoded.discordId));
+      if (!userInfo) {
+        return json({ error: 'Unable to verify user membership. Please try again.' }, 503);
+      }
+      username = userInfo.username;
+      avatar = userInfo.avatar;
+      isAdmin = userInfo.isAdmin;
+      roles = userInfo.roles;
+    } catch {
+      return json({ error: 'Discord is temporarily unreachable. Please try again.' }, 503);
     }
-    username = userInfo.username;
-    avatar = userInfo.avatar;
-    isAdmin = userInfo.isAdmin;
-    roles = userInfo.roles;
   }
+
+  // 6. Burn the old refresh token now that Discord verification succeeded.
+  await db.delete(refreshTokenTable).where(eq(refreshTokenTable.id, storedToken.id));
 
   // 7. Generate new tokens.
   const payload: {

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -54,15 +54,21 @@ function redirectToLogin(): void {
   }
 }
 
-async function refreshToken(): Promise<boolean> {
+type RefreshResult = { ok: true } | { ok: false; retryable: boolean };
+
+async function refreshToken(): Promise<RefreshResult> {
   try {
     const res = await fetchWithTimeout('/auth/refresh', {
       method: 'POST',
       credentials: 'include',
     });
-    return res.ok;
+    if (res.ok) return { ok: true };
+    // 503 = Discord temporarily unreachable, old token still valid → retryable.
+    // 401 = token permanently invalid (expired / revoked).
+    return { ok: false, retryable: res.status === 503 };
   } catch {
-    return false;
+    // Network errors are retryable.
+    return { ok: false, retryable: true };
   }
 }
 
@@ -84,15 +90,22 @@ export async function trySilentRefresh(): Promise<boolean> {
   isSilentRefreshing = true;
   // Set isRefreshing so wrappedFetch queues instead of starting concurrent refresh
   isRefreshing = true;
-  const ok = await refreshToken();
-  if (ok) {
+
+  // Retry up to 3 times total for transient failures (Discord 429/503, network).
+  let result = await refreshToken();
+  for (let attempt = 0; attempt < 2 && !result.ok && result.retryable; attempt++) {
+    await new Promise((r) => setTimeout(r, 1500));
+    result = await refreshToken();
+  }
+
+  if (result.ok) {
     processQueue(null);
   } else {
     processQueue(new Error('Token refresh failed'));
   }
   isRefreshing = false;
   isSilentRefreshing = false;
-  return ok;
+  return result.ok;
 }
 
 // Custom error class to carry API error details
@@ -140,15 +153,21 @@ async function wrappedFetch(
     // Start refreshing
     isRefreshing = true;
 
-    const ok = await refreshToken();
+    const result = await refreshToken();
 
-    if (ok) {
+    if (result.ok) {
       // Refresh succeeded, process queue and retry
       processQueue(null);
       isRefreshing = false;
       response = await makeRequest();
+    } else if (result.retryable) {
+      // Discord temporarily unreachable — reject queue gently, don't redirect.
+      // The next API request will trigger another refresh attempt.
+      processQueue(new Error('Token refresh deferred'));
+      isRefreshing = false;
+      throw new ApiError('Authentication temporarily unavailable. Please try again.', 503);
     } else {
-      // Refresh failed, reject queue and redirect
+      // Refresh failed permanently, reject queue and redirect
       processQueue(new Error('Token refresh failed'));
       isRefreshing = false;
       redirectToLogin();


### PR DESCRIPTION
## Summary

Fix a bug where transient Discord API failures (rate limits, network blips) during token refresh permanently logged users out, forcing re-authentication.

## Root cause

The refresh endpoint in `handleRefresh` deleted the old refresh token from the database **before** calling Discord to re-verify guild membership. If Discord returned an error (429, network issue, etc.), the token was already gone — the next refresh attempt saw "token revoked" and forced re-login.

## Changes

- **Server** (`auth.ts`): Reordered `handleRefresh` so Discord verification runs **before** burning the old refresh token. Added `withRetry()` helper (3 attempts, exponential backoff). Discord failures now return 503 (retryable) instead of 401 (permanent).
- **Frontend** (`client.ts`): `refreshToken()` now distinguishes 503 (retryable) from 401 (permanent) failures. `trySilentRefresh()` retries internally up to 3 times. `wrappedFetch` no longer redirects to login on retryable failures — just throws, letting the next API call trigger another attempt.