### PR TITLE
fix(server): fix priority queue audio desync and metadata refresh

### DIFF
--- a/packages/server/src/GuildPlayer.ts
+++ b/packages/server/src/GuildPlayer.ts
@@ -507,6 +507,64 @@ export class GuildPlayer {
     });
   }
 
+  /**
+   * Update a song's metadata in-place across currentSong, priorityQueue,
+   * and regular queue after a DB edit. Only updates the fields present in
+   * the partial update — other fields are left unchanged.
+   *
+   * Accepts either a single song ID or an array of IDs (for bulk edits).
+   */
+  updateSongMetadata(
+    songIds: string | string[],
+    fields: {
+      nickname?: string | null;
+      artist?: string | null;
+      album?: string | null;
+      artwork?: string | null;
+      tags?: string[];
+      volumeBoost?: number | null;
+    }
+  ): void {
+    const ids = Array.isArray(songIds) ? songIds : [songIds];
+    const idSet = new Set(ids);
+
+    const merge = (s: QueuedSong): QueuedSong => {
+      const updated = { ...s };
+      if ('nickname' in fields) updated.nickname = fields.nickname ?? undefined;
+      if ('artist' in fields) updated.artist = fields.artist ?? undefined;
+      if ('album' in fields) updated.album = fields.album ?? undefined;
+      if ('artwork' in fields) updated.artwork = fields.artwork ?? undefined;
+      if ('tags' in fields) updated.tags = fields.tags;
+      if ('volumeBoost' in fields) updated.volumeBoost = fields.volumeBoost ?? undefined;
+      return updated;
+    };
+
+    let changed = false;
+
+    // Current song
+    if (this.currentSong && idSet.has(this.currentSong.id)) {
+      this.currentSong = merge(this.currentSong);
+      changed = true;
+    }
+
+    // Priority queue
+    for (let i = 0; i < this.priorityQueue.length; i++) {
+      const s = this.priorityQueue[i];
+      if (s && idSet.has(s.id)) {
+        this.priorityQueue[i] = merge(s);
+        changed = true;
+      }
+    }
+
+    // Regular queue
+    const regularUpdated = this.queue.updateWhere((s) => idSet.has(s.id), merge);
+    if (regularUpdated > 0) changed = true;
+
+    if (changed) {
+      this.broadcast();
+    }
+  }
+
   getQueue(): QueuedSong[] {
     return this.queue.toRemaining();
   }
