### PR TITLE
fix(web): fix queue header gap, empty actions menu, and song card truncation

### DIFF
--- a/packages/web/src/components/QueuePanel.tsx
+++ b/packages/web/src/components/QueuePanel.tsx
@@ -102,7 +102,7 @@ export default function QueuePanel({
           variant: 'priority',
           song,
           listIndex: i,
-          key: `${song.id}-p${i}`,
+          key: `p-${song.id}`,
         });
       });
     }
@@ -114,7 +114,7 @@ export default function QueuePanel({
           variant: 'regular',
           song,
           listIndex: i,
-          key: `${song.id}-r${i}`,
+          key: `r-${song.id}`,
         });
       });
     }
@@ -123,10 +123,12 @@ export default function QueuePanel({
 
   const virtualizer = useVirtualizer({
     count: virtualItems.length,
+    getItemKey: (i) => virtualItems[i]?.key,
     getScrollElement: () => scrollRef.current,
     estimateSize: (i) => (virtualItems[i]?.type === 'header' ? 36 : 92),
     overscan: 5,
   });
+
   const isQueueEmpty = queue.length === 0 && priorityQueue.length === 0 && !currentSong;
 
   const handleClear = useCallback(async () => {
@@ -267,6 +269,7 @@ export default function QueuePanel({
           menuOpen={menuOpen}
           onToggleMenu={() => setMenuOpen(!menuOpen)}
           mobileQuickControls={mobileQuickControls}
+          showActions={false}
         />
         <div className="flex-1 p-4 space-y-3">
           <div className="skeleton h-5 w-48 rounded" />
@@ -285,6 +288,7 @@ export default function QueuePanel({
         menuOpen={menuOpen}
         onToggleMenu={() => setMenuOpen(!menuOpen)}
         mobileQuickControls={mobileQuickControls}
+        showActions={menuItems.length > 0}
       />
 
       {/* Fixed content: Now Playing */}
@@ -333,6 +337,8 @@ export default function QueuePanel({
                 return (
                   <div
                     key={item.key}
+                    data-index={virtualRow.index}
+                    ref={virtualizer.measureElement}
                     style={{
                       position: 'absolute',
                       top: 0,
@@ -656,11 +662,13 @@ const PanelHeader = memo(function PanelHeader({
   menuOpen,
   onToggleMenu,
   mobileQuickControls,
+  showActions = true,
 }: {
   triggerRef: React.RefObject<HTMLButtonElement | null>;
   menuOpen: boolean;
   onToggleMenu: () => void;
   mobileQuickControls?: MobileQuickControls;
+  showActions?: boolean;
 }) {
   const mqc = mobileQuickControls;
   const isLoopActive = mqc ? mqc.loopMode !== 'off' : false;
@@ -739,20 +747,22 @@ const PanelHeader = memo(function PanelHeader({
             </Button>
           </>
         )}
-        <Button
-          ref={triggerRef}
-          variant="inherit"
-          size="icon"
-          type="button"
-          aria-haspopup="true"
-          aria-expanded={menuOpen}
-          title="More actions"
-          surface="elevated"
-          className={`${menuOpen ? 'pressed text-accent' : ''}`}
-          onClick={onToggleMenu}
-        >
-          <DotsThreeOutlineVerticalIcon size={18} weight="duotone" />
-        </Button>
+        {showActions && (
+          <Button
+            ref={triggerRef}
+            variant="inherit"
+            size="icon"
+            type="button"
+            aria-haspopup="true"
+            aria-expanded={menuOpen}
+            title="More actions"
+            surface="elevated"
+            className={`${menuOpen ? 'pressed text-accent' : ''}`}
+            onClick={onToggleMenu}
+          >
+            <DotsThreeOutlineVerticalIcon size={18} weight="duotone" />
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/packages/web/src/components/SongCard.tsx
+++ b/packages/web/src/components/SongCard.tsx
@@ -143,7 +143,7 @@ const SongCardInner = ({
             )}
           </div>
           {/* Artist + Duration */}
-          <div className="flex items-center justify-between gap-2 text-xs text-muted">
+          <div className="flex items-center justify-between gap-2 text-xs text-muted overflow-hidden">
             {song.artist ? (
               <span className="flex items-center gap-1 min-w-0">
                 <UserIcon size={12} weight="fill" className="shrink-0" />
@@ -156,7 +156,7 @@ const SongCardInner = ({
           </div>
 
           {/* Album + VolumeBoost */}
-          <div className="flex items-center justify-between gap-2 text-xs text-muted">
+          <div className="flex items-center justify-between gap-2 text-xs text-muted overflow-hidden">
             {song.album ? (
               <span className="flex items-center gap-1 min-w-0">
                 <DiscIcon size={12} weight="fill" className="shrink-0" />
@@ -253,21 +253,21 @@ const SongCardInner = ({
           />
         </div>
         <div className="flex-1 min-w-0 flex flex-col justify-center gap-1.5">
-          <p className="text-sm font-semibold text-fg truncate leading-tight flex items-center gap-1.5">
+          <p className="text-sm font-semibold text-fg leading-tight flex items-center gap-1.5 min-w-0">
             <MusicNoteIcon size={13} weight="fill" className="shrink-0 text-muted" />
-            {song.nickname || song.title}
+            <span className="truncate">{song.nickname || song.title}</span>
           </p>
           <div className="flex items-center gap-2.5 flex-wrap text-xs text-muted min-w-0">
             {song.artist && (
-              <span className="truncate max-w-[16ch] flex items-center gap-1">
+              <span className="max-w-[16ch] flex items-center gap-1 min-w-0">
                 <UserIcon size={12} weight="fill" className="shrink-0" />
-                {song.artist}
+                <span className="truncate">{song.artist}</span>
               </span>
             )}
             {song.album && (
-              <span className="truncate max-w-[20ch] flex items-center gap-1">
+              <span className="max-w-[20ch] flex items-center gap-1 min-w-0">
                 <DiscIcon size={12} weight="fill" className="shrink-0" />
-                {song.album}
+                <span className="truncate">{song.album}</span>
               </span>
             )}
             {tags.length > 0 && <TagTicker tags={tags} isHovered={isRowHovered} />}


### PR DESCRIPTION
## Summary

Three UI fixes for the queue panel and song cards:

1. **Queue header gap** — The virtual list's `measureElement` ref was only attached to song items, not headers. When Up Next items were added, estimated header heights accumulated positioning errors, creating a visible gap between the Queue header and its content. Fixed by attaching `measureElement` to headers and using `getItemKey` with stable song keys so cached measurements survive reordering.

2. **Empty actions menu** — The header actions button (⋯) was always visible, but showed an empty context menu when the user had no queue permissions. Fixed by hiding the button entirely when `menuItems` is empty.

3. **Song card text truncation** — Artist/album text was being cut off without ellipsis because `truncate` was applied to flex containers (text-overflow doesn't work on flex containers) and the parent flex rows lacked `overflow-hidden`. Moved `truncate` to inner spans and added `overflow-hidden` to grid variant rows.

## Changes

- `QueuePanel.tsx`: Add `measureElement` to headers, `getItemKey` to virtualizer, stable song keys, `showActions` prop to PanelHeader
- `SongCard.tsx`: Add `overflow-hidden` to grid artist/album rows; move `truncate` from flex container to inner span in list variant