### PR TITLE
feat(web): add submenu indicator arrow to context menu items

### DIFF
--- a/packages/web/src/components/ContextMenu/MenuItemButton.tsx
+++ b/packages/web/src/components/ContextMenu/MenuItemButton.tsx
@@ -1,3 +1,4 @@
+import { CaretRightIcon } from '@phosphor-icons/react';
 import type { ReactNode } from 'react';
 import type { MenuItem, SubmenuConfig } from '../ContextMenu';
 
@@ -31,7 +32,10 @@ export function MenuItemButton({ item, onClick }: MenuItemButtonProps) {
 			`}
     >
       {item.icon && <span className="shrink-0">{item.icon}</span>}
-      <span className="truncate">{item.label}</span>
+      <span className="truncate flex-1">{item.label}</span>
+      {(item.submenu || item.editSubmenu) && (
+        <CaretRightIcon size={12} weight="duotone" className="shrink-0 ml-auto opacity-50" />
+      )}
     </button>
   );
 }


### PR DESCRIPTION
## Summary

Add a rightwards chevron (caret) icon to context menu items that open a submenu (like "Add to Playlist"), visually indicating a secondary menu transition on click.

## Changes

- Import `CaretRightIcon` from `@phosphor-icons/react` in `MenuItemButton`
- Add `flex-1` to the label span so it expands to fill available space
- Conditionally render `<CaretRightIcon>` when item has `submenu` or `editSubmenu`