### PR TITLE
feat: add bulk select, delete, and edit actions to songs and playlist pages

### DIFF
--- a/packages/server/src/routes/playlists.ts
+++ b/packages/server/src/routes/playlists.ts
@@ -751,6 +751,72 @@ async function handleRemoveSong(
 }
 
 // ---------------------------------------------------------------------------
+// POST /api/playlists/:id/songs/bulk-remove — remove multiple songs from a playlist
+// ---------------------------------------------------------------------------
+async function handleBulkRemoveSongs(
+  ctx: RouteContext,
+  request: Request,
+  playlistId: string
+): Promise<Response> {
+  const guards = await checkGuards(ctx);
+  if (guards instanceof Response) return guards;
+  const { user } = guards;
+
+  const playlist = await findPlaylistOr404(playlistId);
+  if (!playlist) {
+    return json({ error: 'Playlist not found.' }, 404);
+  }
+
+  const accessResult = canAccessPlaylist(playlist, user, undefined);
+  if (!accessResult.ok) {
+    return json({ error: `Only the playlist owner or admins can remove songs.` }, 403);
+  }
+
+  let body: { songIds?: unknown };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return json({ error: 'Invalid JSON body.' }, 400);
+  }
+
+  if (!Array.isArray(body.songIds) || body.songIds.length === 0) {
+    return json({ error: 'songIds must be a non-empty array.' }, 400);
+  }
+
+  const songIds = (body.songIds as string[]).slice(0, 5000);
+
+  // Delete and re-index in a transaction
+  await db.transaction(async (tx) => {
+    await tx
+      .delete(playlistSongTable)
+      .where(
+        and(
+          eq(playlistSongTable.playlistId, playlistId),
+          inArray(playlistSongTable.songId, songIds)
+        )
+      );
+
+    // Re-index remaining songs to close gaps in positions
+    const remaining = await tx
+      .select()
+      .from(playlistSongTable)
+      .where(eq(playlistSongTable.playlistId, playlistId))
+      .orderBy(playlistSongTable.position);
+
+    await Promise.all(
+      remaining.map((ps, index) =>
+        tx.update(playlistSongTable).set({ position: index }).where(eq(playlistSongTable.id, ps.id))
+      )
+    );
+  });
+
+  const value = await getPlaylistSongCount(playlistId);
+  emitPlaylistUpdated(formatPlaylist(playlist, value));
+
+  return json({ removed: songIds.length });
+}
+
+// ---------------------------------------------------------------------------
 // Dispatcher
 // ---------------------------------------------------------------------------
 
@@ -772,6 +838,15 @@ export async function handlePlaylists(ctx: RouteContext, request: Request): Prom
     if (request.method === 'GET') return await handleGetPlaylists(ctx, request);
     if (request.method === 'POST') return await handlePostPlaylist(ctx, request);
     return json({ error: 'Not Found' }, 404);
+  }
+
+  // /api/playlists/:id/songs/bulk-remove POST
+  const bulkRemoveMatch = path.match(/^\/([^/]+)\/songs\/bulk-remove$/);
+  if (bulkRemoveMatch && request.method === 'POST') {
+    const [, playlistId] = bulkRemoveMatch;
+    if (playlistId) {
+      return await handleBulkRemoveSongs(ctx, request, playlistId);
+    }
   }
 
   // /api/playlists/:id/songs/:songId DELETE

--- a/packages/server/src/routes/songs.ts
+++ b/packages/server/src/routes/songs.ts
@@ -96,6 +96,273 @@ function buildFilterClause(tags: string[], sources: string[]): ReturnType<typeof
 }
 
 // ---------------------------------------------------------------------------
