### PR TITLE
ci: auto-create GitHub Releases with changelog notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,4 +55,32 @@ jobs:
           cache-to: type=gha,mode=max
           pull: true
 
+      - name: Extract changelog entry
+        id: changelog
+        run: |
+          VERSION="${{ github.ref_name }}"       # e.g. v0.2.0
+          CHANGELOG_VERSION="${VERSION#v}"        # e.g. 0.2.0
+
+          awk -v ver="$CHANGELOG_VERSION" '
+            $0 ~ "^## \\[" ver "\\]" { found=1; next }
+            found && $0 ~ "^## \\[" { exit }
+            found && $0 ~ "^\\[[^]]+\\]: " { exit }
+            found { print }
+          ' CHANGELOG.md > /tmp/release-notes.md
+
+          echo "notes_file=/tmp/release-notes.md" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        run: |
+          if gh release view "${{ github.ref_name }}" &>/dev/null; then
+            echo "Release ${{ github.ref_name }} already exists, skipping."
+            exit 0
+          fi
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --notes-file /tmp/release-notes.md \
+            docker-compose.yml \
+            .env.example
+        env:
+          GH_TOKEN: ${{ github.token }}
 

--- a/.pi/prompts/release.md
+++ b/.pi/prompts/release.md
@@ -57,9 +57,11 @@ Compute: `v<major>.<minor>.<patch>`.
 
 Tell the user what you determined and why (e.g., "Bumping minor because there are feat commits: v0.1.0 → v0.2.0"). If they disagree, they can provide a different version.
 
-## 4. Update the changelog
+## 4. Update the changelog and version
 
 Check that `CHANGELOG.md` exists. If it doesn't, stop and ask: "No CHANGELOG.md found. Want me to create one?"
+
+### Changelog
 
 Read `CHANGELOG.md`. Replace the `## [Unreleased]` section with:
 
@@ -85,6 +87,14 @@ Then add a new empty `## [Unreleased]` section above the version just released.
 
 Add a link reference at the bottom for the new version (following the existing `[Unreleased]` link pattern).
 
+### Package version
+
+Update the `"version"` field in root `package.json` to the new version **without the `v` prefix** (e.g., `"0.2.0"`, not `"v0.2.0"`).
+
+### Review
+
+Show the generated changelog entry to the user. Ask them to review and edit before proceeding — commit messages often need cleanup to read well as release notes.
+
 ## 5. Create release branch
 
 ```bash
@@ -97,12 +107,21 @@ If the branch already exists, append a counter: `release/v<version>-2`.
 ## 6. Stage, commit, and push
 
 ```bash
-git add CHANGELOG.md
+git add CHANGELOG.md package.json
 git commit -m "chore(release): bump version to v<version>"
 git push -u origin HEAD
 ```
 
-## 7. Create release PR
+## 7. Push the tag
+
+```bash
+git tag v<version>
+git push origin v<version>
+```
+
+This triggers the `release.yml` workflow immediately — Docker build, Docker push to GHCR, and GitHub Release creation with changelog notes and assets. The GitHub Release will be live before the PR is even merged.
+
+## 8. Create release PR
 
 ```bash
 gh pr create \
@@ -122,13 +141,13 @@ EOF
 
 Open the PR URL for the user.
 
-## 8. Post-merge instructions
+## 9. Post-merge instructions
 
 Remind the user:
 
-1. After the release PR merges to `main`, the `release.yml` workflow will build and push the Docker image with the version tag.
-2. Sync `dev` with `main` to keep history linear:
+1. The GitHub Release and Docker image are already live (the tag was pushed in step 7, triggering the workflow).
+2. After the release PR merges to `main`, sync `dev` with `main` to keep history linear:
    ```bash
    git checkout dev && git merge main && git push origin dev
    ```
-3. Once the Docker image is published, create the actual GitHub Release (the workflow creates a draft).
+3. If the PR required changes (code, not just changelog), the tag and release point to the old commit. Delete the release and tag, then re-run from step 6.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PWA support for installable web app experience.
 - Docker-based deployment with pre-built images on GHCR.
 - **Pi skills** — Domain knowledge skills for the Pi coding agent (`.pi/skills/`).
-- **Release workflow** — GitHub Actions workflow for multi-arch Docker image builds triggered by `v*` tags, with draft GitHub releases.
+- **Release workflow** — GitHub Actions workflow triggered by `v*` tags: builds multi-arch Docker images, creates GitHub Releases with changelog notes, and attaches docker-compose.yml and .env.example as assets.
 
 ### Changed
 - **Full UI redesign** — Clay design system with flat matte shadows on buttons and cards, duo-tone color themes (replacing single-accent palettes), and glassmorphism on popups, modals, and tooltips.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "alfira-bot",
+  "version": "0.1.0",
   "private": true,
   "packageManager": "bun@1.3.11",
   "workspaces": [


### PR DESCRIPTION
## Summary

Automates the entire release pipeline. `/release` now bumps `package.json` version alongside the changelog, pushes the tag immediately (triggers the workflow), and the workflow auto-creates the GitHub Release with changelog notes and assets — no manual steps after merging.

## Changes

- **`release.yml`** — New steps extract the version's section from `CHANGELOG.md` and call `gh release create` with it as release notes. Attaches `docker-compose.yml` and `.env.example` as downloadable assets. Idempotent if re-run.
- **`release.md`** — Now bumps `package.json` version, pushes the tag immediately after commit (triggering the workflow before the PR even merges), and adds a review step to clean up auto-generated changelog entries.
- **`package.json`** — Added missing `version` field (`0.1.0`).
- **`CHANGELOG.md`** — Fixed stale "draft GitHub releases" claim in the v0.1.0 release notes.