### PR TITLE
ui(web): polish player bar, sidebar status, inputs, and view toggles

### DIFF
--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { CaretLeftIcon, CraneTowerIcon, GuitarIcon } from '@phosphor-icons/react';
+import { CaretLeftIcon, CraneTowerIcon, GuitarIcon, LinkBreakIcon } from '@phosphor-icons/react';
 import { useEffect, useState } from 'react';
 import { NavLink, Outlet, useNavigate } from 'react-router-dom';
 import { ADMIN_NAV_ITEMS, NAV_ITEMS } from '../constants';
@@ -171,30 +171,23 @@ function LayoutContent() {
 
         {/* Connection status */}
         {connectionStatus !== 'connected' && (
-          <div className="px-3 pb-2">
+          <div className={collapsed ? 'flex justify-center px-2 pb-2' : 'px-3 pb-2'}>
             <div
-              className={`flex items-center gap-2 text-sm font-mono px-2 py-1.5 rounded-lg ${
-                collapsed
-                  ? 'bg-warning/10 text-warning'
-                  : connectionStatus === 'reconnecting'
-                    ? 'bg-warning/10 text-warning'
-                    : 'bg-danger/10 text-danger'
-              }`}
+              title={connectionStatus === 'reconnecting' ? 'Reconnecting...' : 'Disconnected'}
+              className={`flex items-center rounded-xl font-body w-full select-none ${
+                collapsed ? 'justify-center px-0 py-3' : 'px-3 py-3 gap-3'
+              } ${connectionStatus === 'reconnecting' ? 'text-warning' : 'text-danger'}`}
             >
-              <span
-                className={`w-1.5 h-1.5 rounded-full ${
-                  collapsed
-                    ? 'bg-warning animate-pulse'
-                    : connectionStatus === 'reconnecting'
-                      ? 'bg-warning animate-pulse'
-                      : 'bg-danger'
-                }`}
+              {!collapsed && (
+                <span className="mr-auto text-sm text-fg/80">
+                  {connectionStatus === 'reconnecting' ? 'Reconnecting...' : 'Disconnected'}
+                </span>
+              )}
+              <LinkBreakIcon
+                size={22}
+                weight="duotone"
+                className={connectionStatus === 'reconnecting' ? 'animate-pulse' : ''}
               />
-              {collapsed
-                ? null
-                : connectionStatus === 'reconnecting'
-                  ? 'Reconnecting...'
-                  : 'Disconnected'}
             </div>
           </div>
         )}

--- a/packages/web/src/components/NowPlayingBar.tsx
+++ b/packages/web/src/components/NowPlayingBar.tsx
@@ -59,14 +59,14 @@ const PlaybackControls = memo(function PlaybackControls({
         onClick={onPauseResume}
         busy={pauseBusy}
         disabled={!currentSong || pauseBusy || skipBusy}
-        title={isPaused || isStopped ? 'Resume' : 'Pause'}
+        title={isPaused || isStopped ? 'Pause' : 'Resume'}
         hoverColor="hover:text-fg"
         pulse={isPlaying && !isPaused}
       >
         {isPaused || isStopped ? (
-          <PlayIcon size={24} weight="duotone" className="md:w-5 md:h-5" />
-        ) : (
           <PauseIcon size={24} weight="duotone" className="md:w-5 md:h-5" />
+        ) : (
+          <PlayIcon size={24} weight="duotone" className="md:w-5 md:h-5" />
         )}
       </BarButton>
       <BarButton

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -936,7 +936,7 @@
             var(--color-elevated) 0%,
             color-mix(in srgb, var(--color-elevated) 90%, black) 100%
         );
-        border: 1px solid var(--color-border);
+        border: 1px solid transparent;
         box-shadow:
             var(--clay-shadow-flat),
             inset 0 1px 0 0 rgba(255, 255, 255, 0.06);

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -4,6 +4,7 @@ import {
   BombIcon,
   CaretLeftIcon,
   GhostIcon,
+  ListIcon,
   LockIcon,
   LockOpenIcon,
   MagnifyingGlassIcon,
@@ -12,6 +13,7 @@ import {
   PlayIcon,
   PlusCircleIcon,
   ShuffleIcon,
+  SquaresFourIcon,
   TagIcon,
 } from '@phosphor-icons/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -111,6 +113,10 @@ export default function PlaylistDetailPage() {
   const [isFetching, setIsFetching] = useState(false);
   const [isError, setIsError] = useState(false);
   const [search, setSearch] = useState('');
+  const [viewMode, setViewMode] = useState<'grid' | 'list'>(() => {
+    const saved = localStorage.getItem('alfira-playlist-detail-view');
+    return saved === 'grid' ? 'grid' : 'list';
+  });
   const searchRef = useRef(search);
 
   // Keep searchRef in sync with search state
@@ -581,7 +587,7 @@ export default function PlaylistDetailPage() {
         </div>
       </div>
 
-      {/* Search */}
+      {/* Search and view toggle */}
       <div className="flex items-center gap-2 mb-4 md:mb-6">
         <div className="relative flex-1">
           <MagnifyingGlassIcon
@@ -602,6 +608,35 @@ export default function PlaylistDetailPage() {
               void loadPage(1, false, false, value);
             }}
           />
+        </div>
+        {/* View toggle */}
+        <div className="flex gap-1 bg-elevated rounded-lg p-1 shrink-0">
+          <button
+            type="button"
+            onClick={() => {
+              setViewMode('list');
+              localStorage.setItem('alfira-playlist-detail-view', 'list');
+            }}
+            className={`px-2 py-1.5 rounded-md transition-colors cursor-pointer ${
+              viewMode === 'list' ? 'bg-accent text-elevated' : 'text-muted hover:text-fg'
+            }`}
+            title="List view"
+          >
+            <ListIcon size={18} weight="duotone" />
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setViewMode('grid');
+              localStorage.setItem('alfira-playlist-detail-view', 'grid');
+            }}
+            className={`px-2 py-1.5 rounded-md transition-colors cursor-pointer ${
+              viewMode === 'grid' ? 'bg-accent text-elevated' : 'text-muted hover:text-fg'
+            }`}
+            title="Grid view"
+          >
+            <SquaresFourIcon size={18} weight="duotone" />
+          </button>
         </div>
       </div>
 
@@ -628,7 +663,7 @@ export default function PlaylistDetailPage() {
       ) : (
         <VirtualSongList
           items={songItems}
-          viewMode="list"
+          viewMode={viewMode}
           isAdminView={isAdminView}
           playlists={[]}
           isLoading={isLoading}

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -9,7 +9,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { deleteSong, getPlaylistsPage, getSongsPage, startPlayback } from '../api/api';
 import ConfirmModal from '../components/ConfirmModal';
 import NotificationToast from '../components/NotificationToast';
-import { Button } from '../components/ui/Button';
+
 import { VirtualSongList } from '../components/VirtualSongList';
 import { useAdminView } from '../context/AdminViewContext';
 import { usePlayerState } from '../context/PlayerContext';
@@ -169,33 +169,33 @@ export default function SongsPage() {
           />
         </div>
         {/* View toggle */}
-        <div className="flex items-center gap-1">
-          <Button
-            variant="inherit"
-            surface="surface"
-            size="icon"
+        <div className="flex gap-1 bg-elevated rounded-lg p-1">
+          <button
+            type="button"
             onClick={() => {
               setViewMode('list');
               localStorage.setItem('alfira-library-view', 'list');
             }}
-            className={isGrid ? '' : 'pressed text-accent'}
+            className={`px-3 py-1.5 rounded-md text-sm font-body transition-colors cursor-pointer ${
+              !isGrid ? 'bg-accent text-elevated' : 'text-muted hover:text-fg'
+            }`}
             title="List view"
           >
             <ListIcon size={18} weight="duotone" />
-          </Button>
-          <Button
-            variant="inherit"
-            surface="surface"
-            size="icon"
+          </button>
+          <button
+            type="button"
             onClick={() => {
               setViewMode('grid');
               localStorage.setItem('alfira-library-view', 'grid');
             }}
-            className={isGrid ? 'pressed text-accent' : ''}
+            className={`px-2 py-1.5 rounded-md transition-colors cursor-pointer ${
+              isGrid ? 'bg-accent text-elevated' : 'text-muted hover:text-fg'
+            }`}
             title="Grid view"
           >
             <SquaresFourIcon size={18} weight="duotone" />
-          </Button>
+          </button>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

UI polish pass across the web UI.

## Changes

- **Player bar** — Flip play/pause icon to show current state (PauseIcon when paused, PlayIcon when playing)
- **Sidebar** — Redesign connection status indicator with LinkBreakIcon, matching sidebar item rhythm in both collapsed and expanded states
- **Inputs** — Remove idle border on text fields, keep focus ring effect
- **Songs page** — Replace icon button view toggle with pill-style segmented control (matching Requests page)
- **Playlist detail page** — Add list/grid view toggle with localStorage persistence