### PR TITLE
ui(web): add glassmorphism to popups, modals, and tooltips

### DIFF
--- a/packages/web/src/components/AddFilterPopover.tsx
+++ b/packages/web/src/components/AddFilterPopover.tsx
@@ -83,10 +83,7 @@ export default function AddFilterPopover({
 
   return (
     <Backdrop onClose={onClose}>
-      <div
-        className="bg-surface border border-border rounded-xl w-full max-w-sm modal-clay
-        flex flex-col max-h-[70vh] animate-fade-up"
-      >
+      <div className="w-full max-w-sm glass-modal flex flex-col max-h-[70vh] animate-fade-up">
         <div className="p-4 border-b border-border flex items-center justify-between">
           <h3 className="font-body font-semibold text-sm text-fg">Filters</h3>
           <button

--- a/packages/web/src/components/AddSongModal.tsx
+++ b/packages/web/src/components/AddSongModal.tsx
@@ -194,7 +194,7 @@ export default function AddSongModal({
 
   return (
     <Backdrop onClose={onClose}>
-      <div className="bg-surface rounded-xl p-5 md:p-6 w-full max-w-md mx-4 modal-clay animate-fade-up">
+      <div className="p-5 md:p-6 w-full max-w-md mx-4 glass-modal animate-fade-up">
         <h2 className="font-display text-2xl md:text-3xl text-fg tracking-wider mb-1">
           Request Song
         </h2>

--- a/packages/web/src/components/AddSongsModal.tsx
+++ b/packages/web/src/components/AddSongsModal.tsx
@@ -127,10 +127,7 @@ export default function AddSongsModal({
 
   return (
     <Backdrop onClose={onClose}>
-      <div
-        className="bg-surface border border-border rounded-xl w-full max-w-lg modal-clay
-        flex flex-col max-h-[80vh] animate-fade-up"
-      >
+      <div className="w-full max-w-lg glass-modal flex flex-col max-h-[80vh] animate-fade-up">
         <div className="p-4 md:p-5 border-b border-border">
           <h2 className="font-display text-2xl md:text-3xl text-fg tracking-wider">Add Songs</h2>
           <p className="font-mono text-xs text-muted mt-0.5">to "{playlist.name}"</p>

--- a/packages/web/src/components/Backdrop.tsx
+++ b/packages/web/src/components/Backdrop.tsx
@@ -9,7 +9,7 @@ export function Backdrop({
 }) {
   return (
     <div
-      className="fixed inset-0 z-50 bg-black/70 backdrop-blur-sm flex items-center justify-center p-4 cursor-default"
+      className="fixed inset-0 z-50 bg-black/70 flex items-center justify-center p-4 cursor-default"
       onMouseDown={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}

--- a/packages/web/src/components/BulkEditModal.tsx
+++ b/packages/web/src/components/BulkEditModal.tsx
@@ -197,7 +197,7 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
       {/* biome-ignore lint/a11y/useKeyWithClickEvents: modal container, keyboard not applicable */}
       {/* biome-ignore lint/a11y/noStaticElementInteractions: modal container, keyboard not applicable */}
       <div
-        className="bg-elevated rounded-xl border border-border shadow-2xl w-full max-w-md mx-4 p-6 animate-fade-up max-h-[85vh] overflow-y-auto"
+        className="w-full max-w-md mx-4 p-6 glass-modal animate-fade-up max-h-[85vh] overflow-y-auto"
         onClick={(e) => e.stopPropagation()}
       >
         <h2 className="font-display text-lg text-fg mb-1">Edit {count} songs</h2>
@@ -316,7 +316,7 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
                   <input
                     ref={tagInputRef}
                     id="bulk-edit-tags"
-                    className="bg-transparent outline-none flex-1 min-w-[120px] text-sm placeholder:text-faint py-0.5"
+                    className="bg-transparent outline-none flex-1 min-w-30 text-sm placeholder:text-faint py-0.5"
                     placeholder={
                       tags.length === 0 ? 'Type a tag and press Enter...' : 'Add another...'
                     }
@@ -355,7 +355,7 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
               <div className="relative">
                 <div
                   ref={tagDropdownRef}
-                  className="absolute top-1 left-0 right-0 bg-elevated border border-border rounded-lg shadow-lg z-30 max-h-40 overflow-y-auto"
+                  className="absolute top-1 left-0 right-0 glass-popover z-30 max-h-40"
                 >
                   {filtered.map((t, i) => {
                     const c = getTagColorClasses(t.canonicalName, t.color);

--- a/packages/web/src/components/ConfirmModal.tsx
+++ b/packages/web/src/components/ConfirmModal.tsx
@@ -19,7 +19,7 @@ export default function ConfirmModal({
 }: ConfirmModalProps) {
   return (
     <Backdrop onClose={onCancel}>
-      <div className="p-5 md:p-6 w-full max-w-sm mx-4 modal-clay animate-fade-up">
+      <div className="p-5 md:p-6 w-full max-w-sm mx-4 glass-modal animate-fade-up">
         <h2 className="font-display text-2xl md:text-3xl text-fg tracking-wider mb-1">{title}</h2>
         <p className="font-body text-sm text-muted mb-4 md:mb-6">{message}</p>
         <div className="flex gap-2 justify-end">

--- a/packages/web/src/components/ContextMenu.tsx
+++ b/packages/web/src/components/ContextMenu.tsx
@@ -271,7 +271,7 @@ export function ContextMenu({
       onKeyDown={activeEditItemId ? undefined : handleKeyDown}
       onClick={(e) => e.stopPropagation()}
     >
-      <div className="bg-base rounded-2xl clay-floating overflow-hidden animate-fade-up border border-accent/30 outline-2 outline-accent/20">
+      <div className="glass-popover outline-2 outline-accent/20">
         {activeSubmenu ? (
           <SubmenuPanel
             config={activeSubmenu}

--- a/packages/web/src/components/NotificationToast.tsx
+++ b/packages/web/src/components/NotificationToast.tsx
@@ -8,10 +8,10 @@ interface NotificationToastProps {
 export default function NotificationToast({ notification, lift }: NotificationToastProps) {
   return (
     <div
-      className={`fixed ${lift ? 'bottom-48 md:bottom-40' : 'bottom-24'} left-1/2 -translate-x-1/2 z-50 px-4 py-3 rounded-lg modal-clay font-mono text-xs animate-fade-up ${
+      className={`fixed ${lift ? 'bottom-48 md:bottom-40' : 'bottom-24'} left-1/2 -translate-x-1/2 z-50 px-4 py-3 glass-toast font-mono text-xs animate-fade-up ${
         notification.type === 'success'
-          ? 'bg-accent/20 border border-accent/40 text-accent'
-          : 'bg-danger/20 border border-danger/40 text-danger'
+          ? 'bg-accent/15 border-accent/40 text-accent'
+          : 'bg-danger/15 border-danger/40 text-danger'
       }`}
     >
       {notification.message}

--- a/packages/web/src/components/SongEditPanel.tsx
+++ b/packages/web/src/components/SongEditPanel.tsx
@@ -548,7 +548,7 @@ function TagDropdown({
   const dropdown = (
     <div
       ref={dropdownRef}
-      className="fixed z-50 min-w-45 bg-surface rounded-lg border border-border shadow-lg max-h-48 overflow-y-auto"
+      className="fixed z-50 min-w-45 glass-popover max-h-48"
       style={{ top: 0, left: 0 }}
     >
       {filtered.length === 0 ? (

--- a/packages/web/src/components/UserMenu.tsx
+++ b/packages/web/src/components/UserMenu.tsx
@@ -133,7 +133,7 @@ export default function UserMenu({ user, collapsed, onLogout }: UserMenuProps) {
         {avatar}
       </button>
 
-      {/* Popover — mirrors ContextMenu styling: bg-base, clay-floating, animate-fade-up */}
+      {/* Popover — mirrors ContextMenu styling */}
       {open &&
         createPortal(
           <div
@@ -144,7 +144,7 @@ export default function UserMenu({ user, collapsed, onLogout }: UserMenuProps) {
             onKeyDown={(e) => e.stopPropagation()}
             onClick={(e) => e.stopPropagation()}
           >
-            <div className="bg-base rounded-2xl clay-floating overflow-hidden animate-fade-up border border-accent/30 outline-2 outline-accent/20">
+            <div className="glass-popover outline-2 outline-accent/20">
               {/* Username header — mirrors ContextMenu InfoRow */}
               <div className="px-3 py-1.5 text-xs font-mono text-muted flex items-center gap-2">
                 <UserIcon size={14} weight="duotone" className="shrink-0" />

--- a/packages/web/src/components/queue/OverrideModal.tsx
+++ b/packages/web/src/components/queue/OverrideModal.tsx
@@ -32,7 +32,7 @@ export default function OverrideModal({
 
   return (
     <Backdrop onClose={onClose}>
-      <div className="p-5 md:p-6 w-full max-w-sm mx-4 modal-clay animate-fade-up">
+      <div className="p-5 md:p-6 w-full max-w-sm mx-4 glass-modal animate-fade-up">
         <h2 className="font-display text-2xl md:text-3xl text-fg tracking-wider mb-1">Override</h2>
         <p className="font-mono text-xs text-danger mb-4 md:mb-6">
           <WarningIcon size={14} weight="duotone" className="inline mr-1" /> This will stop current

--- a/packages/web/src/components/queue/QuickAddModal.tsx
+++ b/packages/web/src/components/queue/QuickAddModal.tsx
@@ -44,7 +44,7 @@ export default function QuickAddModal({
 
   return (
     <Backdrop onClose={onClose}>
-      <div className="p-5 md:p-6 w-full max-w-sm mx-4 modal-clay animate-fade-up">
+      <div className="p-5 md:p-6 w-full max-w-sm mx-4 glass-modal animate-fade-up">
         <h2 className="font-display text-2xl md:text-3xl text-fg tracking-wider mb-1">Quick Add</h2>
         <p className="font-mono text-xs text-muted mb-4 md:mb-6">
           add a url to Up Next without saving to library

--- a/packages/web/src/components/settings/AdminSection.tsx
+++ b/packages/web/src/components/settings/AdminSection.tsx
@@ -248,7 +248,7 @@ export default function AdminSection() {
                           weight="duotone"
                           className="text-muted cursor-help"
                         />
-                        <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-56 p-2 rounded-lg bg-elevated border border-border text-xs text-muted opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity z-10">
+                        <span className="glass-tooltip absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-56 p-2">
                           {source.helpText}
                         </span>
                       </span>

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1004,13 +1004,6 @@
         border-bottom: 3px solid
             color-mix(in srgb, var(--color-surface) 70%, black);
     }
-    .modal-clay {
-        border-radius: var(--clay-radius-lg);
-        box-shadow:
-            0 5px 0 0 color-mix(in srgb, var(--color-foreground) 60%, black),
-            0 13px 30px -6px rgba(0, 0, 0, 0.4);
-        background: var(--color-foreground);
-    }
 
     .btn-icon-primary {
         @apply w-11 h-11 md:w-10 md:h-10 flex items-center justify-center
@@ -1298,6 +1291,57 @@
         var(--clay-shadow-flat),
         inset 0 1px 0 0 rgba(255, 255, 255, 0.06);
 }
+@utility glass-panel {
+  background:
+    linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.04) 0%,
+      rgba(255, 255, 255, 0.015) 40%,
+      rgba(255, 255, 255, 0.00) 100%
+    ),
+    color-mix(in srgb, var(--color-base) 86%, transparent);
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+}
+[data-mode="light"] .glass-panel {
+  background:
+    linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.06) 0%,
+      rgba(255, 255, 255, 0.025) 50%,
+      rgba(255, 255, 255, 0.00) 100%
+    ),
+    color-mix(in srgb, var(--color-base) 92%, transparent);
+}
+
+/* Glass popover — unified styling for dropdowns, context menus, etc. */
+@utility glass-popover {
+  @apply glass-panel rounded-2xl border border-accent/30 clay-floating overflow-hidden animate-fade-up;
+}
+
+/* Glass hover tooltip — for .group hover-revealed help text */
+/* Glass modal — heavy shadow suitable for centered dialogs */
+/* Glass toast notification — color is set by the component, glass provides blur + shadow */
+@utility glass-toast {
+  @apply rounded-2xl border;
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+  box-shadow:
+    0 5px 0 0 color-mix(in srgb, var(--color-surface) 60%, black),
+    0 13px 30px -6px rgba(0, 0, 0, 0.4);
+}
+
+@utility glass-modal {
+  @apply glass-panel rounded-2xl border border-accent/30;
+  box-shadow:
+    0 5px 0 0 color-mix(in srgb, var(--color-surface) 60%, black),
+    0 13px 30px -6px rgba(0, 0, 0, 0.4);
+}
+
+@utility glass-tooltip {
+  @apply rounded-xl glass-panel border border-accent/30 clay-floating text-xs text-muted opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity z-10;
+}
+
 @utility clay-sidebar-edge {
     box-shadow: var(--clay-shadow-sidebar);
 }

--- a/packages/web/src/pages/LoginPage.tsx
+++ b/packages/web/src/pages/LoginPage.tsx
@@ -39,7 +39,7 @@ export default function LoginPage() {
 
       {/* Card */}
       <div className="relative z-10 w-full max-w-sm mx-4 animate-fade-up">
-        <div className="bg-surface border border-border rounded-xl p-6 md:p-8 modal-clay">
+        <div className="p-6 md:p-8 glass-modal">
           {/* Logo */}
           <div className="mb-6 md:mb-8 text-center">
             <h1 className="font-display text-5xl md:text-6xl text-accent tracking-widest">

--- a/packages/web/src/pages/PermissionsPage.tsx
+++ b/packages/web/src/pages/PermissionsPage.tsx
@@ -320,19 +320,11 @@ function RoleCard({
   return (
     <div className="bg-elevated clay-resting rounded-xl overflow-hidden hover:clay-raised hover:-translate-y-px active:clay-flat active:translate-y-0 transition-all duration-100">
       {/* Header row — clickable to toggle expand */}
-      <div
-        className="flex items-center gap-3 px-5 py-3 cursor-pointer"
+      <button
+        type="button"
+        className="flex items-center gap-3 px-5 py-3 cursor-pointer w-full"
         onClick={onToggleExpand}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            onToggleExpand();
-          }
-        }}
-        role="button"
-        tabIndex={0}
       >
-        {/* Role identity */}
         <span
           className="w-3 h-3 rounded-full shrink-0"
           style={{
@@ -373,7 +365,7 @@ function RoleCard({
         >
           <TrashIcon size={16} weight="duotone" />
         </Button>
-      </div>
+      </button>
 
       {/* Expanded content */}
       {isExpanded && (

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -796,7 +796,7 @@ export default function PlaylistDetailPage() {
         <div className="flex gap-2 shrink-0 items-center">
           <Button
             variant="secondary"
-            className="!rounded-full"
+            className="rounded-full!"
             onClick={() => {
               void handlePlayFromSong(songs[0]?.songId, 'random');
             }}
@@ -821,7 +821,7 @@ export default function PlaylistDetailPage() {
             isOpen={menuOpen}
             surface="surface"
             size="default"
-            className="!rounded-full"
+            className="rounded-full!"
           />
           {menuOpen && (
             <ContextMenu
@@ -904,7 +904,7 @@ export default function PlaylistDetailPage() {
           </Button>
 
           {sortOpen && (
-            <div className="absolute right-0 top-full mt-1.5 w-48 bg-elevated border border-border rounded-lg shadow-lg z-20 py-1 animate-fade-up origin-top-right">
+            <div className="absolute right-0 top-full mt-1.5 w-48 glass-popover z-20 py-1 origin-top-right">
               {SORT_OPTIONS.map((opt) => {
                 const isActive = sort === opt.value;
                 return (

--- a/packages/web/src/pages/PlaylistsPage.tsx
+++ b/packages/web/src/pages/PlaylistsPage.tsx
@@ -137,7 +137,7 @@ function CreatePlaylistModal({ onClose }: { onClose: () => void }) {
     <Backdrop onClose={onClose}>
       <form
         action={formAction}
-        className="bg-surface border border-border rounded-xl p-5 md:p-6 w-full max-w-sm mx-4 modal-clay animate-fade-up"
+        className="p-5 md:p-6 w-full max-w-sm mx-4 glass-modal animate-fade-up"
       >
         <h2 className="font-display text-2xl md:text-3xl text-fg tracking-wider mb-1">
           New Playlist

--- a/packages/web/src/pages/SetupWizard.tsx
+++ b/packages/web/src/pages/SetupWizard.tsx
@@ -255,7 +255,7 @@ export default function SetupWizard() {
         {error && <ErrorBanner message={error} className="mb-6" />}
 
         {/* Step content */}
-        <div className="modal-clay p-6 md:p-8">
+        <div className="glass-modal p-6 md:p-8">
           {step === 'welcome' && (
             <div className="text-center space-y-6">
               <div className="flex justify-center">
@@ -378,7 +378,7 @@ export default function SetupWizard() {
                             weight="duotone"
                             className="text-muted cursor-help"
                           />
-                          <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-56 p-2 rounded-lg bg-elevated border border-border text-xs text-muted opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity z-10">
+                          <span className="glass-tooltip absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-56 p-2">
                             {source.helpText}
                           </span>
                         </span>

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -409,7 +409,7 @@ export default function SongsPage() {
         </div>
         <span className="relative group">
           <QuestionIcon size={20} weight="duotone" className="text-muted cursor-help" />
-          <span className="absolute right-0 top-full mt-2 w-64 p-3 rounded-lg bg-elevated border border-border text-xs text-muted opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity z-10 leading-relaxed">
+          <span className="glass-tooltip absolute right-0 top-full mt-2 w-64 p-3 leading-relaxed">
             Songs are added through the <span className="text-accent">Requests</span> page. Submit a
             URL there — admins review and approve it, or it&rsquo;s added instantly if you have
             permission.
@@ -479,7 +479,7 @@ export default function SongsPage() {
           </Button>
 
           {sortOpen && (
-            <div className="absolute right-0 top-full mt-1.5 w-48 bg-elevated border border-border rounded-lg shadow-lg z-20 py-1 animate-fade-up origin-top-right">
+            <div className="absolute right-0 top-full mt-1.5 w-48 glass-popover z-20 py-1 origin-top-right">
               {SORT_OPTIONS.map((opt) => {
                 const isActive = sort === opt.value;
                 return (


### PR DESCRIPTION
## Summary

Apply a frosted glass effect with accent ring glow across the entire web UI, replacing solid opaque backgrounds with translucent glass panels. Introduced 5 reusable CSS utilities to keep styling consistent and reduce duplication.

## Changes

- **New CSS utilities:** `glass-panel` (frosted base), `glass-popover` (dropdowns/context menus), `glass-tooltip` (hover tooltips), `glass-modal` (dialogs), `glass-toast` (notifications)
- **Context menus & dropdowns** — 5 components unified under `glass-popover`
- **Modals** — 10 components unified under `glass-modal` (ConfirmModal, AddSongModal, AddSongsModal, AddFilterPopover, OverrideModal, QuickAddModal, BulkEditModal, PlaylistsPage, LoginPage, SetupWizard)
- **Hover tooltips** — 3 components unified under `glass-tooltip`
- **Notification toast** — uses `glass-toast` with preserved success/error coloring
- **Removed** `modal-clay` CSS class (fully replaced)
- **Reduced** modal backdrop blur for sharper contrast with glass panels
- **Fixed** PermissionsPage a11y warning (`div role=button` → `<button>`)