### PR TITLE
fix(docker): pass optional env vars through in prod compose

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,6 +24,8 @@ services:
     #   dockerfile: Dockerfile
     #   target: runtime
     restart: unless-stopped
+    env_file:
+      - .env
     environment:
       NODE_ENV: production
       DATABASE_URL: /data/alfira.db


### PR DESCRIPTION
## Summary

The production docker-compose file used an explicit `environment:` block that only passed the 9 core required variables. All optional env vars (`SPOTIFY_CLIENT_ID`, `LOG_LEVEL`, `ENABLED_SOURCES`, `JWT_EXPIRES_IN`, etc.) were silently dropped, breaking Spotify/Apple Music/Tidal source support and preventing users from configuring logging or token expiry.

## Changes

- Added `env_file: .env` to `docker-compose.prod.yml`, matching the pattern already used in the dev compose
- Explicit `environment:` entries take precedence, so the critical vars remain explicitly set