### PR TITLE
ui(web): add icons and accent color to page headers

### DIFF
--- a/packages/web/src/components/QueuePanel.tsx
+++ b/packages/web/src/components/QueuePanel.tsx
@@ -13,6 +13,7 @@ import {
   MusicNoteIcon,
   PlayIcon,
   PlusCircleIcon,
+  QueueIcon,
   RepeatIcon,
   RepeatOnceIcon,
   ShuffleIcon,
@@ -676,7 +677,10 @@ const PanelHeader = memo(function PanelHeader({
 
   return (
     <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
-      <h1 className="font-display text-3xl text-fg tracking-wider">Queue</h1>
+      <h1 className="font-display text-3xl text-accent tracking-wider flex items-center gap-2">
+        <QueueIcon size={24} weight="duotone" className="shrink-0 relative top-1" />
+        Queue
+      </h1>
       <div className="flex items-center gap-1">
         {mqc && (
           <>

--- a/packages/web/src/components/settings/SettingsPage.tsx
+++ b/packages/web/src/components/settings/SettingsPage.tsx
@@ -1,3 +1,4 @@
+import { WrenchIcon } from '@phosphor-icons/react';
 import { useEffect, useState } from 'react';
 import { fetchVersion } from '../../api/api';
 import { useAuth } from '../../context/AuthContext';
@@ -18,7 +19,10 @@ export default function SettingsPage() {
     <div className="p-4 md:p-8">
       {/* Page header */}
       <div className="mb-6 md:mb-8 flex items-end justify-between">
-        <h1 className="font-display text-3xl md:text-4xl text-fg tracking-wider">Settings</h1>
+        <h1 className="font-display text-3xl md:text-4xl text-accent tracking-wider flex items-center gap-2">
+          <WrenchIcon size={28} weight="duotone" className="shrink-0 relative top-1" />
+          Settings
+        </h1>
         {version !== null && <p className="font-mono text-xs text-faint pb-1">{version}</p>}
       </div>
 

--- a/packages/web/src/pages/AudioPage.tsx
+++ b/packages/web/src/pages/AudioPage.tsx
@@ -14,7 +14,10 @@ export default function AudioPage() {
     <div className="p-4 md:p-8">
       {/* Page header */}
       <div className="mb-6 md:mb-8">
-        <h1 className="font-display text-3xl md:text-4xl text-fg tracking-wider">Audio</h1>
+        <h1 className="font-display text-3xl md:text-4xl text-accent tracking-wider flex items-center gap-2">
+          <SlidersHorizontal size={28} weight="duotone" className="shrink-0 relative top-1" />
+          Audio
+        </h1>
         <p className="font-mono text-xs text-muted mt-2">Equalizer and compressor settings</p>
       </div>
 

--- a/packages/web/src/pages/PermissionsPage.tsx
+++ b/packages/web/src/pages/PermissionsPage.tsx
@@ -1,4 +1,4 @@
-import { TrashIcon } from '@phosphor-icons/react';
+import { ShieldCheckIcon, TrashIcon } from '@phosphor-icons/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { fetchPermissions, type PermissionsResponse, updatePermission } from '../api/api';
 import ConfirmModal from '../components/ConfirmModal';
@@ -197,7 +197,10 @@ export default function PermissionsPage() {
     return (
       <div className="p-4 md:p-8">
         <div className="mb-6 md:mb-8">
-          <h1 className="font-display text-3xl md:text-4xl text-fg tracking-wider">Permissions</h1>
+          <h1 className="font-display text-3xl md:text-4xl text-accent tracking-wider flex items-center gap-2">
+            <ShieldCheckIcon size={28} weight="duotone" className="shrink-0 relative top-1" />
+            Permissions
+          </h1>
         </div>
         {error ? (
           <ErrorBanner message={error} />
@@ -213,7 +216,10 @@ export default function PermissionsPage() {
     <div className="p-4 md:p-8">
       {/* Page header */}
       <div className="mb-6 md:mb-8">
-        <h1 className="font-display text-3xl md:text-4xl text-fg tracking-wider">Permissions</h1>
+        <h1 className="font-display text-3xl md:text-4xl text-accent tracking-wider flex items-center gap-2">
+          <ShieldCheckIcon size={28} weight="duotone" className="shrink-0 relative top-1" />
+          Permissions
+        </h1>
         <p className="font-mono text-xs text-muted mt-2">
           Grant specific abilities to non-admin roles. Super-admins always have full access.
         </p>

--- a/packages/web/src/pages/PlaylistsPage.tsx
+++ b/packages/web/src/pages/PlaylistsPage.tsx
@@ -1,5 +1,6 @@
 import type { Playlist, TagItem } from '@alfira-bot/server/shared';
 import { fetchTags } from '@alfira-bot/server/shared/api';
+import { PlaylistIcon } from '@phosphor-icons/react';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getPlaylistsPage } from '../api/api';
@@ -70,7 +71,10 @@ export default function PlaylistsPage() {
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-6 md:mb-8">
         <div>
-          <h1 className="font-display text-3xl md:text-4xl text-fg tracking-wider">Playlists</h1>
+          <h1 className="font-display text-3xl md:text-4xl text-accent tracking-wider flex items-center gap-2">
+            <PlaylistIcon size={28} weight="duotone" className="shrink-0 relative top-1" />
+            Playlists
+          </h1>
           <p className="font-mono text-xs text-muted mt-2">
             Browse & manage playlists
             {hasLoaded ? ` • ${items.length} playlist${items.length !== 1 ? 's' : ''}` : ''}

--- a/packages/web/src/pages/RequestsPage.tsx
+++ b/packages/web/src/pages/RequestsPage.tsx
@@ -1,4 +1,5 @@
 import type { SongRequest } from '@alfira-bot/server/shared';
+import { TrayIcon } from '@phosphor-icons/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { approveRequest, cancelRequest, denyRequest, fetchRequests } from '../api/api';
 import AddSongModal from '../components/AddSongModal';
@@ -114,7 +115,10 @@ export default function RequestsPage() {
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-6 md:mb-8">
         <div>
-          <h1 className="font-display text-3xl md:text-4xl text-fg tracking-wider">Requests</h1>
+          <h1 className="font-display text-3xl md:text-4xl text-accent tracking-wider flex items-center gap-2">
+            <TrayIcon size={28} weight="duotone" className="shrink-0 relative top-1" />
+            Requests
+          </h1>
           <p className="font-mono text-xs text-muted mt-2">
             Submit & review requests{hasLoaded ? ` • ${countLabel}` : ''}
           </p>

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -8,6 +8,7 @@ import {
   FunnelIcon,
   ListIcon,
   MagnifyingGlassIcon,
+  MusicNotesIcon,
   QuestionIcon,
   SortAscendingIcon,
   SquaresFourIcon,
@@ -398,7 +399,10 @@ export default function SongsPage() {
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-6 md:mb-8">
         <div>
-          <h1 className="font-display text-3xl md:text-4xl text-fg tracking-wider">Songs</h1>
+          <h1 className="font-display text-3xl md:text-4xl text-accent tracking-wider flex items-center gap-2">
+            <MusicNotesIcon size={28} weight="duotone" className="shrink-0 relative top-1" />
+            Songs
+          </h1>
           <p className="font-mono text-xs text-muted mt-2">
             Music library{hasLoaded ? ` • ${total} track${total !== 1 ? 's' : ''}` : ''}
           </p>

--- a/packages/web/src/pages/TagsPage.tsx
+++ b/packages/web/src/pages/TagsPage.tsx
@@ -1,6 +1,6 @@
 import { deleteTag, fetchTagSongs, fetchTags, updateTag } from '@alfira-bot/server/shared/api';
 import type { Song } from '@alfira-bot/server/shared/types';
-import { MagnifyingGlassIcon, TrashIcon } from '@phosphor-icons/react';
+import { MagnifyingGlassIcon, TagIcon, TrashIcon } from '@phosphor-icons/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import ConfirmModal from '../components/ConfirmModal';
 import EmptyState from '../components/EmptyState';
@@ -155,7 +155,10 @@ export default function TagsPage() {
     <div className="p-4 md:p-8 flex flex-col h-full">
       {/* Page header */}
       <div className="mb-6 md:mb-8 shrink-0">
-        <h1 className="font-display text-3xl md:text-4xl text-fg tracking-wider">Tags</h1>
+        <h1 className="font-display text-3xl md:text-4xl text-accent tracking-wider flex items-center gap-2">
+          <TagIcon size={28} weight="duotone" className="shrink-0 relative top-1" />
+          Tags
+        </h1>
         <p className="font-mono text-xs text-muted mt-2">
           Manage tags & colors
           {loadingTags ? '' : ` • ${allTags.length} tag${allTags.length !== 1 ? 's' : ''}`}


### PR DESCRIPTION
## Summary

Adds matching Phosphor icons to the left of each page header and tints both icon and text with the primary accent color. Icons match their sidebar navigation counterparts.

## Changes

- **SongsPage** — `MusicNotesIcon` + `text-accent`
- **PlaylistsPage** — `PlaylistIcon` + `text-accent`
- **RequestsPage** — `TrayIcon` + `text-accent`
- **TagsPage** — `TagIcon` + `text-accent`
- **AudioPage** — `SlidersHorizontal` + `text-accent`
- **PermissionsPage** — `ShieldCheckIcon` + `text-accent` (both loading and main render states)
- **QueuePanel** — `QueueIcon` + `text-accent`
- **SettingsPage** — `WrenchIcon` + `text-accent`

Icons are nudged down 4px (`relative top-1`) for visual alignment with text baseline.