### PR TITLE
fix(web): fix filter button styling, stale ref, and sort direction

### DIFF
--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -261,7 +261,9 @@ export default function PlaylistDetailPage() {
   );
 
   const handleOrderToggle = useCallback(() => {
-    setOrder((o) => (o === 'asc' ? 'desc' : 'asc'));
+    const next = orderRef.current === 'asc' ? 'desc' : 'asc';
+    orderRef.current = next;
+    setOrder(next);
     setCurrentPage(1);
     setSongs([]);
     setIsError(false);
@@ -270,10 +272,20 @@ export default function PlaylistDetailPage() {
 
   const handleSortChange = useCallback(
     (newSort: string) => {
-      if (newSort === sort) {
+      if (newSort === sortRef.current) {
         handleOrderToggle();
       } else {
+        // When switching to a text field, default to ascending (A-Z)
+        const newOrder =
+          newSort === 'createdAt' || newSort === 'position' || newSort === 'duration'
+            ? 'desc'
+            : 'asc';
+        sortRef.current = newSort;
         setSort(newSort);
+        if (newOrder !== orderRef.current) {
+          orderRef.current = newOrder;
+          setOrder(newOrder);
+        }
         setSortOpen(false);
         setCurrentPage(1);
         setSongs([]);
@@ -281,12 +293,14 @@ export default function PlaylistDetailPage() {
         void loadPage(1, false, false, searchRef.current);
       }
     },
-    [sort, loadPage, handleOrderToggle]
+    [loadPage, handleOrderToggle]
   );
 
   const handleRemoveTag = useCallback(
     (tag: string) => {
-      setFilterTags((prev) => prev.filter((t) => t !== tag));
+      const next = filterTagsRef.current.filter((t) => t !== tag);
+      filterTagsRef.current = next;
+      setFilterTags(next);
       setCurrentPage(1);
       setSongs([]);
       setIsError(false);
@@ -297,7 +311,9 @@ export default function PlaylistDetailPage() {
 
   const handleRemoveSource = useCallback(
     (source: string) => {
-      setFilterSources((prev) => prev.filter((s) => s !== source));
+      const next = filterSourcesRef.current.filter((s) => s !== source);
+      filterSourcesRef.current = next;
+      setFilterSources(next);
       setCurrentPage(1);
       setSongs([]);
       setIsError(false);
@@ -309,7 +325,11 @@ export default function PlaylistDetailPage() {
   const handleAddTag = useCallback(
     (tag: string) => {
       const normalized = tag.toLowerCase();
-      setFilterTags((prev) => (prev.includes(normalized) ? prev : [...prev, normalized]));
+      const next = filterTagsRef.current.includes(normalized)
+        ? filterTagsRef.current
+        : [...filterTagsRef.current, normalized];
+      filterTagsRef.current = next;
+      setFilterTags(next);
       setCurrentPage(1);
       setSongs([]);
       setIsError(false);
@@ -320,7 +340,11 @@ export default function PlaylistDetailPage() {
 
   const handleAddSource = useCallback(
     (source: string) => {
-      setFilterSources((prev) => (prev.includes(source) ? prev : [...prev, source]));
+      const next = filterSourcesRef.current.includes(source)
+        ? filterSourcesRef.current
+        : [...filterSourcesRef.current, source];
+      filterSourcesRef.current = next;
+      setFilterSources(next);
       setCurrentPage(1);
       setSongs([]);
       setIsError(false);
@@ -764,19 +788,18 @@ export default function PlaylistDetailPage() {
           />
         </div>
 
-        {/* Filter button */}
-        <button
-          type="button"
+        {/* Add filter button */}
+        <Button
+          variant="inherit"
+          surface="surface"
           onClick={() => setFilterPopoverOpen(true)}
-          className={`px-2 py-1.5 rounded-md text-sm transition-colors cursor-pointer ${
-            filterTags.length > 0 || filterSources.length > 0
-              ? 'bg-accent text-elevated'
-              : 'text-muted hover:text-fg'
+          className={`flex items-center gap-1.5 px-2.5 ${
+            filterTags.length > 0 || filterSources.length > 0 ? 'pressed text-accent' : ''
           }`}
-          title="Add filter"
+          title={`Filter${filterTags.length > 0 || filterSources.length > 0 ? ` (${filterTags.length + filterSources.length} active)` : ''}`}
         >
           <FunnelIcon size={16} weight="duotone" />
-        </button>
+        </Button>
 
         {/* Sort dropdown */}
         <div className="relative" ref={sortRefEl}>
@@ -819,11 +842,16 @@ export default function PlaylistDetailPage() {
                         }}
                         title={order === 'asc' ? 'Switch to descending' : 'Switch to ascending'}
                       >
-                        {order === 'asc' ? (
-                          <ArrowUpIcon size={14} weight="bold" />
-                        ) : (
-                          <ArrowDownIcon size={14} weight="bold" />
-                        )}
+                        {(() => {
+                          const isTextField =
+                            sort === 'title' || sort === 'artist' || sort === 'album';
+                          const showDown = isTextField ? order === 'asc' : order !== 'asc';
+                          return showDown ? (
+                            <ArrowDownIcon size={14} weight="bold" />
+                          ) : (
+                            <ArrowUpIcon size={14} weight="bold" />
+                          );
+                        })()}
                       </button>
                     )}
                   </button>

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -134,11 +134,31 @@ export default function SongsPage() {
       if (newSort === sort) {
         handleOrderToggle();
       } else {
-        updateParam('sort', newSort === 'createdAt' ? null : newSort);
+        // When switching to a text field, default to ascending (A-Z).
+        // Update both params atomically — React Router's setSearchParams
+        // sees the same URL for each callback, so two calls would race.
+        const newOrder = newSort === 'createdAt' || newSort === 'duration' ? 'desc' : 'asc';
+        setSearchParams(
+          (prev) => {
+            const next = new URLSearchParams(prev);
+            if (newSort === 'createdAt') {
+              next.delete('sort');
+            } else {
+              next.set('sort', newSort);
+            }
+            if (newOrder === 'asc') {
+              next.set('order', 'asc');
+            } else {
+              next.delete('order');
+            }
+            return next;
+          },
+          { replace: true }
+        );
       }
       setSortOpen(false);
     },
-    [sort, updateParam, handleOrderToggle]
+    [sort, setSearchParams, handleOrderToggle]
   );
 
   // Close sort dropdown on outside click
@@ -385,11 +405,16 @@ export default function SongsPage() {
                         }}
                         title={order === 'asc' ? 'Switch to descending' : 'Switch to ascending'}
                       >
-                        {order === 'asc' ? (
-                          <ArrowUpIcon size={14} weight="bold" />
-                        ) : (
-                          <ArrowDownIcon size={14} weight="bold" />
-                        )}
+                        {(() => {
+                          const isTextField =
+                            sort === 'title' || sort === 'artist' || sort === 'album';
+                          const showDown = isTextField ? order === 'asc' : order !== 'asc';
+                          return showDown ? (
+                            <ArrowDownIcon size={14} weight="bold" />
+                          ) : (
+                            <ArrowUpIcon size={14} weight="bold" />
+                          );
+                        })()}
                       </button>
                     )}
                   </button>


### PR DESCRIPTION
## Summary

Fixes several web UI issues on the Songs and Playlist Detail pages: filter button styling inconsistency, stale ref causing inverted/malfunctioning filters on playlists, sort param race condition, and confusing sort direction defaults/arrows.

## Changes

- **Filter button styling** — Playlist detail filter button now uses the `<Button>` component (`variant="inherit" surface="surface"`) matching the Songs page
- **Stale ref fix** — All sort/filter handlers on PlaylistDetailPage now read from refs directly and update refs synchronously before calling `loadPage()`, fixing filters always being one step behind
- **Sort param race fix** — `handleSortChange` now uses a single `setSearchParams` call to update both sort and order atomically, preventing React Router from overwriting one with the other
- **Smart sort defaults** — Switching to Title/Artist/Album defaults to ascending (A→Z); Date Added/Playlist Order/Duration default to descending (newest/longest first)
- **Field-aware sort arrows** — Text fields (Title, Artist, Album) use ↓ for A→Z and ↑ for Z→A; date/duration fields use the standard ↓ for descending and ↑ for ascending