### PR TITLE
fix(web): unify tag color hashing and improve color selector visibility

### DIFF
--- a/packages/web/src/components/settings/UserSection.tsx
+++ b/packages/web/src/components/settings/UserSection.tsx
@@ -58,14 +58,14 @@ export default function UserSection() {
                   type="button"
                   onClick={() => setColorTheme(t.name)}
                   className={`flex flex-col items-center p-1 rounded-lg transition-all cursor-pointer group ${
-                    isSelected ? 'opacity-100' : 'opacity-50'
+                    isSelected ? 'opacity-100' : 'opacity-80'
                   }`}
                 >
                   <span
-                    className={`w-10 h-10 sm:w-12 sm:h-12 rounded-full flex items-center justify-center transition-all ${
+                    className={`w-10 h-10 sm:w-12 sm:h-12 rounded-full flex items-center justify-center transition-all border border-border/40 ${
                       isSelected
                         ? 'ring-2 ring-offset-2 ring-offset-background ring-foreground'
-                        : 'group-hover:ring-2 group-hover:ring-muted/20'
+                        : 'group-hover:ring-2 group-hover:ring-muted/30'
                     }`}
                     style={{ backgroundColor: t.accentColor }}
                   >

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -57,23 +57,9 @@ import { useBulkSelection } from '../hooks/useBulkSelection';
 import { useNotification } from '../hooks/useNotification';
 import { onSocketEvent } from '../hooks/useSocket';
 import { apiErrorMessage } from '../utils/api';
+import { getTagColorClasses } from '../utils/tagColors';
 
 const ITEMS_PER_PAGE = 24;
-
-const TAG_COLORS: Record<string, { bg: string; text: string }> = {
-  orange: { bg: 'bg-orange-500/15', text: 'text-orange-300' },
-  sky: { bg: 'bg-sky-500/15', text: 'text-sky-300' },
-  emerald: { bg: 'bg-emerald-500/15', text: 'text-emerald-300' },
-  amber: { bg: 'bg-amber-500/15', text: 'text-amber-300' },
-  violet: { bg: 'bg-violet-500/15', text: 'text-violet-300' },
-};
-
-function hashTagColor(tag: string): { bg: string; text: string } {
-  let hash = 5381;
-  for (let i = 0; i < tag.length; i++) hash = (hash * 33) ^ tag.charCodeAt(i);
-  const colors = Object.values(TAG_COLORS);
-  return colors[((hash >>> 0) * 31) % colors.length];
-}
 
 export default function PlaylistDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -766,7 +752,7 @@ export default function PlaylistDetailPage() {
               (() => {
                 const tag = tags.find((t) => t.nameLower === playlistDetail.tagNameLower);
                 const displayName = tag?.canonicalName ?? playlistDetail.tagNameLower;
-                const colors = hashTagColor(displayName);
+                const colors = getTagColorClasses(displayName, tag?.color);
                 return (
                   <span
                     className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium ${colors.bg} ${colors.text}`}

--- a/packages/web/src/pages/TagsPage.tsx
+++ b/packages/web/src/pages/TagsPage.tsx
@@ -8,41 +8,9 @@ import TagTicker from '../components/TagTicker';
 import { ArtworkImage } from '../components/ui/ArtworkImage';
 import { Button } from '../components/ui/Button';
 import { useTagColors } from '../context/TagsContext';
+import { getTagColorClasses, TAG_COLORS } from '../utils/tagColors';
 
-const TAG_COLORS = [
-  {
-    name: 'orange',
-    bg: 'light:bg-orange-500/15 bg-orange-500/20',
-    text: 'light:text-orange-600 text-orange-300',
-  },
-  { name: 'sky', bg: 'light:bg-sky-500/15 bg-sky-500/20', text: 'light:text-sky-600 text-sky-300' },
-  {
-    name: 'emerald',
-    bg: 'light:bg-emerald-500/15 bg-emerald-500/20',
-    text: 'light:text-emerald-600 text-emerald-300',
-  },
-  {
-    name: 'amber',
-    bg: 'light:bg-amber-500/15 bg-amber-500/20',
-    text: 'light:text-amber-700 text-amber-300',
-  },
-  {
-    name: 'violet',
-    bg: 'light:bg-violet-500/15 bg-violet-500/20',
-    text: 'light:text-violet-600 text-violet-300',
-  },
-] as const;
 const TAG_COLOR_NAMES = TAG_COLORS.map((c) => c.name);
-
-function getTagColor(tag: string, explicitColor?: string | null) {
-  if (explicitColor) {
-    const found = TAG_COLORS.find((c) => c.name === explicitColor);
-    if (found) return found;
-  }
-  let hash = 5381;
-  for (let i = 0; i < tag.length; i++) hash = (hash * 33) ^ tag.charCodeAt(i);
-  return TAG_COLORS[((hash >>> 0) * 31) % TAG_COLORS.length];
-}
 
 interface TagItem {
   canonicalName: string;
@@ -111,7 +79,7 @@ export default function TagsPage() {
   const pickColor = useCallback(
     async (color: string) => {
       if (!selected) return;
-      const effectiveColor = getTagColor(selected.canonicalName, selected.color).name;
+      const effectiveColor = getTagColorClasses(selected.canonicalName, selected.color).name;
       if (effectiveColor === color) return; // already the effective color
       // Optimistic update
       setAllTags((prev) =>
@@ -201,7 +169,7 @@ export default function TagsPage() {
               />
             ) : (
               filtered.map((tag) => {
-                const colors = getTagColor(tag.canonicalName, tag.color);
+                const colors = getTagColorClasses(tag.canonicalName, tag.color);
                 const isActive = selected?.nameLower === tag.nameLower;
                 return (
                   <button
@@ -272,22 +240,22 @@ export default function TagsPage() {
                     const colorClasses =
                       TAG_COLORS.find((c) => c.name === colorName) ?? TAG_COLORS[0];
                     const isSelected =
-                      getTagColor(selected.canonicalName, selected.color).name === colorName;
+                      getTagColorClasses(selected.canonicalName, selected.color).name === colorName;
                     return (
                       <button
                         type="button"
                         key={colorName}
                         onClick={() => pickColor(colorName)}
                         title={colorName}
-                        className={`w-6 h-6 rounded-full flex items-center justify-center transition-opacity cursor-pointer ${
+                        className={`w-8 h-8 rounded-full flex items-center justify-center transition-all cursor-pointer border border-border/40 ${
                           isSelected
                             ? 'opacity-100 ring-2 ring-offset-1 ring-offset-surface ring-fg'
-                            : 'opacity-60 hover:opacity-80'
+                            : 'opacity-80 hover:opacity-100'
                         } ${colorClasses.bg} ${colorClasses.text}`}
                       >
                         {isSelected ? (
                           <svg
-                            className="w-3 h-3"
+                            className="w-3.5 h-3.5"
                             fill="currentColor"
                             viewBox="0 0 12 12"
                             aria-hidden="true"

--- a/packages/web/src/utils/tagColors.ts
+++ b/packages/web/src/utils/tagColors.ts
@@ -1,4 +1,4 @@
-const TAG_COLORS = [
+export const TAG_COLORS = [
   {
     name: 'orange' as const,
     bg: 'light:bg-orange-500/15 bg-orange-500/20',


### PR DESCRIPTION
## Summary

Fixed tag colors being inconsistent between the Tags page and other pages (Songs, playlists, etc.) due to duplicated hash algorithms with different logic. Also improved visibility of color selector dots.

## Changes

- **Deduplicated tag color hashing**: TagsPage and PlaylistDetailPage now use the shared `getTagColorClasses` from `utils/tagColors` instead of their own copy with a different algorithm (missing `.toLowerCase()` and an extra `* 31` multiplier)
- **Exported `TAG_COLORS`** from `utils/tagColors` so consumers don't need to redefine the color palette
- **Improved color selector visibility** on Tags page: larger dots (24→32px), higher unselected opacity (60→80%), added border to unselected dots
- **Improved color theme dot visibility** in Settings → User: higher unselected opacity (50→80%), added border, more visible hover ring