### PR TITLE
ui(web): improve metadata edit panel defaults and tag color selection

### DIFF
--- a/packages/web/src/components/SongEditPanel.tsx
+++ b/packages/web/src/components/SongEditPanel.tsx
@@ -44,7 +44,7 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
   const [tags, setTags] = useState<string[]>(songExtended.tags ?? []);
   const [tagInput, setTagInput] = useState('');
   const [volumeBoost, setVolumeBoost] = useState(
-    songExtended.volumeBoost != null ? String(songExtended.volumeBoost) : ''
+    songExtended.volumeBoost != null ? String(songExtended.volumeBoost) : '0'
   );
   const [showTagDropdown, setShowTagDropdown] = useState(false);
   const [availableTags, setAvailableTags] = useState<TagItem[]>([]);
@@ -144,7 +144,9 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
         tags: t,
         volumeBoost: vo,
       } = fieldsRef.current();
-      const parsedBoost = vo.trim() === '' ? null : parseInt(vo.trim(), 10);
+      const parsedRaw = vo.trim() === '' ? null : parseInt(vo.trim(), 10);
+      const parsedBoost =
+        parsedRaw != null && !Number.isNaN(parsedRaw) && parsedRaw !== 0 ? parsedRaw : null;
 
       // Build a partial update — only include fields that actually changed.
       // This prevents concurrent edits from clobbering each other (last-write-wins).
@@ -154,8 +156,7 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
       if (al !== (originalAlbumRef.current ?? '')) data.album = al.trim() || null;
       if (aw !== (originalArtworkRef.current ?? '')) data.artwork = aw.trim() || null;
       if (JSON.stringify(t) !== JSON.stringify(originalTagsRef.current)) data.tags = t;
-      if (parsedBoost !== originalVolumeBoostRef.current)
-        data.volumeBoost = Number.isNaN(parsedBoost) ? null : parsedBoost;
+      if (parsedBoost !== originalVolumeBoostRef.current) data.volumeBoost = parsedBoost;
 
       // Skip if nothing changed
       if (Object.keys(data).length === 0) {
@@ -181,7 +182,9 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
         tags: t,
         volumeBoost: vo,
       } = fieldsRef.current();
-      const parsedBoost = vo.trim() === '' ? null : parseInt(vo.trim(), 10);
+      const parsedRaw = vo.trim() === '' ? null : parseInt(vo.trim(), 10);
+      const parsedBoost =
+        parsedRaw != null && !Number.isNaN(parsedRaw) && parsedRaw !== 0 ? parsedRaw : null;
 
       const data: SongUpdateData = {};
       if (nk !== (originalNicknameRef.current ?? '')) data.nickname = nk.trim() || null;
@@ -189,8 +192,7 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
       if (al !== (originalAlbumRef.current ?? '')) data.album = al.trim() || null;
       if (aw !== (originalArtworkRef.current ?? '')) data.artwork = aw.trim() || null;
       if (JSON.stringify(t) !== JSON.stringify(originalTagsRef.current)) data.tags = t;
-      if (parsedBoost !== originalVolumeBoostRef.current)
-        data.volumeBoost = Number.isNaN(parsedBoost) ? null : parsedBoost;
+      if (parsedBoost !== originalVolumeBoostRef.current) data.volumeBoost = parsedBoost;
 
       if (Object.keys(data).length > 0) {
         void doSave();
@@ -210,12 +212,12 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
       <div className="px-3 md:px-4 pt-4 pb-4 border-t border-border">
         <div className="flex flex-col gap-3">
           <Field
-            id="panel-nickname"
-            label="Nickname"
+            id="panel-name"
+            label="Name"
             value={nickname}
             onChange={setNickname}
             inputRef={inputRef}
-            placeholder="Display name"
+            placeholder={song.title}
             onKeyDown={(e) => {
               if (e.key === 'Enter') void doSave();
             }}
@@ -245,7 +247,7 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
             label="Artwork URL"
             value={artwork}
             onChange={setArtwork}
-            placeholder="https://example.com/artwork.jpg"
+            placeholder={song.thumbnailUrl}
             onKeyDown={(e) => {
               if (e.key === 'Enter') void doSave();
             }}

--- a/packages/web/src/pages/TagsPage.tsx
+++ b/packages/web/src/pages/TagsPage.tsx
@@ -102,6 +102,8 @@ export default function TagsPage() {
   const pickColor = useCallback(
     async (color: string) => {
       if (!selected) return;
+      const effectiveColor = getTagColor(selected.canonicalName, selected.color).name;
+      if (effectiveColor === color) return; // already the effective color
       // Optimistic update
       setAllTags((prev) =>
         prev.map((t) => (t.nameLower === selected.nameLower ? { ...t, color } : t))
@@ -251,7 +253,8 @@ export default function TagsPage() {
                   {TAG_COLOR_NAMES.map((colorName) => {
                     const colorClasses =
                       TAG_COLORS.find((c) => c.name === colorName) ?? TAG_COLORS[0];
-                    const isSelected = selected.color != null && selected.color === colorName;
+                    const isSelected =
+                      getTagColor(selected.canonicalName, selected.color).name === colorName;
                     return (
                       <button
                         type="button"


### PR DESCRIPTION
## Summary

UX improvements to the song metadata edit panel and tag color picker.

## Changes

- **SongEditPanel**: Rename "Nickname" → "Name", show default values as placeholders (song title for Name, thumbnail URL for Artwork), initialize Volume Boost to "0" instead of blank, and treat 0 as no-override in save logic
- **TagsPage**: Fix color picker to show the effective color as selected — when a tag has no explicit color set, highlight the hash-based default color that actually renders in the UI