### PR TITLE
fix(server): use getGuildId() for nodelink filter updates

### DIFF
--- a/packages/server/src/lib/applyNodeLinkFilter.ts
+++ b/packages/server/src/lib/applyNodeLinkFilter.ts
@@ -1,5 +1,6 @@
 import { logger } from '../shared/logger';
 import { updateNodeLinkPlayer } from '../utils/nodelink';
+import { getGuildId } from './config';
 import { lavalink } from './lavalink';
 
 interface CompressorFilterParams {
@@ -34,7 +35,7 @@ export async function applyNodeLinkFilter(
   filters: Record<string, unknown>,
   label: string
 ): Promise<void> {
-  const guildId = process.env.GUILD_ID ?? '';
+  const guildId = getGuildId();
   if (!guildId) {
     logger.warn(`GUILD_ID not set, skipping NodeLink ${label} filter update`);
     return;


### PR DESCRIPTION
## Summary

Audio filter updates (compressor, equalizer) were reading `GUILD_ID` directly from the environment variable, causing them to fail when the guild ID was set via the setup wizard and stored in the database.

## Changes

- Replace `process.env.GUILD_ID ?? ''` with `getGuildId()` in `applyNodeLinkFilter.ts`, which checks the DB-stored value (set by the setup wizard) before falling back to the env var