### PR TITLE
fix(web): reduce more-actions icon size to match adjacent buttons

### DIFF
--- a/packages/web/src/components/ContextMenu.tsx
+++ b/packages/web/src/components/ContextMenu.tsx
@@ -91,7 +91,7 @@ export function ContextMenuTrigger({
       }}
       className={`${className ?? ''} ${isOpen ? 'pressed text-accent' : ''}`}
     >
-      <DotsThreeOutlineVerticalIcon size={22} weight="duotone" />
+      <DotsThreeOutlineVerticalIcon size={18} weight="duotone" />
     </Button>
   );
 }


### PR DESCRIPTION
## Summary

The `ContextMenuTrigger` dots icon was 22px — noticeably larger than the shuffle button (18px) and play button (14px) next to it on the playlist detail page.

## Changes

- `packages/web/src/components/ContextMenu.tsx`: reduced `DotsThreeOutlineVerticalIcon` from `size={22}` to `size={18}` to match surrounding button icon sizes