@@ -584,6 +642,12 @@ export class GuildPlayer {
 
     const prioritySong = this.priorityQueue.shift();
     if (prioritySong) {
+      // The gapless preload was for a different track (the regular-queue
+      // next seen at preload time).  Clear the flag so playSong does a
+      // full cold-start load for this priority track instead of assuming
+      // NodeLink auto-started it.
+      this.gaplessTransition = false;
+
       this.currentSong = prioritySong;
       if (this.currentSong) {
         this.currentSong = { ...this.currentSong, isSeekable: true };

--- a/packages/server/src/PlaybackCursor.ts
+++ b/packages/server/src/PlaybackCursor.ts
@@ -246,6 +246,23 @@ export class PlaybackCursor<T> {
   // ---------------------------------------------------------------------------
 
   /**
+   * Update all items matching the predicate in-place. Returns the number
+   * of items updated.  Modifies buffer entries directly — does not affect
+   * readIndex or playbackOrder.
+   */
+  updateWhere(predicate: (item: T) => boolean, updater: (item: T) => T): number {
+    let count = 0;
+    for (let i = 0; i < this.buffer.length; i++) {
+      const item = this.buffer[i];
+      if (item !== undefined && predicate(item)) {
+        this.buffer[i] = updater(item);
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /**
    * Convert all unplayed items to an array for the queue display.
    *
    * After advance(), readIndex points to the next song to be played

--- a/packages/server/src/routes/songs.ts
+++ b/packages/server/src/routes/songs.ts
@@ -359,6 +359,29 @@ async function handleBulkEdit(ctx: RouteContext, request: Request): Promise<Resp
     }
   }
 
+  // Update the player cache for any of the edited songs that are currently
+  // in the queue / now playing.
+  const bulkPlayer = getPlayer(getGuildId());
+  if (bulkPlayer) {
+    if ('volumeBoost' in data) {
+      const currentSong = bulkPlayer.getCurrentSong();
+      if (currentSong && ids.includes(currentSong.id)) {
+        bulkPlayer.updateVolumeBoost(data.volumeBoost as number);
+      }
+    }
+    const bulkFields: Record<string, unknown> = {};
+    if ('nickname' in data) bulkFields.nickname = data.nickname;
+    if ('artist' in data) bulkFields.artist = data.artist;
+    if ('album' in data) bulkFields.album = data.album;
+    if ('artwork' in data) bulkFields.artwork = data.artwork;
+    if ('tags' in data) bulkFields.tags = data.tags;
+    if ('volumeBoost' in data) bulkFields.volumeBoost = data.volumeBoost;
+    bulkPlayer.updateSongMetadata(
+      ids,
+      bulkFields as Parameters<typeof bulkPlayer.updateSongMetadata>[1]
+    );
+  }
+
   return json({ updated: ids.length });
 }
 
@@ -578,13 +601,28 @@ async function handlePatchSong(ctx: RouteContext, request: Request, id: string):
     }
   }
 
-  // If this song is currently playing, update volume live without restarting
+  // Update the song in the GuildPlayer's cache (currentSong, priorityQueue,
+  // regular queue) so the UI reflects metadata changes immediately.
   const player = getPlayer(getGuildId());
-  if (player && data.volumeBoost !== undefined) {
-    const currentSong = player.getCurrentSong();
-    if (currentSong?.id === id) {
-      player.updateVolumeBoost(data.volumeBoost as number);
+  if (player) {
+    // Volume boost also needs live audio update
+    if (data.volumeBoost !== undefined) {
+      const currentSong = player.getCurrentSong();
+      if (currentSong?.id === id) {
+        player.updateVolumeBoost(data.volumeBoost as number);
+      }
     }
+
+    // Build fields object with only the keys that are actually in data —
+    // undefined values still create keys, which would clear fields in merge.
+    const fields: Record<string, unknown> = {};
+    if ('nickname' in data) fields.nickname = data.nickname;
+    if ('artist' in data) fields.artist = data.artist;
+    if ('album' in data) fields.album = data.album;
+    if ('artwork' in data) fields.artwork = data.artwork;
+    if ('tags' in data) fields.tags = data.tags;
+    if ('volumeBoost' in data) fields.volumeBoost = data.volumeBoost;
+    player.updateSongMetadata(id, fields as Parameters<typeof player.updateSongMetadata>[1]);
   }
 
   return json(formatSong(updatedSong));


### PR DESCRIPTION
## Summary

Fixes two queue-related bugs in the server:

1. **Priority queue audio desync** — When a track was preloaded for gapless playback and a user subsequently added a priority/up-next track, the gapless transition flag caused the wrong audio to play. The UI showed the priority track's metadata but NodeLink was playing the preloaded regular-queue track.

2. **Stale queue metadata after song edit** — Editing a song's nickname/artist/artwork saved to the DB but didn't update the cached copy in the GuildPlayer (currentSong, priorityQueue, regular queue). The UI only updated on page refresh.

## Changes

- `GuildPlayer.ts`: Clear `gaplessTransition` when dequeuing a priority song; add `updateSongMetadata` method to update cached song objects in-place across currentSong/priorityQueue/queue
- `PlaybackCursor.ts`: Add `updateWhere` method for in-place buffer updates
- `routes/songs.ts`: Call `updateSongMetadata` after PATCH and bulk-edit to refresh player cache