### PR TITLE
refactor: extract VirtualList shell and deduplicate source filter patterns

### DIFF
--- a/packages/server/src/lib/search.ts
+++ b/packages/server/src/lib/search.ts
@@ -1,6 +1,19 @@
 import { sql } from 'drizzle-orm';
 import { $client } from '../shared/db';
 
+// ---------------------------------------------------------------------------
+// Source URL → LIKE patterns for server-side source filtering.
+// Must mirror the web's HOST_TO_SOURCE map in packages/web/src/utils/source.ts.
+// ---------------------------------------------------------------------------
+export const SOURCE_LIKE_PATTERNS: Record<string, string[]> = {
+  youtube: ['%youtube.com%', '%youtu.be%'],
+  soundcloud: ['%soundcloud.com%'],
+  spotify: ['%spotify.com%'],
+  applemusic: ['%music.apple.com%'],
+  tidal: ['%tidal.com%'],
+  googledrive: ['%drive.google.com%'],
+};
+
 export function buildSongSearchClause(
   search: string | undefined
 ): ReturnType<typeof sql> | undefined {

--- a/packages/server/src/routes/playlists.ts
+++ b/packages/server/src/routes/playlists.ts
@@ -6,25 +6,13 @@ import { parsePagination } from '../lib/pagination';
 import { canAccessPlaylist } from '../lib/playlistAccess';
 import { checkRateLimit, getClientIp, rateLimitResponse } from '../lib/rateLimit';
 import { checkGuards } from '../lib/routeGuards';
-import { buildSongSearchClause } from '../lib/search';
+import { buildSongSearchClause, SOURCE_LIKE_PATTERNS } from '../lib/search';
 import { emitPlaylistUpdated } from '../lib/socket';
 import { syncPlaylistToTag } from '../lib/syncPlaylistToTag';
 import { validatePlaylistName } from '../lib/validation';
 import { db, tables } from '../shared/db';
 
 const { playlist: playlistTable, playlistSong: playlistSongTable } = tables;
-
-// ---------------------------------------------------------------------------
-// Source URL → LIKE patterns (mirrors songs.ts)
-// ---------------------------------------------------------------------------
-const SOURCE_LIKE_PATTERNS: Record<string, string[]> = {
-  youtube: ['%youtube.com%', '%youtu.be%'],
-  soundcloud: ['%soundcloud.com%'],
-  spotify: ['%spotify.com%'],
-  applemusic: ['%music.apple.com%'],
-  tidal: ['%tidal.com%'],
-  googledrive: ['%drive.google.com%'],
-};
 
 function buildSongOrderBy(field: string, direction: 'ASC' | 'DESC'): ReturnType<typeof sql> {
   switch (field) {

--- a/packages/server/src/routes/songs.ts
+++ b/packages/server/src/routes/songs.ts
@@ -6,7 +6,7 @@ import { json } from '../lib/json';
 import { parsePagination } from '../lib/pagination';
 import { checkRateLimit, getClientIp, rateLimitResponse } from '../lib/rateLimit';
 import { checkGuards } from '../lib/routeGuards';
-import { buildSongSearchClause } from '../lib/search';
+import { buildSongSearchClause, SOURCE_LIKE_PATTERNS } from '../lib/search';
 import { formatSong } from '../lib/serialization';
 import { emitSongDeleted, emitSongUpdated } from '../lib/socket';
 import { reSyncPlaylistsForTags } from '../lib/syncPlaylistToTag';
@@ -22,19 +22,6 @@ import { db, tables } from '../shared/db';
 import { getPlayer } from '../startDiscord';
 
 const { song: songTable } = tables;
-
-// ---------------------------------------------------------------------------
-// Source URL → LIKE patterns for server-side source filtering.
-// Must mirror the web's HOST_TO_SOURCE map in packages/web/src/utils/source.ts.
-// ---------------------------------------------------------------------------
-const SOURCE_LIKE_PATTERNS: Record<string, string[]> = {
-  youtube: ['%youtube.com%', '%youtu.be%'],
-  soundcloud: ['%soundcloud.com%'],
-  spotify: ['%spotify.com%'],
-  applemusic: ['%music.apple.com%'],
-  tidal: ['%tidal.com%'],
-  googledrive: ['%drive.google.com%'],
-};
 
 const ALLOWED_SORTS = ['createdAt', 'title', 'artist', 'album', 'duration'] as const;
 type SortField = (typeof ALLOWED_SORTS)[number];

--- a/packages/web/src/components/VirtualListShell.tsx
+++ b/packages/web/src/components/VirtualListShell.tsx
@@ -1,0 +1,72 @@
+import { memo, useLayoutEffect, useRef } from 'react';
+import EmptyState from './EmptyState';
+import { VirtualListFooter } from './ui/VirtualListFooter';
+
+interface VirtualListShellProps {
+  isLoading: boolean;
+  hasLoaded: boolean;
+  isEmpty: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  hasMore?: boolean;
+  onRetry: () => void;
+  sentinelRef: (el: HTMLDivElement | null) => void;
+  skeleton: React.ReactNode;
+  emptyTitle: string;
+  emptyMessage?: string;
+  endSpacer?: boolean;
+  children: React.ReactNode;
+}
+
+export const VirtualListShell = memo(function VirtualListShell({
+  isLoading,
+  hasLoaded,
+  isEmpty,
+  isFetching,
+  isError,
+  hasMore = false,
+  onRetry,
+  sentinelRef,
+  skeleton,
+  emptyTitle,
+  emptyMessage,
+  endSpacer = false,
+  children,
+}: VirtualListShellProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const showSkeleton = isLoading;
+  const showEmpty = hasLoaded && isEmpty;
+  const showContent = !isLoading && hasLoaded && !isEmpty;
+
+  // Reveal the container only after React has committed all DOM mutations,
+  // so the browser paints all cards at once without any staggered rendering.
+  useLayoutEffect(() => {
+    if (!containerRef.current) return;
+    containerRef.current.style.opacity = showContent || showEmpty || showSkeleton ? '1' : '0';
+  }, [showContent, showEmpty, showSkeleton]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative"
+      style={{ opacity: 0, transition: 'opacity 120ms ease' }}
+    >
+      {showSkeleton && skeleton}
+      {showEmpty && <EmptyState title={emptyTitle} message={emptyMessage} />}
+      {showContent && (
+        <>
+          {children}
+          <VirtualListFooter
+            sentinelRef={sentinelRef}
+            isFetching={isFetching}
+            isError={isError}
+            onRetry={onRetry}
+          />
+          {endSpacer && !isFetching && !isError && !hasMore && <div className="h-4" />}
+        </>
+      )}
+    </div>
+  );
+});
+
+export default VirtualListShell;

--- a/packages/web/src/components/VirtualPlaylistList.tsx
+++ b/packages/web/src/components/VirtualPlaylistList.tsx
@@ -1,8 +1,7 @@
 import type { Playlist } from '@alfira-bot/server/shared';
-import { memo, useLayoutEffect, useRef } from 'react';
-import EmptyState from './EmptyState';
+import { memo } from 'react';
 import PlaylistRow from './PlaylistRow';
-import { VirtualListFooter } from './ui/VirtualListFooter';
+import VirtualListShell from './VirtualListShell';
 
 interface VirtualPlaylistListProps {
   items: Playlist[];
@@ -46,46 +45,31 @@ export const VirtualPlaylistList = memo(function VirtualPlaylistList({
   emptyTitle,
   emptyMessage,
 }: VirtualPlaylistListProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const showSkeleton = isLoading;
-  const showEmpty = hasLoaded && items.length === 0;
-  const showContent = !isLoading && hasLoaded && items.length > 0;
-
-  useLayoutEffect(() => {
-    if (!containerRef.current) return;
-    containerRef.current.style.opacity = showContent || showEmpty || showSkeleton ? '1' : '0';
-  }, [showContent, showEmpty, showSkeleton]);
-
   return (
-    <div
-      ref={containerRef}
-      className="relative"
-      style={{ opacity: 0, transition: 'opacity 120ms ease' }}
+    <VirtualListShell
+      isLoading={isLoading}
+      hasLoaded={hasLoaded}
+      isEmpty={items.length === 0}
+      isFetching={isFetching}
+      isError={isError}
+      onRetry={onRetry}
+      sentinelRef={sentinelRef}
+      skeleton={<SkeletonList />}
+      emptyTitle={emptyTitle}
+      emptyMessage={emptyMessage}
     >
-      {showSkeleton && <SkeletonList />}
-      {showEmpty && <EmptyState title={emptyTitle} message={emptyMessage} />}
-      {showContent && (
-        <>
-          <div className="flex flex-col gap-3">
-            {items.map((playlist) => (
-              <PlaylistRow
-                key={playlist.id}
-                playlist={playlist}
-                animationDelay="0ms"
-                onClick={onRowClick}
-                data-playlist-id={playlist.id}
-              />
-            ))}
-          </div>
-          <VirtualListFooter
-            sentinelRef={sentinelRef}
-            isFetching={isFetching}
-            isError={isError}
-            onRetry={onRetry}
+      <div className="flex flex-col gap-3">
+        {items.map((playlist) => (
+          <PlaylistRow
+            key={playlist.id}
+            playlist={playlist}
+            animationDelay="0ms"
+            onClick={onRowClick}
+            data-playlist-id={playlist.id}
           />
-        </>
-      )}
-    </div>
+        ))}
+      </div>
+    </VirtualListShell>
   );
 });
 

--- a/packages/web/src/components/VirtualRequestList.tsx
+++ b/packages/web/src/components/VirtualRequestList.tsx
@@ -1,8 +1,7 @@
 import type { SongRequest } from '@alfira-bot/server/shared';
-import { memo, useLayoutEffect, useRef } from 'react';
-import EmptyState from './EmptyState';
+import { memo } from 'react';
 import RequestCard from './RequestCard';
-import { VirtualListFooter } from './ui/VirtualListFooter';
+import VirtualListShell from './VirtualListShell';
 
 export interface VirtualRequestListProps {
   items: SongRequest[];
@@ -58,48 +57,33 @@ export const VirtualRequestList = memo(function VirtualRequestList({
   emptyTitle,
   emptyMessage,
 }: VirtualRequestListProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const showSkeleton = isLoading;
-  const showEmpty = hasLoaded && items.length === 0;
-  const showContent = !isLoading && hasLoaded && items.length > 0;
-
-  useLayoutEffect(() => {
-    if (!containerRef.current) return;
-    containerRef.current.style.opacity = showContent || showEmpty || showSkeleton ? '1' : '0';
-  }, [showContent, showEmpty, showSkeleton]);
-
   return (
-    <div
-      ref={containerRef}
-      className="relative"
-      style={{ opacity: 0, transition: 'opacity 120ms ease' }}
+    <VirtualListShell
+      isLoading={isLoading}
+      hasLoaded={hasLoaded}
+      isEmpty={items.length === 0}
+      isFetching={isFetching}
+      isError={isError}
+      onRetry={onRetry}
+      sentinelRef={sentinelRef}
+      skeleton={<SkeletonList />}
+      emptyTitle={emptyTitle}
+      emptyMessage={emptyMessage}
     >
-      {showSkeleton && <SkeletonList />}
-      {showEmpty && <EmptyState title={emptyTitle} message={emptyMessage} />}
-      {showContent && (
-        <>
-          <div className="flex flex-col gap-3">
-            {items.map((req) => (
-              <RequestCard
-                key={req.id}
-                req={req}
-                isOwn={isOwnFn(req.requestedBy)}
-                isAdmin={isAdmin}
-                onApprove={onApprove}
-                onDeny={onDeny}
-                onCancel={onCancel}
-              />
-            ))}
-          </div>
-          <VirtualListFooter
-            sentinelRef={sentinelRef}
-            isFetching={isFetching}
-            isError={isError}
-            onRetry={onRetry}
+      <div className="flex flex-col gap-3">
+        {items.map((req) => (
+          <RequestCard
+            key={req.id}
+            req={req}
+            isOwn={isOwnFn(req.requestedBy)}
+            isAdmin={isAdmin}
+            onApprove={onApprove}
+            onDeny={onDeny}
+            onCancel={onCancel}
           />
-        </>
-      )}
-    </div>
+        ))}
+      </div>
+    </VirtualListShell>
   );
 });
 

--- a/packages/web/src/components/VirtualSongList.tsx
+++ b/packages/web/src/components/VirtualSongList.tsx
@@ -1,8 +1,7 @@
 import type { Playlist, Song } from '@alfira-bot/server/shared';
-import { memo, useLayoutEffect, useRef } from 'react';
-import EmptyState from './EmptyState';
+import { memo } from 'react';
 import SongCard from './SongCard';
-import { VirtualListFooter } from './ui/VirtualListFooter';
+import VirtualListShell from './VirtualListShell';
 
 interface VirtualSongListProps {
   items: Song[];
@@ -108,63 +107,48 @@ export const VirtualSongList = memo(function VirtualSongList({
   isSelected,
   onToggleSelect,
 }: VirtualSongListProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
   const isGrid = viewMode === 'grid';
-  const showSkeleton = isLoading;
-  const showEmpty = hasLoaded && items.length === 0;
-  const showContent = !isLoading && hasLoaded && items.length > 0;
-
-  // Reveal the container only after React has committed all DOM mutations,
-  // so the browser paints all cards at once without any staggered rendering.
-  useLayoutEffect(() => {
-    if (!containerRef.current) return;
-    containerRef.current.style.opacity = showContent || showEmpty || showSkeleton ? '1' : '0';
-  }, [showContent, showEmpty, showSkeleton]);
 
   return (
-    <div
-      ref={containerRef}
-      className="relative"
-      style={{ opacity: 0, transition: 'opacity 120ms ease' }}
+    <VirtualListShell
+      isLoading={isLoading}
+      hasLoaded={hasLoaded}
+      isEmpty={items.length === 0}
+      isFetching={isFetching}
+      isError={isError}
+      hasMore={hasMore}
+      onRetry={onRetry}
+      sentinelRef={sentinelRef}
+      skeleton={isGrid ? <SkeletonGrid /> : <SkeletonList />}
+      emptyTitle={emptyTitle}
+      emptyMessage={emptyMessage}
+      endSpacer
     >
-      {showSkeleton && (isGrid ? <SkeletonGrid /> : <SkeletonList />)}
-      {showEmpty && <EmptyState title={emptyTitle} message={emptyMessage} />}
-      {showContent && (
-        <>
-          <div
-            className={
-              isGrid
-                ? 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-[repeat(auto-fill,minmax(270px,1fr))] gap-3 md:gap-4 items-start'
-                : 'flex flex-col gap-1.5'
-            }
-          >
-            {items.map((song) => (
-              <SongCard
-                key={song.id}
-                song={song}
-                variant={viewMode === 'grid' ? 'grid' : 'list'}
-                isAdminView={isAdminView}
-                playlists={playlists}
-                onDelete={onDelete}
-                onPlay={() => onPlay(song.id)}
-                isPlaying={playingId === song.id}
-                onAddToQueue={() => onAddToQueue(song.id)}
-                selectionMode={selectionMode}
-                isSelected={isSelected?.(song.id) ?? false}
-                onToggleSelect={onToggleSelect ? () => onToggleSelect(song.id) : undefined}
-              />
-            ))}
-          </div>
-          <VirtualListFooter
-            sentinelRef={sentinelRef}
-            isFetching={isFetching}
-            isError={isError}
-            onRetry={onRetry}
+      <div
+        className={
+          isGrid
+            ? 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-[repeat(auto-fill,minmax(270px,1fr))] gap-3 md:gap-4 items-start'
+            : 'flex flex-col gap-1.5'
+        }
+      >
+        {items.map((song) => (
+          <SongCard
+            key={song.id}
+            song={song}
+            variant={viewMode === 'grid' ? 'grid' : 'list'}
+            isAdminView={isAdminView}
+            playlists={playlists}
+            onDelete={onDelete}
+            onPlay={() => onPlay(song.id)}
+            isPlaying={playingId === song.id}
+            onAddToQueue={() => onAddToQueue(song.id)}
+            selectionMode={selectionMode}
+            isSelected={isSelected?.(song.id) ?? false}
+            onToggleSelect={onToggleSelect ? () => onToggleSelect(song.id) : undefined}
           />
-          {!isFetching && !isError && !hasMore && items.length > 0 && <div className="h-4" />}
-        </>
-      )}
-    </div>
+        ))}
+      </div>
+    </VirtualListShell>
   );
 });
 


### PR DESCRIPTION
## Summary

Extracts two repeated code patterns into shared abstractions:

### VirtualListShell

All three `Virtual*List` components shared an identical skeleton/empty/content opacity-reveal pattern (state derivation, `useLayoutEffect` fade, three-branch render, `VirtualListFooter`). Moved into a new `VirtualListShell` wrapper component. Each list component now focuses solely on its items and skeleton, reducing ~20 lines of boilerplate per consumer.

### SOURCE\_LIKE\_PATTERNS

The source URL → LIKE pattern mapping was duplicated identically in `routes/songs.ts` and `routes/playlists.ts`. Moved to `lib/search.ts` as a single exported constant.

## Changes

- **New**: `packages/web/src/components/VirtualListShell.tsx` — shared list wrapper
- **Refactored**: `VirtualSongList`, `VirtualRequestList`, `VirtualPlaylistList` — use `VirtualListShell`
- **Server**: `lib/search.ts` exports `SOURCE_LIKE_PATTERNS`, imported by `routes/songs.ts` and `routes/playlists.ts`