### PR TITLE
chore(auth): add diagnostic logging to token refresh paths

### DIFF
--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -506,6 +506,7 @@ async function withRetry<T>(fn: () => Promise<T>, attempts = 3, baseDelayMs = 50
 async function handleRefresh(ctx: RouteContext): Promise<Response> {
   const refreshToken = ctx.cookies[REFRESH_COOKIE_NAME];
   if (!refreshToken) {
+    logger.warn('Auth refresh failed: no refresh token cookie present');
     return json({ error: 'No refresh token provided.' }, 401);
   }
 
@@ -514,9 +515,11 @@ async function handleRefresh(ctx: RouteContext): Promise<Response> {
   try {
     decoded = jwt.verify(refreshToken, JWT_SECRET_) as { discordId: string; type: string };
     if (decoded.type !== 'refresh') {
+      logger.warn({ decodedType: decoded.type }, 'Auth refresh failed: invalid token type');
       return json({ error: 'Invalid token type.' }, 401);
     }
-  } catch {
+  } catch (err) {
+    logger.warn({ err: (err as Error).message }, 'Auth refresh failed: JWT verification');
     return json({ error: 'Invalid or expired refresh token.' }, 401);
   }
 
@@ -528,11 +531,19 @@ async function handleRefresh(ctx: RouteContext): Promise<Response> {
     .where(eq(refreshTokenTable.tokenHash, tokenHash))
     .limit(1);
   if (!storedToken) {
+    logger.warn(
+      { discordId: decoded.discordId },
+      'Auth refresh failed: token hash not found in DB (revoked or already burned)'
+    );
     return json({ error: 'Refresh token has been revoked.' }, 401);
   }
 
   // 3. Check if the refresh token has expired.
   if (storedToken.expiresAt < new Date()) {
+    logger.warn(
+      { discordId: decoded.discordId, expiresAt: storedToken.expiresAt, now: new Date() },
+      'Auth refresh failed: DB expiresAt has passed'
+    );
     await db.delete(refreshTokenTable).where(eq(refreshTokenTable.id, storedToken.id));
     return json({ error: 'Refresh token has expired.' }, 401);
   }
@@ -563,13 +574,21 @@ async function handleRefresh(ctx: RouteContext): Promise<Response> {
     try {
       const profile = await withRetry(() => fetchDiscordUserProfile(decoded.discordId));
       if (!profile) {
+        logger.warn(
+          { discordId: decoded.discordId },
+          'Auth refresh failed: fetchDiscordUserProfile returned null (setup mode)'
+        );
         return json({ error: 'Unable to verify user identity. Please try again.' }, 503);
       }
       username = profile.username;
       avatar = profile.avatar;
       isAdmin = true;
       isSetupAdmin = true;
-    } catch {
+    } catch (err) {
+      logger.warn(
+        { discordId: decoded.discordId, err: (err as Error).message },
+        'Auth refresh failed: Discord unreachable (setup mode)'
+      );
       return json({ error: 'Discord is temporarily unreachable. Please try again.' }, 503);
     }
   } else {
@@ -577,18 +596,27 @@ async function handleRefresh(ctx: RouteContext): Promise<Response> {
     try {
       const userInfo = await withRetry(() => fetchUserAdminStatus(decoded.discordId));
       if (!userInfo) {
+        logger.warn(
+          { discordId: decoded.discordId },
+          'Auth refresh failed: fetchUserAdminStatus returned null (not in guild or Discord error)'
+        );
         return json({ error: 'Unable to verify user membership. Please try again.' }, 503);
       }
       username = userInfo.username;
       avatar = userInfo.avatar;
       isAdmin = userInfo.isAdmin;
       roles = userInfo.roles;
-    } catch {
+    } catch (err) {
+      logger.warn(
+        { discordId: decoded.discordId, err: (err as Error).message },
+        'Auth refresh failed: Discord unreachable'
+      );
       return json({ error: 'Discord is temporarily unreachable. Please try again.' }, 503);
     }
   }
 
   // 6. Burn the old refresh token now that Discord verification succeeded.
+  logger.info({ discordId: decoded.discordId }, 'Auth refresh succeeded — issuing new tokens');
   await db.delete(refreshTokenTable).where(eq(refreshTokenTable.id, storedToken.id));
 
   // 7. Generate new tokens.

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -48,8 +48,9 @@ function processQueue(error: Error | null): void {
   failedQueue = [];
 }
 
-function redirectToLogin(): void {
+function redirectToLogin(reason: string): void {
   if (window.location.pathname !== '/login') {
+    console.warn(`[auth] redirectToLogin: ${reason}`, new Error().stack);
     window.location.href = '/login';
   }
 }
@@ -75,6 +76,7 @@ async function refreshToken(): Promise<RefreshResult> {
 export async function trySilentRefresh(): Promise<boolean> {
   if (isRefreshing) {
     // wrappedFetch is already doing a refresh — queue and wait for it
+    console.warn('[auth] trySilentRefresh: already refreshing, queuing');
     return new Promise<boolean>((resolve, _reject) => {
       failedQueue.push({
         resolve: () => resolve(true),
@@ -84,9 +86,11 @@ export async function trySilentRefresh(): Promise<boolean> {
   }
 
   if (isSilentRefreshing) {
+    console.warn('[auth] trySilentRefresh: already silent-refreshing, skipping');
     return false;
   }
 
+  console.warn('[auth] trySilentRefresh: starting refresh attempt');
   isSilentRefreshing = true;
   // Set isRefreshing so wrappedFetch queues instead of starting concurrent refresh
   isRefreshing = true;
@@ -94,13 +98,20 @@ export async function trySilentRefresh(): Promise<boolean> {
   // Retry up to 3 times total for transient failures (Discord 429/503, network).
   let result = await refreshToken();
   for (let attempt = 0; attempt < 2 && !result.ok && result.retryable; attempt++) {
+    console.warn(
+      `[auth] trySilentRefresh: retry ${attempt + 1}/2 after ${result.ok ? 'success' : 'retryable failure'}`
+    );
     await new Promise((r) => setTimeout(r, 1500));
     result = await refreshToken();
   }
 
   if (result.ok) {
+    console.warn('[auth] trySilentRefresh: succeeded');
     processQueue(null);
   } else {
+    console.warn(
+      `[auth] trySilentRefresh: failed after retries (ok=${result.ok}, retryable=${result.retryable})`
+    );
     processQueue(new Error('Token refresh failed'));
   }
   isRefreshing = false;
@@ -134,7 +145,7 @@ async function wrappedFetch(
   if (response.status === 401) {
     // Don't retry if this is already a refresh request
     if (url === '/auth/refresh') {
-      redirectToLogin();
+      redirectToLogin('/auth/refresh itself returned 401 — refresh token dead');
       throw new ApiError('Unauthorized', 401);
     }
 
@@ -152,6 +163,7 @@ async function wrappedFetch(
 
     // Start refreshing
     isRefreshing = true;
+    console.warn(`[auth] wrappedFetch: starting refresh after 401 on ${url}`);
 
     const result = await refreshToken();
 
@@ -170,7 +182,7 @@ async function wrappedFetch(
       // Refresh failed permanently, reject queue and redirect
       processQueue(new Error('Token refresh failed'));
       isRefreshing = false;
-      redirectToLogin();
+      redirectToLogin('refreshToken() returned non-retryable failure');
       throw new ApiError('Unauthorized', 401);
     }
   }

--- a/packages/web/src/context/AuthContext.tsx
+++ b/packages/web/src/context/AuthContext.tsx
@@ -33,19 +33,25 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     try {
       const me = await getMe();
       setUser(me);
-    } catch {
+    } catch (err) {
       // First attempt failed (network error, expired token, etc.).
       // trySilentRefresh refreshes the token. If it succeeds, retry getMe
       // once. wrappedFetch handles any further 401s transparently.
+      console.warn('[auth] AuthContext: initial getMe() failed, trying silent refresh', err);
       const refreshed = await trySilentRefresh();
       if (refreshed) {
         try {
           const me = await getMe();
           setUser(me);
-        } catch {
+        } catch (err2) {
+          console.warn(
+            '[auth] AuthContext: getMe() failed after successful refresh, setting user=null',
+            err2
+          );
           setUser(null);
         }
       } else {
+        console.warn('[auth] AuthContext: trySilentRefresh() returned false, setting user=null');
         setUser(null);
       }
     } finally {


### PR DESCRIPTION
## Summary

Adds diagnostic logging to all auth token refresh failure paths and the client-side logout triggers. This instrumentation will help identify the root cause of intermittent session logouts occurring after ~12-24 hours.

## Changes

- **Server** (`packages/server/src/routes/auth.ts`): `logger.warn` on every `/auth/refresh` failure path (missing cookie, JWT failure, DB miss, DB expiry, Discord unreachable), plus `logger.info` on success
- **Client** (`packages/web/src/api/client.ts`): `console.warn` in `redirectToLogin()` with reason + stack trace, `trySilentRefresh()` lifecycle, and `wrappedFetch` refresh trigger point
- **Client** (`packages/web/src/context/AuthContext.tsx`): `console.warn` before each `setUser(null)` call with context about what failed