### PR TITLE
feat: add sort and filter to song library and playlists

### DIFF
--- a/packages/server/src/routes/playlists.ts
+++ b/packages/server/src/routes/playlists.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, inArray } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, sql } from 'drizzle-orm';
 import type { RouteContext } from '../index';
 import { getUserDisplayName, resolveDisplayNames } from '../lib/displayName';
 import { json } from '../lib/json';
@@ -13,6 +13,35 @@ import { validatePlaylistName } from '../lib/validation';
 import { db, tables } from '../shared/db';
 
 const { playlist: playlistTable, playlistSong: playlistSongTable } = tables;
+
+// ---------------------------------------------------------------------------
+// Source URL → LIKE patterns (mirrors songs.ts)
+// ---------------------------------------------------------------------------
+const SOURCE_LIKE_PATTERNS: Record<string, string[]> = {
+  youtube: ['%youtube.com%', '%youtu.be%'],
+  soundcloud: ['%soundcloud.com%'],
+  spotify: ['%spotify.com%'],
+  applemusic: ['%music.apple.com%'],
+  tidal: ['%tidal.com%'],
+  googledrive: ['%drive.google.com%'],
+};
+
+function buildSongOrderBy(field: string, direction: 'ASC' | 'DESC'): ReturnType<typeof sql> {
+  switch (field) {
+    case 'title':
+      return sql`lower(${tables.song.title}) ${sql.raw(direction)}`;
+    case 'artist':
+      return sql`${tables.song.artist} IS NULL, lower(${tables.song.artist}) ${sql.raw(direction)}`;
+    case 'album':
+      return sql`${tables.song.album} IS NULL, lower(${tables.song.album}) ${sql.raw(direction)}`;
+    case 'duration':
+      return sql`${tables.song.duration} ${sql.raw(direction)}`;
+    case 'createdAt':
+      return sql`${tables.song.createdAt} ${sql.raw(direction)}`;
+    default:
+      return sql`${tables.song.createdAt} ${sql.raw(direction)}`;
+  }
+}
 
 async function getPlaylistSongCount(playlistId: string): Promise<number> {
   const result = await db
@@ -217,6 +246,32 @@ async function handleGetPlaylist(
   const { page, limit, skip } = parsePagination(url);
   const search = url.searchParams.get('search')?.trim() ?? '';
 
+  // Sort & filter
+  const sortRaw = url.searchParams.get('sort') ?? 'position';
+  const sortField = ['position', 'title', 'artist', 'album', 'duration', 'createdAt'].includes(
+    sortRaw
+  )
+    ? sortRaw
+    : 'position';
+  const sortOrder = url.searchParams.get('order') === 'asc' ? 'ASC' : 'DESC';
+
+  const tagsParam = url.searchParams.get('tags')?.trim();
+  const sourcesParam = url.searchParams.get('source')?.trim();
+  const filterTags = tagsParam
+    ? tagsParam
+        .split(',')
+        .map((t) => t.trim())
+        .filter(Boolean)
+    : [];
+  const filterSources = sourcesParam
+    ? sourcesParam
+        .split(',')
+        .map((s) => s.trim().toLowerCase())
+        .filter(Boolean)
+    : [];
+
+  const wantsCustomSort = sortField !== 'position';
+
   const playlist = await findPlaylistOr404(id, true);
   if (!playlist) {
     return json({ error: 'Playlist not found.' }, 404);
@@ -227,6 +282,86 @@ async function handleGetPlaylist(
     return json({ error: accessResult.error }, 403);
   }
 
+  // ── Custom sort path: join playlistSong ↔ song, sort + filter in one query ──
+  if (wantsCustomSort || filterTags.length > 0 || filterSources.length > 0) {
+    // Build song-level filter clauses
+    const songFilterClauses: ReturnType<typeof sql>[] = [];
+
+    if (search) {
+      const searchClause = buildSongSearchClause(search);
+      if (searchClause) songFilterClauses.push(searchClause);
+    }
+
+    for (const tag of filterTags) {
+      songFilterClauses.push(sql`lower(${tables.song.tags}) LIKE lower(${`%"${tag}"%`})`);
+    }
+
+    if (filterSources.length > 0) {
+      const sourceOrs: ReturnType<typeof sql>[] = [];
+      for (const source of filterSources) {
+        const patterns = SOURCE_LIKE_PATTERNS[source];
+        if (patterns) {
+          for (const pattern of patterns) {
+            sourceOrs.push(sql`${tables.song.sourceUrl} LIKE ${pattern}`);
+          }
+        }
+      }
+      if (sourceOrs.length > 0) {
+        songFilterClauses.push(sql`(${sql.join(sourceOrs, sql` OR `)})`);
+      }
+    }
+
+    const joinWhere = and(
+      eq(playlistSongTable.playlistId, id),
+      ...(songFilterClauses.length > 0 ? [sql.join(songFilterClauses, sql` AND `)] : [])
+    );
+
+    const orderBy = wantsCustomSort
+      ? buildSongOrderBy(sortField, sortOrder)
+      : playlistSongTable.position;
+
+    const [rows, countResult] = await Promise.all([
+      db
+        .select()
+        .from(playlistSongTable)
+        .innerJoin(tables.song, eq(playlistSongTable.songId, tables.song.id))
+        .where(joinWhere)
+        .orderBy(orderBy)
+        .limit(limit)
+        .offset(skip),
+      db
+        .select({ count: count() })
+        .from(playlistSongTable)
+        .innerJoin(tables.song, eq(playlistSongTable.songId, tables.song.id))
+        .where(joinWhere),
+    ]);
+
+    const total = countResult[0]?.count ?? 0;
+    const songs = rows.map((r) => r.Song);
+    const nameMap = await resolveDisplayNames(songs);
+
+    return json({
+      ...playlist,
+      createdAt:
+        playlist.createdAt instanceof Date ? playlist.createdAt.toISOString() : playlist.createdAt,
+      songs: rows.map((r) =>
+        formatPlaylistSongWithSong(
+          r.PlaylistSong,
+          r.Song,
+          nameMap.get(r.Song.addedBy) ?? r.Song.addedBy
+        )
+      ),
+      createdByDisplayName: await getUserDisplayName(playlist.createdBy),
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    });
+  }
+
+  // ── Default path: position sort, search-only filter ──
   // Build list of song IDs to filter by when searching
   let songIds: string[] = [];
   if (search) {

--- a/packages/server/src/routes/songs.ts
+++ b/packages/server/src/routes/songs.ts
@@ -24,7 +24,79 @@ import { getPlayer } from '../startDiscord';
 const { song: songTable, playlist: playlistTable, playlistSong: playlistSongTable } = tables;
 
 // ---------------------------------------------------------------------------
-// GET /api/songs — paginated list of songs, newest first.
+// Source URL → LIKE patterns for server-side source filtering.
+// Must mirror the web's HOST_TO_SOURCE map in packages/web/src/utils/source.ts.
+// ---------------------------------------------------------------------------
+const SOURCE_LIKE_PATTERNS: Record<string, string[]> = {
+  youtube: ['%youtube.com%', '%youtu.be%'],
+  soundcloud: ['%soundcloud.com%'],
+  spotify: ['%spotify.com%'],
+  applemusic: ['%music.apple.com%'],
+  tidal: ['%tidal.com%'],
+  googledrive: ['%drive.google.com%'],
+};
+
+const ALLOWED_SORTS = ['createdAt', 'title', 'artist', 'album', 'duration'] as const;
+type SortField = (typeof ALLOWED_SORTS)[number];
+
+// ---------------------------------------------------------------------------
+// Build a dynamic ORDER BY clause from sort field + direction.
+// ---------------------------------------------------------------------------
+function buildOrderByClause(
+  sortField: SortField,
+  sortOrder: 'ASC' | 'DESC'
+): ReturnType<typeof sql> {
+  switch (sortField) {
+    case 'title':
+      return sql`lower(title) ${sql.raw(sortOrder)}`;
+    case 'artist':
+      return sql`artist IS NULL, lower(artist) ${sql.raw(sortOrder)}`;
+    case 'album':
+      return sql`album IS NULL, lower(album) ${sql.raw(sortOrder)}`;
+    case 'duration':
+      return sql`duration ${sql.raw(sortOrder)}`;
+    default:
+      return sql`"createdAt" ${sql.raw(sortOrder)}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Build additional filter clauses for tags (AND) and sources (OR).
+// Returns a SQL fragment that can be AND-ed with the search clause, or
+// undefined when no filters are active.
+// ---------------------------------------------------------------------------
+function buildFilterClause(tags: string[], sources: string[]): ReturnType<typeof sql> | undefined {
+  const clauses: ReturnType<typeof sql>[] = [];
+
+  // Tags: AND — song must have every requested tag
+  for (const tag of tags) {
+    // Match JSON-quoted tag name for precision (avoids partial matches like
+    // "rock" matching "bedrock").
+    clauses.push(sql`lower(tags) LIKE lower(${`%"${tag}"%`})`);
+  }
+
+  // Sources: OR — song URL can match any of the requested sources
+  if (sources.length > 0) {
+    const sourceOrs: ReturnType<typeof sql>[] = [];
+    for (const source of sources) {
+      const patterns = SOURCE_LIKE_PATTERNS[source];
+      if (patterns) {
+        for (const pattern of patterns) {
+          sourceOrs.push(sql`"sourceUrl" LIKE ${pattern}`);
+        }
+      }
+    }
+    if (sourceOrs.length > 0) {
+      clauses.push(sql`(${sql.join(sourceOrs, sql` OR `)})`);
+    }
+  }
+
+  if (clauses.length === 0) return undefined;
+  return sql.join(clauses, sql` AND `);
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/songs — paginated list of songs with sort & filter.
 // ---------------------------------------------------------------------------
 async function handleGetSongs(ctx: RouteContext, request: Request): Promise<Response> {
   const guards = await checkGuards(ctx);
@@ -34,16 +106,46 @@ async function handleGetSongs(ctx: RouteContext, request: Request): Promise<Resp
   const { page, limit, skip } = parsePagination(url);
   const search = url.searchParams.get('search')?.trim() ?? '';
 
-  const where = buildSongSearchClause(search || undefined);
+  // Sort
+  const sortRaw = url.searchParams.get('sort') ?? 'createdAt';
+  const sortField: SortField = (ALLOWED_SORTS as readonly string[]).includes(sortRaw)
+    ? (sortRaw as SortField)
+    : 'createdAt';
+  const sortOrder = url.searchParams.get('order') === 'asc' ? 'ASC' : 'DESC';
+
+  // Filters
+  const tagsParam = url.searchParams.get('tags')?.trim();
+  const sourcesParam = url.searchParams.get('source')?.trim();
+  const filterTags = tagsParam
+    ? tagsParam
+        .split(',')
+        .map((t) => t.trim())
+        .filter(Boolean)
+    : [];
+  const filterSources = sourcesParam
+    ? sourcesParam
+        .split(',')
+        .map((s) => s.trim().toLowerCase())
+        .filter(Boolean)
+    : [];
+
+  // Build WHERE clause — search text + tag/source filters
+  const searchClause = buildSongSearchClause(search || undefined);
+  const filterClause = buildFilterClause(filterTags, filterSources);
+
+  let where: ReturnType<typeof sql> | undefined;
+  if (searchClause && filterClause) {
+    where = sql`(${searchClause} AND ${filterClause})`;
+  } else if (searchClause) {
+    where = searchClause;
+  } else if (filterClause) {
+    where = filterClause;
+  }
+
+  const orderBy = buildOrderByClause(sortField, sortOrder);
 
   const [songs, countResult] = await Promise.all([
-    db
-      .select()
-      .from(songTable)
-      .where(where)
-      .orderBy(sql`"createdAt" DESC`)
-      .offset(skip)
-      .limit(limit),
+    db.select().from(songTable).where(where).orderBy(orderBy).offset(skip).limit(limit),
     db.select({ count: sql<number>`count(*)` }).from(songTable).where(where),
   ]);
   const total = parseInt(String(countResult[0]?.count ?? 0), 10);

--- a/packages/server/src/shared/api.ts
+++ b/packages/server/src/shared/api.ts
@@ -113,13 +113,25 @@ export function fetchLogout(): Promise<void> {
 // Songs API Functions
 // ---------------------------------------------------------------------------
 
+export interface FetchSongsOptions {
+  search?: string;
+  sort?: string;
+  order?: string;
+  tags?: string;
+  source?: string;
+}
+
 export function fetchSongsPage(
   page: number,
   limit = 30,
-  search?: string
+  opts?: FetchSongsOptions
 ): Promise<PaginatedResult<Song>> {
   const params = new URLSearchParams({ page: String(page), limit: String(limit) });
-  if (search) params.set('search', search);
+  if (opts?.search) params.set('search', opts.search);
+  if (opts?.sort) params.set('sort', opts.sort);
+  if (opts?.order) params.set('order', opts.order);
+  if (opts?.tags) params.set('tags', opts.tags);
+  if (opts?.source) params.set('source', opts.source);
   return get(`/api/songs?${params}`);
 }
 
@@ -264,11 +276,15 @@ export function fetchPlaylistPage(
   adminView = false,
   page: number,
   limit = 30,
-  search?: string
+  opts?: FetchSongsOptions
 ): Promise<PlaylistDetail & { pagination: PaginationMeta }> {
   const params = new URLSearchParams({ page: String(page), limit: String(limit) });
   if (adminView) params.set('adminView', 'true');
-  if (search) params.set('search', search);
+  if (opts?.search) params.set('search', opts.search);
+  if (opts?.sort) params.set('sort', opts.sort);
+  if (opts?.order) params.set('order', opts.order);
+  if (opts?.tags) params.set('tags', opts.tags);
+  if (opts?.source) params.set('source', opts.source);
   return get(`/api/playlists/${id}?${params}`);
 }
 

--- a/packages/web/src/api/api.ts
+++ b/packages/web/src/api/api.ts
@@ -11,7 +11,11 @@ export type {
   SetupRole,
 } from '@alfira-bot/server/shared';
 
-export type { MyPermissionsResponse, PermissionsResponse } from '@alfira-bot/server/shared/api';
+export type {
+  FetchSongsOptions,
+  MyPermissionsResponse,
+  PermissionsResponse,
+} from '@alfira-bot/server/shared/api';
 // ---------------------------------------------------------------------------
 // Re-export everything from shared API with web-compatible names
 // ---------------------------------------------------------------------------

--- a/packages/web/src/components/AddFilterPopover.tsx
+++ b/packages/web/src/components/AddFilterPopover.tsx
@@ -1,0 +1,189 @@
+import { MagnifyingGlassIcon, XIcon } from '@phosphor-icons/react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { type TagItem, useTagColors } from '../context/TagsContext';
+import { getTagColorClasses } from '../utils/tagColors';
+import { Backdrop } from './Backdrop';
+import { SourceIcon } from './SourceIcons';
+
+// ---------------------------------------------------------------------------
+// Available sources — must mirror the server's SOURCE_LIKE_PATTERNS and the
+// web's HOST_TO_SOURCE map.
+// ---------------------------------------------------------------------------
+const SOURCES: { key: string; label: string }[] = [
+  { key: 'youtube', label: 'YouTube' },
+  { key: 'soundcloud', label: 'SoundCloud' },
+  { key: 'spotify', label: 'Spotify' },
+  { key: 'applemusic', label: 'Apple Music' },
+  { key: 'tidal', label: 'Tidal' },
+  { key: 'googledrive', label: 'Google Drive' },
+];
+
+interface AddFilterPopoverProps {
+  activeTags: string[];
+  activeSources: string[];
+  onAddTag: (tag: string) => void;
+  onRemoveTag: (tag: string) => void;
+  onAddSource: (source: string) => void;
+  onRemoveSource: (source: string) => void;
+  onClose: () => void;
+}
+
+export default function AddFilterPopover({
+  activeTags,
+  activeSources,
+  onAddTag,
+  onRemoveTag,
+  onAddSource,
+  onRemoveSource,
+  onClose,
+}: AddFilterPopoverProps) {
+  const { tags: allTags } = useTagColors();
+  const [tagSearch, setTagSearch] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Focus the search input on mount
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // Sort: active tags first, then alphabetically. Search filters the whole list.
+  const sortedTags = [...allTags].sort((a, b) => {
+    const aActive = activeTags.includes(a.nameLower);
+    const bActive = activeTags.includes(b.nameLower);
+    if (aActive && !bActive) return -1;
+    if (!aActive && bActive) return 1;
+    return a.canonicalName.localeCompare(b.canonicalName);
+  });
+
+  const filteredTags = tagSearch
+    ? sortedTags.filter((t) => t.canonicalName.toLowerCase().includes(tagSearch.toLowerCase()))
+    : sortedTags;
+
+  const handleTagClick = useCallback(
+    (tag: TagItem) => {
+      if (activeTags.includes(tag.nameLower)) {
+        onRemoveTag(tag.nameLower);
+      } else {
+        onAddTag(tag.nameLower);
+      }
+    },
+    [activeTags, onAddTag, onRemoveTag]
+  );
+
+  const handleSourceToggle = useCallback(
+    (sourceKey: string) => {
+      if (activeSources.includes(sourceKey)) {
+        onRemoveSource(sourceKey);
+      } else {
+        onAddSource(sourceKey);
+      }
+    },
+    [activeSources, onAddSource, onRemoveSource]
+  );
+
+  return (
+    <Backdrop onClose={onClose}>
+      <div
+        className="bg-surface border border-border rounded-xl w-full max-w-sm modal-clay
+        flex flex-col max-h-[70vh] animate-fade-up"
+      >
+        <div className="p-4 border-b border-border flex items-center justify-between">
+          <h3 className="font-body font-semibold text-sm text-fg">Filters</h3>
+          <button
+            type="button"
+            className="p-1 rounded hover:bg-elevated transition-colors cursor-pointer"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            <XIcon size={16} weight="bold" className="text-muted" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto">
+          {/* ── Tags section ─────────────────────────────────── */}
+          <div className="p-4 border-b border-border">
+            <p className="font-mono text-[11px] text-muted uppercase tracking-wider mb-2.5">Tags</p>
+
+            <div className="relative mb-2.5">
+              <MagnifyingGlassIcon
+                className="absolute left-2.5 top-1/2 -translate-y-1/2 text-faint w-3.5 h-3.5"
+                weight="duotone"
+              />
+              <input
+                ref={inputRef}
+                className="input pl-8 py-1.5 text-xs"
+                placeholder="Search tags..."
+                value={tagSearch}
+                onChange={(e) => setTagSearch(e.target.value)}
+              />
+            </div>
+
+            {filteredTags.length === 0 ? (
+              <p className="font-mono text-xs text-muted py-2 text-center">
+                {tagSearch ? 'no matching tags' : 'no tags available'}
+              </p>
+            ) : (
+              <div className="flex flex-wrap gap-1.5 max-h-40 overflow-y-auto">
+                {filteredTags.map((tag) => {
+                  const isActive = activeTags.includes(tag.nameLower);
+                  const explicitColor = tag.color ?? null;
+                  const colors = getTagColorClasses(tag.canonicalName, explicitColor);
+                  return (
+                    <button
+                      key={tag.nameLower}
+                      type="button"
+                      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium whitespace-nowrap cursor-pointer transition-opacity hover:opacity-80 active:opacity-70 ${
+                        isActive
+                          ? `${colors.bg} ${colors.text} ring-1 ring-inset ring-current/30`
+                          : `${colors.bg} ${colors.text} opacity-60 hover:opacity-90`
+                      }`}
+                      onClick={() => handleTagClick(tag)}
+                    >
+                      {isActive && <XIcon size={10} weight="bold" />}
+                      {tag.canonicalName}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          {/* ── Sources section ──────────────────────────────── */}
+          <div className="p-4">
+            <p className="font-mono text-[11px] text-muted uppercase tracking-wider mb-2.5">
+              Source
+            </p>
+
+            <div className="space-y-1">
+              {SOURCES.map((source) => {
+                const isActive = activeSources.includes(source.key);
+                return (
+                  <label
+                    key={source.key}
+                    className={`flex items-center gap-3 px-3 py-2 rounded-lg cursor-pointer transition-colors select-none ${
+                      isActive
+                        ? 'bg-accent/5 text-accent'
+                        : 'hover:bg-elevated active:bg-elevated/80 text-muted'
+                    }`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={isActive}
+                      onChange={() => handleSourceToggle(source.key)}
+                      className="sr-only"
+                    />
+                    <span className="flex items-center gap-2 flex-1">
+                      <SourceIcon sourceKey={source.key} />
+                      <span className="font-body text-sm">{source.label}</span>
+                    </span>
+                    {isActive && <span className="text-[11px] font-mono text-accent">active</span>}
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+    </Backdrop>
+  );
+}

--- a/packages/web/src/components/AddSongsModal.tsx
+++ b/packages/web/src/components/AddSongsModal.tsx
@@ -47,7 +47,7 @@ export default function AddSongsModal({
     setHasMore(true);
     setLoading(true);
     debouncedSearchRef.current = debouncedSearch;
-    getSongsPage(1, PAGE_SIZE, debouncedSearch || undefined).then((result) => {
+    getSongsPage(1, PAGE_SIZE, { search: debouncedSearch || undefined }).then((result) => {
       setSongs(result.items);
       setHasMore(result.items.length >= PAGE_SIZE);
       hasMoreRef.current = result.items.length >= PAGE_SIZE;
@@ -69,15 +69,17 @@ export default function AddSongsModal({
     loadingMoreRef.current = true;
     setLoadingMore(true);
     const nextPage = pageRef.current + 1;
-    getSongsPage(nextPage, PAGE_SIZE, debouncedSearchRef.current || undefined).then((result) => {
-      setSongs((prev) => [...prev, ...result.items]);
-      setPage(nextPage);
-      pageRef.current = nextPage;
-      setHasMore(result.items.length >= PAGE_SIZE);
-      hasMoreRef.current = result.items.length >= PAGE_SIZE;
-      loadingMoreRef.current = false;
-      setLoadingMore(false);
-    });
+    getSongsPage(nextPage, PAGE_SIZE, { search: debouncedSearchRef.current || undefined }).then(
+      (result) => {
+        setSongs((prev) => [...prev, ...result.items]);
+        setPage(nextPage);
+        pageRef.current = nextPage;
+        setHasMore(result.items.length >= PAGE_SIZE);
+        hasMoreRef.current = result.items.length >= PAGE_SIZE;
+        loadingMoreRef.current = false;
+        setLoadingMore(false);
+      }
+    );
   }, []);
 
   // Check near-bottom on scroll

--- a/packages/web/src/components/FilterChips.tsx
+++ b/packages/web/src/components/FilterChips.tsx
@@ -1,0 +1,80 @@
+import { TagIcon, XIcon } from '@phosphor-icons/react';
+import { getTagColorClasses } from '../utils/tagColors';
+import { SourceIcon } from './SourceIcons';
+
+// ---------------------------------------------------------------------------
+// Source label map — must mirror AddFilterPopover.SOURCES
+// ---------------------------------------------------------------------------
+const SOURCE_LABELS: Record<string, string> = {
+  youtube: 'YouTube',
+  soundcloud: 'SoundCloud',
+  spotify: 'Spotify',
+  applemusic: 'Apple Music',
+  tidal: 'Tidal',
+  googledrive: 'Google Drive',
+};
+
+interface FilterChipsProps {
+  tags: string[];
+  sources: string[];
+  onRemoveTag: (tag: string) => void;
+  onRemoveSource: (source: string) => void;
+}
+
+export default function FilterChips({
+  tags,
+  sources,
+  onRemoveTag,
+  onRemoveSource,
+}: FilterChipsProps) {
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      {/* Tag chips */}
+      {tags.map((tag) => {
+        const colors = getTagColorClasses(tag, null);
+        return (
+          <span
+            key={`tag-${tag}`}
+            className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium whitespace-nowrap select-none ${colors.bg} ${colors.text}`}
+          >
+            <TagIcon size={11} weight="fill" />
+            <span>{tag}</span>
+            <button
+              type="button"
+              className="ml-0.5 cursor-pointer rounded-full p-px hover:bg-black/10 dark:hover:bg-white/10 transition-colors"
+              onClick={(e) => {
+                e.stopPropagation();
+                onRemoveTag(tag);
+              }}
+              aria-label={`Remove tag filter: ${tag}`}
+            >
+              <XIcon size={10} weight="bold" />
+            </button>
+          </span>
+        );
+      })}
+
+      {/* Source chips */}
+      {sources.map((source) => (
+        <span
+          key={`source-${source}`}
+          className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium whitespace-nowrap select-none bg-elevated text-muted border border-border/50"
+        >
+          <SourceIcon sourceKey={source} />
+          <span>{SOURCE_LABELS[source] ?? source}</span>
+          <button
+            type="button"
+            className="ml-0.5 cursor-pointer rounded-full p-px hover:bg-black/10 dark:hover:bg-white/10 transition-colors"
+            onClick={(e) => {
+              e.stopPropagation();
+              onRemoveSource(source);
+            }}
+            aria-label={`Remove source filter: ${SOURCE_LABELS[source] ?? source}`}
+          >
+            <XIcon size={10} weight="bold" />
+          </button>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/packages/web/src/components/NowPlayingBar.tsx
+++ b/packages/web/src/components/NowPlayingBar.tsx
@@ -59,14 +59,14 @@ const PlaybackControls = memo(function PlaybackControls({
         onClick={onPauseResume}
         busy={pauseBusy}
         disabled={!currentSong || pauseBusy || skipBusy}
-        title={isPaused || isStopped ? 'Pause' : 'Resume'}
+        title={isPaused || isStopped ? 'Play' : 'Pause'}
         hoverColor="hover:text-fg"
         pulse={isPlaying && !isPaused}
       >
         {isPaused || isStopped ? (
-          <PauseIcon size={24} weight="duotone" className="md:w-5 md:h-5" />
-        ) : (
           <PlayIcon size={24} weight="duotone" className="md:w-5 md:h-5" />
+        ) : (
+          <PauseIcon size={24} weight="duotone" className="md:w-5 md:h-5" />
         )}
       </BarButton>
       <BarButton

--- a/packages/web/src/context/TagsContext.tsx
+++ b/packages/web/src/context/TagsContext.tsx
@@ -1,27 +1,31 @@
 import { fetchTags } from '@alfira-bot/server/shared/api';
 import { createContext, type ReactNode, useCallback, useContext, useEffect, useState } from 'react';
 
-interface TagItem {
+export interface TagItem {
   canonicalName: string;
   nameLower: string;
   color?: string | null;
 }
 
 const TagsContext = createContext<{
+  tags: TagItem[];
   tagColorMap: Record<string, string | null>;
   refreshTags: () => void;
 }>({
+  tags: [],
   tagColorMap: {},
   refreshTags: () => undefined,
 });
 
 export function TagsProvider({ children }: { children: ReactNode }) {
+  const [tags, setTags] = useState<TagItem[]>([]);
   const [tagColorMap, setTagColorMap] = useState<Record<string, string | null>>({});
 
   const refreshTags = useCallback(() => {
-    fetchTags().then((tags: TagItem[]) => {
+    fetchTags().then((fetched: TagItem[]) => {
+      setTags(fetched);
       const map: Record<string, string | null> = {};
-      for (const tag of tags) {
+      for (const tag of fetched) {
         map[tag.nameLower] = tag.color ?? null;
       }
       setTagColorMap(map);
@@ -33,7 +37,9 @@ export function TagsProvider({ children }: { children: ReactNode }) {
   }, [refreshTags]);
 
   return (
-    <TagsContext.Provider value={{ tagColorMap, refreshTags }}>{children}</TagsContext.Provider>
+    <TagsContext.Provider value={{ tags, tagColorMap, refreshTags }}>
+      {children}
+    </TagsContext.Provider>
   );
 }
 

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -1,8 +1,13 @@
 import type { Playlist, PlaylistDetail, Song, TagItem } from '@alfira-bot/server/shared';
+import type { FetchSongsOptions } from '@alfira-bot/server/shared/api';
 import { fetchTags, updatePlaylistTag } from '@alfira-bot/server/shared/api';
 import {
+  ArrowDownIcon,
+  ArrowUpIcon,
   BombIcon,
+  CaretDownIcon,
   CaretLeftIcon,
+  FunnelIcon,
   GhostIcon,
   ListIcon,
   LockIcon,
@@ -13,10 +18,11 @@ import {
   PlayIcon,
   PlusCircleIcon,
   ShuffleIcon,
+  SortAscendingIcon,
   SquaresFourIcon,
   TagIcon,
 } from '@phosphor-icons/react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
   deletePlaylist,
@@ -26,11 +32,13 @@ import {
   startPlayback,
   togglePlaylistVisibility,
 } from '../api/api';
+import AddFilterPopover from '../components/AddFilterPopover';
 import AddSongsModal from '../components/AddSongsModal';
 import ConfirmModal from '../components/ConfirmModal';
 import type { MenuItem } from '../components/ContextMenu';
 import { ContextMenu, ContextMenuTrigger } from '../components/ContextMenu';
 import EmptyState from '../components/EmptyState';
+import FilterChips from '../components/FilterChips';
 import NotificationToast from '../components/NotificationToast';
 
 import { Button } from '../components/ui/Button';
@@ -81,6 +89,15 @@ export default function PlaylistDetailPage() {
   const { handleAddToQueue, notification } = useAddToQueue();
   const { notify } = useNotification();
 
+  const SORT_OPTIONS = [
+    { value: 'position', label: 'Playlist Order' },
+    { value: 'createdAt', label: 'Date Added' },
+    { value: 'title', label: 'Title' },
+    { value: 'artist', label: 'Artist' },
+    { value: 'album', label: 'Album' },
+    { value: 'duration', label: 'Duration' },
+  ] as const;
+
   const isOwner = user?.discordId === playlistDetail?.createdBy;
   const canEdit = isAdminView || isOwner || hasPermission('songs.edit');
   const isSmart = !!playlistDetail?.tagNameLower;
@@ -119,6 +136,58 @@ export default function PlaylistDetailPage() {
   });
   const searchRef = useRef(search);
 
+  // Sort & filter state
+  const [sort, setSort] = useState('position');
+  const [order, setOrder] = useState('desc');
+  const [filterTags, setFilterTags] = useState<string[]>([]);
+  const [filterSources, setFilterSources] = useState<string[]>([]);
+  const [sortOpen, setSortOpen] = useState(false);
+  const [filterPopoverOpen, setFilterPopoverOpen] = useState(false);
+  const sortRefEl = useRef<HTMLDivElement>(null);
+  const sortRef = useRef(sort);
+  const orderRef = useRef(order);
+  const filterTagsRef = useRef(filterTags);
+  const filterSourcesRef = useRef(filterSources);
+
+  // Keep refs in sync
+  useEffect(() => {
+    sortRef.current = sort;
+  }, [sort]);
+  useEffect(() => {
+    orderRef.current = order;
+  }, [order]);
+  useEffect(() => {
+    filterTagsRef.current = filterTags;
+  }, [filterTags]);
+  useEffect(() => {
+    filterSourcesRef.current = filterSources;
+  }, [filterSources]);
+
+  // Build stable fetch options for loadPage
+  const songsOpts = useMemo<FetchSongsOptions>(() => {
+    const opts: FetchSongsOptions = {};
+    if (search) opts.search = search;
+    if (sort !== 'position') opts.sort = sort;
+    if (order !== 'desc') opts.order = order;
+    const t = filterTags.join(',');
+    const s = filterSources.join(',');
+    if (t) opts.tags = t;
+    if (s) opts.source = s;
+    return opts;
+  }, [search, sort, order, filterTags, filterSources]);
+
+  // Close sort dropdown on outside click
+  useEffect(() => {
+    if (!sortOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (sortRefEl.current && !sortRefEl.current.contains(e.target as Node)) {
+        setSortOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [sortOpen]);
+
   // Keep searchRef in sync with search state
   useEffect(() => {
     searchRef.current = search;
@@ -143,12 +212,27 @@ export default function PlaylistDetailPage() {
       setIsError(false);
 
       try {
+        const opts: FetchSongsOptions = searchQuery
+          ? {
+              search: searchQuery,
+              sort: sortRef.current,
+              order: orderRef.current,
+            }
+          : {
+              sort: sortRef.current,
+              order: orderRef.current,
+            };
+        const tags = filterTagsRef.current.join(',');
+        const sources = filterSourcesRef.current.join(',');
+        if (tags) opts.tags = tags;
+        if (sources) opts.source = sources;
+
         const pl = await getPlaylistPage(
           idRef.current,
           isAdminViewRef.current,
           page,
           ITEMS_PER_PAGE,
-          searchQuery
+          opts
         );
 
         if (isInitial) {
@@ -174,6 +258,75 @@ export default function PlaylistDetailPage() {
       }
     },
     []
+  );
+
+  const handleOrderToggle = useCallback(() => {
+    setOrder((o) => (o === 'asc' ? 'desc' : 'asc'));
+    setCurrentPage(1);
+    setSongs([]);
+    setIsError(false);
+    void loadPage(1, false, false, searchRef.current);
+  }, [loadPage]);
+
+  const handleSortChange = useCallback(
+    (newSort: string) => {
+      if (newSort === sort) {
+        handleOrderToggle();
+      } else {
+        setSort(newSort);
+        setSortOpen(false);
+        setCurrentPage(1);
+        setSongs([]);
+        setIsError(false);
+        void loadPage(1, false, false, searchRef.current);
+      }
+    },
+    [sort, loadPage, handleOrderToggle]
+  );
+
+  const handleRemoveTag = useCallback(
+    (tag: string) => {
+      setFilterTags((prev) => prev.filter((t) => t !== tag));
+      setCurrentPage(1);
+      setSongs([]);
+      setIsError(false);
+      void loadPage(1, false, false, searchRef.current);
+    },
+    [loadPage]
+  );
+
+  const handleRemoveSource = useCallback(
+    (source: string) => {
+      setFilterSources((prev) => prev.filter((s) => s !== source));
+      setCurrentPage(1);
+      setSongs([]);
+      setIsError(false);
+      void loadPage(1, false, false, searchRef.current);
+    },
+    [loadPage]
+  );
+
+  const handleAddTag = useCallback(
+    (tag: string) => {
+      const normalized = tag.toLowerCase();
+      setFilterTags((prev) => (prev.includes(normalized) ? prev : [...prev, normalized]));
+      setCurrentPage(1);
+      setSongs([]);
+      setIsError(false);
+      void loadPage(1, false, false, searchRef.current);
+    },
+    [loadPage]
+  );
+
+  const handleAddSource = useCallback(
+    (source: string) => {
+      setFilterSources((prev) => (prev.includes(source) ? prev : [...prev, source]));
+      setCurrentPage(1);
+      setSongs([]);
+      setIsError(false);
+      void loadPage(1, false, false, searchRef.current);
+    },
+    [loadPage]
   );
 
   // Initial load
@@ -238,7 +391,8 @@ export default function PlaylistDetailPage() {
           idRef.current,
           isAdminViewRef.current,
           currentPage + 1,
-          ITEMS_PER_PAGE
+          ITEMS_PER_PAGE,
+          songsOpts
         ).then((pl) => {
           setSongs((prev) => [...prev, ...pl.songs].slice(0, ITEMS_PER_PAGE * currentPage));
         });
@@ -587,8 +741,8 @@ export default function PlaylistDetailPage() {
         </div>
       </div>
 
-      {/* Search and view toggle */}
-      <div className="flex items-center gap-2 mb-4 md:mb-6">
+      {/* Search, sort, filter, and view toggle */}
+      <div className="flex items-center gap-2 mb-3">
         <div className="relative flex-1">
           <MagnifyingGlassIcon
             className="absolute left-3 top-1/2 -translate-y-1/2 text-faint w-4 h-4 md:w-3.5 md:h-3.5"
@@ -609,6 +763,76 @@ export default function PlaylistDetailPage() {
             }}
           />
         </div>
+
+        {/* Filter button */}
+        <button
+          type="button"
+          onClick={() => setFilterPopoverOpen(true)}
+          className={`px-2 py-1.5 rounded-md text-sm transition-colors cursor-pointer ${
+            filterTags.length > 0 || filterSources.length > 0
+              ? 'bg-accent text-elevated'
+              : 'text-muted hover:text-fg'
+          }`}
+          title="Add filter"
+        >
+          <FunnelIcon size={16} weight="duotone" />
+        </button>
+
+        {/* Sort dropdown */}
+        <div className="relative" ref={sortRefEl}>
+          <Button
+            variant="inherit"
+            surface="surface"
+            onClick={() => setSortOpen((v) => !v)}
+            className={`flex items-center gap-1.5 px-2.5 ${
+              sortOpen || sort !== 'position' || order !== 'desc' ? 'pressed text-accent' : ''
+            }`}
+            title={`Sort by ${SORT_OPTIONS.find((o) => o.value === sort)?.label ?? 'Playlist Order'} (${order === 'asc' ? 'ascending' : 'descending'})`}
+          >
+            <SortAscendingIcon size={16} weight="duotone" />
+            <CaretDownIcon size={10} weight="fill" className="text-faint" />
+          </Button>
+
+          {sortOpen && (
+            <div className="absolute right-0 top-full mt-1.5 w-48 bg-elevated border border-border rounded-lg shadow-lg z-20 py-1 animate-fade-up origin-top-right">
+              {SORT_OPTIONS.map((opt) => {
+                const isActive = sort === opt.value;
+                return (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    className={`w-full flex items-center justify-between px-3 py-2 text-sm font-body transition-colors ${
+                      isActive
+                        ? 'text-accent bg-accent/5'
+                        : 'text-fg hover:bg-surface active:bg-surface/80'
+                    }`}
+                    onClick={() => handleSortChange(opt.value)}
+                  >
+                    <span>{opt.label}</span>
+                    {isActive && (
+                      <button
+                        type="button"
+                        className="cursor-pointer p-0.5 rounded hover:bg-black/10 dark:hover:bg-white/10 transition-colors"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleOrderToggle();
+                        }}
+                        title={order === 'asc' ? 'Switch to descending' : 'Switch to ascending'}
+                      >
+                        {order === 'asc' ? (
+                          <ArrowUpIcon size={14} weight="bold" />
+                        ) : (
+                          <ArrowDownIcon size={14} weight="bold" />
+                        )}
+                      </button>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
         {/* View toggle */}
         <div className="flex gap-1 bg-elevated rounded-lg p-1 shrink-0">
           <button
@@ -639,6 +863,18 @@ export default function PlaylistDetailPage() {
           </button>
         </div>
       </div>
+
+      {/* Active filter chips */}
+      {(filterTags.length > 0 || filterSources.length > 0) && (
+        <div className="mb-2">
+          <FilterChips
+            tags={filterTags}
+            sources={filterSources}
+            onRemoveTag={handleRemoveTag}
+            onRemoveSource={handleRemoveSource}
+          />
+        </div>
+      )}
 
       {/* Song list */}
       {songItems.length === 0 && !isLoading ? (
@@ -740,6 +976,19 @@ export default function PlaylistDetailPage() {
           confirmLabel="Convert"
           onConfirm={() => handleMakeSmart(tagSmartConfirm)}
           onCancel={() => setTagSmartConfirm(null)}
+        />
+      )}
+
+      {/* Add Filter popover */}
+      {filterPopoverOpen && (
+        <AddFilterPopover
+          activeTags={filterTags}
+          activeSources={filterSources}
+          onAddTag={handleAddTag}
+          onRemoveTag={handleRemoveTag}
+          onAddSource={handleAddSource}
+          onRemoveSource={handleRemoveSource}
+          onClose={() => setFilterPopoverOpen(false)}
         />
       )}
     </div>

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -1,15 +1,24 @@
 import type { Playlist, Song } from '@alfira-bot/server/shared';
+import type { FetchSongsOptions } from '@alfira-bot/server/shared/api';
 import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  CaretDownIcon,
+  FunnelIcon,
   ListIcon,
   MagnifyingGlassIcon,
   QuestionIcon,
+  SortAscendingIcon,
   SquaresFourIcon,
 } from '@phosphor-icons/react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { deleteSong, getPlaylistsPage, getSongsPage, startPlayback } from '../api/api';
+import AddFilterPopover from '../components/AddFilterPopover';
 import ConfirmModal from '../components/ConfirmModal';
+import FilterChips from '../components/FilterChips';
 import NotificationToast from '../components/NotificationToast';
-
+import { Button } from '../components/ui/Button';
 import { VirtualSongList } from '../components/VirtualSongList';
 import { useAdminView } from '../context/AdminViewContext';
 import { usePlayerState } from '../context/PlayerContext';
@@ -21,10 +30,19 @@ import { apiErrorMessage } from '../utils/api';
 
 const ITEMS_PER_PAGE = 24;
 
+type SortField = 'createdAt' | 'title' | 'artist' | 'album' | 'duration';
+
+const SORT_OPTIONS: { value: SortField; label: string }[] = [
+  { value: 'createdAt', label: 'Date Added' },
+  { value: 'title', label: 'Title' },
+  { value: 'artist', label: 'Artist' },
+  { value: 'album', label: 'Album' },
+  { value: 'duration', label: 'Duration' },
+];
+
 export default function SongsPage() {
   const { isAdminView } = useAdminView();
   const { state: queueState } = usePlayerState();
-  const [search, setSearch] = useState('');
   const [viewMode, setViewMode] = useState<'grid' | 'list'>(() => {
     const saved = localStorage.getItem('alfira-library-view');
     return saved === 'grid' ? 'grid' : 'list';
@@ -35,7 +53,157 @@ export default function SongsPage() {
   const { notify } = useNotification();
   const handleSetDeleteId = useCallback((id: string | null) => setDeleteId(id), []);
 
-  // Lazy playlists fetch
+  // Sort dropdown state
+  const [sortOpen, setSortOpen] = useState(false);
+  const sortRef = useRef<HTMLDivElement>(null);
+
+  // Add filter popover state
+  const [filterPopoverOpen, setFilterPopoverOpen] = useState(false);
+
+  // ── URL params ──────────────────────────────────────────────────────
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const search = searchParams.get('search') ?? '';
+  const sort = (searchParams.get('sort') as SortField | null) ?? 'createdAt';
+  const order = searchParams.get('order') ?? 'desc';
+  const filterTags = useMemo(
+    () =>
+      searchParams
+        .get('tags')
+        ?.split(',')
+        .map((t) => t.trim())
+        .filter(Boolean) ?? [],
+    [searchParams]
+  );
+  const filterSources = useMemo(
+    () =>
+      searchParams
+        .get('source')
+        ?.split(',')
+        .map((s) => s.trim().toLowerCase())
+        .filter(Boolean) ?? [],
+    [searchParams]
+  );
+
+  // Local search input mirrors URL param
+  const [searchInput, setSearchInput] = useState(search);
+
+  // Sync search input ← URL (e.g. on browser back/forward)
+  useEffect(() => {
+    setSearchInput(search);
+  }, [search]);
+
+  const updateParam = useCallback(
+    (key: string, value: string | null) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (value) {
+            next.set(key, value);
+          } else {
+            next.delete(key);
+          }
+          return next;
+        },
+        { replace: true }
+      );
+    },
+    [setSearchParams]
+  );
+
+  // Debounced search → URL
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      setSearchInput(value);
+      if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
+      searchTimerRef.current = setTimeout(() => {
+        updateParam('search', value || null);
+      }, 250);
+    },
+    [updateParam]
+  );
+
+  // ── Sort handlers ───────────────────────────────────────────────────
+  const handleOrderToggle = useCallback(() => {
+    updateParam('order', order === 'asc' ? null : 'asc');
+  }, [order, updateParam]);
+
+  const handleSortChange = useCallback(
+    (newSort: SortField) => {
+      if (newSort === sort) {
+        handleOrderToggle();
+      } else {
+        updateParam('sort', newSort === 'createdAt' ? null : newSort);
+      }
+      setSortOpen(false);
+    },
+    [sort, updateParam, handleOrderToggle]
+  );
+
+  // Close sort dropdown on outside click
+  useEffect(() => {
+    if (!sortOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (sortRef.current && !sortRef.current.contains(e.target as Node)) {
+        setSortOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [sortOpen]);
+
+  // ── Filter handlers ─────────────────────────────────────────────────
+  const handleRemoveTag = useCallback(
+    (tag: string) => {
+      const next = filterTags.filter((t) => t !== tag);
+      updateParam('tags', next.length > 0 ? next.join(',') : null);
+    },
+    [filterTags, updateParam]
+  );
+
+  const handleRemoveSource = useCallback(
+    (source: string) => {
+      const next = filterSources.filter((s) => s !== source);
+      updateParam('source', next.length > 0 ? next.join(',') : null);
+    },
+    [filterSources, updateParam]
+  );
+
+  const handleAddTag = useCallback(
+    (tag: string) => {
+      // Normalize to lowercase for consistency
+      const normalized = tag.toLowerCase();
+      if (filterTags.includes(normalized)) return;
+      const next = [...filterTags, normalized];
+      updateParam('tags', next.join(','));
+    },
+    [filterTags, updateParam]
+  );
+
+  const handleAddSource = useCallback(
+    (source: string) => {
+      if (filterSources.includes(source)) return;
+      const next = [...filterSources, source];
+      updateParam('source', next.join(','));
+    },
+    [filterSources, updateParam]
+  );
+
+  // ── Build stable fetch options for the infinite scroll hook ─────────
+  const songsOpts = useMemo<FetchSongsOptions>(() => {
+    const opts: FetchSongsOptions = {};
+    if (search) opts.search = search;
+    if (sort !== 'createdAt') opts.sort = sort;
+    if (order !== 'desc') opts.order = order;
+    const tagsParam = filterTags.join(',');
+    const sourceParam = filterSources.join(',');
+    if (tagsParam) opts.tags = tagsParam;
+    if (sourceParam) opts.source = sourceParam;
+    return opts;
+  }, [search, sort, order, filterTags, filterSources]);
+
+  // ── Lazy playlists fetch ────────────────────────────────────────────
   const [playlists, setPlaylists] = useState<Playlist[]>([]);
   useEffect(() => {
     void getPlaylistsPage(isAdminView, 1, 100)
@@ -45,7 +213,7 @@ export default function SongsPage() {
       });
   }, [isAdminView]);
 
-  // Infinite scroll hook
+  // ── Infinite scroll ─────────────────────────────────────────────────
   const {
     items,
     isLoading,
@@ -58,9 +226,9 @@ export default function SongsPage() {
     removeItem,
     retry,
     sentinelRef,
-  } = useVirtualizedInfiniteScroll<Song, [string]>({
-    fetchPage: async (page, limit, searchQuery) => {
-      const result = await getSongsPage(page, limit, searchQuery);
+  } = useVirtualizedInfiniteScroll<Song, [FetchSongsOptions]>({
+    fetchPage: async (page, limit, opts) => {
+      const result = await getSongsPage(page, limit, opts);
       return {
         items: result.items,
         hasMore: result.pagination.page < result.pagination.totalPages,
@@ -68,12 +236,10 @@ export default function SongsPage() {
       };
     },
     limit: ITEMS_PER_PAGE,
-    deps: [search],
+    deps: [songsOpts],
   });
 
-  // ---------------------------------------------------------------------------
-  // Real-time socket wiring
-  // ---------------------------------------------------------------------------
+  // ── Real-time socket wiring ─────────────────────────────────────────
   useEffect(() => {
     const handleSongAdded = (song: Song) => {
       prepend(song);
@@ -104,9 +270,7 @@ export default function SongsPage() {
     // Socket event will update the songs list
   };
 
-  // ---------------------------------------------------------------------------
-  // Play from song
-  // ---------------------------------------------------------------------------
+  // ── Play from song ──────────────────────────────────────────────────
   const handlePlayFromSong = useCallback(
     async (songId: string) => {
       setPlayingId(songId);
@@ -152,8 +316,8 @@ export default function SongsPage() {
         </span>
       </div>
 
-      {/* Search and view toggle */}
-      <div className="flex items-center gap-2 mb-4 md:mb-6">
+      {/* Search bar + Sort + View toggle */}
+      <div className="flex items-center gap-2 mb-3">
         <div className="relative flex-1">
           <MagnifyingGlassIcon
             className="absolute left-3 top-1/2 -translate-y-1/2 text-faint w-4 h-4 md:w-3.5 md:h-3.5"
@@ -162,12 +326,80 @@ export default function SongsPage() {
           <input
             className="input pl-10"
             placeholder="Search by title, nickname, artist, album, or tag..."
-            value={search}
-            onChange={(e) => {
-              setSearch(e.target.value);
-            }}
+            value={searchInput}
+            onChange={(e) => handleSearchChange(e.target.value)}
           />
         </div>
+
+        {/* Add filter button */}
+        <button
+          type="button"
+          onClick={() => setFilterPopoverOpen(true)}
+          className={`px-2 py-1.5 rounded-md text-sm transition-colors cursor-pointer ${
+            filterTags.length > 0 || filterSources.length > 0
+              ? 'bg-accent text-elevated'
+              : 'text-muted hover:text-fg'
+          }`}
+          title="Add filter"
+        >
+          <FunnelIcon size={16} weight="duotone" />
+        </button>
+
+        {/* Sort dropdown */}
+        <div className="relative" ref={sortRef}>
+          <Button
+            variant="inherit"
+            surface="surface"
+            onClick={() => setSortOpen((v) => !v)}
+            className={`flex items-center gap-1.5 px-2.5 ${
+              sortOpen || sort !== 'createdAt' || order !== 'desc' ? 'pressed text-accent' : ''
+            }`}
+            title={`Sort by ${SORT_OPTIONS.find((o) => o.value === sort)?.label ?? 'Date Added'} (${order === 'asc' ? 'ascending' : 'descending'})`}
+          >
+            <SortAscendingIcon size={16} weight="duotone" />
+            <CaretDownIcon size={10} weight="fill" className="text-faint" />
+          </Button>
+
+          {sortOpen && (
+            <div className="absolute right-0 top-full mt-1.5 w-48 bg-elevated border border-border rounded-lg shadow-lg z-20 py-1 animate-fade-up origin-top-right">
+              {SORT_OPTIONS.map((opt) => {
+                const isActive = sort === opt.value;
+                return (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    className={`w-full flex items-center justify-between px-3 py-2 text-sm font-body transition-colors ${
+                      isActive
+                        ? 'text-accent bg-accent/5'
+                        : 'text-fg hover:bg-surface active:bg-surface/80'
+                    }`}
+                    onClick={() => handleSortChange(opt.value)}
+                  >
+                    <span>{opt.label}</span>
+                    {isActive && (
+                      <button
+                        type="button"
+                        className="cursor-pointer p-0.5 rounded hover:bg-black/10 dark:hover:bg-white/10 transition-colors"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleOrderToggle();
+                        }}
+                        title={order === 'asc' ? 'Switch to descending' : 'Switch to ascending'}
+                      >
+                        {order === 'asc' ? (
+                          <ArrowUpIcon size={14} weight="bold" />
+                        ) : (
+                          <ArrowDownIcon size={14} weight="bold" />
+                        )}
+                      </button>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
         {/* View toggle */}
         <div className="flex gap-1 bg-elevated rounded-lg p-1">
           <button
@@ -199,6 +431,18 @@ export default function SongsPage() {
         </div>
       </div>
 
+      {/* Active filter chips — only shown when filters are active */}
+      {(filterTags.length > 0 || filterSources.length > 0) && (
+        <div className="mb-2">
+          <FilterChips
+            tags={filterTags}
+            sources={filterSources}
+            onRemoveTag={handleRemoveTag}
+            onRemoveSource={handleRemoveSource}
+          />
+        </div>
+      )}
+
       {/* Content */}
       <VirtualSongList
         items={items}
@@ -217,8 +461,20 @@ export default function SongsPage() {
         onAddToQueue={handleAddToQueue}
       />
 
-      {/* Modals */}
+      {/* ── Add Filter popover ────────────────────────────────── */}
+      {filterPopoverOpen && (
+        <AddFilterPopover
+          activeTags={filterTags}
+          activeSources={filterSources}
+          onAddTag={handleAddTag}
+          onRemoveTag={handleRemoveTag}
+          onAddSource={handleAddSource}
+          onRemoveSource={handleRemoveSource}
+          onClose={() => setFilterPopoverOpen(false)}
+        />
+      )}
 
+      {/* Modals */}
       {deleteId && (
         <DeleteConfirmDialog
           song={items.find((s) => s.id === deleteId)}


### PR DESCRIPTION
## Summary

Add sort and filter controls to both the Songs page and Playlist Detail page. Users can now sort by Date Added, Title, Artist, Album, or Duration (asc/desc), and filter by tags (AND logic) and source platform.

## Changes

- **Sort dropdown** on Songs and Playlist Detail pages — select field + toggle asc/desc; clicking active field reverses direction
- **Filter chips** — add/remove tag and source filters via a popover panel; active filters shown as removable chips below search bar
- **Server API** — `GET /api/songs` and `GET /api/playlists/:id` support `sort`, `order`, `tags`, `source` query params
- **URL persistence** — Songs page sort/filter/search state lives in URL query params
- **New components** — `FilterChips` (removable chip bar) and `AddFilterPopover` (toggle panel for tag/source selection)
- **TagsContext** — now exposes full tag list alongside color map
- **Play/pause icon fix** — corrected icon mapping: playing shows Pause, paused shows Play