### PR TITLE
feat(web): add playful empty states with random icons

### DIFF
--- a/packages/web/src/components/EmptyState.tsx
+++ b/packages/web/src/components/EmptyState.tsx
@@ -1,19 +1,82 @@
+import {
+  AlienIcon,
+  BombIcon,
+  CakeIcon,
+  CatIcon,
+  CookieIcon,
+  GhostIcon,
+  MoonIcon,
+  OnigiriIcon,
+  PizzaIcon,
+  PlanetIcon,
+  RocketLaunchIcon,
+  SkullIcon,
+  SmileyAngryIcon,
+  SockIcon,
+  SwordIcon,
+  ToiletPaperIcon,
+  YinYangIcon,
+} from '@phosphor-icons/react';
+import { useState } from 'react';
+
+const IdleIcons = [
+  AlienIcon,
+  BombIcon,
+  CakeIcon,
+  CatIcon,
+  CookieIcon,
+  GhostIcon,
+  MoonIcon,
+  OnigiriIcon,
+  PizzaIcon,
+  PlanetIcon,
+  RocketLaunchIcon,
+  SkullIcon,
+  SmileyAngryIcon,
+  SockIcon,
+  SwordIcon,
+  ToiletPaperIcon,
+  YinYangIcon,
+];
+
+let lastIndex = -1;
+export function getRandomIdleIcon() {
+  let idx: number;
+  do {
+    idx = Math.floor(Math.random() * IdleIcons.length);
+  } while (IdleIcons.length > 1 && idx === lastIndex);
+  lastIndex = idx;
+  return IdleIcons[idx] ?? IdleIcons[0];
+}
+
 export default function EmptyState({
   title,
   message,
   isAdmin,
   onAdd,
   addLabel,
+  compact = false,
 }: {
   title: string;
   message?: string;
-  isAdmin: boolean;
-  onAdd: () => void;
-  addLabel: string;
+  isAdmin?: boolean;
+  onAdd?: () => void;
+  addLabel?: string;
+  compact?: boolean;
 }) {
+  const [Icon] = useState(getRandomIdleIcon);
   return (
-    <div className="text-center py-24">
-      <p className="font-display text-4xl text-faint tracking-wider mb-2">{title}</p>
+    <div className={`text-center ${compact ? 'py-8' : 'py-24'}`}>
+      <div
+        className={`rounded-full bg-elevated border border-border flex items-center justify-center mx-auto ${compact ? 'w-10 h-10 mb-2' : 'w-12 h-12 mb-3'}`}
+      >
+        <Icon size={compact ? 16 : 20} weight="duotone" className="text-faint" />
+      </div>
+      <p
+        className={`font-display text-faint tracking-wider ${compact ? 'text-xl mb-1' : 'text-4xl mb-2'}`}
+      >
+        {title}
+      </p>
       {message ? (
         <p className="font-mono text-xs text-faint">{message}</p>
       ) : isAdmin ? (
@@ -23,9 +86,7 @@ export default function EmptyState({
           </button>{' '}
           to get started
         </p>
-      ) : (
-        <p className="font-mono text-xs text-faint">no songs have been added yet</p>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/packages/web/src/components/QueuePanel.tsx
+++ b/packages/web/src/components/QueuePanel.tsx
@@ -1,41 +1,25 @@
 import type { QueuedSong } from '@alfira-bot/server/shared';
 import { formatDuration } from '@alfira-bot/server/shared';
 import {
-  AlienIcon,
   ArrowDownIcon,
   ArrowLineDownIcon,
   ArrowLineUpIcon,
   ArrowUpIcon,
   BombIcon,
-  CakeIcon,
-  CatIcon,
   CircleNotchIcon,
-  CookieIcon,
   DotsThreeOutlineVerticalIcon,
-  GhostIcon,
   LightningIcon,
   ListIcon,
-  MoonIcon,
   MusicNoteIcon,
-  OnigiriIcon,
-  PizzaIcon,
-  PlanetIcon,
   PlayIcon,
   PlusCircleIcon,
   RepeatIcon,
   RepeatOnceIcon,
-  RocketLaunchIcon,
   ShuffleIcon,
   SkipForwardIcon,
-  SkullIcon,
-  SmileyAngryIcon,
-  SockIcon,
-  SwordIcon,
-  ToiletPaperIcon,
   TrashIcon,
   UserCircleIcon,
   UserIcon,
-  YinYangIcon,
 } from '@phosphor-icons/react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { memo, useCallback, useMemo, useRef, useState } from 'react';
@@ -49,6 +33,7 @@ import { useAdminView } from '../context/AdminViewContext';
 import { usePermissions } from '../context/PermissionsContext';
 import { usePlayer } from '../context/PlayerContext';
 import { getSourceKey } from '../utils/source';
+import { getRandomIdleIcon } from './EmptyState';
 import { Button } from './ui/Button';
 import { DurationBadge } from './ui/DurationBadge';
 import { VolumeBoostBadge } from './ui/VolumeBoostBadge';
@@ -844,36 +829,6 @@ const NowPlayingCard = memo(function NowPlayingCard({
     </div>
   );
 });
-
-const IdleIcons = [
-  AlienIcon,
-  BombIcon,
-  CakeIcon,
-  CatIcon,
-  CookieIcon,
-  GhostIcon,
-  MoonIcon,
-  OnigiriIcon,
-  PizzaIcon,
-  PlanetIcon,
-  RocketLaunchIcon,
-  SkullIcon,
-  SmileyAngryIcon,
-  SockIcon,
-  SwordIcon,
-  ToiletPaperIcon,
-  YinYangIcon,
-];
-
-let lastIndex = -1;
-function getRandomIdleIcon() {
-  let idx: number;
-  do {
-    idx = Math.floor(Math.random() * IdleIcons.length);
-  } while (IdleIcons.length > 1 && idx === lastIndex);
-  lastIndex = idx;
-  return IdleIcons[idx] ?? IdleIcons[0];
-}
 
 const IdleCard = memo(function IdleCard() {
   const [Icon] = useState(getRandomIdleIcon);

--- a/packages/web/src/components/VirtualPlaylistList.tsx
+++ b/packages/web/src/components/VirtualPlaylistList.tsx
@@ -1,5 +1,6 @@
 import type { Playlist } from '@alfira-bot/server/shared';
 import { memo } from 'react';
+import EmptyState from './EmptyState';
 import PlaylistRow from './PlaylistRow';
 import { VirtualListFooter } from './ui/VirtualListFooter';
 
@@ -11,6 +12,8 @@ interface VirtualPlaylistListProps {
   onRetry: () => void;
   sentinelRef: (el: HTMLDivElement | null) => void;
   onRowClick: (e: React.MouseEvent) => void;
+  emptyTitle: string;
+  emptyMessage?: string;
 }
 
 function SkeletonList() {
@@ -38,13 +41,15 @@ export const VirtualPlaylistList = memo(function VirtualPlaylistList({
   onRetry,
   sentinelRef,
   onRowClick,
+  emptyTitle,
+  emptyMessage,
 }: VirtualPlaylistListProps) {
   if (isLoading) {
     return <SkeletonList />;
   }
 
   if (items.length === 0) {
-    return null;
+    return <EmptyState title={emptyTitle} message={emptyMessage} />;
   }
 
   return (

--- a/packages/web/src/components/VirtualRequestList.tsx
+++ b/packages/web/src/components/VirtualRequestList.tsx
@@ -1,5 +1,6 @@
 import type { SongRequest } from '@alfira-bot/server/shared';
 import { memo } from 'react';
+import EmptyState from './EmptyState';
 import RequestCard from './RequestCard';
 import { VirtualListFooter } from './ui/VirtualListFooter';
 
@@ -15,6 +16,8 @@ export interface VirtualRequestListProps {
   onApprove: (id: string) => void;
   onDeny: (id: string) => void;
   onCancel: (id: string) => void;
+  emptyTitle: string;
+  emptyMessage?: string;
 }
 
 function SkeletonList() {
@@ -50,13 +53,15 @@ export const VirtualRequestList = memo(function VirtualRequestList({
   onApprove,
   onDeny,
   onCancel,
+  emptyTitle,
+  emptyMessage,
 }: VirtualRequestListProps) {
   if (isLoading) {
     return <SkeletonList />;
   }
 
   if (items.length === 0) {
-    return null;
+    return <EmptyState title={emptyTitle} message={emptyMessage} />;
   }
 
   return (

--- a/packages/web/src/components/VirtualSongList.tsx
+++ b/packages/web/src/components/VirtualSongList.tsx
@@ -1,5 +1,6 @@
 import type { Playlist, Song } from '@alfira-bot/server/shared';
 import { memo } from 'react';
+import EmptyState from './EmptyState';
 import SongCard from './SongCard';
 import { VirtualListFooter } from './ui/VirtualListFooter';
 
@@ -18,6 +19,8 @@ interface VirtualSongListProps {
   onDelete: (id: string) => void;
   onPlay: (id: string) => void;
   onAddToQueue: (id: string) => void;
+  emptyTitle: string;
+  emptyMessage?: string;
 }
 
 function SkeletonGrid() {
@@ -93,13 +96,15 @@ export const VirtualSongList = memo(function VirtualSongList({
   onDelete,
   onPlay,
   onAddToQueue,
+  emptyTitle,
+  emptyMessage,
 }: VirtualSongListProps) {
   if (isLoading) {
     return viewMode === 'grid' ? <SkeletonGrid /> : <SkeletonList />;
   }
 
   if (items.length === 0) {
-    return null;
+    return <EmptyState title={emptyTitle} message={emptyMessage} />;
   }
 
   const isGrid = viewMode === 'grid';

--- a/packages/web/src/hooks/useVirtualizedInfiniteScroll.ts
+++ b/packages/web/src/hooks/useVirtualizedInfiniteScroll.ts
@@ -31,7 +31,7 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[]>({
   deps = [] as unknown as A,
 }: UseInfiniteScrollOptions<T, A>): UseInfiniteScrollReturn<T> {
   const [items, setItems] = useState<T[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
   const [isFetching, setIsFetching] = useState(false);
   const [isError, setIsError] = useState(false);
   const [hasMore, setHasMore] = useState(true);
@@ -42,6 +42,7 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[]>({
   const isFetchingRef = useRef(false);
   const isMountedRef = useRef(true);
   const hasEverLoadedRef = useRef(false);
+  const loadingTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   hasMoreRef.current = hasMore;
   isFetchingRef.current = isFetching;
@@ -62,11 +63,16 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[]>({
       if (!isInitial && !hasMoreRef.current) return;
 
       if (isInitial) {
-        // Only show a full skeleton on the very first load.
+        // Delay the skeleton by 200ms — if the fetch completes faster,
+        // the skeleton is never rendered, avoiding a flash.
         // On subsequent deps changes (tab switch, filter change), keep
-        // stale items visible to avoid flickering.
+        // stale items visible instead.
         if (!hasEverLoadedRef.current) {
-          setIsLoading(true);
+          loadingTimerRef.current = setTimeout(() => {
+            if (isMountedRef.current) {
+              setIsLoading(true);
+            }
+          }, 200);
         }
       } else {
         setIsFetching(true);
@@ -95,6 +101,10 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[]>({
         if (!isMountedRef.current) return;
         setIsError(true);
       } finally {
+        if (loadingTimerRef.current) {
+          clearTimeout(loadingTimerRef.current);
+          loadingTimerRef.current = undefined;
+        }
         if (isMountedRef.current) {
           setIsLoading(false);
           setIsFetching(false);
@@ -154,6 +164,10 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[]>({
 
     return () => {
       isMountedRef.current = false;
+      if (loadingTimerRef.current) {
+        clearTimeout(loadingTimerRef.current);
+        loadingTimerRef.current = undefined;
+      }
     };
   }, [...deps, loadPage]);
 

--- a/packages/web/src/hooks/useVirtualizedInfiniteScroll.ts
+++ b/packages/web/src/hooks/useVirtualizedInfiniteScroll.ts
@@ -41,6 +41,7 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[]>({
   const hasMoreRef = useRef(true);
   const isFetchingRef = useRef(false);
   const isMountedRef = useRef(true);
+  const hasEverLoadedRef = useRef(false);
 
   hasMoreRef.current = hasMore;
   isFetchingRef.current = isFetching;
@@ -61,7 +62,12 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[]>({
       if (!isInitial && !hasMoreRef.current) return;
 
       if (isInitial) {
-        setIsLoading(true);
+        // Only show a full skeleton on the very first load.
+        // On subsequent deps changes (tab switch, filter change), keep
+        // stale items visible to avoid flickering.
+        if (!hasEverLoadedRef.current) {
+          setIsLoading(true);
+        }
       } else {
         setIsFetching(true);
       }
@@ -72,6 +78,8 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[]>({
       try {
         const result = await fetchPageRef.current(page, limit, ...searchArgs);
         if (!isMountedRef.current) return;
+
+        hasEverLoadedRef.current = true;
 
         if (isInitial) {
           setItems(result.items);

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -32,6 +32,12 @@
     }
 }
 
+@keyframes skeleton-appear {
+    to {
+        opacity: 1;
+    }
+}
+
 @keyframes shimmer {
     0% {
         background-position: -400px 0;
@@ -595,6 +601,7 @@
 
 @layer components {
     .skeleton {
+        opacity: 0;
         background: linear-gradient(
             90deg,
             var(--color-elevated) 25%,
@@ -602,7 +609,9 @@
             var(--color-elevated) 75%
         );
         background-size: 400px 100%;
-        animation: shimmer 1.4s infinite linear;
+        animation:
+            skeleton-appear 0s 0.2s forwards,
+            shimmer 1.4s 0.2s infinite linear;
         border-radius: 4px;
     }
 

--- a/packages/web/src/pages/PermissionsPage.tsx
+++ b/packages/web/src/pages/PermissionsPage.tsx
@@ -2,6 +2,7 @@ import { TrashIcon } from '@phosphor-icons/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { fetchPermissions, type PermissionsResponse, updatePermission } from '../api/api';
 import ConfirmModal from '../components/ConfirmModal';
+import EmptyState from '../components/EmptyState';
 import { Button } from '../components/ui/Button';
 import Checkbox from '../components/ui/Checkbox';
 import { ErrorBanner } from '../components/ui/ErrorBanner';
@@ -222,12 +223,10 @@ export default function PermissionsPage() {
 
       {/* Managed role cards */}
       {managedRoles.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-16 text-center">
-          <p className="text-sm text-muted mb-1">No managed roles yet</p>
-          <p className="text-xs text-muted">
-            Add a role above to start configuring granular permissions.
-          </p>
-        </div>
+        <EmptyState
+          title="No Managed Roles"
+          message="Add a role above to start configuring granular permissions"
+        />
       ) : (
         <div className="space-y-4">
           {managedRoles.map((role) => (

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -907,15 +907,10 @@ export default function PlaylistDetailPage() {
       {/* Song list */}
       {songItems.length === 0 && !isLoading ? (
         isSmart ? (
-          <div className="text-center py-24">
-            <p className="font-display text-4xl text-faint tracking-wider mb-2">No Songs Yet</p>
-            <p className="font-mono text-xs text-faint">
-              This playlist tracks the "
-              {tags.find((t) => t.nameLower === playlistDetail.tagNameLower)?.canonicalName ??
-                playlistDetail.tagNameLower}
-              " tag. Tag some songs to populate it.
-            </p>
-          </div>
+          <EmptyState
+            title="No Songs Yet"
+            message={`This playlist tracks the "${tags.find((t) => t.nameLower === playlistDetail.tagNameLower)?.canonicalName ?? playlistDetail.tagNameLower}" tag. Tag some songs to populate it.`}
+          />
         ) : (
           <EmptyState
             title="Empty Playlist"
@@ -943,6 +938,8 @@ export default function PlaylistDetailPage() {
           }}
           onPlay={handlePlayFromSong}
           onAddToQueue={handleAddToQueue}
+          emptyTitle="No Songs"
+          emptyMessage="Add songs to this playlist"
         />
       )}
 

--- a/packages/web/src/pages/PlaylistsPage.tsx
+++ b/packages/web/src/pages/PlaylistsPage.tsx
@@ -94,6 +94,8 @@ export default function PlaylistsPage() {
         onRetry={retry}
         sentinelRef={sentinelRef}
         onRowClick={handleRowClick}
+        emptyTitle="No Playlists Yet"
+        emptyMessage="Create one to get started"
       />
 
       {showCreate && <CreatePlaylistModal onClose={() => setShowCreate(false)} />}

--- a/packages/web/src/pages/RequestsPage.tsx
+++ b/packages/web/src/pages/RequestsPage.tsx
@@ -157,6 +157,10 @@ export default function RequestsPage() {
         onApprove={handleApprove}
         onDeny={handleDeny}
         onCancel={handleCancel}
+        emptyTitle={tab === 'pending' ? 'No Pending Requests' : 'No Request History'}
+        emptyMessage={
+          tab === 'pending' ? 'Nothing to review right now' : 'Submit a request to get started'
+        }
       />
 
       {/* Modals */}

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -483,6 +483,16 @@ export default function SongsPage() {
         onDelete={handleSetDeleteId}
         onPlay={handlePlayFromSong}
         onAddToQueue={handleAddToQueue}
+        emptyTitle={
+          search || filterTags.length > 0 || filterSources.length > 0
+            ? 'No Matches'
+            : 'No Songs Yet'
+        }
+        emptyMessage={
+          search || filterTags.length > 0 || filterSources.length > 0
+            ? 'Try adjusting your search or filters'
+            : 'Submit a request to add songs'
+        }
       />
 
       {/* ── Add Filter popover ────────────────────────────────── */}

--- a/packages/web/src/pages/TagsPage.tsx
+++ b/packages/web/src/pages/TagsPage.tsx
@@ -3,6 +3,7 @@ import type { Song } from '@alfira-bot/server/shared/types';
 import { MagnifyingGlassIcon, TrashIcon } from '@phosphor-icons/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import ConfirmModal from '../components/ConfirmModal';
+import EmptyState from '../components/EmptyState';
 import TagTicker from '../components/TagTicker';
 import { Button } from '../components/ui/Button';
 import { useTagColors } from '../context/TagsContext';
@@ -179,9 +180,13 @@ export default function TagsPage() {
                 Loading…
               </div>
             ) : filtered.length === 0 ? (
-              <div className="flex items-center justify-center h-20 text-muted text-sm">
-                {search ? 'No tags match your search.' : 'No tags yet.'}
-              </div>
+              <EmptyState
+                compact
+                title={search ? 'No Matches' : 'No Tags Yet'}
+                message={
+                  search ? 'No tags match your search' : 'Tags are created when you tag songs'
+                }
+              />
             ) : (
               filtered.map((tag) => {
                 const colors = getTagColor(tag.canonicalName, tag.color);


### PR DESCRIPTION
## Summary

Replaces bare "no items" text (or blank space) with a consistent, playful empty state pattern across all pages — featuring a randomly selected fun icon and a clear message. Also eliminates skeleton flash on page navigation and tab switches.

## Changes

- **EmptyState component** — centralized random icon logic (17 fun icons), added `compact` variant for tighter spaces. All empty states now show an icon circle + title + message
- **Virtual list components** (RequestList, SongList, PlaylistList) — render `EmptyState` instead of returning `null` when empty, accepting `emptyTitle`/`emptyMessage` props
- **QueuePanel** — deduplicated; imports shared icon logic from EmptyState
- **Pages updated with empty states:**
  - Requests: tab-aware messages ("No Pending Requests" / "No Request History")
  - Songs: context-aware ("No Matches" with active filters, "No Songs Yet" otherwise)
  - Playlists: "No Playlists Yet"
  - Tags: left-pane empty state with compact EmptyState
  - Permissions: "No Managed Roles"
  - PlaylistDetail: smart-playlist empty state uses EmptyState with icon
- **useVirtualizedInfiniteScroll** — fixed tab-switch flicker by only showing skeleton on first mount, not on subsequent deps changes
- **Skeleton CSS** — debounced visibility by 200ms. Skeletons start invisible and only appear if the fetch takes longer than 200ms, eliminating flash on fast page navigations