### PR TITLE
fix(web): prevent multiple context menus from opening simultaneously

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -8,6 +8,7 @@ import { NotificationProvider } from './context/NotificationContext';
 import { PermissionsProvider } from './context/PermissionsContext';
 import { PlayerProvider } from './context/PlayerContext';
 import { SongEditProvider } from './context/SongEditContext';
+import { SongMenuProvider } from './context/SongMenuContext';
 import { TagsProvider } from './context/TagsContext';
 import { ThemeProvider } from './context/ThemeContext';
 import AudioPage from './pages/AudioPage';
@@ -29,39 +30,41 @@ export default function App() {
             <PermissionsProvider>
               <NotificationProvider>
                 <SongEditProvider>
-                  <Routes>
-                    <Route path="/login" element={<LoginPage />} />
-                    <Route
-                      path="/setup"
-                      element={
-                        <ProtectedRoute>
-                          <SetupWizard />
-                        </ProtectedRoute>
-                      }
-                    />
-                    <Route
-                      path="/"
-                      element={
-                        <ProtectedRoute>
-                          {/* PlayerProvider lives inside ProtectedRoute so it only polls while a user is authenticated. */}
-                          <PlayerProvider>
-                            <Layout />
-                          </PlayerProvider>
-                        </ProtectedRoute>
-                      }
-                    >
-                      <Route index element={<Navigate to="/songs" replace />} />
-                      <Route path="songs" element={<SongsPage />} />
-                      <Route path="playlists" element={<PlaylistsPage />} />
-                      <Route path="playlists/:id" element={<PlaylistDetailPage />} />
-                      <Route path="settings" element={<SettingsPage />} />
-                      <Route path="audio" element={<AudioPage />} />
-                      <Route path="tags" element={<TagsPage />} />
-                      <Route path="permissions" element={<PermissionsPage />} />
-                      <Route path="requests" element={<RequestsPage />} />
-                    </Route>
-                    <Route path="*" element={<Navigate to="/" replace />} />
-                  </Routes>
+                  <SongMenuProvider>
+                    <Routes>
+                      <Route path="/login" element={<LoginPage />} />
+                      <Route
+                        path="/setup"
+                        element={
+                          <ProtectedRoute>
+                            <SetupWizard />
+                          </ProtectedRoute>
+                        }
+                      />
+                      <Route
+                        path="/"
+                        element={
+                          <ProtectedRoute>
+                            {/* PlayerProvider lives inside ProtectedRoute so it only polls while a user is authenticated. */}
+                            <PlayerProvider>
+                              <Layout />
+                            </PlayerProvider>
+                          </ProtectedRoute>
+                        }
+                      >
+                        <Route index element={<Navigate to="/songs" replace />} />
+                        <Route path="songs" element={<SongsPage />} />
+                        <Route path="playlists" element={<PlaylistsPage />} />
+                        <Route path="playlists/:id" element={<PlaylistDetailPage />} />
+                        <Route path="settings" element={<SettingsPage />} />
+                        <Route path="audio" element={<AudioPage />} />
+                        <Route path="tags" element={<TagsPage />} />
+                        <Route path="permissions" element={<PermissionsPage />} />
+                        <Route path="requests" element={<RequestsPage />} />
+                      </Route>
+                      <Route path="*" element={<Navigate to="/" replace />} />
+                    </Routes>
+                  </SongMenuProvider>
                 </SongEditProvider>
               </NotificationProvider>
             </PermissionsProvider>

--- a/packages/web/src/components/ContextMenu.tsx
+++ b/packages/web/src/components/ContextMenu.tsx
@@ -271,7 +271,7 @@ export function ContextMenu({
       onKeyDown={activeEditItemId ? undefined : handleKeyDown}
       onClick={(e) => e.stopPropagation()}
     >
-      <div className="bg-base rounded-2xl clay-floating overflow-hidden animate-fade-up">
+      <div className="bg-base rounded-2xl clay-floating overflow-hidden animate-fade-up border border-accent/30 outline-2 outline-accent/20">
         {activeSubmenu ? (
           <SubmenuPanel
             config={activeSubmenu}

--- a/packages/web/src/components/UserMenu.tsx
+++ b/packages/web/src/components/UserMenu.tsx
@@ -144,7 +144,7 @@ export default function UserMenu({ user, collapsed, onLogout }: UserMenuProps) {
             onKeyDown={(e) => e.stopPropagation()}
             onClick={(e) => e.stopPropagation()}
           >
-            <div className="bg-base rounded-2xl clay-floating overflow-hidden animate-fade-up">
+            <div className="bg-base rounded-2xl clay-floating overflow-hidden animate-fade-up border border-accent/30 outline-2 outline-accent/20">
               {/* Username header — mirrors ContextMenu InfoRow */}
               <div className="px-3 py-1.5 text-xs font-mono text-muted flex items-center gap-2">
                 <UserIcon size={14} weight="duotone" className="shrink-0" />

--- a/packages/web/src/context/SongMenuContext.tsx
+++ b/packages/web/src/context/SongMenuContext.tsx
@@ -1,0 +1,27 @@
+import { createContext, type ReactNode, useCallback, useContext, useState } from 'react';
+
+const SongMenuContext = createContext<{
+  activeMenuSongId: string | null;
+  setActiveMenuSongId: (id: string | null) => void;
+}>({
+  activeMenuSongId: null,
+  setActiveMenuSongId: () => {
+    /* noop */
+  },
+});
+
+export function SongMenuProvider({ children }: { children: ReactNode }) {
+  const [activeMenuSongId, setActiveMenuSongIdState] = useState<string | null>(null);
+
+  const setActiveMenuSongId = useCallback((id: string | null) => {
+    setActiveMenuSongIdState(id);
+  }, []);
+
+  return (
+    <SongMenuContext value={{ activeMenuSongId, setActiveMenuSongId }}>{children}</SongMenuContext>
+  );
+}
+
+export function useSongMenu() {
+  return useContext(SongMenuContext);
+}

--- a/packages/web/src/hooks/useSongActions.tsx
+++ b/packages/web/src/hooks/useSongActions.tsx
@@ -9,6 +9,7 @@ import {
 import { useCallback, useMemo, useOptimistic, useRef, useState } from 'react';
 import { addSongToPlaylist } from '../api/api';
 import type { MenuItem } from '../components/ContextMenu';
+import { useSongMenu } from '../context/SongMenuContext';
 import { useNotification } from './useNotification';
 
 interface UseSongActionsOptions {
@@ -32,7 +33,15 @@ export function useSongActions({
   onRemove,
   removeLabel,
 }: UseSongActionsOptions) {
-  const [menuOpen, setMenuOpen] = useState(false);
+  const { activeMenuSongId, setActiveMenuSongId } = useSongMenu();
+  const menuOpen = activeMenuSongId === song.id;
+  const setMenuOpen = useCallback(
+    (open: boolean | ((prev: boolean) => boolean)) => {
+      const next = typeof open === 'function' ? open(menuOpen) : open;
+      setActiveMenuSongId(next ? song.id : null);
+    },
+    [menuOpen, song.id, setActiveMenuSongId]
+  );
   const [addedTo, setAddedTo] = useState<Set<string>>(new Set());
   const triggerRef = useRef<HTMLButtonElement>(null);
 

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -486,7 +486,7 @@
         inset 0 2px 3px 0 rgba(0, 0, 0, 0.15),
         inset 0 1px 1px 0 rgba(255, 255, 255, 0.04);
     --clay-shadow-floating:
-        0 7px 0 0 color-mix(in srgb, var(--color-surface) 60%, black),
+        0 2px 0 0 color-mix(in srgb, var(--color-surface) 60%, black),
         inset 0 2px 3px 0 rgba(0, 0, 0, 0.15),
         inset 0 1px 1px 0 rgba(255, 255, 255, 0.04);
     --clay-shadow-flat:
@@ -515,7 +515,7 @@
         0 5px 12px -2px rgba(0, 0, 0, 0.16),
         0 -6px 14px -4px rgba(0, 0, 0, 0.18);
     --clay-shadow-floating:
-        0 7px 0 0 color-mix(in srgb, var(--color-surface) 60%, black),
+        0 2px 0 0 color-mix(in srgb, var(--color-surface) 60%, black),
         0 8px 16px -4px rgba(0, 0, 0, 0.2),
         0 -9px 18px -6px rgba(0, 0, 0, 0.20);
     --clay-shadow-sidebar: 4px 0 16px -4px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
## Summary

Fixes a bug where clicking the context menu trigger on a second song would leave the first menu open, resulting in two overlapping context menus. Also applies UI polish to context menu surfaces.

## Changes

- **New `SongMenuContext`** — tracks which song's context menu is currently active, ensuring only one can be open at a time (follows the `SongEditContext` pattern)
- **`useSongActions`** — `menuOpen` is now derived from the shared context instead of local state
- **CSS** — lightened `clay-floating` drop shadow from 7px to 2px offset in both color modes
- **ContextMenu / UserMenu** — added accent-colored border and outline rings matching the search input focus style