### PR TITLE
fix(web): eliminate content flash on page navigation and artwork loading

### DIFF
--- a/packages/web/src/components/AddSongModal.tsx
+++ b/packages/web/src/components/AddSongModal.tsx
@@ -5,6 +5,7 @@ import { useTagColors } from '../context/TagsContext';
 import { apiErrorMessage } from '../utils/api';
 import { getTagColorClasses } from '../utils/tagColors';
 import { Backdrop } from './Backdrop';
+import { ArtworkImage } from './ui/ArtworkImage';
 import { Button } from './ui/Button';
 import Checkbox from './ui/Checkbox';
 import { Spinner } from './ui/Spinner';
@@ -259,11 +260,13 @@ export default function AddSongModal({
             {/* Thumbnail + title + duration + source */}
             <div className="flex items-center gap-3 -mb-1">
               {(preview.artworkUrl || preview.thumbnailUrl) && (
-                <img
-                  src={preview.artworkUrl || preview.thumbnailUrl}
-                  alt="Album art"
-                  className="w-12 h-12 rounded border border-border object-cover shrink-0"
-                />
+                <div className="w-12 h-12 rounded border border-border shrink-0 overflow-hidden bg-elevated">
+                  <ArtworkImage
+                    src={preview.artworkUrl || preview.thumbnailUrl}
+                    alt="Album art"
+                    className="w-full h-full"
+                  />
+                </div>
               )}
               <div className="flex flex-col gap-0.5 min-w-0">
                 <span className="font-body text-sm text-fg truncate">{preview.title}</span>

--- a/packages/web/src/components/AddSongsModal.tsx
+++ b/packages/web/src/components/AddSongsModal.tsx
@@ -4,6 +4,7 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { addSongToPlaylist, getSongsPage } from '../api/api';
 import { Backdrop } from './Backdrop';
+import { ArtworkImage } from './ui/ArtworkImage';
 import { Button } from './ui/Button';
 
 const PAGE_SIZE = 30;
@@ -211,13 +212,12 @@ const SongRow = memo(function SongRow({
 }) {
   return (
     <div className="flex items-center gap-2 md:gap-3 px-4 md:px-5 py-3 hover:bg-elevated active:bg-elevated/80 transition-colors duration-100">
-      <div className="overflow-hidden w-10 h-10 md:w-8 md:h-8 rounded border border-border shrink-0">
-        <img
+      <div className="overflow-hidden w-10 h-10 md:w-8 md:h-8 rounded border border-border shrink-0 bg-elevated">
+        <ArtworkImage
           src={song.artwork ?? song.thumbnailUrl}
           alt={song.nickname || song.title}
-          className="w-full h-full object-cover scale-[1.33]"
-          loading="lazy"
-          decoding="async"
+          className="w-full h-full"
+          imageClassName="scale-[1.33]"
         />
       </div>
       <span className="flex-1 font-body text-sm text-fg truncate">

--- a/packages/web/src/components/NowPlayingBar.tsx
+++ b/packages/web/src/components/NowPlayingBar.tsx
@@ -20,6 +20,7 @@ import { BarButton } from './BarButton';
 import QueuePanel from './QueuePanel';
 import { SourceIcon } from './SourceIcons';
 import TagTicker from './TagTicker';
+import { ArtworkImage } from './ui/ArtworkImage';
 import { Button } from './ui/Button';
 import { VolumeBoostBadge } from './ui/VolumeBoostBadge';
 
@@ -347,13 +348,13 @@ interface AlbumArtProps {
 
 const AlbumArt = memo(function AlbumArt({ currentSong }: AlbumArtProps) {
   return (
-    <div className="w-12 h-12 md:w-14 md:h-14 rounded border border-border shrink-0 overflow-hidden relative">
+    <div className="w-12 h-12 md:w-14 md:h-14 rounded border border-border shrink-0 overflow-hidden relative bg-elevated">
       {currentSong ? (
-        <img
+        <ArtworkImage
           src={currentSong.artwork ?? currentSong.thumbnailUrl}
           alt={currentSong.title}
-          className="w-full h-full object-cover scale-[1.33]"
-          decoding="async"
+          className="w-full h-full"
+          imageClassName="scale-[1.33]"
         />
       ) : (
         <div className="w-full h-full flex items-center justify-center">

--- a/packages/web/src/components/PlaylistRow.tsx
+++ b/packages/web/src/components/PlaylistRow.tsx
@@ -1,6 +1,7 @@
 import type { Playlist } from '@alfira-bot/server/shared';
 import { CaretRightIcon, GhostIcon, PlaylistIcon, TagIcon } from '@phosphor-icons/react';
 import { memo } from 'react';
+import { ArtworkImage } from './ui/ArtworkImage';
 import { Card } from './ui/Card';
 
 interface PlaylistRowProps {
@@ -51,13 +52,7 @@ export const PlaylistRow = memo(
               {cells.map((url, i) => (
                 // biome-ignore lint/suspicious/noArrayIndexKey: cells are always exactly 4, never reorder
                 <div key={i} className="overflow-hidden bg-elevated">
-                  <img
-                    src={url ?? undefined}
-                    alt=""
-                    className="w-full h-full object-cover"
-                    loading="lazy"
-                    decoding="async"
-                  />
+                  <ArtworkImage src={url ?? undefined} alt="" className="w-full h-full" />
                 </div>
               ))}
             </div>

--- a/packages/web/src/components/QueuePanel.tsx
+++ b/packages/web/src/components/QueuePanel.tsx
@@ -34,6 +34,7 @@ import { usePermissions } from '../context/PermissionsContext';
 import { usePlayer } from '../context/PlayerContext';
 import { getSourceKey } from '../utils/source';
 import { getRandomIdleIcon } from './EmptyState';
+import { ArtworkImage } from './ui/ArtworkImage';
 import { Button } from './ui/Button';
 import { DurationBadge } from './ui/DurationBadge';
 import { VolumeBoostBadge } from './ui/VolumeBoostBadge';
@@ -574,13 +575,12 @@ const QueueSongItem = memo(function QueueSongItem({
         </span>
 
         {/* Thumbnail */}
-        <div className="overflow-hidden w-10 h-10 rounded border border-border shrink-0">
-          <img
+        <div className="overflow-hidden w-10 h-10 rounded border border-border shrink-0 bg-elevated">
+          <ArtworkImage
             src={song.artwork ?? song.thumbnailUrl}
             alt={song.nickname || song.title}
-            className="w-full h-full object-cover scale-[1.33]"
-            loading="lazy"
-            decoding="async"
+            className="w-full h-full"
+            imageClassName="scale-[1.33]"
           />
         </div>
 
@@ -769,12 +769,12 @@ const NowPlayingCard = memo(function NowPlayingCard({
     <div className="card overflow-hidden" style={{ background: 'var(--color-base)' }}>
       <div className="flex gap-4 p-4">
         {/* Artwork */}
-        <div className="relative shrink-0 overflow-hidden rounded-xl">
-          <img
+        <div className="relative shrink-0 overflow-hidden rounded-xl bg-elevated">
+          <ArtworkImage
             src={song.artwork ?? song.thumbnailUrl}
             alt={song.nickname || song.title}
-            className="w-20 h-20 rounded-xl border border-border object-cover scale-[1.33]"
-            decoding="async"
+            className="w-20 h-20 rounded-xl border border-border"
+            imageClassName="scale-[1.33]"
           />
         </div>
 

--- a/packages/web/src/components/RequestCard.tsx
+++ b/packages/web/src/components/RequestCard.tsx
@@ -3,6 +3,7 @@ import { formatDuration } from '@alfira-bot/server/shared';
 import { CheckCircleIcon, TrashIcon, XCircleIcon } from '@phosphor-icons/react';
 import { memo } from 'react';
 import { SourceIcon } from './SourceIcons';
+import { ArtworkImage } from './ui/ArtworkImage';
 import { Button } from './ui/Button';
 import { Card } from './ui/Card';
 
@@ -40,10 +41,10 @@ export const RequestCard = memo(function RequestCard({
     <Card className="rounded-xl flex items-center gap-4 p-4">
       {/* Thumbnail */}
       {thumbnailUrl ? (
-        <img
+        <ArtworkImage
           src={thumbnailUrl}
           alt=""
-          className="w-14 h-14 rounded-lg object-cover shrink-0 border border-border"
+          className="w-14 h-14 rounded-lg shrink-0 border border-border"
         />
       ) : (
         <div className="w-14 h-14 rounded-lg bg-muted/20 shrink-0 flex items-center justify-center">

--- a/packages/web/src/components/SongCard.tsx
+++ b/packages/web/src/components/SongCard.tsx
@@ -9,6 +9,7 @@ import { ContextMenu, ContextMenuTrigger } from './ContextMenu';
 import SongEditPanel from './SongEditPanel';
 import { SourceIcon } from './SourceIcons';
 import TagTicker from './TagTicker';
+import { ArtworkImage } from './ui/ArtworkImage';
 import { Card } from './ui/Card';
 import { DurationBadge } from './ui/DurationBadge';
 import { PlayButton } from './ui/PlayButton';
@@ -81,20 +82,18 @@ const SongCardInner = ({
     return (
       <Card
         hoverable={!!isAdminView}
-        animate
         className={`rounded-lg flex flex-col${isAdminView ? ' group cursor-pointer' : ''}`}
         style={gridStyle}
         data-song-edit-container
         onClick={() => canEdit && setOpenSongId(isOpen ? null : song.id)}
       >
         {/* Clean thumbnail */}
-        <div className="relative aspect-square overflow-hidden rounded-lg border border-border m-3 mb-0">
-          <img
+        <div className="relative aspect-square overflow-hidden rounded-lg border border-border m-3 mb-0 bg-elevated">
+          <ArtworkImage
             src={song.artwork ?? song.thumbnailUrl}
             alt=""
-            className="w-full h-full object-cover scale-[1.33]"
-            loading="lazy"
-            decoding="async"
+            className="w-full h-full"
+            imageClassName="scale-[1.33]"
           />
         </div>
 
@@ -199,13 +198,12 @@ const SongCardInner = ({
         onMouseEnter={() => setIsRowHovered(true)}
         onMouseLeave={() => setIsRowHovered(false)}
       >
-        <div className="overflow-hidden w-16 h-16 rounded border border-border shrink-0">
-          <img
+        <div className="overflow-hidden w-16 h-16 rounded border border-border shrink-0 bg-elevated">
+          <ArtworkImage
             src={song.artwork ?? song.thumbnailUrl}
             alt={song.nickname || song.title}
-            className="w-full h-full object-cover scale-[1.33]"
-            loading="lazy"
-            decoding="async"
+            className="w-full h-full"
+            imageClassName="scale-[1.33]"
           />
         </div>
         <div className="flex-1 min-w-0 flex flex-col justify-center gap-1.5">

--- a/packages/web/src/components/VirtualPlaylistList.tsx
+++ b/packages/web/src/components/VirtualPlaylistList.tsx
@@ -1,5 +1,5 @@
 import type { Playlist } from '@alfira-bot/server/shared';
-import { memo } from 'react';
+import { memo, useLayoutEffect, useRef } from 'react';
 import EmptyState from './EmptyState';
 import PlaylistRow from './PlaylistRow';
 import { VirtualListFooter } from './ui/VirtualListFooter';
@@ -9,6 +9,7 @@ interface VirtualPlaylistListProps {
   isLoading: boolean;
   isFetching: boolean;
   isError: boolean;
+  hasLoaded: boolean;
   onRetry: () => void;
   sentinelRef: (el: HTMLDivElement | null) => void;
   onRowClick: (e: React.MouseEvent) => void;
@@ -38,40 +39,52 @@ export const VirtualPlaylistList = memo(function VirtualPlaylistList({
   isLoading,
   isFetching,
   isError,
+  hasLoaded,
   onRetry,
   sentinelRef,
   onRowClick,
   emptyTitle,
   emptyMessage,
 }: VirtualPlaylistListProps) {
-  if (isLoading) {
-    return <SkeletonList />;
-  }
+  const containerRef = useRef<HTMLDivElement>(null);
+  const showSkeleton = isLoading;
+  const showEmpty = hasLoaded && items.length === 0;
+  const showContent = !isLoading && hasLoaded && items.length > 0;
 
-  if (items.length === 0) {
-    return <EmptyState title={emptyTitle} message={emptyMessage} />;
-  }
+  useLayoutEffect(() => {
+    if (!containerRef.current) return;
+    containerRef.current.style.opacity = showContent || showEmpty || showSkeleton ? '1' : '0';
+  }, [showContent, showEmpty, showSkeleton]);
 
   return (
-    <div className="relative">
-      <div className="flex flex-col gap-3">
-        {items.map((playlist) => (
-          <PlaylistRow
-            key={playlist.id}
-            playlist={playlist}
-            animationDelay="0ms"
-            onClick={onRowClick}
-            data-playlist-id={playlist.id}
+    <div
+      ref={containerRef}
+      className="relative"
+      style={{ opacity: 0, transition: 'opacity 120ms ease' }}
+    >
+      {showSkeleton && <SkeletonList />}
+      {showEmpty && <EmptyState title={emptyTitle} message={emptyMessage} />}
+      {showContent && (
+        <>
+          <div className="flex flex-col gap-3">
+            {items.map((playlist) => (
+              <PlaylistRow
+                key={playlist.id}
+                playlist={playlist}
+                animationDelay="0ms"
+                onClick={onRowClick}
+                data-playlist-id={playlist.id}
+              />
+            ))}
+          </div>
+          <VirtualListFooter
+            sentinelRef={sentinelRef}
+            isFetching={isFetching}
+            isError={isError}
+            onRetry={onRetry}
           />
-        ))}
-      </div>
-
-      <VirtualListFooter
-        sentinelRef={sentinelRef}
-        isFetching={isFetching}
-        isError={isError}
-        onRetry={onRetry}
-      />
+        </>
+      )}
     </div>
   );
 });

--- a/packages/web/src/components/VirtualRequestList.tsx
+++ b/packages/web/src/components/VirtualRequestList.tsx
@@ -1,5 +1,5 @@
 import type { SongRequest } from '@alfira-bot/server/shared';
-import { memo } from 'react';
+import { memo, useLayoutEffect, useRef } from 'react';
 import EmptyState from './EmptyState';
 import RequestCard from './RequestCard';
 import { VirtualListFooter } from './ui/VirtualListFooter';
@@ -9,6 +9,7 @@ export interface VirtualRequestListProps {
   isLoading: boolean;
   isFetching: boolean;
   isError: boolean;
+  hasLoaded: boolean;
   isOwnFn: (requestedBy: string) => boolean;
   isAdmin: boolean;
   onRetry: () => void;
@@ -46,6 +47,7 @@ export const VirtualRequestList = memo(function VirtualRequestList({
   isLoading,
   isFetching,
   isError,
+  hasLoaded,
   isOwnFn,
   isAdmin,
   onRetry,
@@ -56,36 +58,47 @@ export const VirtualRequestList = memo(function VirtualRequestList({
   emptyTitle,
   emptyMessage,
 }: VirtualRequestListProps) {
-  if (isLoading) {
-    return <SkeletonList />;
-  }
+  const containerRef = useRef<HTMLDivElement>(null);
+  const showSkeleton = isLoading;
+  const showEmpty = hasLoaded && items.length === 0;
+  const showContent = !isLoading && hasLoaded && items.length > 0;
 
-  if (items.length === 0) {
-    return <EmptyState title={emptyTitle} message={emptyMessage} />;
-  }
+  useLayoutEffect(() => {
+    if (!containerRef.current) return;
+    containerRef.current.style.opacity = showContent || showEmpty || showSkeleton ? '1' : '0';
+  }, [showContent, showEmpty, showSkeleton]);
 
   return (
-    <div className="relative">
-      <div className="flex flex-col gap-3">
-        {items.map((req) => (
-          <RequestCard
-            key={req.id}
-            req={req}
-            isOwn={isOwnFn(req.requestedBy)}
-            isAdmin={isAdmin}
-            onApprove={onApprove}
-            onDeny={onDeny}
-            onCancel={onCancel}
+    <div
+      ref={containerRef}
+      className="relative"
+      style={{ opacity: 0, transition: 'opacity 120ms ease' }}
+    >
+      {showSkeleton && <SkeletonList />}
+      {showEmpty && <EmptyState title={emptyTitle} message={emptyMessage} />}
+      {showContent && (
+        <>
+          <div className="flex flex-col gap-3">
+            {items.map((req) => (
+              <RequestCard
+                key={req.id}
+                req={req}
+                isOwn={isOwnFn(req.requestedBy)}
+                isAdmin={isAdmin}
+                onApprove={onApprove}
+                onDeny={onDeny}
+                onCancel={onCancel}
+              />
+            ))}
+          </div>
+          <VirtualListFooter
+            sentinelRef={sentinelRef}
+            isFetching={isFetching}
+            isError={isError}
+            onRetry={onRetry}
           />
-        ))}
-      </div>
-
-      <VirtualListFooter
-        sentinelRef={sentinelRef}
-        isFetching={isFetching}
-        isError={isError}
-        onRetry={onRetry}
-      />
+        </>
+      )}
     </div>
   );
 });

--- a/packages/web/src/components/VirtualSongList.tsx
+++ b/packages/web/src/components/VirtualSongList.tsx
@@ -1,5 +1,5 @@
 import type { Playlist, Song } from '@alfira-bot/server/shared';
-import { memo } from 'react';
+import { memo, useLayoutEffect, useRef } from 'react';
 import EmptyState from './EmptyState';
 import SongCard from './SongCard';
 import { VirtualListFooter } from './ui/VirtualListFooter';
@@ -13,6 +13,7 @@ interface VirtualSongListProps {
   isFetching: boolean;
   isError: boolean;
   hasMore: boolean;
+  hasLoaded: boolean;
   playingId: string | null;
   onRetry: () => void;
   sentinelRef: (el: HTMLDivElement | null) => void;
@@ -90,6 +91,7 @@ export const VirtualSongList = memo(function VirtualSongList({
   isFetching,
   isError,
   hasMore,
+  hasLoaded,
   playingId,
   onRetry,
   sentinelRef,
@@ -99,46 +101,59 @@ export const VirtualSongList = memo(function VirtualSongList({
   emptyTitle,
   emptyMessage,
 }: VirtualSongListProps) {
-  if (isLoading) {
-    return viewMode === 'grid' ? <SkeletonGrid /> : <SkeletonList />;
-  }
-
-  if (items.length === 0) {
-    return <EmptyState title={emptyTitle} message={emptyMessage} />;
-  }
-
+  const containerRef = useRef<HTMLDivElement>(null);
   const isGrid = viewMode === 'grid';
+  const showSkeleton = isLoading;
+  const showEmpty = hasLoaded && items.length === 0;
+  const showContent = !isLoading && hasLoaded && items.length > 0;
+
+  // Reveal the container only after React has committed all DOM mutations,
+  // so the browser paints all cards at once without any staggered rendering.
+  useLayoutEffect(() => {
+    if (!containerRef.current) return;
+    containerRef.current.style.opacity = showContent || showEmpty || showSkeleton ? '1' : '0';
+  }, [showContent, showEmpty, showSkeleton]);
 
   return (
-    <div className="relative">
-      <div
-        className={
-          isGrid
-            ? 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-[repeat(auto-fill,minmax(270px,1fr))] gap-3 md:gap-4 items-start'
-            : 'flex flex-col gap-1.5'
-        }
-      >
-        {items.map((song) => (
-          <SongCard
-            key={song.id}
-            song={song}
-            variant={viewMode === 'grid' ? 'grid' : 'list'}
-            isAdminView={isAdminView}
-            playlists={playlists}
-            onDelete={onDelete}
-            onPlay={() => onPlay(song.id)}
-            isPlaying={playingId === song.id}
-            onAddToQueue={() => onAddToQueue(song.id)}
+    <div
+      ref={containerRef}
+      className="relative"
+      style={{ opacity: 0, transition: 'opacity 120ms ease' }}
+    >
+      {showSkeleton && (isGrid ? <SkeletonGrid /> : <SkeletonList />)}
+      {showEmpty && <EmptyState title={emptyTitle} message={emptyMessage} />}
+      {showContent && (
+        <>
+          <div
+            className={
+              isGrid
+                ? 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-[repeat(auto-fill,minmax(270px,1fr))] gap-3 md:gap-4 items-start'
+                : 'flex flex-col gap-1.5'
+            }
+          >
+            {items.map((song) => (
+              <SongCard
+                key={song.id}
+                song={song}
+                variant={viewMode === 'grid' ? 'grid' : 'list'}
+                isAdminView={isAdminView}
+                playlists={playlists}
+                onDelete={onDelete}
+                onPlay={() => onPlay(song.id)}
+                isPlaying={playingId === song.id}
+                onAddToQueue={() => onAddToQueue(song.id)}
+              />
+            ))}
+          </div>
+          <VirtualListFooter
+            sentinelRef={sentinelRef}
+            isFetching={isFetching}
+            isError={isError}
+            onRetry={onRetry}
           />
-        ))}
-      </div>
-      <VirtualListFooter
-        sentinelRef={sentinelRef}
-        isFetching={isFetching}
-        isError={isError}
-        onRetry={onRetry}
-      />
-      {!isFetching && !isError && !hasMore && items.length > 0 && <div className="h-4" />}
+          {!isFetching && !isError && !hasMore && items.length > 0 && <div className="h-4" />}
+        </>
+      )}
     </div>
   );
 });

--- a/packages/web/src/components/settings/AdminSection.tsx
+++ b/packages/web/src/components/settings/AdminSection.tsx
@@ -50,6 +50,7 @@ export default function AdminSection() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [successMsg, setSuccessMsg] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
     async function load() {
@@ -77,6 +78,8 @@ export default function AdminSection() {
         }
       } catch {
         setError('Could not load settings.');
+      } finally {
+        setLoaded(true);
       }
     }
     load();
@@ -152,6 +155,8 @@ export default function AdminSection() {
       .map((s) => s.trim())
       .filter(Boolean)
   );
+
+  if (!loaded) return null;
 
   return (
     <div className="space-y-6">

--- a/packages/web/src/components/settings/CompressorSection.tsx
+++ b/packages/web/src/components/settings/CompressorSection.tsx
@@ -33,6 +33,7 @@ export default function CompressorSection() {
   const [values, setValues] = useState<CompressorValues>(DEFAULTS);
   const [savedValues, setSavedValues] = useState<CompressorValues>(DEFAULTS);
   const [saving, setSaving] = useState(false);
+  const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
     async function load() {
@@ -45,9 +46,12 @@ export default function CompressorSection() {
         }
       } catch {
         // silently fail
+      } finally {
+        setLoaded(true);
       }
     }
     if (canManage) load();
+    else setLoaded(true);
   }, [canManage]);
 
   const hasChanges = JSON.stringify(values) !== JSON.stringify(savedValues);
@@ -79,6 +83,8 @@ export default function CompressorSection() {
   }
 
   const dimmed = !canManage;
+
+  if (!loaded) return null;
 
   return (
     <div className={`space-y-3 ${dimmed ? 'opacity-40 pointer-events-none' : ''}`}>

--- a/packages/web/src/components/ui/ArtworkImage.tsx
+++ b/packages/web/src/components/ui/ArtworkImage.tsx
@@ -1,0 +1,43 @@
+import { DiscIcon } from '@phosphor-icons/react';
+import { useState } from 'react';
+
+interface ArtworkImageProps {
+  src?: string | null;
+  alt?: string;
+  className?: string;
+  /** Additional classes applied directly to the <img>, e.g. "scale-[1.33]" */
+  imageClassName?: string;
+}
+
+export function ArtworkImage({
+  src,
+  alt = '',
+  className = '',
+  imageClassName = '',
+}: ArtworkImageProps) {
+  const [loaded, setLoaded] = useState(false);
+
+  if (!src) return null;
+
+  return (
+    <div className={`relative ${className}`}>
+      {!loaded && (
+        <div className="absolute inset-0 bg-elevated flex items-center justify-center">
+          <DiscIcon
+            size={20}
+            weight="duotone"
+            className="text-faint animate-[spin_3s_linear_infinite]"
+          />
+        </div>
+      )}
+      <img
+        src={src}
+        alt={alt}
+        loading="lazy"
+        decoding="async"
+        onLoad={() => setLoaded(true)}
+        className={`absolute inset-0 w-full h-full object-cover transition-opacity duration-200 ${loaded ? 'opacity-100' : 'opacity-0'} ${imageClassName}`}
+      />
+    </div>
+  );
+}

--- a/packages/web/src/hooks/useVirtualizedInfiniteScroll.ts
+++ b/packages/web/src/hooks/useVirtualizedInfiniteScroll.ts
@@ -17,6 +17,7 @@ export interface UseInfiniteScrollReturn<T> {
   isError: boolean;
   hasMore: boolean;
   total: number;
+  hasLoaded: boolean;
   prepend: (item: T) => void;
   updateItem: (item: T) => void;
   removeItem: (id: string) => void;
@@ -36,6 +37,7 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[]>({
   const [isError, setIsError] = useState(false);
   const [hasMore, setHasMore] = useState(true);
   const [total, setTotal] = useState(0);
+  const [hasLoaded, setHasLoaded] = useState(false);
 
   const pageRef = useRef(1);
   const hasMoreRef = useRef(true);
@@ -43,6 +45,7 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[]>({
   const isMountedRef = useRef(true);
   const hasEverLoadedRef = useRef(false);
   const loadingTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const resetInProgressRef = useRef(false);
 
   hasMoreRef.current = hasMore;
   isFetchingRef.current = isFetching;
@@ -65,6 +68,7 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[]>({
       if (!isInitial && !hasMoreRef.current) return;
 
       if (isInitial) {
+        resetInProgressRef.current = true;
         // Delay the skeleton by 200ms — if the fetch completes faster,
         // the skeleton is never rendered, avoiding a flash.
         // On subsequent deps changes (tab switch, filter change), keep
@@ -107,9 +111,11 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[]>({
           clearTimeout(loadingTimerRef.current);
           loadingTimerRef.current = undefined;
         }
+        resetInProgressRef.current = false;
         if (isMountedRef.current) {
           setIsLoading(false);
           setIsFetching(false);
+          setHasLoaded(true);
         }
       }
     },
@@ -117,7 +123,7 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[]>({
   );
 
   const fetchMore = useCallback(() => {
-    if (!hasMoreRef.current || isFetchingRef.current) return;
+    if (!hasMoreRef.current || isFetchingRef.current || resetInProgressRef.current) return;
     const nextPage = pageRef.current + 1;
     void loadPage(nextPage);
   }, [loadPage]);
@@ -131,6 +137,7 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[]>({
   }, [loadPage]);
 
   const prepend = useCallback((item: T) => {
+    if (resetInProgressRef.current) return;
     setItems((prev) => {
       if (prev.some((i) => (i as { id: string }).id === (item as { id: string }).id)) return prev;
       return [item, ...prev];
@@ -138,12 +145,14 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[]>({
   }, []);
 
   const updateItem = useCallback((item: T) => {
+    if (resetInProgressRef.current) return;
     setItems((prev) =>
       prev.map((i) => ((i as { id: string }).id === (item as { id: string }).id ? item : i))
     );
   }, []);
 
   const removeItem = useCallback((id: string) => {
+    if (resetInProgressRef.current) return;
     setItems((prev) => prev.filter((i) => (i as { id: string }).id !== id));
   }, []);
 
@@ -166,6 +175,7 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[]>({
 
     return () => {
       isMountedRef.current = false;
+      resetInProgressRef.current = false;
       if (loadingTimerRef.current) {
         clearTimeout(loadingTimerRef.current);
         loadingTimerRef.current = undefined;
@@ -210,6 +220,7 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[]>({
     isError,
     hasMore,
     total,
+    hasLoaded,
     prepend,
     updateItem,
     removeItem,

--- a/packages/web/src/pages/PermissionsPage.tsx
+++ b/packages/web/src/pages/PermissionsPage.tsx
@@ -186,13 +186,24 @@ export default function PermissionsPage() {
   }, [data, mapping]);
 
   // Loading state ---------------------------------------------------------
+  // Loading state — deferred 200ms to avoid flash on fast loads
+  const [showLoading, setShowLoading] = useState(false);
+  useEffect(() => {
+    const t = setTimeout(() => setShowLoading(true), 200);
+    return () => clearTimeout(t);
+  }, []);
+
   if (!data) {
     return (
       <div className="p-4 md:p-8">
         <div className="mb-6 md:mb-8">
           <h1 className="font-display text-3xl md:text-4xl text-fg tracking-wider">Permissions</h1>
         </div>
-        {error ? <ErrorBanner message={error} /> : <p className="text-sm text-muted">Loading…</p>}
+        {error ? (
+          <ErrorBanner message={error} />
+        ) : (
+          showLoading && <p className="text-sm text-muted">Loading…</p>
+        )}
       </div>
     );
   }

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -929,6 +929,7 @@ export default function PlaylistDetailPage() {
           isFetching={isFetching}
           isError={isError}
           hasMore={hasMore}
+          hasLoaded={!isLoading}
           playingId={playingSongId}
           onRetry={retry}
           sentinelRef={sentinelRef}

--- a/packages/web/src/pages/PlaylistsPage.tsx
+++ b/packages/web/src/pages/PlaylistsPage.tsx
@@ -21,7 +21,7 @@ export default function PlaylistsPage() {
   const [showCreate, setShowCreate] = useState(false);
   const { notification } = useNotification();
 
-  const { items, isLoading, isFetching, isError, prepend, retry, sentinelRef } =
+  const { items, isLoading, isFetching, isError, hasLoaded, prepend, retry, sentinelRef } =
     useVirtualizedInfiniteScroll<Playlist, [boolean]>({
       fetchPage: async (page, limit, admin) => {
         const result = await getPlaylistsPage(admin, page, limit);
@@ -73,7 +73,7 @@ export default function PlaylistsPage() {
           <h1 className="font-display text-3xl md:text-4xl text-fg tracking-wider">Playlists</h1>
           <p className="font-mono text-xs text-muted mt-2">
             Browse & manage playlists
-            {isLoading ? '' : ` • ${items.length} playlist${items.length !== 1 ? 's' : ''}`}
+            {hasLoaded ? ` • ${items.length} playlist${items.length !== 1 ? 's' : ''}` : ''}
           </p>
         </div>
         <Button
@@ -91,6 +91,7 @@ export default function PlaylistsPage() {
         isLoading={isLoading}
         isFetching={isFetching}
         isError={isError}
+        hasLoaded={hasLoaded}
         onRetry={retry}
         sentinelRef={sentinelRef}
         onRowClick={handleRowClick}

--- a/packages/web/src/pages/RequestsPage.tsx
+++ b/packages/web/src/pages/RequestsPage.tsx
@@ -23,23 +23,33 @@ export default function RequestsPage() {
   const [actionError, setActionError] = useState<string | null>(null);
   const autoRedirected = useRef(false);
 
-  const { items, isLoading, isFetching, isError, total, removeItem, retry, reset, sentinelRef } =
-    useVirtualizedInfiniteScroll<SongRequest, [string, boolean]>({
-      fetchPage: async (page, limit, currentTab, currentMineOnly) => {
-        const status = currentTab === 'pending' ? 'pending' : 'all';
-        const result = await fetchRequests(page, limit, {
-          status,
-          mine: currentMineOnly || undefined,
-        });
-        return {
-          items: result.items,
-          hasMore: result.pagination.page < result.pagination.totalPages,
-          total: result.pagination.total,
-        };
-      },
-      limit: ITEMS_PER_PAGE,
-      deps: [tab, mineOnly],
-    });
+  const {
+    items,
+    isLoading,
+    isFetching,
+    isError,
+    total,
+    hasLoaded,
+    removeItem,
+    retry,
+    reset,
+    sentinelRef,
+  } = useVirtualizedInfiniteScroll<SongRequest, [string, boolean]>({
+    fetchPage: async (page, limit, currentTab, currentMineOnly) => {
+      const status = currentTab === 'pending' ? 'pending' : 'all';
+      const result = await fetchRequests(page, limit, {
+        status,
+        mine: currentMineOnly || undefined,
+      });
+      return {
+        items: result.items,
+        hasMore: result.pagination.page < result.pagination.totalPages,
+        total: result.pagination.total,
+      };
+    },
+    limit: ITEMS_PER_PAGE,
+    deps: [tab, mineOnly],
+  });
 
   const handleApprove = async (id: string) => {
     setActionError(null);
@@ -97,7 +107,7 @@ export default function RequestsPage() {
     }
   });
 
-  const countLabel = isLoading ? '—' : `${total} request${total !== 1 ? 's' : ''}`;
+  const countLabel = hasLoaded ? `${total} request${total !== 1 ? 's' : ''}` : '—';
 
   return (
     <div className="p-4 md:p-8">
@@ -106,7 +116,7 @@ export default function RequestsPage() {
         <div>
           <h1 className="font-display text-3xl md:text-4xl text-fg tracking-wider">Requests</h1>
           <p className="font-mono text-xs text-muted mt-2">
-            Submit & review requests{isLoading ? '' : ` • ${countLabel}`}
+            Submit & review requests{hasLoaded ? ` • ${countLabel}` : ''}
           </p>
         </div>
         <Button
@@ -164,6 +174,7 @@ export default function RequestsPage() {
         isError={isError}
         isOwnFn={isOwnFn}
         isAdmin={isAdminView}
+        hasLoaded={hasLoaded}
         onRetry={retry}
         sentinelRef={sentinelRef}
         onApprove={handleApprove}

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -241,6 +241,7 @@ export default function SongsPage() {
     isError,
     hasMore,
     total,
+    hasLoaded,
     prepend,
     updateItem,
     removeItem,
@@ -323,7 +324,7 @@ export default function SongsPage() {
         <div>
           <h1 className="font-display text-3xl md:text-4xl text-fg tracking-wider">Songs</h1>
           <p className="font-mono text-xs text-muted mt-2">
-            Music library{isLoading ? '' : ` • ${total} track${total !== 1 ? 's' : ''}`}
+            Music library{hasLoaded ? ` • ${total} track${total !== 1 ? 's' : ''}` : ''}
           </p>
         </div>
         <span className="relative group">
@@ -477,6 +478,7 @@ export default function SongsPage() {
         isFetching={isFetching}
         isError={isError}
         hasMore={hasMore}
+        hasLoaded={hasLoaded}
         playingId={playingId}
         onRetry={retry}
         sentinelRef={sentinelRef}

--- a/packages/web/src/pages/TagsPage.tsx
+++ b/packages/web/src/pages/TagsPage.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import ConfirmModal from '../components/ConfirmModal';
 import EmptyState from '../components/EmptyState';
 import TagTicker from '../components/TagTicker';
+import { ArtworkImage } from '../components/ui/ArtworkImage';
 import { Button } from '../components/ui/Button';
 import { useTagColors } from '../context/TagsContext';
 
@@ -60,6 +61,12 @@ export default function TagsPage() {
   const [savingName, setSavingName] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const { refreshTags } = useTagColors();
+
+  const [showTagsLoading, setShowTagsLoading] = useState(false);
+  useEffect(() => {
+    const t = setTimeout(() => setShowTagsLoading(true), 200);
+    return () => clearTimeout(t);
+  }, []);
 
   useEffect(() => {
     fetchTags()
@@ -176,9 +183,11 @@ export default function TagsPage() {
 
           <div className="flex-1 overflow-y-auto">
             {loadingTags ? (
-              <div className="flex items-center justify-center h-20 text-muted text-sm">
-                Loading…
-              </div>
+              showTagsLoading ? (
+                <div className="flex items-center justify-center h-20 text-muted text-sm">
+                  Loading…
+                </div>
+              ) : null
             ) : filtered.length === 0 ? (
               <EmptyState
                 compact
@@ -309,11 +318,10 @@ export default function TagsPage() {
                         >
                           <div className="w-12 h-12 rounded border border-border shrink-0 overflow-hidden bg-base">
                             {(song.artwork ?? song.thumbnailUrl) ? (
-                              <img
+                              <ArtworkImage
                                 src={song.artwork ?? song.thumbnailUrl}
                                 alt=""
-                                className="w-full h-full object-cover"
-                                loading="lazy"
+                                className="w-full h-full"
                               />
                             ) : (
                               <div className="w-full h-full flex items-center justify-center text-faint text-[10px]" />


### PR DESCRIPTION
## Summary

Fixes multiple visual flash issues when navigating between pages: empty states flashing before data loads, artwork images showing alt text before loading, count labels flickering, and settings forms rendering defaults before API data arrives.

## Changes

- **Virtual list rendering** — Unified skeleton/empty/content into a single container with useLayoutEffect-controlled opacity to keep all cards hidden until the browser can paint them atomically
- **Empty state gating** — Added hasLoaded state to useVirtualizedInfiniteScroll, empty state now only shows after the first fetch completes (not during the initial grace period)
- **Socket event race guard** — Added resetInProgressRef to block prepend/update/remove mutations during active fetches, preventing items from being inserted into stale lists
- **Artwork loading** — New ArtworkImage component renders a spinning DiscIcon while images load, then fades in the image onLoad; replaces all raw <img> tags for artwork/thumbnails
- **Count labels** — Page header track/playlist/request counts now gate on hasLoaded instead of isLoading
- **Settings pages** — Added 200ms loading delays and loaded guards to PermissionsPage, TagsPage, CompressorSection, and AdminSection