### PR TITLE
feat(web): smooth tag ticker return and tags page carousel

### DIFF
--- a/packages/web/src/components/TagTicker.tsx
+++ b/packages/web/src/components/TagTicker.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTagColors } from '../context/TagsContext';
 import { getTagColorClasses } from '../utils/tagColors';
 
@@ -13,6 +13,8 @@ const TagTicker = memo(({ tags, isHovered: externalHovered }: TagTickerProps) =>
   const [shouldScroll, setShouldScroll] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
   const [duration, setDuration] = useState(15);
+  const prevHoveredRef = useRef(false);
+  const durationRef = useRef(15);
   const { tagColorMap } = useTagColors();
 
   const dedupedTags = useMemo(() => [...new Set(tags)], [tags]);
@@ -25,7 +27,9 @@ const TagTicker = memo(({ tags, isHovered: externalHovered }: TagTickerProps) =>
 
       if (overflow) {
         const contentWidth = innerRef.current.scrollWidth;
-        setDuration(Math.max(10, contentWidth * 0.02));
+        const d = Math.max(10, contentWidth * 0.02);
+        setDuration(d);
+        durationRef.current = d;
       }
     }
   }, [tags]);
@@ -48,19 +52,64 @@ const TagTicker = memo(({ tags, isHovered: externalHovered }: TagTickerProps) =>
     [dedupedTags, tagColorMap]
   );
 
-  if (dedupedTags.length === 0) return null;
-
   const effectiveHovered = externalHovered ?? isHovered;
 
-  const animationStyle: React.CSSProperties =
-    shouldScroll && effectiveHovered
-      ? {
-          width: 'max-content',
-          animation: `ticker-scroll ${duration}s linear infinite`,
-        }
-      : shouldScroll
-        ? { width: 'max-content' }
-        : {};
+  // Smooth return on de-hover: pause animation at current position, then transition back to 0
+  useLayoutEffect(() => {
+    if (!shouldScroll) return;
+
+    const prev = prevHoveredRef.current;
+    prevHoveredRef.current = effectiveHovered;
+
+    if (prev && !effectiveHovered) {
+      // De-hovered: capture paused position and transition back to start
+      const el = innerRef.current;
+      if (!el) return;
+
+      const computed = getComputedStyle(el);
+      const matrix = new DOMMatrixReadOnly(computed.transform);
+      const x = matrix.m41;
+
+      // Replace animation with static transform at captured position
+      el.style.animation = 'none';
+      el.style.transform = `translateX(${x}px)`;
+      el.offsetHeight; // force layout
+
+      // Transition back to 0
+      el.style.transition = 'transform 0.5s ease-out';
+      el.style.transform = 'translateX(0)';
+
+      const onEnd = () => {
+        el.style.transition = '';
+        el.style.transform = '';
+        el.style.animation = '';
+        el.removeEventListener('transitionend', onEnd);
+      };
+      el.addEventListener('transitionend', onEnd);
+
+      return () => el.removeEventListener('transitionend', onEnd);
+    }
+
+    if (!prev && effectiveHovered) {
+      // Re-hovered: cancel any in-progress return and restart animation
+      const el = innerRef.current;
+      if (el) {
+        el.style.transition = '';
+        el.style.transform = '';
+        el.style.animation = `ticker-scroll ${durationRef.current}s linear infinite`;
+      }
+    }
+  }, [effectiveHovered, shouldScroll]);
+
+  if (dedupedTags.length === 0) return null;
+
+  const animationStyle: React.CSSProperties = shouldScroll
+    ? {
+        width: 'max-content',
+        animation: `ticker-scroll ${duration}s linear infinite`,
+        animationPlayState: effectiveHovered ? 'running' : 'paused',
+      }
+    : {};
 
   return (
     <div

--- a/packages/web/src/pages/TagsPage.tsx
+++ b/packages/web/src/pages/TagsPage.tsx
@@ -3,6 +3,7 @@ import type { Song } from '@alfira-bot/server/shared/types';
 import { MagnifyingGlassIcon, TrashIcon } from '@phosphor-icons/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import ConfirmModal from '../components/ConfirmModal';
+import TagTicker from '../components/TagTicker';
 import { Button } from '../components/ui/Button';
 import { useTagColors } from '../context/TagsContext';
 
@@ -329,26 +330,7 @@ export default function TagsPage() {
                                 </span>
                               )}
                             </div>
-                            {allTags.length > 0 && (
-                              <div className="flex items-center gap-1 mt-0.5 flex-wrap">
-                                {allTags.slice(0, 3).map((tag) => {
-                                  const c = getTagColor(tag);
-                                  return (
-                                    <span
-                                      key={tag}
-                                      className={`inline-flex items-center px-1 py-px rounded text-[10px] font-mono ${c.bg} ${c.text}`}
-                                    >
-                                      {tag}
-                                    </span>
-                                  );
-                                })}
-                                {allTags.length > 3 && (
-                                  <span className="text-[10px] text-faint font-mono">
-                                    +{allTags.length - 3}
-                                  </span>
-                                )}
-                              </div>
-                            )}
+                            {allTags.length > 0 && <TagTicker tags={allTags} />}
                           </div>
                           <Button
                             variant="inherit"


### PR DESCRIPTION
## Summary

Replaces manual tag truncation on the Tags page with the existing TagTicker carousel component, and adds a smooth CSS transition when de-hovering the ticker so it animates back to its starting position instead of snapping.

## Changes

- **TagsPage**: use `<TagTicker>` instead of `slice(0,3)` + `+N` truncation for song tag lists
- **TagTicker**: on de-hover, pause the ticker animation at its current position and transition `translateX` back to 0 over 0.5s with ease-out. Re-hovering during the return cancels the transition and restarts scrolling.