+// POST /api/songs/bulk-delete — delete multiple songs at once.
+// ---------------------------------------------------------------------------
+async function handleBulkDelete(ctx: RouteContext, request: Request): Promise<Response> {
+  const guards = await checkGuards(ctx, { admin: true, permission: 'songs.delete' });
+  if (guards instanceof Response) return guards;
+
+  let body: { ids?: unknown };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return json({ error: 'Invalid JSON body.' }, 400);
+  }
+
+  if (!Array.isArray(body.ids) || body.ids.length === 0) {
+    return json({ error: 'ids must be a non-empty array of song IDs.' }, 400);
+  }
+
+  const ids = body.ids.slice(0, 5000) as string[];
+
+  // Delete songs from DB
+  await db.delete(songTable).where(inArray(songTable.id, ids));
+
+  // Emit deleted events for each song so connected clients update in real time
+  for (const id of ids) {
+    emitSongDeleted(id);
+  }
+
+  return json({ deleted: ids.length });
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/songs/bulk-tag — add or set tags on multiple songs at once.
+// ---------------------------------------------------------------------------
+async function handleBulkTag(ctx: RouteContext, request: Request): Promise<Response> {
+  const guards = await checkGuards(ctx, { admin: true, permission: 'songs.edit' });
+  if (guards instanceof Response) return guards;
+
+  let body: { ids?: unknown; tags?: unknown; mode?: unknown };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return json({ error: 'Invalid JSON body.' }, 400);
+  }
+
+  if (!Array.isArray(body.ids) || body.ids.length === 0) {
+    return json({ error: 'ids must be a non-empty array of song IDs.' }, 400);
+  }
+
+  const tagsResult = validateTags(body.tags);
+  if (!tagsResult.ok) return tagsResult.response;
+
+  const ids = (body.ids as string[]).slice(0, 5000);
+  const newTags = await canonicalizeTags(tagsResult.value);
+  const mode = body.mode === 'set' ? 'set' : 'add'; // "add" is default (merge with existing)
+
+  // Fetch existing songs
+  const existingSongs = await db.select().from(songTable).where(inArray(songTable.id, ids));
+
+  const updatedIds: string[] = [];
+
+  if (mode === 'set') {
+    // Replace tags entirely
+    await db.update(songTable).set({ tags: newTags }).where(inArray(songTable.id, ids));
+    updatedIds.push(...ids);
+  } else {
+    // Merge: add new tags to each song's existing tags
+    for (const song of existingSongs) {
+      const existingTags = song.tags ?? [];
+      const merged = [...new Set([...existingTags, ...newTags])];
+      await db.update(songTable).set({ tags: merged }).where(eq(songTable.id, song.id));
+      updatedIds.push(song.id);
+    }
+  }
+
+  // Re-fetch updated songs and emit events
+  const updatedSongs = await db.select().from(songTable).where(inArray(songTable.id, updatedIds));
+
+  for (const s of updatedSongs) {
+    emitSongUpdated(formatSong(s));
+  }
+
+  // If tags changed, re-sync any smart playlists tracking affected tags
+  if (newTags.length > 0) {
+    const affectedPlaylists = await db
+      .select({ id: playlistTable.id, tagNameLower: playlistTable.tagNameLower })
+      .from(playlistTable)
+      .where(
+        and(
+          sql`${playlistTable.tagNameLower} IS NOT NULL`,
+          inArray(
+            playlistTable.tagNameLower,
+            newTags.map((t) => t.toLowerCase())
+          )
+        )
+      );
+
+    for (const pl of affectedPlaylists) {
+      if (pl.tagNameLower) {
+        await syncPlaylistToTag(pl.id);
+        const [updatedPl] = await db
+          .select()
+          .from(playlistTable)
+          .where(eq(playlistTable.id, pl.id))
+          .limit(1);
+        if (updatedPl) {
+          const songCountResult = await db
+            .select({ count: sql<number>`count(*)` })
+            .from(playlistSongTable)
+            .where(eq(playlistSongTable.playlistId, pl.id));
+          const count = songCountResult[0]?.count ?? 0;
+          emitPlaylistUpdated({
+            ...updatedPl,
+            createdAt: updatedPl.createdAt.toISOString(),
+            _count: { songs: count },
+          });
+        }
+      }
+    }
+  }
+
+  return json({ updated: updatedSongs.length, tags: newTags });
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/songs/bulk-edit — set metadata fields on multiple songs at once.
+// Fields left undefined are skipped. Fields listed in clearFields are set to null.
+// ---------------------------------------------------------------------------
+async function handleBulkEdit(ctx: RouteContext, request: Request): Promise<Response> {
+  const guards = await checkGuards(ctx, { admin: true, permission: 'songs.edit' });
+  if (guards instanceof Response) return guards;
+
+  let body: {
+    ids?: unknown;
+    nickname?: unknown;
+    artist?: unknown;
+    album?: unknown;
+    artwork?: unknown;
+    tags?: unknown;
+    volumeBoost?: unknown;
+    clearFields?: unknown;
+  };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return json({ error: 'Invalid JSON body.' }, 400);
+  }
+
+  if (!Array.isArray(body.ids) || body.ids.length === 0) {
+    return json({ error: 'ids must be a non-empty array of song IDs.' }, 400);
+  }
+
+  const ids = (body.ids as string[]).slice(0, 5000);
+  const clearFields: string[] = Array.isArray(body.clearFields)
+    ? (body.clearFields as string[])
+    : [];
+
+  const data: Record<string, unknown> = {};
+
+  // Nickname
+  if ('nickname' in body && body.nickname !== undefined) {
+    const result = validateNickname(body.nickname);
+    if (!result.ok) return result.response;
+    data.nickname = result.value;
+  } else if (clearFields.includes('nickname')) {
+    data.nickname = null;
+  }
+
+  // Artist
+  if ('artist' in body && body.artist !== undefined) {
+    data.artist = validateOptionalString(body.artist);
+  } else if (clearFields.includes('artist')) {
+    data.artist = null;
+  }
+
+  // Album
+  if ('album' in body && body.album !== undefined) {
+    data.album = validateOptionalString(body.album);
+  } else if (clearFields.includes('album')) {
+    data.album = null;
+  }
+
+  // Artwork
+  if ('artwork' in body && body.artwork !== undefined) {
+    const artworkResult = validateArtworkUrl(body.artwork);
+    if (!artworkResult.ok) return artworkResult.response;
+    data.artwork = artworkResult.value;
+  } else if (clearFields.includes('artwork')) {
+    data.artwork = null;
+  }
+
+  // Tags
+  if ('tags' in body && body.tags !== undefined) {
+    const tagsResult = validateTags(body.tags);
+    if (!tagsResult.ok) return tagsResult.response;
+    data.tags = await canonicalizeTags(tagsResult.value);
+  } else if (clearFields.includes('tags')) {
+    data.tags = [];
+  }
+
+  // Volume boost
+  if ('volumeBoost' in body && body.volumeBoost !== undefined) {
+    const volumeResult = validateVolumeBoost(body.volumeBoost);
+    if (!volumeResult.ok) return volumeResult.response;
+    data.volumeBoost = volumeResult.value;
+  } else if (clearFields.includes('volumeBoost')) {
+    data.volumeBoost = null;
+  }
+
+  if (Object.keys(data).length === 0) {
+    return json({ error: 'No fields to update.' }, 400);
+  }
+
+  await db.update(songTable).set(data).where(inArray(songTable.id, ids));
+
+  // Re-fetch updated songs and emit events
+  const updatedSongs = await db.select().from(songTable).where(inArray(songTable.id, ids));
+
+  for (const s of updatedSongs) {
+    emitSongUpdated(formatSong(s));
+  }
+
+  // If tags changed, re-sync any smart playlists tracking affected tags
+  if ('tags' in data) {
+    const tagValues = (data.tags as string[]) ?? [];
+    if (tagValues.length > 0) {
+      const affectedPlaylists = await db
+        .select({ id: playlistTable.id, tagNameLower: playlistTable.tagNameLower })
+        .from(playlistTable)
+        .where(
+          and(
+            sql`${playlistTable.tagNameLower} IS NOT NULL`,
+            inArray(
+              playlistTable.tagNameLower,
+              tagValues.map((t) => t.toLowerCase())
+            )
+          )
+        );
+
+      for (const pl of affectedPlaylists) {
+        if (pl.tagNameLower) {
+          await syncPlaylistToTag(pl.id);
+          const [updatedPl] = await db
+            .select()
+            .from(playlistTable)
+            .where(eq(playlistTable.id, pl.id))
+            .limit(1);
+          if (updatedPl) {
+            const songCountResult = await db
+              .select({ count: sql<number>`count(*)` })
+              .from(playlistSongTable)
+              .where(eq(playlistSongTable.playlistId, pl.id));
+            const count = songCountResult[0]?.count ?? 0;
+            emitPlaylistUpdated({
+              ...updatedPl,
+              createdAt: updatedPl.createdAt.toISOString(),
+              _count: { songs: count },
+            });
+          }
+        }
+      }
+    }
+  }
+
+  return json({ updated: ids.length });
+}
+
+// ---------------------------------------------------------------------------
 // GET /api/songs — paginated list of songs with sort & filter.
 // ---------------------------------------------------------------------------
 async function handleGetSongs(ctx: RouteContext, request: Request): Promise<Response> {
@@ -343,6 +610,21 @@ export async function handleSongs(ctx: RouteContext, request: Request): Promise<
   // GET /api/songs
   if (request.method === 'GET' && pathname === '/api/songs') {
     return await handleGetSongs(ctx, request);
+  }
+
+  // POST /api/songs/bulk-delete
+  if (request.method === 'POST' && pathname === '/api/songs/bulk-delete') {
+    return await handleBulkDelete(ctx, request);
+  }
+
+  // POST /api/songs/bulk-tag
+  if (request.method === 'POST' && pathname === '/api/songs/bulk-tag') {
+    return await handleBulkTag(ctx, request);
+  }
+
+  // POST /api/songs/bulk-edit
+  if (request.method === 'POST' && pathname === '/api/songs/bulk-edit') {
+    return await handleBulkEdit(ctx, request);
   }
 
   // DELETE /api/songs/:id

--- a/packages/server/src/shared/api.ts
+++ b/packages/server/src/shared/api.ts
@@ -212,6 +212,32 @@ export function deleteSong(id: string): Promise<void> {
   return remove(`/api/songs/${id}`);
 }
 
+export function bulkDeleteSongs(ids: string[]): Promise<{ deleted: number }> {
+  return post('/api/songs/bulk-delete', { ids });
+}
+
+export function bulkTagSongs(
+  ids: string[],
+  tags: string[],
+  mode: 'add' | 'set' = 'add'
+): Promise<{ updated: number; tags: string[] }> {
+  return post('/api/songs/bulk-tag', { ids, tags, mode });
+}
+
+export interface BulkEditData {
+  nickname?: string | null;
+  artist?: string | null;
+  album?: string | null;
+  artwork?: string | null;
+  tags?: string[];
+  volumeBoost?: number | null;
+  clearFields?: string[];
+}
+
+export function bulkEditSongs(ids: string[], data: BulkEditData): Promise<{ updated: number }> {
+  return post('/api/songs/bulk-edit', { ids, ...data });
+}
+
 /**
  * Data for updating a song. Only provide fields you want to change.
  */
@@ -309,6 +335,13 @@ export function addSongToPlaylist(playlistId: string, songId: string): Promise<v
 
 export function removeSongFromPlaylist(playlistId: string, songId: string): Promise<void> {
   return remove(`/api/playlists/${playlistId}/songs/${songId}`);
+}
+
+export function bulkRemoveSongsFromPlaylist(
+  playlistId: string,
+  songIds: string[]
+): Promise<{ removed: number }> {
+  return post(`/api/playlists/${playlistId}/songs/bulk-remove`, { songIds });
 }
 
 export function togglePlaylistVisibility(

--- a/packages/web/src/api/api.ts
+++ b/packages/web/src/api/api.ts
@@ -12,6 +12,7 @@ export type {
 } from '@alfira-bot/server/shared';
 
 export type {
+  BulkEditData,
   FetchSongsOptions,
   MyPermissionsResponse,
   PermissionsResponse,
@@ -23,6 +24,10 @@ export {
   addSongToPlaylist,
   addToPriorityQueue,
   approveRequest,
+  bulkDeleteSongs,
+  bulkEditSongs,
+  bulkRemoveSongsFromPlaylist,
+  bulkTagSongs,
   type CreateRequestResult,
   cancelRequest,
   completeSetup,

--- a/packages/web/src/components/BulkActionBar.tsx
+++ b/packages/web/src/components/BulkActionBar.tsx
@@ -1,0 +1,87 @@
+import { TagIcon, TrashIcon, XIcon } from '@phosphor-icons/react';
+import { Button } from './ui/Button';
+
+interface BulkActionBarProps {
+  count: number;
+  loadedCount: number;
+  totalCount: number;
+  canDelete: boolean;
+  canTag: boolean;
+  deleteLabel?: string;
+  onDelete: () => void;
+  onTag: () => void;
+  onSelectAll: () => void;
+  onDeselectAll: () => void;
+  isDeleting?: boolean;
+}
+
+export default function BulkActionBar({
+  count,
+  loadedCount,
+  totalCount,
+  canDelete,
+  canTag,
+  deleteLabel = 'Delete selected',
+  onDelete,
+  onTag,
+  onSelectAll,
+  onDeselectAll,
+  isDeleting,
+}: BulkActionBarProps) {
+  const allLoadedSelected = count > 0 && count === loadedCount;
+  const selectLabel =
+    loadedCount < totalCount ? `Select all ${loadedCount}` : `Select all ${totalCount}`;
+
+  return (
+    <div className="fixed bottom-22 md:bottom-20 left-0 right-0 z-50 flex justify-center pb-4 md:pb-6 pointer-events-none">
+      <div className="pointer-events-auto flex items-center gap-3 px-4 py-3 bg-elevated border border-border rounded-xl shadow-2xl animate-fade-up">
+        <span className="text-sm font-mono text-fg tabular-nums">
+          {count} / {totalCount} selected
+        </span>
+
+        <button
+          type="button"
+          className="text-xs text-muted hover:text-accent transition-colors cursor-pointer"
+          onClick={allLoadedSelected ? onDeselectAll : onSelectAll}
+        >
+          {allLoadedSelected ? 'Deselect all' : selectLabel}
+        </button>
+
+        <div className="w-px h-5 bg-border" />
+
+        {canDelete && (
+          <Button
+            variant="danger"
+            className="text-xs flex items-center gap-1.5"
+            onClick={onDelete}
+            disabled={isDeleting}
+          >
+            <TrashIcon size={14} weight="duotone" />
+            {deleteLabel}
+          </Button>
+        )}
+
+        {canTag && (
+          <Button
+            variant="inherit"
+            surface="surface"
+            className="text-xs flex items-center gap-1.5"
+            onClick={onTag}
+          >
+            <TagIcon size={14} weight="duotone" />
+            Edit selected
+          </Button>
+        )}
+
+        <button
+          type="button"
+          className="ml-1 p-1 text-muted hover:text-fg transition-colors cursor-pointer"
+          onClick={onDeselectAll}
+          title="Clear selection"
+        >
+          <XIcon size={16} weight="bold" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/BulkActionBar.tsx
+++ b/packages/web/src/components/BulkActionBar.tsx
@@ -33,7 +33,7 @@ export default function BulkActionBar({
     loadedCount < totalCount ? `Select all ${loadedCount}` : `Select all ${totalCount}`;
 
   return (
-    <div className="fixed bottom-22 md:bottom-20 left-0 right-0 z-50 flex justify-center pb-4 md:pb-6 pointer-events-none">
+    <div className="fixed bottom-20 md:bottom-18 left-0 right-0 z-50 flex justify-center pb-4 md:pb-6 pointer-events-none">
       <div className="pointer-events-auto flex items-center gap-3 px-4 py-3 bg-elevated border border-border rounded-xl shadow-2xl animate-fade-up">
         <span className="text-sm font-mono text-fg tabular-nums">
           {count} / {totalCount} selected

--- a/packages/web/src/components/BulkEditModal.tsx
+++ b/packages/web/src/components/BulkEditModal.tsx
@@ -1,0 +1,471 @@
+import { type BulkEditData, fetchTags, type TagItem } from '@alfira-bot/server/shared/api';
+import { EraserIcon, XIcon } from '@phosphor-icons/react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTagColors } from '../context/TagsContext';
+import { getTagColorClasses } from '../utils/tagColors';
+import { Backdrop } from './Backdrop';
+import { Button } from './ui/Button';
+
+interface BulkEditModalProps {
+  count: number;
+  onApply: (data: BulkEditData) => void;
+  onClose: () => void;
+  isApplying?: boolean;
+}
+
+type EditableField = Extract<keyof BulkEditData, string>;
+
+const EDITABLE_FIELDS: { key: EditableField; label: string; placeholder: string }[] = [
+  { key: 'nickname', label: 'Nickname', placeholder: 'Custom display name' },
+  { key: 'artist', label: 'Artist', placeholder: 'Artist name' },
+  { key: 'album', label: 'Album', placeholder: 'Album name' },
+  { key: 'artwork', label: 'Artwork URL', placeholder: 'https://example.com/artwork.jpg' },
+];
+
+export default function BulkEditModal({ count, onApply, onClose, isApplying }: BulkEditModalProps) {
+  const { tagColorMap } = useTagColors();
+
+  // Text fields
+  const [nickname, setNickname] = useState('');
+  const [artist, setArtist] = useState('');
+  const [album, setAlbum] = useState('');
+  const [artwork, setArtwork] = useState('');
+
+  // Tags
+  const [tags, setTags] = useState<string[]>([]);
+  const [tagInput, setTagInput] = useState('');
+  const [availableTags, setAvailableTags] = useState<TagItem[]>([]);
+  const [showDropdown, setShowDropdown] = useState(false);
+  const [highlightedIdx, setHighlightedIdx] = useState(0);
+  const tagInputRef = useRef<HTMLInputElement>(null);
+  const tagAreaRef = useRef<HTMLDivElement>(null);
+  const tagDropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close tag dropdown when clicking outside
+  useEffect(() => {
+    if (!showDropdown) return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (
+        tagAreaRef.current &&
+        !tagAreaRef.current.contains(target) &&
+        tagDropdownRef.current &&
+        !tagDropdownRef.current.contains(target)
+      ) {
+        setShowDropdown(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [showDropdown]);
+
+  // Volume boost
+  const [volumeBoost, setVolumeBoost] = useState('');
+
+  // Clear toggles
+  const [clearFields, setClearFields] = useState<Set<string>>(new Set());
+
+  // Fetch available tags on mount
+  useEffect(() => {
+    fetchTags()
+      .then(setAvailableTags)
+      .catch(() => {
+        // Non-critical
+      });
+  }, []);
+
+  const filtered = availableTags.filter(
+    (t) =>
+      tagInput.trim() === '' ||
+      t.canonicalName.toLowerCase().includes(tagInput.toLowerCase()) ||
+      t.nameLower.includes(tagInput.toLowerCase())
+  );
+
+  const addTag = useCallback(() => {
+    const trimmed = tagInput.trim().toLowerCase();
+    if (!trimmed || tags.includes(trimmed)) return;
+    setTags((prev) => [...prev, trimmed]);
+    setTagInput('');
+    setHighlightedIdx(0);
+  }, [tagInput, tags]);
+
+  const removeTag = useCallback((tag: string) => {
+    setTags((prev) => prev.filter((t) => t !== tag));
+  }, []);
+
+  const handleTagKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      if (showDropdown && highlightedIdx >= 0 && filtered[highlightedIdx]) {
+        const tag = filtered[highlightedIdx].nameLower;
+        if (!tags.includes(tag)) {
+          setTags((prev) => [...prev, tag]);
+        }
+        setTagInput('');
+        setHighlightedIdx(0);
+      } else {
+        addTag();
+      }
+      return;
+    }
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setHighlightedIdx((prev) => Math.min(prev + 1, filtered.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setHighlightedIdx((prev) => Math.max(prev - 1, 0));
+    } else if (e.key === 'Escape') {
+      setShowDropdown(false);
+    }
+  };
+
+  const toggleClear = (field: string) => {
+    setClearFields((prev) => {
+      const next = new Set(prev);
+      if (next.has(field)) {
+        next.delete(field);
+      } else {
+        next.add(field);
+      }
+      return next;
+    });
+  };
+
+  // Volume boost slider derived values
+  const volumeNumeric =
+    volumeBoost.trim() === '' || volumeBoost.trim() === '-'
+      ? 0
+      : Math.min(200, Math.max(-100, Number.parseInt(volumeBoost, 10) || 0));
+  const volumePct = `${((volumeNumeric - -100) / (200 - -100)) * 100}%`;
+
+  const handleApply = () => {
+    const data: BulkEditData = {};
+    let hasChanges = false;
+
+    // Text fields: include if non-empty or marked for clear
+    const textFields: { key: keyof BulkEditData; value: string }[] = [
+      { key: 'nickname', value: nickname },
+      { key: 'artist', value: artist },
+      { key: 'album', value: album },
+      { key: 'artwork', value: artwork },
+    ];
+
+    for (const { key, value } of textFields) {
+      if (clearFields.has(key)) {
+        (data as Record<string, unknown>)[key] = null;
+        hasChanges = true;
+      } else if (value.trim()) {
+        (data as Record<string, unknown>)[key] = value.trim();
+        hasChanges = true;
+      }
+    }
+
+    // Tags: include if non-empty or marked for clear
+    if (clearFields.has('tags')) {
+      data.tags = [];
+      hasChanges = true;
+    } else if (tags.length > 0) {
+      data.tags = tags;
+      hasChanges = true;
+    }
+
+    // Volume boost
+    if (clearFields.has('volumeBoost')) {
+      data.volumeBoost = null;
+      hasChanges = true;
+    } else if (volumeBoost.trim()) {
+      const parsed = Number.parseFloat(volumeBoost.trim());
+      if (!Number.isNaN(parsed)) {
+        data.volumeBoost = parsed;
+        hasChanges = true;
+      }
+    }
+
+    if (!hasChanges) return;
+
+    // Include clearFields for the backend
+    if (clearFields.size > 0) {
+      data.clearFields = [...clearFields];
+    }
+
+    onApply(data);
+  };
+
+  return (
+    <Backdrop onClose={onClose}>
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: modal container, keyboard not applicable */}
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: modal container, keyboard not applicable */}
+      <div
+        className="bg-elevated rounded-xl border border-border shadow-2xl w-full max-w-md mx-4 p-6 animate-fade-up max-h-[85vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="font-display text-lg text-fg mb-1">Edit {count} songs</h2>
+        <p className="text-xs text-muted font-mono mb-4">
+          Fill in fields you want to change. Blank fields are left unchanged. Use clear to reset a
+          field.
+        </p>
+
+        <div className="flex flex-col gap-3">
+          {EDITABLE_FIELDS.map(({ key, label, placeholder }) => (
+            <div key={key} className="flex items-start gap-2">
+              <div className="flex-1">
+                <label
+                  htmlFor={`bulk-edit-${key}`}
+                  className="block font-mono text-[10px] text-muted uppercase mb-1"
+                >
+                  {label}
+                </label>
+                <input
+                  id={`bulk-edit-${key}`}
+                  className={`input text-sm w-full${clearFields.has(key) ? ' opacity-30 pointer-events-none' : ''}`}
+                  placeholder={placeholder}
+                  value={(() => {
+                    switch (key) {
+                      case 'nickname':
+                        return nickname;
+                      case 'artist':
+                        return artist;
+                      case 'album':
+                        return album;
+                      case 'artwork':
+                        return artwork;
+                      default:
+                        return '';
+                    }
+                  })()}
+                  onChange={(e) => {
+                    switch (key) {
+                      case 'nickname':
+                        setNickname(e.target.value);
+                        break;
+                      case 'artist':
+                        setArtist(e.target.value);
+                        break;
+                      case 'album':
+                        setAlbum(e.target.value);
+                        break;
+                      case 'artwork':
+                        setArtwork(e.target.value);
+                        break;
+                    }
+                  }}
+                  disabled={clearFields.has(key)}
+                />
+              </div>
+              <label className="flex flex-col items-center gap-0.5 shrink-0 pt-5 cursor-pointer">
+                <input
+                  type="checkbox"
+                  className="sr-only peer"
+                  checked={clearFields.has(key)}
+                  onChange={() => toggleClear(key)}
+                />
+                <span className="text-[9px] font-mono uppercase text-muted peer-checked:text-danger transition-colors">
+                  Clear
+                </span>
+                <EraserIcon
+                  size={12}
+                  weight="duotone"
+                  className="text-muted peer-checked:text-danger transition-colors"
+                />
+              </label>
+            </div>
+          ))}
+
+          {/* Tags field */}
+          <div>
+            <div className="flex items-start gap-2">
+              <div className="flex-1">
+                <label
+                  htmlFor="bulk-edit-tags"
+                  className="block font-mono text-[10px] text-muted uppercase mb-1"
+                >
+                  Tags
+                </label>
+                {/* biome-ignore lint/a11y/useKeyWithClickEvents: container click focuses inner input */}
+                {/* biome-ignore lint/a11y/noStaticElementInteractions: container click focuses inner input */}
+                <div
+                  ref={tagAreaRef}
+                  className={`input text-sm flex flex-wrap gap-1.5 items-center min-h-9.5 cursor-text relative${clearFields.has('tags') ? ' opacity-30 pointer-events-none' : ''}`}
+                  onClick={() => {
+                    tagInputRef.current?.focus();
+                    setShowDropdown(true);
+                  }}
+                >
+                  {tags.map((tag) => {
+                    const c = getTagColorClasses(tag, tagColorMap[tag.toLowerCase()]);
+                    return (
+                      <span
+                        key={tag}
+                        className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium ${c.bg} ${c.text} ${c.border} border`}
+                      >
+                        {tag}
+                        <button
+                          type="button"
+                          className="cursor-pointer opacity-60 hover:opacity-100"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            removeTag(tag);
+                          }}
+                        >
+                          <XIcon size={10} weight="bold" />
+                        </button>
+                      </span>
+                    );
+                  })}
+                  <input
+                    ref={tagInputRef}
+                    id="bulk-edit-tags"
+                    className="bg-transparent outline-none flex-1 min-w-[120px] text-sm placeholder:text-faint py-0.5"
+                    placeholder={
+                      tags.length === 0 ? 'Type a tag and press Enter...' : 'Add another...'
+                    }
+                    value={tagInput}
+                    onChange={(e) => {
+                      setTagInput(e.target.value);
+                      setShowDropdown(true);
+                      setHighlightedIdx(0);
+                    }}
+                    onFocus={() => setShowDropdown(true)}
+                    onKeyDown={handleTagKeyDown}
+                    disabled={clearFields.has('tags')}
+                  />
+                </div>
+              </div>
+              <label className="flex flex-col items-center gap-0.5 shrink-0 pt-5 cursor-pointer">
+                <input
+                  type="checkbox"
+                  className="sr-only peer"
+                  checked={clearFields.has('tags')}
+                  onChange={() => toggleClear('tags')}
+                />
+                <span className="text-[9px] font-mono uppercase text-muted peer-checked:text-danger transition-colors">
+                  Clear
+                </span>
+                <EraserIcon
+                  size={12}
+                  weight="duotone"
+                  className="text-muted peer-checked:text-danger transition-colors"
+                />
+              </label>
+            </div>
+
+            {/* Tag suggestions dropdown */}
+            {showDropdown && filtered.length > 0 && (
+              <div className="relative">
+                <div
+                  ref={tagDropdownRef}
+                  className="absolute top-1 left-0 right-0 bg-elevated border border-border rounded-lg shadow-lg z-30 max-h-40 overflow-y-auto"
+                >
+                  {filtered.map((t, i) => {
+                    const c = getTagColorClasses(t.canonicalName, t.color);
+                    return (
+                      <button
+                        key={t.nameLower}
+                        type="button"
+                        className={`w-full text-left px-3 py-1.5 text-sm transition-colors cursor-pointer ${
+                          i === highlightedIdx
+                            ? 'bg-accent/10 text-accent'
+                            : 'text-fg hover:bg-surface'
+                        }`}
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          if (!tags.includes(t.nameLower)) {
+                            setTags((prev) => [...prev, t.nameLower]);
+                          }
+                          setTagInput('');
+                          setHighlightedIdx(0);
+                          setShowDropdown(false);
+                          tagInputRef.current?.focus();
+                        }}
+                      >
+                        <span
+                          className={`inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium ${c.bg} ${c.text}`}
+                        >
+                          {t.canonicalName}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Volume boost field */}
+          <div className="flex items-start gap-2">
+            <div className="flex-1">
+              <label
+                htmlFor="bulk-edit-volumeboost"
+                className="block font-mono text-[10px] text-muted uppercase mb-1"
+              >
+                Volume Boost (dB)
+              </label>
+              <div className="flex items-center gap-3">
+                <input
+                  id="bulk-edit-volumeboost"
+                  className="input text-sm w-16 text-center disabled:opacity-30 disabled:cursor-not-allowed"
+                  placeholder="0"
+                  type="text"
+                  value={volumeBoost}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    if (v === '' || /^-?\d*$/.test(v)) setVolumeBoost(v);
+                  }}
+                  onBlur={() => {
+                    if (volumeBoost.trim() === '' || volumeBoost.trim() === '-') {
+                      setVolumeBoost('0');
+                    } else {
+                      const n = Number.parseInt(volumeBoost, 10);
+                      if (!Number.isNaN(n)) {
+                        setVolumeBoost(String(Math.min(200, Math.max(-100, n))));
+                      }
+                    }
+                  }}
+                  disabled={clearFields.has('volumeBoost')}
+                />
+                <span className="text-xs text-muted font-mono w-8 text-left">dB</span>
+                <input
+                  type="range"
+                  min={-100}
+                  max={200}
+                  value={volumeNumeric}
+                  onChange={(e) => setVolumeBoost(e.target.value)}
+                  className={`volume-range-input${clearFields.has('volumeBoost') ? ' opacity-30 pointer-events-none' : ''}`}
+                  disabled={clearFields.has('volumeBoost')}
+                  style={{ ['--volume-pct' as string]: volumePct } as React.CSSProperties}
+                />
+              </div>
+            </div>
+            <label className="flex flex-col items-center gap-0.5 shrink-0 pt-5 cursor-pointer">
+              <input
+                type="checkbox"
+                className="sr-only peer"
+                checked={clearFields.has('volumeBoost')}
+                onChange={() => toggleClear('volumeBoost')}
+              />
+              <span className="text-[9px] font-mono uppercase text-muted peer-checked:text-danger transition-colors">
+                Clear
+              </span>
+              <EraserIcon
+                size={12}
+                weight="duotone"
+                className="text-muted peer-checked:text-danger transition-colors"
+              />
+            </label>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex justify-end gap-2 mt-4">
+          <Button variant="inherit" surface="surface" onClick={onClose} className="text-xs">
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={handleApply} disabled={isApplying} className="text-xs">
+            {isApplying ? 'Applying...' : `Apply to ${count} songs`}
+          </Button>
+        </div>
+      </div>
+    </Backdrop>
+  );
+}

--- a/packages/web/src/components/NotificationToast.tsx
+++ b/packages/web/src/components/NotificationToast.tsx
@@ -2,12 +2,13 @@ import type { Notification } from '../hooks/useNotification';
 
 interface NotificationToastProps {
   notification: Notification;
+  lift?: boolean;
 }
 
-export default function NotificationToast({ notification }: NotificationToastProps) {
+export default function NotificationToast({ notification, lift }: NotificationToastProps) {
   return (
     <div
-      className={`fixed bottom-24 left-1/2 -translate-x-1/2 z-50 px-4 py-3 rounded-lg modal-clay font-mono text-xs animate-fade-up ${
+      className={`fixed ${lift ? 'bottom-36 md:bottom-32' : 'bottom-24'} left-1/2 -translate-x-1/2 z-50 px-4 py-3 rounded-lg modal-clay font-mono text-xs animate-fade-up ${
         notification.type === 'success'
           ? 'bg-accent/20 border border-accent/40 text-accent'
           : 'bg-danger/20 border border-danger/40 text-danger'

--- a/packages/web/src/components/NotificationToast.tsx
+++ b/packages/web/src/components/NotificationToast.tsx
@@ -8,7 +8,7 @@ interface NotificationToastProps {
 export default function NotificationToast({ notification, lift }: NotificationToastProps) {
   return (
     <div
-      className={`fixed ${lift ? 'bottom-36 md:bottom-32' : 'bottom-24'} left-1/2 -translate-x-1/2 z-50 px-4 py-3 rounded-lg modal-clay font-mono text-xs animate-fade-up ${
+      className={`fixed ${lift ? 'bottom-48 md:bottom-40' : 'bottom-24'} left-1/2 -translate-x-1/2 z-50 px-4 py-3 rounded-lg modal-clay font-mono text-xs animate-fade-up ${
         notification.type === 'success'
           ? 'bg-accent/20 border border-accent/40 text-accent'
           : 'bg-danger/20 border border-danger/40 text-danger'

--- a/packages/web/src/components/SongCard.tsx
+++ b/packages/web/src/components/SongCard.tsx
@@ -11,6 +11,7 @@ import { SourceIcon } from './SourceIcons';
 import TagTicker from './TagTicker';
 import { ArtworkImage } from './ui/ArtworkImage';
 import { Card } from './ui/Card';
+import Checkbox from './ui/Checkbox';
 import { DurationBadge } from './ui/DurationBadge';
 import { PlayButton } from './ui/PlayButton';
 import { VolumeBoostBadge } from './ui/VolumeBoostBadge';
@@ -31,6 +32,10 @@ interface SongCardProps {
   onPlay: () => void;
   isPlaying?: boolean;
   onAddToQueue: () => void;
+  /** Show a selection checkbox (bulk action mode) */
+  selectionMode?: boolean;
+  isSelected?: boolean;
+  onToggleSelect?: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -48,6 +53,9 @@ const SongCardInner = ({
   onPlay,
   isPlaying,
   onAddToQueue,
+  selectionMode = false,
+  isSelected = false,
+  onToggleSelect,
 }: SongCardProps) => {
   const { openSongId, setOpenSongId } = useSongEdit();
   const { hasPermission } = usePermissions();
@@ -79,13 +87,21 @@ const SongCardInner = ({
   if (variant === 'grid') {
     const tags = song.tags ?? [];
 
+    const handleGridClick = () => {
+      if (selectionMode) {
+        onToggleSelect?.();
+      } else if (canEdit) {
+        setOpenSongId(isOpen ? null : song.id);
+      }
+    };
+
     return (
       <Card
-        hoverable={!!isAdminView}
-        className={`rounded-lg flex flex-col${isAdminView ? ' group cursor-pointer' : ''}`}
+        hoverable={!!isAdminView && !selectionMode}
+        className={`rounded-lg flex flex-col${(isAdminView && !selectionMode) || selectionMode ? ' cursor-pointer' : ''}${selectionMode ? ' select-none hover:ring-2 hover:ring-accent/50' : ''}${isAdminView && !selectionMode ? ' group' : ''}`}
         style={gridStyle}
         data-song-edit-container
-        onClick={() => canEdit && setOpenSongId(isOpen ? null : song.id)}
+        onClick={handleGridClick}
       >
         {/* Clean thumbnail */}
         <div className="relative aspect-square overflow-hidden rounded-lg border border-border m-3 mb-0 bg-elevated">
@@ -95,6 +111,21 @@ const SongCardInner = ({
             className="w-full h-full"
             imageClassName="scale-[1.33]"
           />
+          {/* Selection checkbox overlay */}
+          {selectionMode && (
+            <div
+              className="absolute top-2 left-2 z-10"
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') onToggleSelect?.();
+              }}
+              role="button"
+              tabIndex={0}
+            >
+              <Checkbox checked={isSelected} onChange={() => onToggleSelect?.()} size="md" />
+            </div>
+          )}
+          {isSelected && <div className="absolute inset-0 bg-accent/20 pointer-events-none" />}
         </div>
 
         {/* Info */}
@@ -176,28 +207,43 @@ const SongCardInner = ({
 
   const tags = song.tags ?? [];
 
+  const handleListClick = () => {
+    if (selectionMode) {
+      onToggleSelect?.();
+    } else if (canEdit) {
+      setOpenSongId(isOpen ? null : song.id);
+    }
+  };
+
   return (
     <Card
-      hoverable={!!isAdminView}
-      className="rounded-lg flex flex-col"
+      hoverable={!!isAdminView && !selectionMode}
+      className={`rounded-lg flex flex-col${selectionMode ? ' select-none hover:ring-2 hover:ring-accent/50' : ''}${isSelected ? ' ring-2 ring-accent' : ''}`}
       data-song-id={song.id}
       data-song-edit-container
     >
       <div
         className="flex items-center gap-3 md:gap-4 px-4 py-4"
-        onClick={() => canEdit && setOpenSongId(isOpen ? null : song.id)}
+        onClick={handleListClick}
         onKeyDown={(e) => {
-          if (canEdit && (e.key === 'Enter' || e.key === ' ')) {
+          if ((e.key === 'Enter' || e.key === ' ') && !selectionMode) {
             e.preventDefault();
-            setOpenSongId(isOpen ? null : song.id);
+            if (canEdit) setOpenSongId(isOpen ? null : song.id);
           }
         }}
         role="button"
         tabIndex={0}
-        style={canEdit ? { cursor: 'pointer' } : undefined}
+        style={canEdit || selectionMode ? { cursor: 'pointer' } : undefined}
         onMouseEnter={() => setIsRowHovered(true)}
         onMouseLeave={() => setIsRowHovered(false)}
       >
+        {/* Selection checkbox */}
+        {selectionMode && (
+          <span onClick={(e) => e.stopPropagation()}>
+            <Checkbox checked={isSelected} onChange={() => onToggleSelect?.()} size="md" />
+          </span>
+        )}
+
         <div className="overflow-hidden w-16 h-16 rounded border border-border shrink-0 bg-elevated">
           <ArtworkImage
             src={song.artwork ?? song.thumbnailUrl}

--- a/packages/web/src/components/VirtualSongList.tsx
+++ b/packages/web/src/components/VirtualSongList.tsx
@@ -17,11 +17,15 @@ interface VirtualSongListProps {
   playingId: string | null;
   onRetry: () => void;
   sentinelRef: (el: HTMLDivElement | null) => void;
-  onDelete: (id: string) => void;
+  onDelete?: (id: string) => void;
   onPlay: (id: string) => void;
   onAddToQueue: (id: string) => void;
   emptyTitle: string;
   emptyMessage?: string;
+  // Bulk selection
+  selectionMode?: boolean;
+  isSelected?: (id: string) => boolean;
+  onToggleSelect?: (id: string) => void;
 }
 
 function SkeletonGrid() {
@@ -100,6 +104,9 @@ export const VirtualSongList = memo(function VirtualSongList({
   onAddToQueue,
   emptyTitle,
   emptyMessage,
+  selectionMode = false,
+  isSelected,
+  onToggleSelect,
 }: VirtualSongListProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const isGrid = viewMode === 'grid';
@@ -142,6 +149,9 @@ export const VirtualSongList = memo(function VirtualSongList({
                 onPlay={() => onPlay(song.id)}
                 isPlaying={playingId === song.id}
                 onAddToQueue={() => onAddToQueue(song.id)}
+                selectionMode={selectionMode}
+                isSelected={isSelected?.(song.id) ?? false}
+                onToggleSelect={onToggleSelect ? () => onToggleSelect(song.id) : undefined}
               />
             ))}
           </div>

--- a/packages/web/src/hooks/useBulkSelection.ts
+++ b/packages/web/src/hooks/useBulkSelection.ts
@@ -1,0 +1,45 @@
+import { useCallback, useState } from 'react';
+
+export interface BulkSelection {
+  selectedIds: Set<string>;
+  count: number;
+  isSelected: (id: string) => boolean;
+  toggle: (id: string) => void;
+  selectAll: (ids: string[]) => void;
+  clearAll: () => void;
+}
+
+export function useBulkSelection(): BulkSelection {
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  const isSelected = useCallback((id: string) => selectedIds.has(id), [selectedIds]);
+
+  const toggle = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const selectAll = useCallback((ids: string[]) => {
+    setSelectedIds(new Set(ids));
+  }, []);
+
+  const clearAll = useCallback(() => {
+    setSelectedIds(new Set());
+  }, []);
+
+  return {
+    selectedIds,
+    count: selectedIds.size,
+    isSelected,
+    toggle,
+    selectAll,
+    clearAll,
+  };
+}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -854,42 +854,59 @@
            disabled:cursor-not-allowed min-h-11 md:min-h-0;
         border-radius: var(--clay-radius-lg);
         color: #fff;
-           background: linear-gradient(
-            180deg,
-            color-mix(in srgb, var(--color-danger) 75%, white) 0%,
-            var(--color-danger) 100%
-        );
+        background: color-mix(in srgb, var(--color-danger) 95%, white);
         box-shadow:
-            0 3px 0 0 color-mix(in srgb, var(--color-danger) 50%, black),
-            0 4px 8px -2px rgba(0, 0, 0, 0.3),
-            inset 0 1px 1px 0 rgba(255, 255, 255, 0.08);
+            0 2px 0 0 color-mix(in srgb, var(--color-danger) 100%, black 35%),
+            inset 0 2px 3px 0 rgba(0, 0, 0, 0.15),
+            inset 0 1px 1px 0 rgba(255, 255, 255, 0.04);
     }
     .btn-danger:hover {
         transform: var(--btn-transform-hover);
+        background: color-mix(in srgb, var(--color-danger) 88%, white);
         box-shadow:
-            0 4px 0 0 color-mix(in srgb, var(--color-danger) 50%, black),
-            0 6px 12px -2px rgba(0, 0, 0, 0.35),
-            inset 0 1px 1px 0 rgba(255, 255, 255, 0.08);
-        background: linear-gradient(
-            180deg,
-            color-mix(in srgb, var(--color-danger) 65%, white) 0%,
-            var(--color-danger) 100%
-        );
+            0 4px 0 0 color-mix(in srgb, var(--color-danger) 100%, black 35%),
+            inset 0 2px 3px 0 rgba(0, 0, 0, 0.15),
+            inset 0 1px 1px 0 rgba(255, 255, 255, 0.04);
     }
     .btn-danger:active {
-        transform: var(--btn-transform-active);
+        transform: var(--btn-transform-active-md);
         scale: var(--btn-scale-active);
+        background: var(--color-danger);
         box-shadow:
             0 1px 0 0 color-mix(in srgb, var(--color-danger) 100%, black 20%),
             inset 0 2px 3px 0 rgba(0, 0, 0, 0.15);
     }
     .btn-danger.pressed {
-        transform: var(--btn-transform-active);
+        transform: var(--btn-transform-active-md);
         scale: var(--btn-scale-active);
-        box-shadow: inset 0 2px 4px 0 rgba(0, 0, 0, 0.25);
+        background: color-mix(in srgb, var(--color-danger) 75%, black);
+        box-shadow: inset 0 2px 3px 0 rgba(0, 0, 0, 0.2);
     }
+
     [data-mode="light"] .btn-danger {
-        color: #1a1a1a;
+        color: #fff;
+        background: var(--color-danger);
+        box-shadow:
+            0 2px 0 0 color-mix(in srgb, var(--color-danger) 80%, black),
+            0 2px 4px rgba(0, 0, 0, 0.08),
+            0 0 0 1px rgba(0, 0, 0, 0.04);
+    }
+    [data-mode="light"] .btn-danger:hover {
+        background: color-mix(in srgb, var(--color-danger) 92%, white);
+        box-shadow:
+            0 3px 0 0 color-mix(in srgb, var(--color-danger) 80%, black),
+            0 3px 6px rgba(0, 0, 0, 0.1),
+            0 0 0 1px rgba(0, 0, 0, 0.06);
+    }
+    [data-mode="light"] .btn-danger:active {
+        background: color-mix(in srgb, var(--color-danger) 95%, black);
+        box-shadow:
+            0 1px 0 0 color-mix(in srgb, var(--color-danger) 100%, black 15%),
+            inset 0 2px 3px 0 rgba(0, 0, 0, 0.08);
+    }
+    [data-mode="light"] .btn-danger.pressed {
+        background: color-mix(in srgb, var(--color-danger) 90%, black);
+        box-shadow: inset 0 2px 3px 0 rgba(0, 0, 0, 0.15);
     }
 
     .btn-discord {

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -7,6 +7,7 @@ import {
   BombIcon,
   CaretDownIcon,
   CaretLeftIcon,
+  CheckSquareIcon,
   FunnelIcon,
   GhostIcon,
   ListIcon,
@@ -25,6 +26,8 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
+  bulkEditSongs,
+  bulkRemoveSongsFromPlaylist,
   deletePlaylist,
   getPlaylistPage,
   removeSongFromPlaylist,
@@ -34,6 +37,8 @@ import {
 } from '../api/api';
 import AddFilterPopover from '../components/AddFilterPopover';
 import AddSongsModal from '../components/AddSongsModal';
+import BulkActionBar from '../components/BulkActionBar';
+import BulkEditModal from '../components/BulkEditModal';
 import ConfirmModal from '../components/ConfirmModal';
 import type { MenuItem } from '../components/ContextMenu';
 import { ContextMenu, ContextMenuTrigger } from '../components/ContextMenu';
@@ -48,6 +53,7 @@ import { useAuth } from '../context/AuthContext';
 import { usePermissions } from '../context/PermissionsContext';
 import { usePlayerState } from '../context/PlayerContext';
 import { useAddToQueue } from '../hooks/useAddToQueue';
+import { useBulkSelection } from '../hooks/useBulkSelection';
 import { useNotification } from '../hooks/useNotification';
 import { onSocketEvent } from '../hooks/useSocket';
 import { apiErrorMessage } from '../utils/api';
@@ -100,7 +106,17 @@ export default function PlaylistDetailPage() {
 
   const isOwner = user?.discordId === playlistDetail?.createdBy;
   const canEdit = isAdminView || isOwner || hasPermission('songs.edit');
+  const canBulk = canEdit;
   const isSmart = !!playlistDetail?.tagNameLower;
+
+  // Bulk selection
+  const bulk = useBulkSelection();
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [bulkRemoving, setBulkRemoving] = useState(false);
+  const [bulkRemoveConfirm, setBulkRemoveConfirm] = useState(false);
+  const [bulkEditingOpen, setBulkEditingOpen] = useState(false);
+  const [bulkEditingApplying, setBulkEditingApplying] = useState(false);
+
   const menuTriggerRef = useRef<HTMLButtonElement>(null);
   const [menuOpen, setMenuOpen] = useState(false);
 
@@ -126,6 +142,7 @@ export default function PlaylistDetailPage() {
   // Pagination state
   const [currentPage, setCurrentPage] = useState(1);
   const [hasMore, setHasMore] = useState(true);
+  const [totalSongs, setTotalSongs] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [isFetching, setIsFetching] = useState(false);
   const [isError, setIsError] = useState(false);
@@ -239,15 +256,18 @@ export default function PlaylistDetailPage() {
           setPlaylistDetail(pl);
           setSongs(pl.songs);
           setRenameValue(pl.name);
+          setTotalSongs(pl.pagination.total);
         } else if (isRefetch) {
           // Socket-triggered refetch: replace songs so we don't accumulate duplicates.
           setSongs(pl.songs);
           setPlaylistDetail(pl);
+          setTotalSongs(pl.pagination.total);
         } else {
           // User scroll: accumulate songs from the new page.
           setSongs((prev) => [...prev, ...pl.songs]);
           // Keep latest playlist metadata
           setPlaylistDetail(pl);
+          setTotalSongs(pl.pagination.total);
         }
         setHasMore(pl.songs.length === ITEMS_PER_PAGE);
       } catch {
@@ -425,6 +445,55 @@ export default function PlaylistDetailPage() {
       setRemoveId(null);
     }
   };
+
+  // ── Bulk actions ─────────────────────────────────────────────────────
+  const handleBulkRemove = useCallback(() => {
+    setBulkRemoveConfirm(true);
+  }, []);
+
+  const executeBulkRemove = useCallback(async () => {
+    if (!playlistDetail || bulk.count === 0) return;
+    setBulkRemoveConfirm(false);
+    setBulkRemoving(true);
+    try {
+      const allIds = [...bulk.selectedIds];
+      const chunkSize = 500;
+      for (let i = 0; i < allIds.length; i += chunkSize) {
+        await bulkRemoveSongsFromPlaylist(playlistDetail.id, allIds.slice(i, i + chunkSize));
+      }
+      setSongs((prev) => prev.filter((ps) => !bulk.selectedIds.has(ps.songId)));
+      notify(`Removed ${allIds.length} song${allIds.length !== 1 ? 's' : ''}`, 'success');
+    } catch (err: unknown) {
+      notify(apiErrorMessage(err, 'Failed to remove songs.'), 'error', 5000);
+    } finally {
+      setBulkRemoving(false);
+      bulk.clearAll();
+      setSelectionMode(false);
+    }
+  }, [playlistDetail, bulk, notify]);
+
+  const handleBulkEdit = useCallback(
+    async (data: import('@alfira-bot/server/shared/api').BulkEditData) => {
+      if (bulk.count === 0) return;
+      setBulkEditingApplying(true);
+      try {
+        const allIds = [...bulk.selectedIds];
+        const chunkSize = 500;
+        for (let i = 0; i < allIds.length; i += chunkSize) {
+          await bulkEditSongs(allIds.slice(i, i + chunkSize), data);
+        }
+        notify(`Updated ${allIds.length} song${allIds.length !== 1 ? 's' : ''}`, 'success');
+        setBulkEditingOpen(false);
+      } catch (err: unknown) {
+        notify(apiErrorMessage(err, 'Failed to update songs.'), 'error', 5000);
+      } finally {
+        setBulkEditingApplying(false);
+        bulk.clearAll();
+        setSelectionMode(false);
+      }
+    },
+    [bulk, notify]
+  );
 
   const handleDeletePlaylist = async () => {
     if (!playlistDetail) return;
@@ -788,6 +857,24 @@ export default function PlaylistDetailPage() {
           />
         </div>
 
+        {/* Select toggle (only visible to users with bulk permissions) */}
+        {canBulk && (
+          <Button
+            variant="inherit"
+            surface="surface"
+            onClick={() => {
+              if (selectionMode) bulk.clearAll();
+              setSelectionMode((v) => !v);
+            }}
+            className={`flex items-center gap-1.5 px-2.5 ${
+              selectionMode ? 'pressed text-accent' : ''
+            }`}
+            title={selectionMode ? 'Exit selection mode' : 'Select songs'}
+          >
+            <CheckSquareIcon size={16} weight="duotone" />
+          </Button>
+        )}
+
         {/* Add filter button */}
         <Button
           variant="inherit"
@@ -933,12 +1020,19 @@ export default function PlaylistDetailPage() {
           playingId={playingSongId}
           onRetry={retry}
           sentinelRef={sentinelRef}
-          onDelete={(id) => {
-            const ps = songs.find((p) => p.songId === id);
-            if (ps) setRemoveId(ps.songId);
-          }}
+          onDelete={
+            selectionMode
+              ? undefined
+              : (id) => {
+                  const ps = songs.find((p) => p.songId === id);
+                  if (ps) setRemoveId(ps.songId);
+                }
+          }
           onPlay={handlePlayFromSong}
           onAddToQueue={handleAddToQueue}
+          selectionMode={selectionMode}
+          isSelected={bulk.isSelected}
+          onToggleSelect={bulk.toggle}
           emptyTitle="No Songs"
           emptyMessage="Add songs to this playlist"
         />
@@ -956,7 +1050,26 @@ export default function PlaylistDetailPage() {
         />
       )}
       {/* Notification Toast */}
-      {notification && <NotificationToast notification={notification} />}
+      {notification && (
+        <NotificationToast notification={notification} lift={selectionMode && bulk.count !== 0} />
+      )}
+      {bulkRemoveConfirm && (
+        <ConfirmModal
+          title="Remove Songs"
+          message={
+            <>
+              Remove{' '}
+              <span className="text-fg font-semibold">
+                {bulk.count} song{bulk.count !== 1 ? 's' : ''}
+              </span>{' '}
+              from this playlist? The songs won&lsquo;t be deleted from the library.
+            </>
+          }
+          confirmLabel="Remove"
+          onConfirm={executeBulkRemove}
+          onCancel={() => setBulkRemoveConfirm(false)}
+        />
+      )}
       {removeId && (
         <ConfirmModal
           title="Remove Song"
@@ -1015,6 +1128,33 @@ export default function PlaylistDetailPage() {
           onAddSource={handleAddSource}
           onRemoveSource={handleRemoveSource}
           onClose={() => setFilterPopoverOpen(false)}
+        />
+      )}
+
+      {/* Bulk action bar */}
+      {selectionMode && bulk.count > 0 && (
+        <BulkActionBar
+          count={bulk.count}
+          loadedCount={songItems.length}
+          totalCount={totalSongs}
+          canDelete={canEdit}
+          canTag={canEdit}
+          deleteLabel="Remove selected"
+          onDelete={handleBulkRemove}
+          onTag={() => setBulkEditingOpen(true)}
+          onSelectAll={() => bulk.selectAll(songItems.map((s) => s.id))}
+          onDeselectAll={bulk.clearAll}
+          isDeleting={bulkRemoving}
+        />
+      )}
+
+      {/* Bulk edit modal */}
+      {bulkEditingOpen && (
+        <BulkEditModal
+          count={bulk.count}
+          onApply={handleBulkEdit}
+          onClose={() => setBulkEditingOpen(false)}
+          isApplying={bulkEditingApplying}
         />
       )}
     </div>

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -4,6 +4,7 @@ import {
   ArrowDownIcon,
   ArrowUpIcon,
   CaretDownIcon,
+  CheckSquareIcon,
   FunnelIcon,
   ListIcon,
   MagnifyingGlassIcon,
@@ -13,16 +14,27 @@ import {
 } from '@phosphor-icons/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { deleteSong, getPlaylistsPage, getSongsPage, startPlayback } from '../api/api';
+import {
+  bulkDeleteSongs,
+  bulkEditSongs,
+  deleteSong,
+  getPlaylistsPage,
+  getSongsPage,
+  startPlayback,
+} from '../api/api';
 import AddFilterPopover from '../components/AddFilterPopover';
+import BulkActionBar from '../components/BulkActionBar';
+import BulkEditModal from '../components/BulkEditModal';
 import ConfirmModal from '../components/ConfirmModal';
 import FilterChips from '../components/FilterChips';
 import NotificationToast from '../components/NotificationToast';
 import { Button } from '../components/ui/Button';
 import { VirtualSongList } from '../components/VirtualSongList';
 import { useAdminView } from '../context/AdminViewContext';
+import { usePermissions } from '../context/PermissionsContext';
 import { usePlayerState } from '../context/PlayerContext';
 import { useAddToQueue } from '../hooks/useAddToQueue';
+import { useBulkSelection } from '../hooks/useBulkSelection';
 import { useNotification } from '../hooks/useNotification';
 import { onSocketEvent } from '../hooks/useSocket';
 import { useVirtualizedInfiniteScroll } from '../hooks/useVirtualizedInfiniteScroll';
@@ -42,6 +54,7 @@ const SORT_OPTIONS: { value: SortField; label: string }[] = [
 
 export default function SongsPage() {
   const { isAdminView } = useAdminView();
+  const { hasPermission } = usePermissions();
   const { state: queueState } = usePlayerState();
   const [viewMode, setViewMode] = useState<'grid' | 'list'>(() => {
     const saved = localStorage.getItem('alfira-library-view');
@@ -59,6 +72,18 @@ export default function SongsPage() {
 
   // Add filter popover state
   const [filterPopoverOpen, setFilterPopoverOpen] = useState(false);
+
+  // Bulk selection
+  const bulk = useBulkSelection();
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [bulkDeleting, setBulkDeleting] = useState(false);
+  const [bulkDeleteConfirm, setBulkDeleteConfirm] = useState(false);
+  const [bulkEditingOpen, setBulkEditingOpen] = useState(false);
+  const [bulkEditingApplying, setBulkEditingApplying] = useState(false);
+
+  const canDelete = isAdminView || hasPermission('songs.delete');
+  const canEdit = isAdminView || hasPermission('songs.edit');
+  const canBulk = canDelete || canEdit;
 
   // ── URL params ──────────────────────────────────────────────────────
   const [searchParams, setSearchParams] = useSearchParams();
@@ -291,6 +316,57 @@ export default function SongsPage() {
     // Socket event will update the songs list
   };
 
+  // ── Bulk actions ─────────────────────────────────────────────────────
+  const handleBulkDelete = useCallback(() => {
+    setBulkDeleteConfirm(true);
+  }, []);
+
+  const executeBulkDelete = useCallback(async () => {
+    if (bulk.count === 0) return;
+    setBulkDeleteConfirm(false);
+    setBulkDeleting(true);
+    try {
+      const allIds = [...bulk.selectedIds];
+      const chunkSize = 500;
+      for (let i = 0; i < allIds.length; i += chunkSize) {
+        await bulkDeleteSongs(allIds.slice(i, i + chunkSize));
+      }
+      for (const id of allIds) {
+        removeItem(id);
+      }
+      notify(`Deleted ${allIds.length} song${allIds.length !== 1 ? 's' : ''}`, 'success');
+    } catch (err: unknown) {
+      notify(apiErrorMessage(err, 'Failed to delete songs.'), 'error', 5000);
+    } finally {
+      setBulkDeleting(false);
+      bulk.clearAll();
+      setSelectionMode(false);
+    }
+  }, [bulk, removeItem, notify]);
+
+  const handleBulkEdit = useCallback(
+    async (data: import('@alfira-bot/server/shared/api').BulkEditData) => {
+      if (bulk.count === 0) return;
+      setBulkEditingApplying(true);
+      try {
+        const allIds = [...bulk.selectedIds];
+        const chunkSize = 500;
+        for (let i = 0; i < allIds.length; i += chunkSize) {
+          await bulkEditSongs(allIds.slice(i, i + chunkSize), data);
+        }
+        notify(`Updated ${allIds.length} song${allIds.length !== 1 ? 's' : ''}`, 'success');
+        setBulkEditingOpen(false);
+      } catch (err: unknown) {
+        notify(apiErrorMessage(err, 'Failed to update songs.'), 'error', 5000);
+      } finally {
+        setBulkEditingApplying(false);
+        bulk.clearAll();
+        setSelectionMode(false);
+      }
+    },
+    [bulk, notify]
+  );
+
   // ── Play from song ──────────────────────────────────────────────────
   const handlePlayFromSong = useCallback(
     async (songId: string) => {
@@ -351,6 +427,24 @@ export default function SongsPage() {
             onChange={(e) => handleSearchChange(e.target.value)}
           />
         </div>
+
+        {/* Select toggle (only visible to users with bulk permissions) */}
+        {canBulk && (
+          <Button
+            variant="inherit"
+            surface="surface"
+            onClick={() => {
+              if (selectionMode) bulk.clearAll();
+              setSelectionMode((v) => !v);
+            }}
+            className={`flex items-center gap-1.5 px-2.5 ${
+              selectionMode ? 'pressed text-accent' : ''
+            }`}
+            title={selectionMode ? 'Exit selection mode' : 'Select songs'}
+          >
+            <CheckSquareIcon size={16} weight="duotone" />
+          </Button>
+        )}
 
         {/* Add filter button */}
         <Button
@@ -482,9 +576,12 @@ export default function SongsPage() {
         playingId={playingId}
         onRetry={retry}
         sentinelRef={sentinelRef}
-        onDelete={handleSetDeleteId}
+        onDelete={selectionMode ? undefined : handleSetDeleteId}
         onPlay={handlePlayFromSong}
         onAddToQueue={handleAddToQueue}
+        selectionMode={selectionMode}
+        isSelected={bulk.isSelected}
+        onToggleSelect={bulk.toggle}
         emptyTitle={
           search || filterTags.length > 0 || filterSources.length > 0
             ? 'No Matches'
@@ -519,8 +616,54 @@ export default function SongsPage() {
         />
       )}
 
+      {bulkDeleteConfirm && (
+        <ConfirmModal
+          title="Delete Songs"
+          message={
+            <>
+              Permanently delete{' '}
+              <span className="text-fg font-semibold">
+                {bulk.count} song{bulk.count !== 1 ? 's' : ''}
+              </span>{' '}
+              from the library? This cannot be undone.
+            </>
+          }
+          confirmLabel="Delete"
+          onConfirm={executeBulkDelete}
+          onCancel={() => setBulkDeleteConfirm(false)}
+        />
+      )}
+
       {/* Notification Toast */}
-      {notification && <NotificationToast notification={notification} />}
+      {notification && (
+        <NotificationToast notification={notification} lift={selectionMode && bulk.count !== 0} />
+      )}
+
+      {/* Bulk action bar */}
+      {selectionMode && bulk.count > 0 && (
+        <BulkActionBar
+          count={bulk.count}
+          loadedCount={items.length}
+          totalCount={total}
+          canDelete={canDelete}
+          canTag={canEdit}
+          onDelete={handleBulkDelete}
+          onTag={() => setBulkEditingOpen(true)}
+          onSelectAll={() => bulk.selectAll(items.map((s) => s.id))}
+          onDeselectAll={bulk.clearAll}
+          isDeleting={bulkDeleting}
+        />
+      )}
+
+      {/* Bulk edit modal */}
+      {bulkEditingOpen && (
+        <BulkEditModal
+          count={bulk.count}
+          onApply={handleBulkEdit}
+          onClose={() => setBulkEditingOpen(false)}
+          isApplying={bulkEditingApplying}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Adds selection-mode bulk actions to the Songs page and Playlist detail page. Users can now select multiple songs and perform bulk delete, bulk metadata editing, or bulk remove from playlist.

## Changes

- **Backend** — 3 new endpoints: `POST /api/songs/bulk-delete`, `POST /api/songs/bulk-edit`, `POST /api/playlists/:id/songs/bulk-remove` with proper permission guards and 5000-ID caps
- **Shared API** — New client functions: `bulkDeleteSongs`, `bulkEditSongs`, `bulkRemoveSongsFromPlaylist` with frontend-side chunking (500 per request)
- **`useBulkSelection` hook** — Manages selected ID set with toggle/selectAll/clearAll
- **`BulkActionBar`** — Floating bottom bar showing selection count, select-all, delete, and edit buttons; positioned above the NowPlayingBar
- **`BulkEditModal`** — Full metadata editor for bulk-editing nickname, artist, album, artwork, tags, and volume boost with per-field clear toggles
- **`SongCard`** — Selection-mode checkbox in both grid and list variants with hover ring, cursor pointer, and `select-none`
- **`VirtualSongList`** — Passes selection props through to SongCard
- **SongsPage / PlaylistDetailPage** — Select toggle button (permission-gated), bulk action bar integration, delete confirmation modal
- **`btn-danger` CSS** — Updated to clay styling matching `btn-inherit` design
- **Notification toast** — Lifts above the bulk action bar when visible