### PR TITLE
fix(web): fix request history tab blank and new request not appearing

### DIFF
--- a/packages/web/src/components/AddSongModal.tsx
+++ b/packages/web/src/components/AddSongModal.tsx
@@ -14,9 +14,11 @@ type Step = 'url' | 'metadata';
 export default function AddSongModal({
   onClose,
   onAdded,
+  onRequestCreated,
 }: {
   onClose: () => void;
   onAdded: (song: Song) => void;
+  onRequestCreated?: () => void;
 }) {
   const { tagColorMap } = useTagColors();
 
@@ -97,6 +99,7 @@ export default function AddSongModal({
         sourceUrl: url.trim(),
       });
 
+      onRequestCreated?.();
       if (result.autoApproved) {
         setSuccessMsg(
           `Imported ${result.importedCount ?? result.songs?.length ?? 0} songs from "${result.playlistTitle ?? 'playlist'}".`
@@ -131,6 +134,7 @@ export default function AddSongModal({
         volumeBoost: parsedBoost != null && !Number.isNaN(parsedBoost) ? parsedBoost : null,
       });
 
+      onRequestCreated?.();
       if (result.autoApproved) {
         if (result.song) {
           onAdded(result.song);

--- a/packages/web/src/hooks/useVirtualizedInfiniteScroll.ts
+++ b/packages/web/src/hooks/useVirtualizedInfiniteScroll.ts
@@ -50,13 +50,15 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[]>({
   const fetchPageRef = useRef(fetchPage);
   fetchPageRef.current = fetchPage;
 
+  const depsRef = useRef(deps);
+  depsRef.current = deps;
+
   const sentinelRefInternal = useRef<HTMLDivElement | null>(null);
   const observerRef = useRef<IntersectionObserver | null>(null);
   // Initial value is a no-op; immediately overwritten after render
   // biome-ignore lint/suspicious/noEmptyBlockStatements: initial no-op value is immediately replaced
   const fetchMoreFnRef = useRef<() => void>(() => {});
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally uses deps inside via fetchPageRef; deps changes trigger refetch via useEffect
   const loadPage = useCallback(
     async (page: number, isInitial = false, searchOverride?: string) => {
       if (isFetchingRef.current) return;
@@ -79,7 +81,7 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[]>({
       }
       setIsError(false);
 
-      const searchArgs = (searchOverride !== undefined ? [searchOverride] : deps) as A;
+      const searchArgs = (searchOverride !== undefined ? [searchOverride] : depsRef.current) as A;
 
       try {
         const result = await fetchPageRef.current(page, limit, ...searchArgs);

--- a/packages/web/src/pages/RequestsPage.tsx
+++ b/packages/web/src/pages/RequestsPage.tsx
@@ -23,7 +23,7 @@ export default function RequestsPage() {
   const [actionError, setActionError] = useState<string | null>(null);
   const autoRedirected = useRef(false);
 
-  const { items, isLoading, isFetching, isError, total, removeItem, retry, sentinelRef } =
+  const { items, isLoading, isFetching, isError, total, removeItem, retry, reset, sentinelRef } =
     useVirtualizedInfiniteScroll<SongRequest, [string, boolean]>({
       fetchPage: async (page, limit, currentTab, currentMineOnly) => {
         const status = currentTab === 'pending' ? 'pending' : 'all';
@@ -76,14 +76,26 @@ export default function RequestsPage() {
     [user?.discordId]
   );
 
-  // If pending tab is empty on initial load, switch to history
+  // Redirect to history if pending is empty after the initial fetch completes.
+  // Detected by watching for items[] reference change (setItems always creates a
+  // new array). A mount guard skips the initial render + Strict Mode double-invoke.
+  const mounted = useRef(false);
+  const prevItemsRef = useRef(items);
   useEffect(() => {
+    const itemsChanged = prevItemsRef.current !== items;
+    prevItemsRef.current = items;
+
+    if (!mounted.current) {
+      mounted.current = true;
+      return;
+    }
+    if (!itemsChanged) return;
     if (autoRedirected.current) return;
-    if (!isLoading && tab === 'pending' && total === 0) {
+    if (tab === 'pending' && total === 0) {
       autoRedirected.current = true;
       setTab('closed');
     }
-  }, [isLoading, tab, total]);
+  });
 
   const countLabel = isLoading ? '—' : `${total} request${total !== 1 ? 's' : ''}`;
 
@@ -169,6 +181,9 @@ export default function RequestsPage() {
           onClose={() => setShowAddModal(false)}
           onAdded={() => {
             setShowAddModal(false);
+          }}
+          onRequestCreated={() => {
+            reset();
           }}
         />
       )}


### PR DESCRIPTION
## Summary

Fixes two bugs on the Requests page and a stale-closure issue in the virtualized infinite scroll hook.

## Changes

- **RequestsPage: fix auto-redirect race** — the `!isLoading && tab === 'pending' && total === 0` redirect condition fired on mount before data loaded, causing the History tab to appear blank. Replaced with an items-reference comparison + mount guard that fires only after the initial fetch completes.
- **RequestsPage: refresh list after creating a request** — the hook's `reset()` is now called via `onRequestCreated` when a new song request is submitted, so the new entry appears without requiring a manual tab switch.
- **useVirtualizedInfiniteScroll: fix stale closure in `loadPage`** — added `depsRef` to track current deps. Previously `reset()` and `fetchMore` used stale closure `deps` values, causing wrong data to be fetched after a tab switch.
- **AddSongModal: add `onRequestCreated` callback** — optional prop fired after any successful request creation, enabling parent components to refresh their list.