### PR TITLE
fix(server): fix URL playlist detection and re-request blocking

### DIFF
--- a/packages/server/src/routes/requests.ts
+++ b/packages/server/src/routes/requests.ts
@@ -122,10 +122,12 @@ async function handlePreviewRequest(ctx: RouteContext, request: Request): Promis
     .where(eq(songTable.sourceId, metadata.sourceId))
     .limit(1);
 
+  // alreadyExists only counts pending requests — a song that was previously
+  // approved but later deleted from the library should be re-requestable.
   const [existingReq] = await db
     .select()
     .from(requestTable)
-    .where(eq(requestTable.sourceId, metadata.sourceId))
+    .where(and(eq(requestTable.sourceId, metadata.sourceId), eq(requestTable.status, 'pending')))
     .limit(1);
 
   return json({
@@ -188,12 +190,13 @@ async function handleCreateRequest(ctx: RouteContext, request: Request): Promise
   if (!urlResult.ok) return urlResult.response;
   const originalUrl = urlResult.value;
 
-  const autoApprove = await userCanAutoApprove(ctx);
-  const isPlaylist = isPlaylistUrl(originalUrl);
-
-  // Strip ?list= for single-track URLs only
+  // Strip any ?list=... query param so YouTube video URLs with a playlist
+  // parameter (e.g. youtu.be/VIDEO_ID?list=MIX_ID) aren't misdetected as
+  // a full playlist import. Skip stripping when the client explicitly requests
+  // a playlist import via type: 'playlist'.
   let url = originalUrl;
-  if (!isPlaylist) {
+  const explicitPlaylist = (body as { type?: string }).type === 'playlist';
+  if (!explicitPlaylist) {
     try {
       const parsed = new URL(url);
       parsed.searchParams.delete('list');
@@ -202,6 +205,9 @@ async function handleCreateRequest(ctx: RouteContext, request: Request): Promise
       // leave URL unchanged
     }
   }
+
+  const autoApprove = await userCanAutoApprove(ctx);
+  const isPlaylist = isPlaylistUrl(url);
 
   // --- Playlist request ---
   if (isPlaylist) {
@@ -383,11 +389,12 @@ async function handleCreateRequest(ctx: RouteContext, request: Request): Promise
     );
   }
 
-  // Check duplicates: existing requests (any status)
+  // Check duplicates: only block on pending requests. Completed (approved/denied)
+  // requests don't prevent re-requesting — the song may have been deleted since.
   const [existingReq] = await db
     .select()
     .from(requestTable)
-    .where(eq(requestTable.sourceId, metadata.sourceId))
+    .where(and(eq(requestTable.sourceId, metadata.sourceId), eq(requestTable.status, 'pending')))
     .limit(1);
 
   if (existingReq) {

--- a/packages/server/src/shared/api.ts
+++ b/packages/server/src/shared/api.ts
@@ -141,6 +141,8 @@ export function fetchSongsPage(
 
 export interface RequestCreateData {
   sourceUrl: string;
+  /** Explicitly request a playlist import — skips ?list= stripping. */
+  type?: 'playlist';
   notifyDm?: boolean;
   nickname?: string | null;
   artist?: string | null;
@@ -163,6 +165,7 @@ export interface CreateRequestResult {
 export function createRequest(data: RequestCreateData): Promise<CreateRequestResult> {
   return post('/api/requests', {
     sourceUrl: data.sourceUrl,
+    type: data.type,
     notifyDm: data.notifyDm ?? false,
     ...(data.nickname != null && { nickname: data.nickname }),
     ...(data.artist != null && { artist: data.artist }),

--- a/packages/web/src/components/AddSongModal.tsx
+++ b/packages/web/src/components/AddSongModal.tsx
@@ -98,6 +98,7 @@ export default function AddSongModal({
     try {
       const result = await createRequest({
         sourceUrl: url.trim(),
+        type: 'playlist',
       });
 
       onRequestCreated?.();


### PR DESCRIPTION
## Summary

Fixes two bugs in the song request import flow:
1. YouTube video URLs with `?list=` query params (e.g. `youtu.be/VID?list=MIX`) were misdetected as playlist imports
2. Songs previously approved then deleted from the library couldn't be re-requested

## Changes

- **Strip `?list=` before playlist detection** — `handleCreateRequest` now cleans the URL before `isPlaylistUrl()`, mirroring `handlePreviewRequest`. When the client explicitly sends `type: 'playlist'`, stripping is skipped so legitimate playlist imports still work.
- **Only block on pending requests** — Duplicate checks in `handleCreateRequest` and `handlePreviewRequest` now filter to `status = 'pending'` instead of all statuses. Previously-approved (and later deleted) songs can be re-requested.
- **Client sends `type: 'playlist'`** — `AddSongModal` includes `type: 'playlist'` when the user clicks "Import Playlist", so the server knows to preserve the `?list=` param.