### PR TITLE
ui(web): elevate audio page with cards, eq visualizer, and toggle controls

### DIFF
--- a/packages/web/src/components/settings/CompressorSection.tsx
+++ b/packages/web/src/components/settings/CompressorSection.tsx
@@ -1,8 +1,8 @@
+import { ArrowCounterClockwise, FloppyDisk } from '@phosphor-icons/react';
 import { useEffect, useState } from 'react';
 import { useAdminView } from '../../context/AdminViewContext';
 import { usePermissions } from '../../context/PermissionsContext';
 import { Button } from '../ui/Button';
-import SettingsToggle from './SettingsToggle';
 
 const DEFAULTS = { enabled: false, threshold: -6, ratio: 4.0, attack: 5, release: 50, gain: 3 };
 
@@ -82,16 +82,26 @@ export default function CompressorSection() {
 
   return (
     <div className={`space-y-3 ${dimmed ? 'opacity-40 pointer-events-none' : ''}`}>
-      <div className="flex items-center justify-between">
-        <h4 className="font-mono text-[11px] text-muted uppercase tracking-wider">Compressor</h4>
-        <SettingsToggle
-          label=""
-          checked={values.enabled}
-          onChange={(enabled) => setValues((v) => ({ ...v, enabled }))}
-        />
+      <div className="flex items-center gap-3">
+        <span className="font-mono text-[11px] text-muted w-20 shrink-0">Enabled</span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={values.enabled}
+          onClick={() => setValues((v) => ({ ...v, enabled: !v.enabled }))}
+          className={`relative shrink-0 w-9 h-5 rounded-full transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface ${
+            values.enabled ? 'bg-accent' : 'bg-border'
+          }`}
+        >
+          <span
+            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform bg-elevated ${
+              values.enabled ? 'translate-x-4' : 'translate-x-0'
+            }`}
+          />
+        </button>
       </div>
 
-      <div className="space-y-2">
+      <div className={`space-y-2 ${!values.enabled ? 'opacity-40' : ''}`}>
         {SLIDERS.map(({ key, label, min, max, step, unit }) => (
           <div key={key} className="flex items-center gap-3">
             <span className="font-mono text-[11px] text-muted w-20 shrink-0">{label}</span>
@@ -120,12 +130,24 @@ export default function CompressorSection() {
         ))}
       </div>
 
-      <div className="flex gap-3 pt-1 justify-end">
-        <Button variant="primary" onClick={handleSave} disabled={!hasChanges || saving}>
-          {saving ? 'Saving…' : 'Save Changes'}
+      <div className="flex gap-2 pt-1 justify-end">
+        <Button
+          variant="primary"
+          size="icon"
+          onClick={handleSave}
+          disabled={!hasChanges || saving}
+          title={saving ? 'Saving…' : 'Save Changes'}
+        >
+          <FloppyDisk size={16} weight="duotone" />
         </Button>
-        <Button variant="inherit" surface="elevated" onClick={handleReset}>
-          Reset to Defaults
+        <Button
+          variant="inherit"
+          size="icon"
+          surface="elevated"
+          onClick={handleReset}
+          title="Reset to Defaults"
+        >
+          <ArrowCounterClockwise size={16} weight="duotone" />
         </Button>
       </div>
     </div>

--- a/packages/web/src/components/settings/EqualizerSection.tsx
+++ b/packages/web/src/components/settings/EqualizerSection.tsx
@@ -1,3 +1,4 @@
+import { ArrowCounterClockwise, FloppyDisk } from '@phosphor-icons/react';
 import { useEffect, useState } from 'react';
 import { useAdminView } from '../../context/AdminViewContext';
 import { usePermissions } from '../../context/PermissionsContext';
@@ -29,6 +30,7 @@ export default function EqualizerSection() {
   const canManage = isAdminView || hasPermission('audio.manage');
   const [bands, setBands] = useState<number[]>(DEFAULT_BANDS);
   const [savedBands, setSavedBands] = useState<number[]>(DEFAULT_BANDS);
+  const [eqEnabled, setEqEnabled] = useState(true);
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
@@ -47,7 +49,9 @@ export default function EqualizerSection() {
     if (canManage) load();
   }, [canManage]);
 
-  const hasChanges = JSON.stringify(bands) !== JSON.stringify(savedBands);
+  // When off, save sends flat bands; when on, save sends real bands
+  const effectiveBands = eqEnabled ? bands : DEFAULT_BANDS;
+  const hasChanges = JSON.stringify(effectiveBands) !== JSON.stringify(savedBands);
 
   async function handleSave() {
     setSaving(true);
@@ -55,10 +59,10 @@ export default function EqualizerSection() {
       const res = await fetch('/api/settings/equalizer', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ bands }),
+        body: JSON.stringify({ bands: effectiveBands }),
       });
       if (res.ok) {
-        setSavedBands(bands);
+        setSavedBands(effectiveBands);
       } else {
         console.error('Failed to save equalizer settings:', res.status);
       }
@@ -83,45 +87,126 @@ export default function EqualizerSection() {
     return `${offset > 0 ? '+' : ''}${offset}`;
   }
 
+  // EQ curve SVG visualization
+  const curvePath = (() => {
+    const W = 280;
+    const H = 60;
+    const pad = 8;
+    const plotH = H - pad * 2;
+    const pts = bands.map((v, i) => {
+      const x = pad + (i / (bands.length - 1)) * (W - pad * 2);
+      const y = pad + plotH - (v / 100) * plotH;
+      return `${x},${y}`;
+    });
+    const centerY = H / 2;
+    const fillPts = `${pad},${pad + plotH} ${pts.join(' ')} ${W - pad},${pad + plotH}`;
+    return { pts: pts.join(' '), fillPts, centerY, W, H, pad };
+  })();
+
+  const dimmed = !canManage;
+  const slidersDimmed = !eqEnabled;
+
   return (
-    <div className={`space-y-3 ${!canManage ? 'opacity-40 pointer-events-none' : ''}`}>
-      <h4 className="font-mono text-[11px] text-muted uppercase tracking-wider">Equalizer</h4>
-      <div className="flex flex-wrap justify-center gap-2 md:flex-nowrap">
+    <div className={`space-y-4 ${dimmed ? 'opacity-40 pointer-events-none' : ''}`}>
+      {/* Enabled toggle */}
+      <div className="flex items-center gap-3">
+        <span className="font-mono text-[11px] text-muted w-20 shrink-0">Enabled</span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={eqEnabled}
+          onClick={() => setEqEnabled(!eqEnabled)}
+          className={`relative shrink-0 w-9 h-5 rounded-full transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface ${
+            eqEnabled ? 'bg-accent' : 'bg-border'
+          }`}
+        >
+          <span
+            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform bg-elevated ${
+              eqEnabled ? 'translate-x-4' : 'translate-x-0'
+            }`}
+          />
+        </button>
+      </div>
+
+      {/* EQ curve preview */}
+      <svg viewBox={`0 0 ${curvePath.W} ${curvePath.H}`} className="w-full h-14" aria-hidden="true">
+        <line
+          x1={curvePath.pad}
+          y1={curvePath.centerY}
+          x2={curvePath.W - curvePath.pad}
+          y2={curvePath.centerY}
+          stroke="var(--color-border)"
+          strokeWidth="1"
+          strokeDasharray="4 3"
+        />
+        <polygon points={curvePath.fillPts} fill="var(--color-accent)" opacity="0.07" />
+        <polyline
+          points={curvePath.pts}
+          fill="none"
+          stroke="var(--color-accent)"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          opacity="0.7"
+        />
+      </svg>
+
+      {/* Sliders */}
+      <div
+        className={`flex flex-wrap justify-center gap-2 md:flex-nowrap ${slidersDimmed ? 'opacity-40' : ''}`}
+      >
         {bands.map((value, i) => (
           // biome-ignore lint/suspicious/noArrayIndexKey: static UI elements with stable order
           <div key={i} className="flex flex-col items-center gap-1 shrink-0">
             <span className="font-mono text-[10px] text-muted">{FREQ_LABELS[i]}</span>
-            <input
-              type="range"
-              min={0}
-              max={100}
-              step={1}
-              value={value}
-              onChange={(e) => updateBand(i, parseInt(e.target.value, 10))}
-              className="range-input"
-              style={
-                {
-                  writingMode: 'vertical-lr',
-                  direction: 'rtl',
-                  width: '8px',
-                  height: '120px',
-                  borderRadius: '4px',
-                  background: `linear-gradient(to top, var(--color-accent) 0%, var(--color-accent) ${(value / 100) * 100}%, var(--color-border) ${(value / 100) * 100}%, var(--color-border) 100%)`,
-                } as React.CSSProperties
-              }
-            />
+            <div className="relative h-[120px] w-2">
+              <input
+                type="range"
+                min={0}
+                max={100}
+                step={1}
+                value={value}
+                onChange={(e) => updateBand(i, parseInt(e.target.value, 10))}
+                className="range-input"
+                style={
+                  {
+                    writingMode: 'vertical-lr',
+                    direction: 'rtl',
+                    width: '8px',
+                    height: '120px',
+                    borderRadius: '4px',
+                    background: `linear-gradient(to top, var(--color-accent) 0%, var(--color-accent) ${(value / 100) * 100}%, var(--color-border) ${(value / 100) * 100}%, var(--color-border) 100%)`,
+                  } as React.CSSProperties
+                }
+              />
+              <div className="absolute inset-x-0 top-1/2 h-px bg-border/50 pointer-events-none" />
+            </div>
             <span className="font-mono text-[10px] text-fg min-w-[2em] text-right">
               {gainDisplay(value)}
             </span>
           </div>
         ))}
       </div>
-      <div className="flex gap-3 pt-1 justify-end">
-        <Button variant="primary" onClick={handleSave} disabled={!hasChanges || saving}>
-          {saving ? 'Saving…' : 'Save Changes'}
+
+      {/* Actions */}
+      <div className="flex gap-2 pt-1 justify-end">
+        <Button
+          variant="primary"
+          size="icon"
+          onClick={handleSave}
+          disabled={!hasChanges || saving}
+          title={saving ? 'Saving…' : 'Save Changes'}
+        >
+          <FloppyDisk size={16} weight="duotone" />
         </Button>
-        <Button variant="inherit" surface="elevated" onClick={handleReset}>
-          Reset to Defaults
+        <Button
+          variant="inherit"
+          size="icon"
+          surface="elevated"
+          onClick={handleReset}
+          title="Reset to Defaults"
+        >
+          <ArrowCounterClockwise size={16} weight="duotone" />
         </Button>
       </div>
     </div>

--- a/packages/web/src/pages/AudioPage.tsx
+++ b/packages/web/src/pages/AudioPage.tsx
@@ -1,3 +1,4 @@
+import { ArrowsDownUp, SlidersHorizontal } from '@phosphor-icons/react';
 import CompressorSection from '../components/settings/CompressorSection';
 import EqualizerSection from '../components/settings/EqualizerSection';
 import { useAdminView } from '../context/AdminViewContext';
@@ -17,15 +18,39 @@ export default function AudioPage() {
         <p className="font-mono text-xs text-muted mt-2">Equalizer and compressor settings</p>
       </div>
 
-      <div className="space-y-2">
-        {canManage && <EqualizerSection />}
-        {canManage && (
-          <>
-            <div className="border-t border-muted/20 my-4" />
-            <CompressorSection />
-          </>
-        )}
-      </div>
+      {!canManage ? (
+        <div className="flex flex-col items-center justify-center py-20 text-center">
+          <p className="text-sm text-muted mb-1">No access to audio settings</p>
+          <p className="text-xs text-muted">
+            You need the <span className="text-fg font-medium">audio.manage</span> permission or an
+            admin role to manage equalizer and compressor settings.
+          </p>
+        </div>
+      ) : (
+        <div className="lg:grid lg:grid-cols-2 lg:gap-8">
+          {/* Equalizer */}
+          <section className="mb-8 lg:mb-0">
+            <h2 className="font-mono text-xs text-muted uppercase tracking-wider mb-4 flex items-center gap-2">
+              <SlidersHorizontal size={14} weight="duotone" />
+              Equalizer
+            </h2>
+            <div className="bg-elevated clay-resting rounded-lg p-5">
+              <EqualizerSection />
+            </div>
+          </section>
+
+          {/* Compressor */}
+          <section>
+            <h2 className="font-mono text-xs text-muted uppercase tracking-wider mb-4 flex items-center gap-2">
+              <ArrowsDownUp size={14} weight="duotone" />
+              Compressor
+            </h2>
+            <div className="bg-elevated clay-resting rounded-lg p-5">
+              <CompressorSection />
+            </div>
+          </section>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Brings the Audio page up to the standard of the rest of the UI — adds card containers, section headers with icons, a real-time EQ curve visualization, enabled toggles on both sections, and a responsive side-by-side layout on large screens.

## Changes

- **AudioPage.tsx** — Wrap EQ and compressor sections in `bg-elevated clay-resting rounded-lg` cards with section headers and Phosphor icons. Add unauthorized state when user lacks `audio.manage`. Side-by-side grid layout at `lg` breakpoint.
- **EqualizerSection.tsx** — Real-time SVG EQ curve visualization with filled area and dashed center line. Center-line indicator on vertical sliders. Frontend-only enabled toggle (off → saves flat bands, on → saves real bands). Dimmed sliders when off (still interactive). Icon-only save/reset buttons.
- **CompressorSection.tsx** — Inline enabled toggle replacing full-width SettingsToggle. Sliders dim when disabled. Icon-only save/reset buttons.