### PR TITLE
feat: persist equalizer on/off state

### DIFF
--- a/packages/server/src/routes/equalizer.ts
+++ b/packages/server/src/routes/equalizer.ts
@@ -13,6 +13,7 @@ import { db, tables } from '../shared/db';
 
 interface EqualizerPayload {
   bands: number[]; // length 15, each 0-100
+  enabled: boolean;
 }
 
 async function handleEqualizerGet(ctx: RouteContext): Promise<Response> {
@@ -20,14 +21,18 @@ async function handleEqualizerGet(ctx: RouteContext): Promise<Response> {
   if (guards instanceof Response) return guards;
 
   const row = await db
-    .select(EQ_BAND_COLUMNS)
+    .select({
+      ...EQ_BAND_COLUMNS,
+      eqEnabled: tables.guildSettings.eqEnabled,
+    })
     .from(tables.guildSettings)
     .where(eq(tables.guildSettings.id, 1))
     .get();
 
   const bands = eqBandsFromRow(row);
+  const enabled = row?.eqEnabled ?? true;
 
-  return json({ bands });
+  return json({ bands, enabled });
 }
 
 async function handleEqualizerPatch(ctx: RouteContext, request: Request): Promise<Response> {
@@ -41,7 +46,12 @@ async function handleEqualizerPatch(ctx: RouteContext, request: Request): Promis
     return json({ error: 'Invalid JSON' }, 400);
   }
 
-  const { bands } = body;
+  const { bands, enabled } = body;
+
+  // Validate: enabled must be boolean
+  if (typeof enabled !== 'boolean') {
+    return json({ error: 'enabled must be boolean' }, 400);
+  }
 
   // Validate: must be array of 15 integers, each 0-100
   if (!Array.isArray(bands) || bands.length !== 15) {
@@ -57,17 +67,17 @@ async function handleEqualizerPatch(ctx: RouteContext, request: Request): Promis
   // Upsert into DB
   await db
     .insert(tables.guildSettings)
-    .values({ id: 1, ...eqBandValues(bands) })
+    .values({ id: 1, eqEnabled: enabled, ...eqBandValues(bands) })
     .onConflictDoUpdate({
       target: tables.guildSettings.id,
-      set: eqBandValues(bands),
+      set: { eqEnabled: enabled, ...eqBandValues(bands) },
     })
     .run();
 
   // Apply to live NodeLink player if connected
   await applyNodeLinkFilter({ equalizer: buildEqualizerFilter(bands) }, 'equalizer');
 
-  return json({ bands });
+  return json({ bands, enabled });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/shared/db/migrations/0059_add_eq_enabled.sql
+++ b/packages/server/src/shared/db/migrations/0059_add_eq_enabled.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "guildSettings" ADD COLUMN "eqEnabled" integer NOT NULL DEFAULT 1;

--- a/packages/server/src/shared/db/schema.ts
+++ b/packages/server/src/shared/db/schema.ts
@@ -94,6 +94,7 @@ export const guildSettings = sqliteTable('guildSettings', {
   compressorAttack: integer('compressorAttack').notNull().default(5), // ms, 0 to 100
   compressorRelease: integer('compressorRelease').notNull().default(50), // ms, 10 to 1000
   compressorGain: integer('compressorGain').notNull().default(3), // dB, 0 to 24
+  eqEnabled: integer('eqEnabled', { mode: 'boolean' }).notNull().default(true),
   eqBand0: integer('eqBand0').notNull().default(50),
   eqBand1: integer('eqBand1').notNull().default(50),
   eqBand2: integer('eqBand2').notNull().default(50),

--- a/packages/server/src/shared/types.ts
+++ b/packages/server/src/shared/types.ts
@@ -72,6 +72,7 @@ export interface CompressorSettings {
 // ---------------------------------------------------------------------------
 export interface EqualizerSettings {
   bands: number[]; // length 15, values 0–100, 50 = neutral (0 dB)
+  enabled: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/components/settings/EqualizerSection.tsx
+++ b/packages/web/src/components/settings/EqualizerSection.tsx
@@ -31,27 +31,36 @@ export default function EqualizerSection() {
   const [bands, setBands] = useState<number[]>(DEFAULT_BANDS);
   const [savedBands, setSavedBands] = useState<number[]>(DEFAULT_BANDS);
   const [eqEnabled, setEqEnabled] = useState(true);
+  const [savedEnabled, setSavedEnabled] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
     async function load() {
       try {
         const res = await fetch('/api/settings/equalizer');
         if (res.ok) {
-          const data = (await res.json()) as { bands: number[] };
+          const data = (await res.json()) as { bands: number[]; enabled: boolean };
           setBands(data.bands);
           setSavedBands(data.bands);
+          const enabled = data.enabled ?? true;
+          setEqEnabled(enabled);
+          setSavedEnabled(enabled);
         }
       } catch {
         // silently fail
+      } finally {
+        setLoaded(true);
       }
     }
     if (canManage) load();
+    else setLoaded(true);
   }, [canManage]);
 
   // When off, save sends flat bands; when on, save sends real bands
   const effectiveBands = eqEnabled ? bands : DEFAULT_BANDS;
-  const hasChanges = JSON.stringify(effectiveBands) !== JSON.stringify(savedBands);
+  const hasChanges =
+    JSON.stringify(effectiveBands) !== JSON.stringify(savedBands) || eqEnabled !== savedEnabled;
 
   async function handleSave() {
     setSaving(true);
@@ -59,10 +68,11 @@ export default function EqualizerSection() {
       const res = await fetch('/api/settings/equalizer', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ bands: effectiveBands }),
+        body: JSON.stringify({ bands: effectiveBands, enabled: eqEnabled }),
       });
       if (res.ok) {
         setSavedBands(effectiveBands);
+        setSavedEnabled(eqEnabled);
       } else {
         console.error('Failed to save equalizer settings:', res.status);
       }
@@ -105,6 +115,8 @@ export default function EqualizerSection() {
 
   const dimmed = !canManage;
   const slidersDimmed = !eqEnabled;
+
+  if (!loaded) return null;
 
   return (
     <div className={`space-y-4 ${dimmed ? 'opacity-40 pointer-events-none' : ''}`}>


### PR DESCRIPTION
## Summary

Adds persistence for the EQ enabled/disabled toggle so users can save whether the equalizer is on or off. The audio pipeline is unchanged — when off, flat bands are sent and the GuildPlayer naturally applies no EQ.

## Changes

- **server/db**: Add `eqEnabled` boolean column to `guildSettings` (defaults to `true`) with migration `0059_add_eq_enabled.sql`
- **server/routes/equalizer**: GET returns `{ bands, enabled }`, PATCH accepts and stores both
- **server/shared/types**: Add `enabled: boolean` to `EqualizerSettings`
- **web/EqualizerSection**: Loads/saves `enabled` state from API; tracks `savedEnabled` for accurate change detection; adds `loaded` flag to prevent flash of wrong toggle state on mount