### PR TITLE
ui(web): add subtitles to idle timeout and public url settings

### DIFF
--- a/packages/web/src/components/settings/AdminSection.tsx
+++ b/packages/web/src/components/settings/AdminSection.tsx
@@ -345,6 +345,10 @@ export default function AdminSection() {
               Idle Timeout
             </h3>
           </div>
+          <p className="text-xs text-muted">
+            Alfira leaves the voice channel after this many minutes of inactivity (no music
+            playing).
+          </p>
           <div className="flex items-center gap-4 mt-4">
             <input
               type="range"
@@ -373,6 +377,10 @@ export default function AdminSection() {
               Public URL
             </h3>
           </div>
+          <p className="text-xs text-muted">
+            The external URL where this Alfira instance is reachable. Used for OAuth redirects and
+            other features.
+          </p>
           <input
             type="text"
             value={publicUrl ?? ''}


### PR DESCRIPTION
## Summary

Adds descriptive subtitles to the Idle Timeout and Public URL settings in the admin section, matching the pattern used by all other settings sections.

## Changes

- **Idle Timeout**: Added subtitle explaining Alfira leaves the voice channel after the configured minutes of inactivity
- **Public URL**: Added subtitle explaining the URL is used for OAuth redirects and other features