### PR TITLE
ui(web): refine song list card layout, sizing, and tag display

### DIFF
--- a/packages/web/src/components/ContextMenu.tsx
+++ b/packages/web/src/components/ContextMenu.tsx
@@ -91,7 +91,7 @@ export function ContextMenuTrigger({
       }}
       className={`${className ?? ''} ${isOpen ? 'pressed text-accent' : ''}`}
     >
-      <DotsThreeOutlineVerticalIcon size={18} weight="duotone" />
+      <DotsThreeOutlineVerticalIcon size={22} weight="duotone" />
     </Button>
   );
 }

--- a/packages/web/src/components/SongCard.tsx
+++ b/packages/web/src/components/SongCard.tsx
@@ -1,6 +1,5 @@
 import type { Playlist, Song } from '@alfira-bot/server/shared';
-import { formatDuration } from '@alfira-bot/server/shared';
-import { ClockIcon, DiscIcon, MusicNoteIcon, TagIcon, UserIcon } from '@phosphor-icons/react';
+import { DiscIcon, MusicNoteIcon, UserIcon } from '@phosphor-icons/react';
 import React, { useMemo, useState } from 'react';
 import { usePermissions } from '../context/PermissionsContext';
 import { useSongEdit } from '../context/SongEditContext';
@@ -31,36 +30,6 @@ interface SongCardProps {
   onPlay: () => void;
   isPlaying?: boolean;
   onAddToQueue: () => void;
-}
-
-// ---------------------------------------------------------------------------
-// List-variant metadata bar
-// ---------------------------------------------------------------------------
-interface MetaInfoProps {
-  song: Song;
-  isHovered?: boolean;
-  sourceKey: string | null;
-}
-
-function MetaInfo({ song, isHovered, sourceKey }: MetaInfoProps) {
-  const tags = song.tags ?? [];
-  return (
-    <>
-      {sourceKey && (
-        <span className="flex items-center shrink-0 grayscale opacity-50 [&_svg]:w-3 [&_svg]:h-3">
-          <SourceIcon sourceKey={sourceKey} />
-        </span>
-      )}
-      <DurationBadge seconds={song.duration} />
-      <VolumeBoostBadge volumeBoost={song.volumeBoost} />
-      {tags.length > 0 && (
-        <div className="flex items-center gap-1 text-xs text-muted max-w-[20rem] justify-end">
-          <TagTicker tags={tags} isHovered={isHovered} />
-          <TagIcon size={11} weight="fill" className="shrink-0" />
-        </div>
-      )}
-    </>
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -178,6 +147,8 @@ const SongCardInner = ({
 
   // ── List variant ──────────────────────────────────────────────────────
 
+  const tags = song.tags ?? [];
+
   return (
     <Card
       hoverable={!!isAdminView}
@@ -186,7 +157,7 @@ const SongCardInner = ({
       data-song-edit-container
     >
       <div
-        className="flex items-center gap-1.5 md:gap-2 px-3 md:px-4 py-3"
+        className="flex items-center gap-3 md:gap-4 px-4 py-4"
         onClick={() => canEdit && setOpenSongId(isOpen ? null : song.id)}
         onKeyDown={(e) => {
           if (canEdit && (e.key === 'Enter' || e.key === ' ')) {
@@ -200,7 +171,7 @@ const SongCardInner = ({
         onMouseEnter={() => setIsRowHovered(true)}
         onMouseLeave={() => setIsRowHovered(false)}
       >
-        <div className="overflow-hidden w-14 h-14 md:w-12 md:h-12 rounded border border-border shrink-0">
+        <div className="overflow-hidden w-16 h-16 rounded border border-border shrink-0">
           <img
             src={song.artwork ?? song.thumbnailUrl}
             alt={song.nickname || song.title}
@@ -209,58 +180,47 @@ const SongCardInner = ({
             decoding="async"
           />
         </div>
-        <div className="flex-1 min-w-0 flex flex-col gap-px">
-          <p
-            className={`flex items-center gap-1 truncate${song.nickname ? ' text-xs font-mono text-muted' : ' text-fg font-sm'}`}
-          >
-            {song.nickname && (
-              <MusicNoteIcon size={11} weight="fill" className="shrink-0 text-muted" />
-            )}
-            <span className="truncate">{song.nickname || song.title}</span>
+        <div className="flex-1 min-w-0 flex flex-col justify-center gap-1.5">
+          <p className="text-sm font-semibold text-fg truncate leading-tight flex items-center gap-1.5">
+            <MusicNoteIcon size={13} weight="fill" className="shrink-0 text-muted" />
+            {song.nickname || song.title}
           </p>
-          {song.artist && (
-            <p className="flex items-center gap-1 text-xs font-mono text-muted truncate">
-              <UserIcon size={11} weight="fill" className="shrink-0 text-muted" />
-              <span className="truncate">{song.artist}</span>
-            </p>
-          )}
-          {song.album && (
-            <p className="flex items-center gap-1 text-xs font-mono text-muted truncate">
-              <DiscIcon size={11} weight="fill" className="shrink-0 text-muted" />
-              <span className="truncate">{song.album}</span>
-            </p>
-          )}
-          {(() => {
-            const tags = song.tags ?? [];
-            return (
-              <>
-                <span className="flex items-center gap-1 text-xs text-muted md:hidden">
-                  <ClockIcon size={11} weight="fill" className="shrink-0" />
-                  {formatDuration(song.duration)}
-                </span>
-                {tags.length > 0 && (
-                  <div className="flex items-center gap-1 text-sm text-muted mt-1 md:hidden">
-                    <TagIcon size={11} weight="fill" className="shrink-0" />
-                    <TagTicker tags={tags} />
-                  </div>
-                )}
-              </>
-            );
-          })()}
-        </div>
-        <div className="hidden md:flex flex-col items-end gap-px shrink-0 mr-2">
-          <MetaInfo song={song} isHovered={isRowHovered} sourceKey={sourceKey} />
+          <div className="flex items-center gap-2.5 flex-wrap text-xs text-muted min-w-0">
+            {song.artist && (
+              <span className="truncate max-w-[16ch] flex items-center gap-1">
+                <UserIcon size={12} weight="fill" className="shrink-0" />
+                {song.artist}
+              </span>
+            )}
+            {song.album && (
+              <span className="truncate max-w-[20ch] flex items-center gap-1">
+                <DiscIcon size={12} weight="fill" className="shrink-0" />
+                {song.album}
+              </span>
+            )}
+            {tags.length > 0 && <TagTicker tags={tags} isHovered={isRowHovered} />}
+          </div>
+          <div className="flex items-center gap-2.5 flex-wrap text-xs text-muted min-w-0">
+            {sourceKey && (
+              <span className="flex items-center shrink-0 [&_svg]:w-3.5 [&_svg]:h-3.5">
+                <SourceIcon sourceKey={sourceKey} />
+              </span>
+            )}
+            <DurationBadge seconds={song.duration} />
+            <VolumeBoostBadge volumeBoost={song.volumeBoost} />
+          </div>
         </div>
         <PlayButton
           onClick={onPlay}
           isPlaying={!!isPlaying}
-          className="p-2.5 md:p-1 disabled:opacity-50"
+          className="w-12 h-12 disabled:opacity-50"
         />
         <ContextMenuTrigger
           ref={triggerRef}
           onToggle={() => setMenuOpen((v) => !v)}
           isOpen={menuOpen}
           onMouseDown={(e) => e.preventDefault()}
+          className="w-12 h-12"
         />
         {menuOpen && (
           <ContextMenu

--- a/packages/web/src/components/TagTicker.tsx
+++ b/packages/web/src/components/TagTicker.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTagColors } from '../context/TagsContext';
 import { getTagColorClasses } from '../utils/tagColors';
 
@@ -15,12 +15,15 @@ const TagTicker = memo(({ tags, isHovered: externalHovered }: TagTickerProps) =>
   const [duration, setDuration] = useState(15);
   const { tagColorMap } = useTagColors();
 
+  const dedupedTags = useMemo(() => [...new Set(tags)], [tags]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-run when tags change to remeasure overflow
   useEffect(() => {
     if (outerRef.current && innerRef.current && outerRef.current.clientWidth > 0) {
       const overflow = innerRef.current.scrollWidth > outerRef.current.clientWidth;
-      setShouldScroll(overflow || tags.length > 3);
+      setShouldScroll(overflow);
 
-      if (overflow || tags.length > 3) {
+      if (overflow) {
         const contentWidth = innerRef.current.scrollWidth;
         setDuration(Math.max(10, contentWidth * 0.02));
       }
@@ -29,7 +32,7 @@ const TagTicker = memo(({ tags, isHovered: externalHovered }: TagTickerProps) =>
 
   const renderTags = useCallback(
     (prefix: string) =>
-      tags.map((tag) => {
+      dedupedTags.map((tag) => {
         const tagKey = tag.toLowerCase();
         const explicitColor = tagColorMap[tagKey];
         const colors = getTagColorClasses(tag, explicitColor);
@@ -42,10 +45,10 @@ const TagTicker = memo(({ tags, isHovered: externalHovered }: TagTickerProps) =>
           </span>
         );
       }),
-    [tags, tagColorMap]
+    [dedupedTags, tagColorMap]
   );
 
-  if (tags.length === 0) return null;
+  if (dedupedTags.length === 0) return null;
 
   const effectiveHovered = externalHovered ?? isHovered;
 
@@ -70,7 +73,6 @@ const TagTicker = memo(({ tags, isHovered: externalHovered }: TagTickerProps) =>
           WebkitMaskImage:
             'linear-gradient(to right, transparent, black 8%, black 80%, transparent)',
         }),
-        cursor: 'default',
       }}
       onMouseEnter={() => {
         if (externalHovered === undefined) setIsHovered(true);

--- a/packages/web/src/components/VirtualSongList.tsx
+++ b/packages/web/src/components/VirtualSongList.tsx
@@ -44,20 +44,20 @@ function SkeletonGrid() {
 
 function SkeletonList() {
   return (
-    <div className="flex flex-col gap-1">
+    <div className="flex flex-col gap-1.5">
       {Array.from({ length: 8 }).map((_, i) => (
         <div
           // biome-ignore lint/suspicious/noArrayIndexKey: skeleton items are static placeholders
           key={`skeleton-${i}`}
-          className="flex items-center gap-2 md:gap-4 px-3 md:px-4 py-3 rounded-lg bg-elevated clay-resting"
+          className="flex items-center gap-3 md:gap-4 px-4 py-4 rounded-lg bg-elevated clay-resting"
         >
-          <div className="skeleton w-14 h-14 md:w-12 md:h-12 rounded border border-border shrink-0" />
-          <div className="flex-1 min-w-0">
-            <div className="skeleton h-3 w-3/4" />
-            <div className="skeleton h-2 w-1/2 mt-1" />
+          <div className="skeleton w-16 h-16 rounded border border-border shrink-0" />
+          <div className="flex-1 min-w-0 flex flex-col gap-2">
+            <div className="skeleton h-3.5 w-2/5" />
+            <div className="skeleton h-3 w-3/5" />
           </div>
-          <div className="skeleton h-3 w-10 shrink-0 hidden md:block" />
           <div className="skeleton h-6 w-6 shrink-0" />
+          <div className="skeleton h-4 w-4 shrink-0" />
         </div>
       ))}
     </div>
@@ -96,7 +96,7 @@ export const VirtualSongList = memo(function VirtualSongList({
         className={
           isGrid
             ? 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-[repeat(auto-fill,minmax(270px,1fr))] gap-3 md:gap-4 items-start'
-            : 'flex flex-col gap-1'
+            : 'flex flex-col gap-1.5'
         }
       >
         {items.map((song) => (

--- a/packages/web/src/components/ui/DurationBadge.tsx
+++ b/packages/web/src/components/ui/DurationBadge.tsx
@@ -26,8 +26,8 @@ export const DurationBadge = memo(function DurationBadge({
 
   return (
     <span className={`flex items-center gap-1.5 font-mono text-xs text-muted ${className}`}>
-      {formatDuration(seconds)}
       <ClockIcon size={11} weight="fill" className="shrink-0" />
+      {formatDuration(seconds)}
     </span>
   );
 });

--- a/packages/web/src/components/ui/PlayButton.tsx
+++ b/packages/web/src/components/ui/PlayButton.tsx
@@ -29,9 +29,9 @@ export const PlayButton = memo(function PlayButton({
       title={title}
     >
       {isPlaying ? (
-        <CircleNotchIcon size={18} weight="bold" className="animate-spin" />
+        <CircleNotchIcon size={22} weight="bold" className="animate-spin" />
       ) : (
-        <PlayIcon size={18} weight="duotone" />
+        <PlayIcon size={22} weight="duotone" />
       )}
     </Button>
   );

--- a/packages/web/src/components/ui/VolumeBoostBadge.tsx
+++ b/packages/web/src/components/ui/VolumeBoostBadge.tsx
@@ -18,9 +18,9 @@ export const VolumeBoostBadge = memo(function VolumeBoostBadge({
       className={`flex items-center gap-0.5 text-xs ${className}`}
       style={{ color: isBoost ? '#22c55e' : '#eab308' }}
     >
+      <HeadphonesIcon size={11} weight="fill" className="shrink-0" />
       {isBoost ? '+' : ''}
       {volumeBoost}%
-      <HeadphonesIcon size={11} weight="fill" className="shrink-0" />
     </span>
   );
 });


### PR DESCRIPTION
## Summary

Redesign the song list view cards with larger artwork, bigger fonts, two-row metadata layout, and deduplicated tag display.

## Changes

- **SongCard**: larger artwork (64×64 consistent), bumped fonts, split metadata into two rows (artist/album/tags + source/duration/volume), larger action buttons
- **PlayButton / ContextMenuTrigger**: bumped icon size from 18→22px, button shells to 48px in list view
- **DurationBadge / VolumeBoostBadge**: flipped icons to left of text
- **TagTicker**: deduplicate tags, only scroll on actual overflow (not count threshold), removed cursor override
- **VirtualSongList**: updated skeleton loading states to match new card sizing