### PR TITLE
refactor(server): extract shared route table from route dispatchers

### DIFF
--- a/packages/server/src/lib/routeTable.ts
+++ b/packages/server/src/lib/routeTable.ts
@@ -1,0 +1,107 @@
+import type { RouteContext } from '../index';
+import { json } from './json';
+import { checkRateLimit, getClientIp, rateLimitResponse } from './rateLimit';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A route handler receives ctx, request, and extracted path params. */
+export type RouteHandler = (
+  ctx: RouteContext,
+  request: Request,
+  params: Record<string, string>
+) => Response | Promise<Response>;
+
+/** A route entry: [HTTP method, path pattern, handler]. */
+export type RouteEntry = [method: string, pattern: string, handler: RouteHandler];
+
+export interface RouteTableConfig {
+  /** Optional rate limit applied to all non-GET requests on this route group. */
+  rateLimit?: { windowMs: number; maxRequests: number; bucket: string };
+  routes: RouteEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// matchPath — template-based path matching with :param extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Match a path against a template with `:param` placeholders.
+ * Returns named parameters on match, null otherwise.
+ *
+ * Leading/trailing slashes are ignored — `/queue` and `/queue/` are equivalent.
+ *
+ * Example: matchPath('/abc/songs/123', '/:id/songs/:songId')
+ *   => { id: 'abc', songId: '123' }
+ */
+export function matchPath(path: string, template: string): Record<string, string> | null {
+  const pathParts = path.split('/').filter(Boolean);
+  const tplParts = template.split('/').filter(Boolean);
+  if (pathParts.length !== tplParts.length) return null;
+
+  const params: Record<string, string> = {};
+  for (let i = 0; i < tplParts.length; i++) {
+    const tpl = tplParts[i];
+    const seg = pathParts[i];
+    if (!tpl || !seg) return null;
+    if (tpl.startsWith(':')) {
+      params[tpl.slice(1)] = seg;
+    } else if (tpl !== seg) {
+      return null;
+    }
+  }
+  return params;
+}
+
+// ---------------------------------------------------------------------------
+// routeTable — produces a dispatcher function from a route table
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a route dispatcher function for the given URL prefix.
+ *
+ * The returned function has the standard `(ctx, request) => Promise<Response>`
+ * signature used by all Alfira route modules.
+ *
+ * Routes are matched in registration order. The first matching method+pattern
+ * wins. Unmatched requests receive `{"error":"Not Found"}` (404).
+ *
+ * When `rateLimit` is configured, non-GET requests are rate-limited per IP
+ * before any route handler runs.
+ */
+export function routeTable(
+  prefix: string,
+  config: RouteTableConfig
+): (ctx: RouteContext, request: Request) => Promise<Response> {
+  const { rateLimit, routes } = config;
+
+  return async function dispatch(ctx: RouteContext, request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const path = url.pathname.slice(prefix.length) || '/';
+
+    // Rate-limit non-GET requests.
+    if (rateLimit && request.method !== 'GET') {
+      const ip = getClientIp(request);
+      if (
+        !checkRateLimit(rateLimit.bucket, ip, {
+          windowMs: rateLimit.windowMs,
+          maxRequests: rateLimit.maxRequests,
+        })
+      ) {
+        return rateLimitResponse(60);
+      }
+    }
+
+    for (const [method, pattern, handler] of routes) {
+      if (request.method !== method) continue;
+
+      const params = matchPath(path, pattern);
+      if (params === null) continue;
+
+      return await handler(ctx, request, params);
+    }
+
+    return json({ error: 'Not Found' }, 404);
+  };
+}

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -5,6 +5,7 @@ import type { RouteContext } from '../index';
 import { getGuildId } from '../lib/config';
 import { json } from '../lib/json';
 import { getClientIp } from '../lib/rateLimit';
+import { routeTable } from '../lib/routeTable';
 import { db, tables } from '../shared/db';
 import { logger } from '../shared/logger';
 
@@ -341,30 +342,21 @@ async function generateAndStoreTokens(
 // Route handlers
 // ---------------------------------------------------------------------------
 
-export async function handleAuth(ctx: RouteContext, request: Request): Promise<Response> {
-  const url = new URL(request.url);
-  const pathname = url.pathname;
+export const handleAuth = routeTable('/auth', {
+  routes: [
+    ['GET', '/login', handleLogin],
+    ['GET', '/callback', handleCallback],
+    ['POST', '/refresh', handleRefresh],
+    ['GET', '/me', handleMe],
+    ['POST', '/logout', handleLogout],
+  ],
+});
 
-  if (request.method === 'GET' && pathname === '/auth/login') {
-    return handleLogin(request);
-  }
-  if (request.method === 'GET' && pathname === '/auth/callback') {
-    return await handleCallback(request, url);
-  }
-  if (request.method === 'POST' && pathname === '/auth/refresh') {
-    return await handleRefresh(ctx);
-  }
-  if (request.method === 'GET' && pathname === '/auth/me') {
-    return await handleMe(ctx);
-  }
-  if (request.method === 'POST' && pathname === '/auth/logout') {
-    return await handleLogout(ctx);
-  }
-
-  return json({ error: 'Not Found' }, 404);
-}
-
-function handleLogin(request: Request): Response {
+function handleLogin(
+  _ctx: RouteContext,
+  request: Request,
+  _params: Record<string, string>
+): Response {
   const ip = getClientIp(request);
   if (!authRateLimit(ip)) {
     return json(
@@ -381,7 +373,12 @@ function handleLogin(request: Request): Response {
   return Response.redirect(`https://discord.com/oauth2/authorize?${params}`, 302);
 }
 
-async function handleCallback(request: Request, url: URL): Promise<Response> {
+async function handleCallback(
+  _ctx: RouteContext,
+  request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
+  const url = new URL(request.url);
   const ip = getClientIp(request);
   if (!authRateLimit(ip)) {
     return json(
@@ -503,7 +500,11 @@ async function withRetry<T>(fn: () => Promise<T>, attempts = 3, baseDelayMs = 50
   throw lastErr;
 }
 
-async function handleRefresh(ctx: RouteContext): Promise<Response> {
+async function handleRefresh(
+  ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
   const refreshToken = ctx.cookies[REFRESH_COOKIE_NAME];
   if (!refreshToken) {
     logger.warn('Auth refresh failed: no refresh token cookie present');
@@ -661,7 +662,11 @@ async function handleRefresh(ctx: RouteContext): Promise<Response> {
   return new Response(JSON.stringify({ user: payload }), { status: 200, headers });
 }
 
-async function handleMe(ctx: RouteContext): Promise<Response> {
+async function handleMe(
+  ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
   if (!ctx.user) {
     return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
   }
@@ -675,7 +680,11 @@ async function handleMe(ctx: RouteContext): Promise<Response> {
   return json({ user: ctx.user });
 }
 
-async function handleLogout(ctx: RouteContext): Promise<Response> {
+async function handleLogout(
+  ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
   const refreshToken = ctx.cookies[REFRESH_COOKIE_NAME];
   if (refreshToken) {
     try {

--- a/packages/server/src/routes/compressor.ts
+++ b/packages/server/src/routes/compressor.ts
@@ -2,6 +2,7 @@ import type { RouteContext } from '../index';
 import { applyNodeLinkFilter, buildCompressorFilter } from '../lib/applyNodeLinkFilter';
 import { json } from '../lib/json';
 import { checkGuards } from '../lib/routeGuards';
+import { routeTable } from '../lib/routeTable';
 import { db, tables } from '../shared/db';
 
 interface CompressorPayload {
@@ -13,7 +14,11 @@ interface CompressorPayload {
   gain: number;
 }
 
-export async function handleCompressor(ctx: RouteContext, request: Request): Promise<Response> {
+async function handleCompressorRequest(
+  ctx: RouteContext,
+  request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
   const guards = await checkGuards(ctx, { admin: true, permission: 'audio.manage' });
   if (guards instanceof Response) return guards;
 
@@ -69,3 +74,10 @@ export async function handleCompressor(ctx: RouteContext, request: Request): Pro
 
   return json({ enabled, threshold, ratio, attack, release, gain });
 }
+
+export const handleCompressor = routeTable('/api/settings/compressor', {
+  routes: [
+    ['GET', '/', handleCompressorRequest],
+    ['PATCH', '/', handleCompressorRequest],
+  ],
+});

--- a/packages/server/src/routes/equalizer.ts
+++ b/packages/server/src/routes/equalizer.ts
@@ -9,6 +9,7 @@ import {
 } from '../lib/eqBands';
 import { json } from '../lib/json';
 import { checkGuards } from '../lib/routeGuards';
+import { routeTable } from '../lib/routeTable';
 import { db, tables } from '../shared/db';
 
 interface EqualizerPayload {
@@ -16,7 +17,11 @@ interface EqualizerPayload {
   enabled: boolean;
 }
 
-async function handleEqualizerGet(ctx: RouteContext): Promise<Response> {
+async function handleEqualizerGet(
+  ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
   const guards = await checkGuards(ctx, { admin: true, permission: 'audio.manage' });
   if (guards instanceof Response) return guards;
 
@@ -35,7 +40,11 @@ async function handleEqualizerGet(ctx: RouteContext): Promise<Response> {
   return json({ bands, enabled });
 }
 
-async function handleEqualizerPatch(ctx: RouteContext, request: Request): Promise<Response> {
+async function handleEqualizerPatch(
+  ctx: RouteContext,
+  request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
   const guards = await checkGuards(ctx, { admin: true, permission: 'audio.manage' });
   if (guards instanceof Response) return guards;
 
@@ -80,12 +89,9 @@ async function handleEqualizerPatch(ctx: RouteContext, request: Request): Promis
   return json({ bands, enabled });
 }
 
-// ---------------------------------------------------------------------------
-// Dispatcher
-// ---------------------------------------------------------------------------
-
-export async function handleEqualizer(ctx: RouteContext, request: Request): Promise<Response> {
-  if (request.method === 'GET') return await handleEqualizerGet(ctx);
-  if (request.method === 'PATCH') return await handleEqualizerPatch(ctx, request);
-  return json({ error: 'Not Found' }, 404);
-}
+export const handleEqualizer = routeTable('/api/settings/equalizer', {
+  routes: [
+    ['GET', '/', handleEqualizerGet],
+    ['PATCH', '/', handleEqualizerPatch],
+  ],
+});

--- a/packages/server/src/routes/generalSettings.ts
+++ b/packages/server/src/routes/generalSettings.ts
@@ -2,6 +2,7 @@ import { eq } from 'drizzle-orm';
 import type { RouteContext } from '../index';
 import { json } from '../lib/json';
 import { checkGuards } from '../lib/routeGuards';
+import { routeTable } from '../lib/routeTable';
 import type { GeneralSettings } from '../shared';
 import { db, tables } from '../shared/db';
 import { SOURCE_DEFINITIONS } from '../startDiscord';
@@ -33,7 +34,11 @@ const SETTINGS_COLUMNS = {
 // ---------------------------------------------------------------------------
 // GET /api/settings/general
 // ---------------------------------------------------------------------------
-async function handleGetGeneral(ctx: RouteContext): Promise<Response> {
+async function handleGetGeneral(
+  ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
   const guards = await checkGuards(ctx, { admin: true });
   if (guards instanceof Response) return guards;
 
@@ -77,7 +82,11 @@ interface GeneralSettingsPatch {
   enabledSources?: string;
 }
 
-async function handlePatchGeneral(ctx: RouteContext, request: Request): Promise<Response> {
+async function handlePatchGeneral(
+  ctx: RouteContext,
+  request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
   const guards = await checkGuards(ctx, { admin: true });
   if (guards instanceof Response) return guards;
 
@@ -185,14 +194,9 @@ async function handlePatchGeneral(ctx: RouteContext, request: Request): Promise<
   return json(attachAvailableSources(row as Omit<GeneralSettings, 'availableSources'>));
 }
 
-// ---------------------------------------------------------------------------
-// Dispatcher
-// ---------------------------------------------------------------------------
-export async function handleGeneralSettings(
-  ctx: RouteContext,
-  request: Request
-): Promise<Response> {
-  if (request.method === 'GET') return await handleGetGeneral(ctx);
-  if (request.method === 'PATCH') return await handlePatchGeneral(ctx, request);
-  return json({ error: 'Not Found' }, 404);
-}
+export const handleGeneralSettings = routeTable('/api/settings/general', {
+  routes: [
+    ['GET', '/', handleGetGeneral],
+    ['PATCH', '/', handlePatchGeneral],
+  ],
+});

--- a/packages/server/src/routes/permissions.ts
+++ b/packages/server/src/routes/permissions.ts
@@ -3,6 +3,7 @@ import type { RouteContext } from '../index';
 import { getGuildId } from '../lib/config';
 import { json } from '../lib/json';
 import { checkGuards } from '../lib/routeGuards';
+import { routeTable } from '../lib/routeTable';
 import { PERMISSION_CATEGORIES, PERMISSION_LABELS, type PermissionAction } from '../shared';
 import { db, tables } from '../shared/db';
 import { logger } from '../shared/logger';
@@ -53,7 +54,11 @@ async function fetchGuildRoles(): Promise<SetupRole[]> {
 // ---------------------------------------------------------------------------
 // GET /api/permissions
 // ---------------------------------------------------------------------------
-async function handleGetPermissions(ctx: RouteContext): Promise<Response> {
+async function handleGetPermissions(
+  ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
   const guards = await checkGuards(ctx, { admin: true });
   if (guards instanceof Response) return guards;
 
@@ -95,7 +100,11 @@ async function handleGetPermissions(ctx: RouteContext): Promise<Response> {
 // PATCH /api/permissions
 // Body: { action: PermissionAction; roleIds: string[] }
 // ---------------------------------------------------------------------------
-async function handlePatchPermissions(ctx: RouteContext, request: Request): Promise<Response> {
+async function handlePatchPermissions(
+  ctx: RouteContext,
+  request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
   const guards = await checkGuards(ctx, { admin: true });
   if (guards instanceof Response) return guards;
 
@@ -139,7 +148,11 @@ async function handlePatchPermissions(ctx: RouteContext, request: Request): Prom
 // ---------------------------------------------------------------------------
 // GET /api/permissions/me — returns permissions for the current user
 // ---------------------------------------------------------------------------
-async function handleGetMyPermissions(ctx: RouteContext): Promise<Response> {
+async function handleGetMyPermissions(
+  ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
   const user = ctx.user;
   if (!user) {
     return json({ error: 'Not authenticated.' }, 401);
@@ -159,19 +172,10 @@ async function handleGetMyPermissions(ctx: RouteContext): Promise<Response> {
   return json({ permissions });
 }
 
-// ---------------------------------------------------------------------------
-// Dispatcher
-// ---------------------------------------------------------------------------
-export async function handlePermissions(ctx: RouteContext, request: Request): Promise<Response> {
-  const url = new URL(request.url);
-  const pathname = url.pathname;
-
-  // GET /api/permissions/me
-  if (request.method === 'GET' && pathname === '/api/permissions/me') {
-    return await handleGetMyPermissions(ctx);
-  }
-
-  if (request.method === 'GET') return await handleGetPermissions(ctx);
-  if (request.method === 'PATCH') return await handlePatchPermissions(ctx, request);
-  return json({ error: 'Not Found' }, 404);
-}
+export const handlePermissions = routeTable('/api/permissions', {
+  routes: [
+    ['GET', '/me', handleGetMyPermissions],
+    ['GET', '/', handleGetPermissions],
+    ['PATCH', '/', handlePatchPermissions],
+  ],
+});

--- a/packages/server/src/routes/player.ts
+++ b/packages/server/src/routes/player.ts
@@ -5,8 +5,8 @@ import { json } from '../lib/json';
 import { lavalink } from '../lib/lavalink';
 import { requirePlayer, requirePlaying } from '../lib/player';
 import { canAccessPlaylist } from '../lib/playlistAccess';
-import { checkRateLimit, getClientIp, rateLimitResponse } from '../lib/rateLimit';
 import { checkGuards } from '../lib/routeGuards';
+import { routeTable } from '../lib/routeTable';
 import {
   clampMaxVideos,
   fetchPlaylistMetadata,
@@ -30,7 +30,11 @@ const { song: songTable } = tables;
 // ---------------------------------------------------------------------------
 // GET /api/player/queue — returns current queue state
 // ---------------------------------------------------------------------------
-function handleGetQueue(ctx: RouteContext): Response {
+function handleGetQueue(
+  ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Response {
   const guards = checkGuards(ctx);
   if (guards instanceof Response) return guards;
 
@@ -136,7 +140,11 @@ async function handlePlay(ctx: RouteContext, request: Request): Promise<Response
 // ---------------------------------------------------------------------------
 // POST /api/player/skip — skip current song
 // ---------------------------------------------------------------------------
-async function handleSkip(ctx: RouteContext): Promise<Response> {
+async function handleSkip(
+  ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
   const guards = await checkGuards(ctx, { voice: true });
   if (guards instanceof Response) return guards;
 
@@ -150,7 +158,11 @@ async function handleSkip(ctx: RouteContext): Promise<Response> {
 // ---------------------------------------------------------------------------
 // POST /api/player/leave — stop and disconnect
 // ---------------------------------------------------------------------------
-async function handleLeave(ctx: RouteContext): Promise<Response> {
+async function handleLeave(
+  ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
   const guards = await checkGuards(ctx, { voice: true });
   if (guards instanceof Response) return guards;
 
@@ -195,7 +207,11 @@ async function handleLoop(ctx: RouteContext, request: Request): Promise<Response
 // ---------------------------------------------------------------------------
 // POST /api/player/shuffle — shuffle queue (admin only)
 // ---------------------------------------------------------------------------
-async function handleShuffle(ctx: RouteContext): Promise<Response> {
+async function handleShuffle(
+  ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
   const guards = await checkGuards(ctx, { admin: true, voice: true, permission: 'queue.manage' });
   if (guards instanceof Response) return guards;
 
@@ -212,7 +228,11 @@ async function handleShuffle(ctx: RouteContext): Promise<Response> {
 // ---------------------------------------------------------------------------
 // POST /api/player/unshuffle — restore original queue order (admin only)
 // ---------------------------------------------------------------------------
-async function handleUnshuffle(ctx: RouteContext): Promise<Response> {
+async function handleUnshuffle(
+  ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
   const guards = await checkGuards(ctx, { admin: true, voice: true, permission: 'queue.manage' });
   if (guards instanceof Response) return guards;
 
@@ -343,7 +363,11 @@ async function handleQuickAddPlaylist(ctx: RouteContext, request: Request): Prom
 // ---------------------------------------------------------------------------
 // POST /api/player/pause-toggle — pause/resume
 // ---------------------------------------------------------------------------
-async function handlePauseToggle(ctx: RouteContext): Promise<Response> {
+async function handlePauseToggle(
+  ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
   const guards = await checkGuards(ctx, { voice: true });
   if (guards instanceof Response) return guards;
 
@@ -384,7 +408,11 @@ async function handleSeek(ctx: RouteContext, request: Request): Promise<Response
 // ---------------------------------------------------------------------------
 // POST /api/player/clear — clear queue (admin only)
 // ---------------------------------------------------------------------------
-async function handleClear(ctx: RouteContext): Promise<Response> {
+async function handleClear(
+  ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
   const guards = await checkGuards(ctx, { admin: true, voice: true, permission: 'queue.manage' });
   if (guards instanceof Response) return guards;
 
@@ -463,8 +491,9 @@ async function handleOverride(ctx: RouteContext, request: Request): Promise<Resp
 async function handleRemoveFromQueue(
   ctx: RouteContext,
   _request: Request,
-  songId: string
+  params: Record<string, string>
 ): Promise<Response> {
+  const { songId } = params;
   const guards = await checkGuards(ctx, { admin: true, voice: true, permission: 'queue.manage' });
   if (guards instanceof Response) return guards;
 
@@ -486,8 +515,9 @@ async function handleRemoveFromQueue(
 async function handlePromoteSong(
   ctx: RouteContext,
   _request: Request,
-  songId: string
+  params: Record<string, string>
 ): Promise<Response> {
+  const { songId } = params;
   const guards = await checkGuards(ctx, { admin: true, voice: true, permission: 'queue.manage' });
   if (guards instanceof Response) return guards;
 
@@ -509,8 +539,9 @@ async function handlePromoteSong(
 async function handleDemoteSong(
   ctx: RouteContext,
   _request: Request,
-  songId: string
+  params: Record<string, string>
 ): Promise<Response> {
+  const { songId } = params;
   const guards = await checkGuards(ctx, { admin: true, voice: true, permission: 'queue.manage' });
   if (guards instanceof Response) return guards;
 
@@ -570,56 +601,26 @@ async function handleReorderQueue(ctx: RouteContext, request: Request): Promise<
 // Dispatcher
 // ---------------------------------------------------------------------------
 
-export async function handlePlayer(ctx: RouteContext, request: Request): Promise<Response> {
-  const url = new URL(request.url);
-  const pathname = url.pathname;
-
-  // Strip /api/player prefix
-  const path = pathname.slice('/api/player'.length);
-
-  // Rate-limit mutation endpoints — 30 requests per 60s per IP.
-  // GET /queue is exempt to allow the UI to poll freely.
-  if (request.method !== 'GET') {
-    const ip = getClientIp(request);
-    if (!checkRateLimit('player-mutations', ip, { windowMs: 60_000, maxRequests: 30 })) {
-      return rateLimitResponse(60);
-    }
-  }
-
-  if (path === '/queue' && request.method === 'GET') return await handleGetQueue(ctx);
-  // Static paths checked before dynamic /queue/:songId
-  if (path === '/queue/reorder' && request.method === 'PATCH')
-    return await handleReorderQueue(ctx, request);
-  // Dynamic: /queue/:songId/promote
-  if (path.startsWith('/queue/') && path.endsWith('/promote') && request.method === 'POST') {
-    const songId = path.slice('/queue/'.length, -'/promote'.length);
-    if (songId.length > 0) return await handlePromoteSong(ctx, request, songId);
-  }
-  // Dynamic: /queue/:songId/demote
-  if (path.startsWith('/queue/') && path.endsWith('/demote') && request.method === 'POST') {
-    const songId = path.slice('/queue/'.length, -'/demote'.length);
-    if (songId.length > 0) return await handleDemoteSong(ctx, request, songId);
-  }
-  // Dynamic: /queue/:songId
-  if (path.startsWith('/queue/') && request.method === 'DELETE') {
-    const songId = path.slice('/queue/'.length);
-    if (songId.length > 0) return await handleRemoveFromQueue(ctx, request, songId);
-  }
-  if (path === '/play' && request.method === 'POST') return await handlePlay(ctx, request);
-  if (path === '/skip' && request.method === 'POST') return await handleSkip(ctx);
-  if (path === '/leave' && request.method === 'POST') return await handleLeave(ctx);
-  if (path === '/loop' && request.method === 'POST') return await handleLoop(ctx, request);
-  if (path === '/shuffle' && request.method === 'POST') return await handleShuffle(ctx);
-  if (path === '/unshuffle' && request.method === 'POST') return await handleUnshuffle(ctx);
-  if (path === '/quick-add' && request.method === 'POST') return await handleQuickAdd(ctx, request);
-  if (path === '/quick-add-playlist' && request.method === 'POST')
-    return await handleQuickAddPlaylist(ctx, request);
-  if (path === '/pause-toggle' && request.method === 'POST') return await handlePauseToggle(ctx);
-  if (path === '/seek' && request.method === 'POST') return await handleSeek(ctx, request);
-  if (path === '/clear' && request.method === 'POST') return await handleClear(ctx);
-  if (path === '/add-to-priority' && request.method === 'POST')
-    return await handleAddToPriority(ctx, request);
-  if (path === '/override' && request.method === 'POST') return await handleOverride(ctx, request);
-
-  return json({ error: 'Not Found' }, 404);
-}
+export const handlePlayer = routeTable('/api/player', {
+  rateLimit: { windowMs: 60_000, maxRequests: 30, bucket: 'player-mutations' },
+  routes: [
+    ['GET', '/queue', handleGetQueue],
+    ['PATCH', '/queue/reorder', handleReorderQueue],
+    ['POST', '/queue/:songId/promote', handlePromoteSong],
+    ['POST', '/queue/:songId/demote', handleDemoteSong],
+    ['DELETE', '/queue/:songId', handleRemoveFromQueue],
+    ['POST', '/add-to-priority', handleAddToPriority],
+    ['POST', '/clear', handleClear],
+    ['POST', '/leave', handleLeave],
+    ['POST', '/loop', handleLoop],
+    ['POST', '/override', handleOverride],
+    ['POST', '/pause-toggle', handlePauseToggle],
+    ['POST', '/play', handlePlay],
+    ['POST', '/quick-add', handleQuickAdd],
+    ['POST', '/quick-add-playlist', handleQuickAddPlaylist],
+    ['POST', '/seek', handleSeek],
+    ['POST', '/shuffle', handleShuffle],
+    ['POST', '/skip', handleSkip],
+    ['POST', '/unshuffle', handleUnshuffle],
+  ],
+});

--- a/packages/server/src/routes/playlists.ts
+++ b/packages/server/src/routes/playlists.ts
@@ -4,8 +4,8 @@ import { getUserDisplayName, resolveDisplayNames } from '../lib/displayName';
 import { json } from '../lib/json';
 import { parsePagination } from '../lib/pagination';
 import { canAccessPlaylist } from '../lib/playlistAccess';
-import { checkRateLimit, getClientIp, rateLimitResponse } from '../lib/rateLimit';
 import { checkGuards } from '../lib/routeGuards';
+import { routeTable } from '../lib/routeTable';
 import { buildSongSearchClause, SOURCE_LIKE_PATTERNS } from '../lib/search';
 import { emitPlaylistUpdated } from '../lib/socket';
 import { syncPlaylistToTag } from '../lib/syncPlaylistToTag';
@@ -223,8 +223,9 @@ async function handlePostPlaylist(ctx: RouteContext, request: Request): Promise<
 async function handleGetPlaylist(
   ctx: RouteContext,
   request: Request,
-  id: string
+  params: Record<string, string>
 ): Promise<Response> {
+  const { id } = params;
   const guards = await checkGuards(ctx);
   if (guards instanceof Response) return guards;
   const { user } = guards;
@@ -434,8 +435,9 @@ async function handleGetPlaylist(
 async function handlePatchVisibility(
   ctx: RouteContext,
   request: Request,
-  id: string
+  params: Record<string, string>
 ): Promise<Response> {
+  const { id } = params;
   const guards = await checkGuards(ctx);
   if (guards instanceof Response) return guards;
   const { user } = guards;
@@ -484,8 +486,9 @@ async function handlePatchVisibility(
 async function handlePatchPlaylist(
   ctx: RouteContext,
   request: Request,
-  id: string
+  params: Record<string, string>
 ): Promise<Response> {
+  const { id } = params;
   const guards = await checkGuards(ctx);
   if (guards instanceof Response) return guards;
   const { user } = guards;
@@ -554,8 +557,9 @@ async function handlePatchPlaylist(
 async function handleDeletePlaylist(
   ctx: RouteContext,
   _request: Request,
-  id: string
+  params: Record<string, string>
 ): Promise<Response> {
+  const { id } = params;
   const guards = await checkGuards(ctx);
   if (guards instanceof Response) return guards;
   const { user } = guards;
@@ -578,7 +582,12 @@ async function handleDeletePlaylist(
 // ---------------------------------------------------------------------------
 // POST /api/playlists/:id/songs — add a song to a playlist
 // ---------------------------------------------------------------------------
-async function handleAddSong(ctx: RouteContext, request: Request, id: string): Promise<Response> {
+async function handleAddSong(
+  ctx: RouteContext,
+  request: Request,
+  params: Record<string, string>
+): Promise<Response> {
+  const { id } = params;
   const guards = await checkGuards(ctx);
   if (guards instanceof Response) return guards;
   const { user } = guards;
@@ -681,9 +690,9 @@ async function handleAddSong(ctx: RouteContext, request: Request, id: string): P
 async function handleRemoveSong(
   ctx: RouteContext,
   _request: Request,
-  playlistId: string,
-  songId: string
+  params: Record<string, string>
 ): Promise<Response> {
+  const { id: playlistId, songId } = params;
   const guards = await checkGuards(ctx);
   if (guards instanceof Response) return guards;
   const { user } = guards;
@@ -744,8 +753,9 @@ async function handleRemoveSong(
 async function handleBulkRemoveSongs(
   ctx: RouteContext,
   request: Request,
-  playlistId: string
+  params: Record<string, string>
 ): Promise<Response> {
+  const { id: playlistId } = params;
   const guards = await checkGuards(ctx);
   if (guards instanceof Response) return guards;
   const { user } = guards;
@@ -805,89 +815,17 @@ async function handleBulkRemoveSongs(
 }
 
 // ---------------------------------------------------------------------------
-// Path helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Match a path against a template with `:param` placeholders.
- * Returns named parameters on match, null otherwise.
- * Does NOT handle method matching — callers check `request.method`.
- *
- * Example: matchPath('/abc/xyz/songs/123', '/:id/songs/:songId') => { id: 'abc/xyz', songId: '123' }
- */
-function matchPath(path: string, template: string): Record<string, string> | null {
-  const pathParts = path.split('/').filter(Boolean);
-  const tplParts = template.split('/').filter(Boolean);
-  if (pathParts.length !== tplParts.length) return null;
-
-  const params: Record<string, string> = {};
-  for (let i = 0; i < tplParts.length; i++) {
-    const tpl = tplParts[i];
-    const seg = pathParts[i];
-    if (!tpl || !seg) return null;
-    if (tpl.startsWith(':')) {
-      params[tpl.slice(1)] = seg;
-    } else if (tpl !== seg) {
-      return null;
-    }
-  }
-  return params;
-}
-
-// ---------------------------------------------------------------------------
-// Dispatcher
-// ---------------------------------------------------------------------------
-
-export async function handlePlaylists(ctx: RouteContext, request: Request): Promise<Response> {
-  const url = new URL(request.url);
-  const pathname = url.pathname;
-
-  // Rate-limit mutation endpoints — 20 requests per 60s per IP.
-  if (request.method !== 'GET') {
-    const ip = getClientIp(request);
-    if (!checkRateLimit('playlists-mutations', ip, { windowMs: 60_000, maxRequests: 20 })) {
-      return rateLimitResponse(60);
-    }
-  }
-
-  // Strip /api/playlists prefix
-  const path = pathname.slice('/api/playlists'.length) || '/';
-
-  // GET /api/playlists
-  if (request.method === 'GET' && path === '/') return await handleGetPlaylists(ctx, request);
-
-  // POST /api/playlists
-  if (request.method === 'POST' && path === '/') return await handlePostPlaylist(ctx, request);
-
-  // POST /api/playlists/:id/songs/bulk-remove
-  let params = matchPath(path, '/:id/songs/bulk-remove');
-  if (params && request.method === 'POST') {
-    return await handleBulkRemoveSongs(ctx, request, params.id);
-  }
-
-  // DELETE /api/playlists/:id/songs/:songId
-  params = matchPath(path, '/:id/songs/:songId');
-  if (params && request.method === 'DELETE') {
-    return await handleRemoveSong(ctx, request, params.id, params.songId);
-  }
-
-  // POST /api/playlists/:id/songs
-  params = matchPath(path, '/:id/songs');
-  if (params && request.method === 'POST') return await handleAddSong(ctx, request, params.id);
-
-  // PATCH /api/playlists/:id/visibility
-  params = matchPath(path, '/:id/visibility');
-  if (params && request.method === 'PATCH')
-    return await handlePatchVisibility(ctx, request, params.id);
-
-  // GET / PATCH / DELETE /api/playlists/:id
-  params = matchPath(path, '/:id');
-  if (params) {
-    const { id } = params;
-    if (request.method === 'GET') return await handleGetPlaylist(ctx, request, id);
-    if (request.method === 'PATCH') return await handlePatchPlaylist(ctx, request, id);
-    if (request.method === 'DELETE') return await handleDeletePlaylist(ctx, request, id);
-  }
-
-  return json({ error: 'Not Found' }, 404);
-}
+export const handlePlaylists = routeTable('/api/playlists', {
+  rateLimit: { windowMs: 60_000, maxRequests: 20, bucket: 'playlists-mutations' },
+  routes: [
+    ['GET', '/', handleGetPlaylists],
+    ['POST', '/', handlePostPlaylist],
+    ['POST', '/:id/songs/bulk-remove', handleBulkRemoveSongs],
+    ['DELETE', '/:id/songs/:songId', handleRemoveSong],
+    ['POST', '/:id/songs', handleAddSong],
+    ['PATCH', '/:id/visibility', handlePatchVisibility],
+    ['GET', '/:id', handleGetPlaylist],
+    ['PATCH', '/:id', handlePatchPlaylist],
+    ['DELETE', '/:id', handleDeletePlaylist],
+  ],
+});

--- a/packages/server/src/routes/requests.ts
+++ b/packages/server/src/routes/requests.ts
@@ -5,6 +5,7 @@ import { json } from '../lib/json';
 import { sendRequestDm, sendRequestNotification } from '../lib/notifications';
 import { parsePagination } from '../lib/pagination';
 import { checkGuards } from '../lib/routeGuards';
+import { routeTable } from '../lib/routeTable';
 import { formatSong } from '../lib/serialization';
 import { emitSongAdded } from '../lib/socket';
 import { canonicalizeTags } from '../lib/tagCanonicalization';
@@ -573,8 +574,9 @@ async function handleGetRequests(ctx: RouteContext, request: Request): Promise<R
 async function handlePatchRequest(
   ctx: RouteContext,
   request: Request,
-  id: string
+  params: Record<string, string>
 ): Promise<Response> {
+  const { id } = params;
   const guards = await checkGuards(ctx, { admin: true });
   if (guards instanceof Response) return guards;
   const { user } = guards;
@@ -783,8 +785,9 @@ async function handlePatchRequest(
 async function handleDeleteRequest(
   ctx: RouteContext,
   _request: Request,
-  id: string
+  params: Record<string, string>
 ): Promise<Response> {
+  const { id } = params;
   const guards = await checkGuards(ctx);
   if (guards instanceof Response) return guards;
   const { user } = guards;
@@ -808,39 +811,12 @@ async function handleDeleteRequest(
   return new Response(null, { status: 204 });
 }
 
-// ---------------------------------------------------------------------------
-// Dispatcher
-// ---------------------------------------------------------------------------
-export async function handleRequests(ctx: RouteContext, request: Request): Promise<Response> {
-  const url = new URL(request.url);
-  const pathname = url.pathname;
-
-  // POST /api/requests/preview
-  if (request.method === 'POST' && pathname === '/api/requests/preview') {
-    return await handlePreviewRequest(ctx, request);
-  }
-
-  // GET /api/requests
-  if (request.method === 'GET' && pathname === '/api/requests') {
-    return await handleGetRequests(ctx, request);
-  }
-
-  // POST /api/requests
-  if (request.method === 'POST' && pathname === '/api/requests') {
-    return await handleCreateRequest(ctx, request);
-  }
-
-  // PATCH /api/requests/:id
-  if (request.method === 'PATCH' && pathname.startsWith('/api/requests/')) {
-    const id = pathname.slice('/api/requests/'.length);
-    return await handlePatchRequest(ctx, request, id);
-  }
-
-  // DELETE /api/requests/:id
-  if (request.method === 'DELETE' && pathname.startsWith('/api/requests/')) {
-    const id = pathname.slice('/api/requests/'.length);
-    return await handleDeleteRequest(ctx, request, id);
-  }
-
-  return json({ error: 'Not Found' }, 404);
-}
+export const handleRequests = routeTable('/api/requests', {
+  routes: [
+    ['POST', '/preview', handlePreviewRequest],
+    ['GET', '/', handleGetRequests],
+    ['POST', '/', handleCreateRequest],
+    ['PATCH', '/:id', handlePatchRequest],
+    ['DELETE', '/:id', handleDeleteRequest],
+  ],
+});

--- a/packages/server/src/routes/setup.ts
+++ b/packages/server/src/routes/setup.ts
@@ -3,6 +3,7 @@ import type { RouteContext } from '../index';
 import { refreshGuildId } from '../lib/config';
 import { json } from '../lib/json';
 import { checkGuards } from '../lib/routeGuards';
+import { routeTable } from '../lib/routeTable';
 import type { SetupChannel, SetupGuild, SetupRole } from '../shared';
 import { db, tables } from '../shared/db';
 import { logger } from '../shared/logger';
@@ -19,7 +20,11 @@ function botHeaders(): Record<string, string> {
 // GET /api/setup/status
 // Public — the frontend needs this to decide whether to show the wizard.
 // ---------------------------------------------------------------------------
-async function handleGetStatus(): Promise<Response> {
+async function handleGetStatus(
+  _ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
   try {
     const row = await db
       .select({
@@ -71,7 +76,11 @@ async function handleGetStatus(): Promise<Response> {
 // GET /api/setup/guilds
 // Setup-mode guard — returns guilds the bot is a member of.
 // ---------------------------------------------------------------------------
-async function handleGetGuilds(ctx: RouteContext): Promise<Response> {
+async function handleGetGuilds(
+  ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
   const guards = await checkGuards(ctx, { setupMode: true });
   if (guards instanceof Response) return guards;
 
@@ -108,7 +117,12 @@ async function handleGetGuilds(ctx: RouteContext): Promise<Response> {
 // GET /api/setup/roles?guildId=...
 // Setup-mode guard — returns roles for a specific guild.
 // ---------------------------------------------------------------------------
-async function handleGetRoles(ctx: RouteContext, url: URL): Promise<Response> {
+async function handleGetRoles(
+  ctx: RouteContext,
+  request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
+  const url = new URL(request.url);
   const guards = await checkGuards(ctx, { setupMode: true });
   if (guards instanceof Response) return guards;
 
@@ -154,7 +168,12 @@ async function handleGetRoles(ctx: RouteContext, url: URL): Promise<Response> {
 // GET /api/setup/channels?guildId=...
 // Setup-mode guard — returns text channels for a specific guild.
 // ---------------------------------------------------------------------------
-async function handleGetChannels(ctx: RouteContext, url: URL): Promise<Response> {
+async function handleGetChannels(
+  ctx: RouteContext,
+  request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
+  const url = new URL(request.url);
   const guards = await checkGuards(ctx, { setupMode: true });
   if (guards instanceof Response) return guards;
 
@@ -198,7 +217,11 @@ async function handleGetChannels(ctx: RouteContext, url: URL): Promise<Response>
 // POST /api/setup/complete
 // Setup-mode guard — saves the configuration and marks setup as done.
 // ---------------------------------------------------------------------------
-async function handlePostComplete(ctx: RouteContext, request: Request): Promise<Response> {
+async function handlePostComplete(
+  ctx: RouteContext,
+  request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
   const guards = await checkGuards(ctx, { setupMode: true });
   if (guards instanceof Response) return guards;
 
@@ -304,24 +327,13 @@ async function handlePostComplete(ctx: RouteContext, request: Request): Promise<
   }
 }
 
-// ---------------------------------------------------------------------------
-// Dispatcher
-// ---------------------------------------------------------------------------
-export async function handleSetup(ctx: RouteContext, request: Request): Promise<Response> {
-  const url = new URL(request.url);
-  const path = url.pathname.slice('/api/setup'.length);
-
-  if (path === '' || path === '/') {
-    if (request.method === 'GET') return await handleGetStatus();
-    return json({ error: 'Method Not Allowed' }, 405);
-  }
-
-  if (path === '/status' && request.method === 'GET') return await handleGetStatus();
-  if (path === '/guilds' && request.method === 'GET') return await handleGetGuilds(ctx);
-  if (path === '/roles' && request.method === 'GET') return await handleGetRoles(ctx, url);
-  if (path === '/channels' && request.method === 'GET') return await handleGetChannels(ctx, url);
-  if (path === '/complete' && request.method === 'POST')
-    return await handlePostComplete(ctx, request);
-
-  return json({ error: 'Not Found' }, 404);
-}
+export const handleSetup = routeTable('/api/setup', {
+  routes: [
+    ['GET', '/', handleGetStatus],
+    ['GET', '/status', handleGetStatus],
+    ['GET', '/guilds', handleGetGuilds],
+    ['GET', '/roles', handleGetRoles],
+    ['GET', '/channels', handleGetChannels],
+    ['POST', '/complete', handlePostComplete],
+  ],
+});

--- a/packages/server/src/routes/songs.ts
+++ b/packages/server/src/routes/songs.ts
@@ -4,8 +4,8 @@ import { getGuildId } from '../lib/config';
 import { resolveDisplayNames } from '../lib/displayName';
 import { json } from '../lib/json';
 import { parsePagination } from '../lib/pagination';
-import { checkRateLimit, getClientIp, rateLimitResponse } from '../lib/rateLimit';
 import { checkGuards } from '../lib/routeGuards';
+import { routeTable } from '../lib/routeTable';
 import { buildSongSearchClause, SOURCE_LIKE_PATTERNS } from '../lib/search';
 import { formatSong } from '../lib/serialization';
 import { emitSongDeleted, emitSongUpdated } from '../lib/socket';
@@ -381,8 +381,9 @@ async function handleGetSongs(ctx: RouteContext, request: Request): Promise<Resp
 async function handleDeleteSong(
   ctx: RouteContext,
   _request: Request,
-  id: string
+  params: Record<string, string>
 ): Promise<Response> {
+  const { id } = params;
   const guards = await checkGuards(ctx, { admin: true, permission: 'songs.delete' });
   if (guards instanceof Response) return guards;
 
@@ -402,7 +403,12 @@ async function handleDeleteSong(
 // ---------------------------------------------------------------------------
 // PATCH /api/songs/:id — update song fields. Admin only.
 // ---------------------------------------------------------------------------
-async function handlePatchSong(ctx: RouteContext, request: Request, id: string): Promise<Response> {
+async function handlePatchSong(
+  ctx: RouteContext,
+  request: Request,
+  params: Record<string, string>
+): Promise<Response> {
+  const { id } = params;
   const guards = await checkGuards(ctx, { admin: true, permission: 'songs.edit' });
   if (guards instanceof Response) return guards;
 
@@ -509,54 +515,14 @@ async function handlePatchSong(ctx: RouteContext, request: Request, id: string):
   return json(formatSong(updatedSong));
 }
 
-// ---------------------------------------------------------------------------
-// Dispatcher
-// ---------------------------------------------------------------------------
-
-export async function handleSongs(ctx: RouteContext, request: Request): Promise<Response> {
-  const url = new URL(request.url);
-  const pathname = url.pathname;
-
-  // Rate-limit mutation endpoints — 20 requests per 60s per IP.
-  // GET is exempt to allow the UI to fetch pages freely.
-  if (request.method !== 'GET') {
-    const ip = getClientIp(request);
-    if (!checkRateLimit('songs-mutations', ip, { windowMs: 60_000, maxRequests: 20 })) {
-      return rateLimitResponse(60);
-    }
-  }
-
-  // GET /api/songs
-  if (request.method === 'GET' && pathname === '/api/songs') {
-    return await handleGetSongs(ctx, request);
-  }
-
-  // POST /api/songs/bulk-delete
-  if (request.method === 'POST' && pathname === '/api/songs/bulk-delete') {
-    return await handleBulkDelete(ctx, request);
-  }
-
-  // POST /api/songs/bulk-tag
-  if (request.method === 'POST' && pathname === '/api/songs/bulk-tag') {
-    return await handleBulkTag(ctx, request);
-  }
-
-  // POST /api/songs/bulk-edit
-  if (request.method === 'POST' && pathname === '/api/songs/bulk-edit') {
-    return await handleBulkEdit(ctx, request);
-  }
-
-  // DELETE /api/songs/:id
-  if (request.method === 'DELETE' && pathname.startsWith('/api/songs/')) {
-    const id = pathname.slice('/api/songs/'.length);
-    return await handleDeleteSong(ctx, request, id);
-  }
-
-  // PATCH /api/songs/:id
-  if (request.method === 'PATCH' && pathname.startsWith('/api/songs/')) {
-    const id = pathname.slice('/api/songs/'.length);
-    return await handlePatchSong(ctx, request, id);
-  }
-
-  return json({ error: 'Not Found' }, 404);
-}
+export const handleSongs = routeTable('/api/songs', {
+  rateLimit: { windowMs: 60_000, maxRequests: 20, bucket: 'songs-mutations' },
+  routes: [
+    ['GET', '/', handleGetSongs],
+    ['POST', '/bulk-delete', handleBulkDelete],
+    ['POST', '/bulk-tag', handleBulkTag],
+    ['POST', '/bulk-edit', handleBulkEdit],
+    ['DELETE', '/:id', handleDeleteSong],
+    ['PATCH', '/:id', handlePatchSong],
+  ],
+});

--- a/packages/server/src/routes/tags.ts
+++ b/packages/server/src/routes/tags.ts
@@ -2,6 +2,7 @@ import { eq, sql } from 'drizzle-orm';
 import type { RouteContext } from '../index';
 import { json } from '../lib/json';
 import { checkGuards } from '../lib/routeGuards';
+import { routeTable } from '../lib/routeTable';
 import { emitPlaylistUpdated } from '../lib/socket';
 import { db, tables } from '../shared/db';
 
@@ -10,7 +11,52 @@ const { tag: tagTable, song: songTable, playlist: playlistTable } = tables;
 const TAG_COLORS = ['orange', 'sky', 'emerald', 'amber', 'violet'] as const;
 type TagColor = (typeof TAG_COLORS)[number];
 
-async function handleGetTagSongs(ctx: RouteContext, nameLower: string): Promise<Response> {
+// ---------------------------------------------------------------------------
+// GET /api/tags — list all tags
+// ---------------------------------------------------------------------------
+async function handleGetTagsList(
+  ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
+  const guards = await checkGuards(ctx);
+  if (guards instanceof Response) return guards;
+
+  const tags = await db
+    .select({
+      nameLower: tagTable.nameLower,
+      canonicalName: tagTable.canonicalName,
+      color: tagTable.color,
+    })
+    .from(tagTable)
+    .orderBy(tagTable.canonicalName)
+    .all();
+
+  return json({ tags });
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/tags/:nameLower — get single tag
+// ---------------------------------------------------------------------------
+async function handleGetTag(
+  ctx: RouteContext,
+  _request: Request,
+  params: Record<string, string>
+): Promise<Response> {
+  const { nameLower } = params;
+  const guards = await checkGuards(ctx);
+  if (guards instanceof Response) return guards;
+  const [tag] = await db.select().from(tagTable).where(eq(tagTable.nameLower, nameLower)).limit(1);
+  if (!tag) return json({ error: 'Tag not found.' }, 404);
+  return json({ tag });
+}
+
+async function handleGetTagSongs(
+  ctx: RouteContext,
+  _request: Request,
+  params: Record<string, string>
+): Promise<Response> {
+  const { nameLower } = params;
   const guards = await checkGuards(ctx);
   if (guards instanceof Response) return guards;
 
@@ -27,9 +73,17 @@ async function handleGetTagSongs(ctx: RouteContext, nameLower: string): Promise<
 
 async function handlePatchTag(
   ctx: RouteContext,
-  nameLower: string,
-  body: Record<string, unknown>
+  request: Request,
+  params: Record<string, string>
 ): Promise<Response> {
+  const { nameLower } = params;
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return json({ error: 'Invalid JSON body.' }, 400);
+  }
   const guards = await checkGuards(ctx, { admin: true, permission: 'tags.manage' });
   if (guards instanceof Response) return guards;
 
@@ -74,7 +128,12 @@ async function handlePatchTag(
   return json({ tag: updated });
 }
 
-async function handleDeleteTag(ctx: RouteContext, nameLower: string): Promise<Response> {
+async function handleDeleteTag(
+  ctx: RouteContext,
+  _request: Request,
+  params: Record<string, string>
+): Promise<Response> {
+  const { nameLower } = params;
   const guards = await checkGuards(ctx, { admin: true, permission: 'tags.manage' });
   if (guards instanceof Response) return guards;
 
@@ -134,73 +193,12 @@ async function handleDeleteTag(ctx: RouteContext, nameLower: string): Promise<Re
   return json({ success: true });
 }
 
-export async function handleTags(ctx: RouteContext, request: Request): Promise<Response> {
-  const url = new URL(request.url);
-  const pathname = url.pathname;
-
-  // GET /api/tags
-  if (request.method === 'GET' && pathname === '/api/tags') {
-    const guards = await checkGuards(ctx);
-    if (guards instanceof Response) return guards;
-
-    const tags = await db
-      .select({
-        nameLower: tagTable.nameLower,
-        canonicalName: tagTable.canonicalName,
-        color: tagTable.color,
-      })
-      .from(tagTable)
-      .orderBy(tagTable.canonicalName)
-      .all();
-
-    return json({ tags });
-  }
-
-  // GET /api/tags/:nameLower/songs — get all songs with this tag
-  if (request.method === 'GET' && pathname.match(/^\/api\/tags\/([^/]+)\/songs$/)) {
-    const match = pathname.match(/^\/api\/tags\/([^/]+)\/songs$/);
-    const nameLower = match?.[1];
-    if (!nameLower) return json({ error: 'Not Found' }, 404);
-    return handleGetTagSongs(ctx, nameLower);
-  }
-
-  // GET /api/tags/:nameLower — get single tag
-  if (request.method === 'GET' && pathname.startsWith('/api/tags/')) {
-    const nameLower = pathname.slice('/api/tags/'.length);
-    const guards = await checkGuards(ctx);
-    if (guards instanceof Response) return guards;
-    const [tag] = await db
-      .select()
-      .from(tagTable)
-      .where(eq(tagTable.nameLower, nameLower))
-      .limit(1);
-    if (!tag) return json({ error: 'Tag not found.' }, 404);
-    return json({ tag });
-  }
-
-  // PATCH /api/tags/:nameLower
-  if (request.method === 'PATCH' && pathname.startsWith('/api/tags/')) {
-    const nameLower = pathname.slice('/api/tags/'.length);
-    if (nameLower.includes('/')) {
-      return json({ error: 'Not Found' }, 404);
-    }
-    let body: Record<string, unknown>;
-    try {
-      body = (await request.json()) as typeof body;
-    } catch {
-      return json({ error: 'Invalid JSON body.' }, 400);
-    }
-    return handlePatchTag(ctx, nameLower, body);
-  }
-
-  // DELETE /api/tags/:nameLower
-  if (request.method === 'DELETE' && pathname.startsWith('/api/tags/')) {
-    const nameLower = pathname.slice('/api/tags/'.length);
-    if (nameLower.includes('/')) {
-      return json({ error: 'Not Found' }, 404);
-    }
-    return handleDeleteTag(ctx, nameLower);
-  }
-
-  return json({ error: 'Not Found' }, 404);
-}
+export const handleTags = routeTable('/api/tags', {
+  routes: [
+    ['GET', '/', handleGetTagsList],
+    ['GET', '/:nameLower/songs', handleGetTagSongs],
+    ['GET', '/:nameLower', handleGetTag],
+    ['PATCH', '/:nameLower', handlePatchTag],
+    ['DELETE', '/:nameLower', handleDeleteTag],
+  ],
+});


### PR DESCRIPTION
## Summary

Replace 11 hand-rolled route dispatchers with a single `routeTable()` function in `packages/server/src/lib/routeTable.ts`. Each route file now declares its routes as a table of `[method, pattern, handler]` tuples instead of manual if-chains with ad-hoc path extraction.

## Changes

- **New:** `packages/server/src/lib/routeTable.ts` — shared `matchPath()` + `routeTable()` with optional rate limiting
- **Migrated:** All 11 route files in `packages/server/src/routes/` — dispatchers replaced with route table declarations
- **Normalized:** 3 inconsistent path-matching styles (`startsWith`+`slice`, `startsWith`+`endsWith`, template `matchPath`) → single `matchPath`
- **Consolidated:** Rate-limit preambles in songs, playlists, and player now declared as a config option
- **Inlined:** `tags.ts` body-parsing and `setup.ts` URL construction moved from dispatchers into handlers

Net: −74 lines across route files, +107 lines for the shared module.