### PR TITLE
fix(web): fix card active state firing on button clicks in chromium

### DIFF
--- a/packages/web/src/components/SongCard.tsx
+++ b/packages/web/src/components/SongCard.tsx
@@ -107,7 +107,10 @@ const SongCardInner = ({
               ref={triggerRef}
               onToggle={() => setMenuOpen((v) => !v)}
               isOpen={menuOpen}
-              onMouseDown={(e) => e.preventDefault()}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
             />
           </div>
 
@@ -219,7 +222,10 @@ const SongCardInner = ({
           ref={triggerRef}
           onToggle={() => setMenuOpen((v) => !v)}
           isOpen={menuOpen}
-          onMouseDown={(e) => e.preventDefault()}
+          onMouseDown={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
           className="w-12 h-12"
         />
         {menuOpen && (

--- a/packages/web/src/components/ui/Card.tsx
+++ b/packages/web/src/components/ui/Card.tsx
@@ -15,7 +15,7 @@ export const Card = memo(function Card({
   ...rest
 }: CardProps) {
   const hoverClasses = hoverable
-    ? 'hover:clay-raised hover:-translate-y-px active:clay-flat active:translate-y-0'
+    ? 'hover:clay-raised hover:-translate-y-px [&:active:not(:has(button:active))]:clay-flat [&:active:not(:has(button:active))]:translate-y-0'
     : '';
   const animateClasses = animate ? 'animate-fade-up opacity-0' : '';
 

--- a/packages/web/src/components/ui/PlayButton.tsx
+++ b/packages/web/src/components/ui/PlayButton.tsx
@@ -19,7 +19,10 @@ export const PlayButton = memo(function PlayButton({
     <Button
       variant="primary"
       size="icon"
-      onMouseDown={(e) => e.preventDefault()}
+      onMouseDown={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      }}
       onClick={(e) => {
         e.stopPropagation();
         onClick();


### PR DESCRIPTION
## Summary

Fixes a cross-browser inconsistency where clicking the play or more-actions buttons in a song card caused the entire card to visually depress in Chromium. Firefox (Zen Browser) did not exhibit this behavior.

## Root Cause

CSS `:active` pseudo-class cascades to parent elements when any descendant is pressed. Firefox suppresses this when `preventDefault()` is called on `mousedown`, but Chromium does not — so button clicks inside the card triggered the card's `active:clay-flat active:translate-y-0` styles.

## Changes

- **Card.tsx**: Replaced `active:clay-flat active:translate-y-0` with `[&:active:not(:has(button:active))]:clay-flat [&:active:not(:has(button:active))]:translate-y-0` — active styles now only apply when no button descendant is being pressed
- **PlayButton.tsx**: Added `e.stopPropagation()` on `mousedown` (defense-in-depth)
- **SongCard.tsx**: Added `e.stopPropagation()` on `mousedown` for both `ContextMenuTrigger` instances (defense-in-depth)