### PR TITLE
ui(web): redesign permissions page with role-centric cards

### DIFF
--- a/packages/web/src/components/ui/RoleComboBox.tsx
+++ b/packages/web/src/components/ui/RoleComboBox.tsx
@@ -1,0 +1,169 @@
+import { CaretDown } from '@phosphor-icons/react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface RoleOption {
+  id: string;
+  name: string;
+  color: number;
+}
+
+interface RoleComboBoxProps {
+  roles: RoleOption[];
+  onSelect: (role: RoleOption) => void;
+  placeholder?: string;
+}
+
+export default function RoleComboBox({
+  roles,
+  onSelect,
+  placeholder = 'Search roles…',
+}: RoleComboBoxProps) {
+  const [query, setQuery] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  const normalizedQuery = query.toLowerCase().trim();
+  const filtered = normalizedQuery
+    ? roles.filter((r) => r.name.toLowerCase().includes(normalizedQuery))
+    : roles;
+
+  // Reset highlight when filtered list changes (query changes cause re-filter)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset on query change
+  useEffect(() => {
+    setHighlightedIndex(0);
+  }, [query]);
+
+  // Scroll highlighted item into view
+  useEffect(() => {
+    if (isOpen && listRef.current) {
+      const item = listRef.current.children[highlightedIndex] as HTMLLIElement | undefined;
+      item?.scrollIntoView({ block: 'nearest' });
+    }
+  }, [highlightedIndex, isOpen]);
+
+  // Click outside to close
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (
+        listRef.current &&
+        !listRef.current.contains(e.target as Node) &&
+        inputRef.current &&
+        !inputRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [isOpen]);
+
+  const selectRole = useCallback(
+    (role: RoleOption) => {
+      onSelect(role);
+      setQuery('');
+      setIsOpen(false);
+      inputRef.current?.blur();
+    },
+    [onSelect]
+  );
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (!isOpen) {
+      if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+        setIsOpen(true);
+        e.preventDefault();
+        return;
+      }
+      return;
+    }
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setHighlightedIndex((prev) => (prev + 1) % Math.max(filtered.length, 1));
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setHighlightedIndex((prev) => (prev - 1 + filtered.length) % Math.max(filtered.length, 1));
+        break;
+      case 'Enter':
+        e.preventDefault();
+        if (filtered[highlightedIndex]) {
+          selectRole(filtered[highlightedIndex]);
+        }
+        break;
+      case 'Escape':
+        e.preventDefault();
+        setIsOpen(false);
+        inputRef.current?.blur();
+        break;
+    }
+  };
+
+  return (
+    <div className="relative w-full max-w-sm">
+      <div className="relative">
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setIsOpen(true);
+          }}
+          onFocus={() => setIsOpen(true)}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          className="w-full bg-surface border border-border rounded-lg px-3 py-2 pr-9 text-sm text-fg placeholder:text-muted
+                     focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-accent/30
+                     transition-colors"
+        />
+        <CaretDown
+          size={16}
+          weight="bold"
+          className="absolute right-3 top-1/2 -translate-y-1/2 text-muted pointer-events-none transition-transform"
+          style={isOpen ? { transform: 'translateY(-50%) rotate(180deg)' } : undefined}
+        />
+      </div>
+
+      {isOpen && (
+        <ul
+          ref={listRef}
+          className="absolute z-20 mt-1 w-full max-h-52 overflow-y-auto bg-elevated border border-border rounded-lg shadow-lg
+                     text-sm"
+        >
+          {filtered.length === 0 ? (
+            <li className="px-3 py-2 text-muted italic">No roles found</li>
+          ) : (
+            filtered.map((role, i) => (
+              <li
+                key={role.id}
+                onMouseDown={(e) => {
+                  e.preventDefault(); // prevent input blur before click
+                  selectRole(role);
+                }}
+                onMouseEnter={() => setHighlightedIndex(i)}
+                className={`flex items-center gap-2 px-3 py-2 cursor-pointer transition-colors
+                  ${i === highlightedIndex ? 'bg-accent/10 text-fg' : 'text-fg hover:bg-surface'}
+                `}
+              >
+                <span
+                  className="w-2.5 h-2.5 rounded-full shrink-0"
+                  style={{
+                    backgroundColor: role.color
+                      ? `#${role.color.toString(16).padStart(6, '0')}`
+                      : 'var(--color-muted)',
+                  }}
+                />
+                <span className="truncate">{role.name}</span>
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/pages/PermissionsPage.tsx
+++ b/packages/web/src/pages/PermissionsPage.tsx
@@ -1,21 +1,78 @@
-import { useEffect, useState } from 'react';
+import { TrashIcon } from '@phosphor-icons/react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { fetchPermissions, type PermissionsResponse, updatePermission } from '../api/api';
+import ConfirmModal from '../components/ConfirmModal';
+import { Button } from '../components/ui/Button';
 import Checkbox from '../components/ui/Checkbox';
 import { ErrorBanner } from '../components/ui/ErrorBanner';
+import RoleComboBox from '../components/ui/RoleComboBox';
 
+// ---------------------------------------------------------------------------
+// Static config — mirrors shared/types.ts PERMISSION_CATEGORIES
+// ---------------------------------------------------------------------------
+const CATEGORY_META = {
+  Library: {
+    icon: '▣',
+    actions: ['songs.edit', 'songs.delete', 'songs.import', 'requests.autoapprove'] as const,
+  },
+  Playback: {
+    icon: '▶',
+    actions: ['queue.quickadd', 'queue.manage', 'queue.override'] as const,
+  },
+  Management: {
+    icon: '⚙',
+    actions: ['tags.manage', 'audio.manage'] as const,
+  },
+} as const;
+
+type CategoryKey = keyof typeof CATEGORY_META;
+
+const ALL_CATEGORIES: { key: CategoryKey; icon: string; actions: readonly string[] }[] = [
+  { key: 'Library', icon: CATEGORY_META.Library.icon, actions: CATEGORY_META.Library.actions },
+  { key: 'Playback', icon: CATEGORY_META.Playback.icon, actions: CATEGORY_META.Playback.actions },
+  {
+    key: 'Management',
+    icon: CATEGORY_META.Management.icon,
+    actions: CATEGORY_META.Management.actions,
+  },
+];
+
+const ALL_ACTIONS = ALL_CATEGORIES.flatMap((c) => c.actions);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function categorySummary(
+  mapping: Record<string, string[]>,
+  roleId: string,
+  actions: readonly string[]
+): { granted: number; total: number } {
+  const granted = actions.filter((a) => (mapping[a] ?? []).includes(roleId)).length;
+  return { granted, total: actions.length };
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
 export default function PermissionsPage() {
   const [data, setData] = useState<PermissionsResponse | null>(null);
   const [mapping, setMapping] = useState<Record<string, string[]>>({});
+  const [savedMapping, setSavedMapping] = useState<Record<string, string[]>>({});
+  const [explicitlyManaged, setExplicitlyManaged] = useState<Set<string>>(new Set());
+  const [expandedRoles, setExpandedRoles] = useState<Set<string>>(new Set());
+  const [roleToRemove, setRoleToRemove] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [successMsg, setSuccessMsg] = useState<string | null>(null);
 
+  // Load ------------------------------------------------------------------
   useEffect(() => {
     async function load() {
       try {
         const result = await fetchPermissions();
         setData(result);
         setMapping(result.mapping);
+        setSavedMapping(result.mapping);
       } catch {
         setError('Could not load permissions.');
       }
@@ -23,7 +80,37 @@ export default function PermissionsPage() {
     load();
   }, []);
 
-  function toggleRole(action: string, roleId: string) {
+  // Has changes? (strip empty arrays before comparing — toggling on then off
+  // shouldn't count as a change)
+  const hasChanges = useMemo(() => {
+    const normalize = (m: Record<string, string[]>) => {
+      const out: Record<string, string[]> = {};
+      for (const [k, v] of Object.entries(m)) {
+        if (v.length > 0) out[k] = v;
+      }
+      return JSON.stringify(out);
+    };
+    return normalize(mapping) !== normalize(savedMapping);
+  }, [mapping, savedMapping]);
+
+  // Derived state ---------------------------------------------------------
+  const managedRoleIds = useMemo(() => {
+    const fromMapping = new Set(Object.values(mapping).flat());
+    return new Set([...fromMapping, ...explicitlyManaged]);
+  }, [mapping, explicitlyManaged]);
+
+  const managedRoles = useMemo(() => {
+    if (!data) return [];
+    return data.roles.filter((r) => managedRoleIds.has(r.id));
+  }, [data, managedRoleIds]);
+
+  const unmanagedRoles = useMemo(() => {
+    if (!data) return [];
+    return data.roles.filter((r) => !managedRoleIds.has(r.id));
+  }, [data, managedRoleIds]);
+
+  // Actions ---------------------------------------------------------------
+  const togglePermission = useCallback((roleId: string, action: string) => {
     setMapping((prev) => {
       const current = new Set(prev[action] ?? []);
       if (current.has(roleId)) {
@@ -33,18 +120,61 @@ export default function PermissionsPage() {
       }
       return { ...prev, [action]: [...current] };
     });
-  }
+  }, []);
 
-  async function handleSave() {
+  const addRole = useCallback((role: { id: string; name: string; color: number }) => {
+    setExplicitlyManaged((prev) => new Set(prev).add(role.id));
+    setExpandedRoles((prev) => new Set(prev).add(role.id));
+  }, []);
+
+  const confirmRemoveRole = useCallback((roleId: string) => {
+    setRoleToRemove(roleId);
+  }, []);
+
+  const removeRole = useCallback(() => {
+    if (!roleToRemove) return;
+    const roleId = roleToRemove;
+    setRoleToRemove(null);
+
+    setMapping((prev) => {
+      const next: Record<string, string[]> = {};
+      for (const action of Object.keys(prev)) {
+        next[action] = (prev[action] ?? []).filter((id) => id !== roleId);
+      }
+      return next;
+    });
+    setExplicitlyManaged((prev) => {
+      const next = new Set(prev);
+      next.delete(roleId);
+      return next;
+    });
+    setExpandedRoles((prev) => {
+      const next = new Set(prev);
+      next.delete(roleId);
+      return next;
+    });
+  }, [roleToRemove]);
+
+  const toggleExpanded = useCallback((roleId: string) => {
+    setExpandedRoles((prev) => {
+      const next = new Set(prev);
+      if (next.has(roleId)) next.delete(roleId);
+      else next.add(roleId);
+      return next;
+    });
+  }, []);
+
+  const handleSave = useCallback(async () => {
     if (!data) return;
     setSaving(true);
     setError(null);
     setSuccessMsg(null);
 
     try {
-      // Save each action's role assignments
-      const actions = data.categories.flatMap((c) => c.actions);
-      await Promise.all(actions.map((action) => updatePermission(action, mapping[action] ?? [])));
+      await Promise.all(
+        ALL_ACTIONS.map((action) => updatePermission(action, mapping[action] ?? []))
+      );
+      setSavedMapping({ ...mapping });
       setSuccessMsg('Permissions saved.');
       setTimeout(() => setSuccessMsg(null), 3000);
     } catch (err: unknown) {
@@ -52,8 +182,9 @@ export default function PermissionsPage() {
     } finally {
       setSaving(false);
     }
-  }
+  }, [data, mapping]);
 
+  // Loading state ---------------------------------------------------------
   if (!data) {
     return (
       <div className="p-4 md:p-8">
@@ -65,8 +196,7 @@ export default function PermissionsPage() {
     );
   }
 
-  const { roles, categories, labels } = data;
-
+  // Render ----------------------------------------------------------------
   return (
     <div className="p-4 md:p-8">
       {/* Page header */}
@@ -85,71 +215,181 @@ export default function PermissionsPage() {
         </div>
       )}
 
-      <div className="space-y-6">
-        {categories.map((category) => (
-          <section key={category.label}>
-            <h2 className="font-mono text-xs text-muted uppercase tracking-wider mb-3">
-              {category.label}
-            </h2>
-            <div className="bg-elevated border border-border rounded-xl p-5 space-y-4">
-              {category.actions.map((action) => (
-                <div key={action} className="space-y-2">
-                  <h3 className="text-sm text-fg font-medium">{labels[action] ?? action}</h3>
-                  {roles.length === 0 ? (
-                    <p className="text-xs text-muted italic">No roles available.</p>
-                  ) : (
-                    <div className="flex flex-wrap gap-2">
-                      {roles.map((role) => {
-                        const isSelected = (mapping[action] ?? []).includes(role.id);
-                        return (
-                          <label
-                            key={role.id}
-                            className={`flex items-center gap-2 px-3 py-1.5 rounded-lg border cursor-pointer transition-colors text-sm ${
-                              isSelected
-                                ? 'border-accent bg-accent/5'
-                                : 'border-border hover:border-muted'
-                            }`}
-                          >
-                            <Checkbox
-                              checked={isSelected}
-                              onChange={() => toggleRole(action, role.id)}
-                            />
-                            <span
-                              className="w-2 h-2 rounded-full shrink-0"
-                              style={{
-                                backgroundColor: role.color
-                                  ? `#${role.color.toString(16).padStart(6, '0')}`
-                                  : 'var(--color-muted)',
-                              }}
-                            />
-                            <span>{role.name}</span>
-                          </label>
-                        );
-                      })}
-                    </div>
-                  )}
-                </div>
-              ))}
-            </div>
-          </section>
-        ))}
+      {/* Add role combobox */}
+      <div className="mb-6">
+        <RoleComboBox roles={unmanagedRoles} onSelect={addRole} placeholder="Add a role…" />
       </div>
 
+      {/* Managed role cards */}
+      {managedRoles.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <p className="text-sm text-muted mb-1">No managed roles yet</p>
+          <p className="text-xs text-muted">
+            Add a role above to start configuring granular permissions.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {managedRoles.map((role) => (
+            <RoleCard
+              key={role.id}
+              role={role}
+              mapping={mapping}
+              labels={data.labels}
+              isExpanded={expandedRoles.has(role.id)}
+              onToggleExpand={() => toggleExpanded(role.id)}
+              onTogglePermission={(action) => togglePermission(role.id, action)}
+              onRemove={() => confirmRemoveRole(role.id)}
+            />
+          ))}
+        </div>
+      )}
+
       {/* Save */}
-      <div className="flex gap-3 pt-6 justify-end">
-        <button
-          type="button"
-          onClick={handleSave}
-          disabled={saving}
-          className={`font-body text-sm px-4 py-1.5 rounded transition-colors ${
-            !saving
-              ? 'bg-accent text-elevated cursor-pointer'
-              : 'bg-elevated text-muted cursor-not-allowed'
-          }`}
-        >
+      <div className="flex gap-3 pt-5 justify-end">
+        <Button variant="primary" onClick={handleSave} disabled={!hasChanges || saving}>
           {saving ? 'Saving…' : 'Save Changes'}
-        </button>
+        </Button>
       </div>
+
+      {/* Confirm remove */}
+      {roleToRemove && (
+        <ConfirmModal
+          title="Remove Role"
+          message={
+            <>
+              This will clear all permissions for{' '}
+              <span className="text-fg font-medium">
+                {data.roles.find((r) => r.id === roleToRemove)?.name ?? roleToRemove}
+              </span>
+              .
+            </>
+          }
+          confirmLabel="Remove"
+          onConfirm={removeRole}
+          onCancel={() => setRoleToRemove(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// RoleCard
+// ---------------------------------------------------------------------------
+interface RoleCardProps {
+  role: { id: string; name: string; color: number };
+  mapping: Record<string, string[]>;
+  labels: Record<string, string>;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+  onTogglePermission: (action: string) => void;
+  onRemove: () => void;
+}
+
+function RoleCard({
+  role,
+  mapping,
+  labels,
+  isExpanded,
+  onToggleExpand,
+  onTogglePermission,
+  onRemove,
+}: RoleCardProps) {
+  const summaries = ALL_CATEGORIES.map((cat) => ({
+    ...cat,
+    summary: categorySummary(mapping, role.id, cat.actions),
+  }));
+
+  return (
+    <div className="bg-elevated clay-resting rounded-xl overflow-hidden hover:clay-raised hover:-translate-y-px active:clay-flat active:translate-y-0 transition-all duration-100">
+      {/* Header row — clickable to toggle expand */}
+      <div
+        className="flex items-center gap-3 px-5 py-3 cursor-pointer"
+        onClick={onToggleExpand}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onToggleExpand();
+          }
+        }}
+        role="button"
+        tabIndex={0}
+      >
+        {/* Role identity */}
+        <span
+          className="w-3 h-3 rounded-full shrink-0"
+          style={{
+            backgroundColor: role.color
+              ? `#${role.color.toString(16).padStart(6, '0')}`
+              : 'var(--color-muted)',
+          }}
+        />
+        <span className="text-sm font-medium text-fg">{role.name}</span>
+
+        {/* Category badges */}
+        <div className="flex items-center gap-4 ml-auto">
+          {summaries.map((cat) => (
+            <span
+              key={cat.key}
+              className={`flex items-center gap-1.5 text-xs font-mono
+                ${cat.summary.granted > 0 ? 'text-accent' : 'text-muted'}`}
+            >
+              <span className="text-sm">{cat.icon}</span>
+              <span>
+                {cat.summary.granted}/{cat.summary.total}
+              </span>
+            </span>
+          ))}
+        </div>
+
+        {/* Remove */}
+        <Button
+          variant="danger"
+          size="icon"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
+          title={`Remove ${role.name}`}
+          aria-label={`Remove ${role.name}`}
+          className="shrink-0"
+        >
+          <TrashIcon size={16} weight="duotone" />
+        </Button>
+      </div>
+
+      {/* Expanded content */}
+      {isExpanded && (
+        <div className="border-t border-border px-5 py-4">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+            {summaries.map((cat) => (
+              <div key={cat.key}>
+                <h4 className="text-xs font-mono text-muted uppercase tracking-wider mb-2.5">
+                  <span className="text-sm mr-1.5">{cat.icon}</span>
+                  {cat.key}
+                </h4>
+                <div className="space-y-2">
+                  {cat.actions.map((action) => {
+                    const checked = (mapping[action] ?? []).includes(role.id);
+                    return (
+                      <label
+                        key={action}
+                        className="flex items-center gap-2.5 text-sm text-fg cursor-pointer group"
+                      >
+                        <Checkbox checked={checked} onChange={() => onTogglePermission(action)} />
+                        <span className="group-hover:text-fg transition-colors">
+                          {labels[action] ?? action}
+                        </span>
+                      </label>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Replaces the action-centric checkbox matrix (all roles visible all the time) with a role-centric card layout. Users now add roles to a managed list via a searchable combobox, then configure permissions per role in expandable cards.

## Changes

- **New `RoleComboBox` component** — searchable dropdown for adding roles to management, with keyboard navigation and click-outside-to-close
- **Rewritten `PermissionsPage`** — role-centric cards instead of action×role grid:
  - Each managed role gets a card with at-a-glance badge summaries (`▣ 3/4  ▶ 2/3  ⚙ 1/2`)
  - Cards expand inline to show permission checkboxes in 3-column desktop layout
  - Full card header is clickable to toggle expand (matching song list card behavior)
  - Clay hover/click animations match song/tag card styling
  - Remove button styled like tag delete button (danger icon variant)
  - Save button matches settings page pattern — disabled when no changes detected
  - Confirm modal on role removal to prevent accidental clearing