### PR TITLE
refactor(web): extract pageheader component from repeated page header markup

### DIFF
--- a/packages/web/src/components/ui/PageHeader.tsx
+++ b/packages/web/src/components/ui/PageHeader.tsx
@@ -1,0 +1,36 @@
+import type React from 'react';
+
+interface PageHeaderProps {
+  icon: React.ElementType;
+  title: string;
+  subtitle?: string | React.ReactNode;
+  children?: React.ReactNode;
+}
+
+export function PageHeader({ icon: Icon, title, subtitle, children }: PageHeaderProps) {
+  const heading = (
+    <h1 className="font-display text-3xl md:text-4xl text-accent tracking-wider flex items-center gap-2">
+      <Icon size={28} weight="duotone" className="shrink-0 relative top-1" />
+      {title}
+    </h1>
+  );
+
+  if (children) {
+    return (
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-6 md:mb-8 shrink-0">
+        <div>
+          {heading}
+          {subtitle && <p className="font-mono text-xs text-muted mt-2">{subtitle}</p>}
+        </div>
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-6 md:mb-8 shrink-0">
+      {heading}
+      {subtitle && <p className="font-mono text-xs text-muted mt-2">{subtitle}</p>}
+    </div>
+  );
+}

--- a/packages/web/src/pages/AudioPage.tsx
+++ b/packages/web/src/pages/AudioPage.tsx
@@ -1,6 +1,7 @@
 import { ArrowsDownUp, SlidersHorizontal } from '@phosphor-icons/react';
 import CompressorSection from '../components/settings/CompressorSection';
 import EqualizerSection from '../components/settings/EqualizerSection';
+import { PageHeader } from '../components/ui/PageHeader';
 import { useAdminView } from '../context/AdminViewContext';
 import { usePermissions } from '../context/PermissionsContext';
 
@@ -12,14 +13,11 @@ export default function AudioPage() {
 
   return (
     <div className="p-4 md:p-8">
-      {/* Page header */}
-      <div className="mb-6 md:mb-8">
-        <h1 className="font-display text-3xl md:text-4xl text-accent tracking-wider flex items-center gap-2">
-          <SlidersHorizontal size={28} weight="duotone" className="shrink-0 relative top-1" />
-          Audio
-        </h1>
-        <p className="font-mono text-xs text-muted mt-2">Equalizer and compressor settings</p>
-      </div>
+      <PageHeader
+        icon={SlidersHorizontal}
+        title="Audio"
+        subtitle="Equalizer and compressor settings"
+      />
 
       {!canManage ? (
         <div className="flex flex-col items-center justify-center py-20 text-center">

--- a/packages/web/src/pages/PermissionsPage.tsx
+++ b/packages/web/src/pages/PermissionsPage.tsx
@@ -6,6 +6,7 @@ import EmptyState from '../components/EmptyState';
 import { Button } from '../components/ui/Button';
 import Checkbox from '../components/ui/Checkbox';
 import { ErrorBanner } from '../components/ui/ErrorBanner';
+import { PageHeader } from '../components/ui/PageHeader';
 import RoleComboBox from '../components/ui/RoleComboBox';
 
 // ---------------------------------------------------------------------------
@@ -196,12 +197,7 @@ export default function PermissionsPage() {
   if (!data) {
     return (
       <div className="p-4 md:p-8">
-        <div className="mb-6 md:mb-8">
-          <h1 className="font-display text-3xl md:text-4xl text-accent tracking-wider flex items-center gap-2">
-            <ShieldCheckIcon size={28} weight="duotone" className="shrink-0 relative top-1" />
-            Permissions
-          </h1>
-        </div>
+        <PageHeader icon={ShieldCheckIcon} title="Permissions" />
         {error ? (
           <ErrorBanner message={error} />
         ) : (
@@ -214,16 +210,11 @@ export default function PermissionsPage() {
   // Render ----------------------------------------------------------------
   return (
     <div className="p-4 md:p-8">
-      {/* Page header */}
-      <div className="mb-6 md:mb-8">
-        <h1 className="font-display text-3xl md:text-4xl text-accent tracking-wider flex items-center gap-2">
-          <ShieldCheckIcon size={28} weight="duotone" className="shrink-0 relative top-1" />
-          Permissions
-        </h1>
-        <p className="font-mono text-xs text-muted mt-2">
-          Grant specific abilities to non-admin roles. Super-admins always have full access.
-        </p>
-      </div>
+      <PageHeader
+        icon={ShieldCheckIcon}
+        title="Permissions"
+        subtitle="Grant specific abilities to non-admin roles. Super-admins always have full access."
+      />
 
       {error && <ErrorBanner message={error} className="mb-4" />}
 

--- a/packages/web/src/pages/PlaylistsPage.tsx
+++ b/packages/web/src/pages/PlaylistsPage.tsx
@@ -7,6 +7,7 @@ import { getPlaylistsPage } from '../api/api';
 import { Backdrop } from '../components/Backdrop';
 import NotificationToast from '../components/NotificationToast';
 import { Button } from '../components/ui/Button';
+import { PageHeader } from '../components/ui/PageHeader';
 import { VirtualPlaylistList } from '../components/VirtualPlaylistList';
 import { useAdminView } from '../context/AdminViewContext';
 import { CreatePlaylistSubmitButton, useCreatePlaylist } from '../hooks/useCreatePlaylist';
@@ -68,18 +69,11 @@ export default function PlaylistsPage() {
 
   return (
     <div className="p-4 md:p-8">
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-6 md:mb-8">
-        <div>
-          <h1 className="font-display text-3xl md:text-4xl text-accent tracking-wider flex items-center gap-2">
-            <PlaylistIcon size={28} weight="duotone" className="shrink-0 relative top-1" />
-            Playlists
-          </h1>
-          <p className="font-mono text-xs text-muted mt-2">
-            Browse & manage playlists
-            {hasLoaded ? ` • ${items.length} playlist${items.length !== 1 ? 's' : ''}` : ''}
-          </p>
-        </div>
+      <PageHeader
+        icon={PlaylistIcon}
+        title="Playlists"
+        subtitle={`Browse & manage playlists${hasLoaded ? ` • ${items.length} playlist${items.length !== 1 ? 's' : ''}` : ''}`}
+      >
         <Button
           variant="primary"
           onClick={() => setShowCreate(true)}
@@ -87,7 +81,7 @@ export default function PlaylistsPage() {
         >
           + New Playlist
         </Button>
-      </div>
+      </PageHeader>
 
       {/* List */}
       <VirtualPlaylistList

--- a/packages/web/src/pages/RequestsPage.tsx
+++ b/packages/web/src/pages/RequestsPage.tsx
@@ -6,6 +6,7 @@ import AddSongModal from '../components/AddSongModal';
 import { Button } from '../components/ui/Button';
 import Checkbox from '../components/ui/Checkbox';
 import { ErrorBanner } from '../components/ui/ErrorBanner';
+import { PageHeader } from '../components/ui/PageHeader';
 import VirtualRequestList from '../components/VirtualRequestList';
 import { useAdminView } from '../context/AdminViewContext';
 import { useAuth } from '../context/AuthContext';
@@ -112,17 +113,11 @@ export default function RequestsPage() {
 
   return (
     <div className="p-4 md:p-8">
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-6 md:mb-8">
-        <div>
-          <h1 className="font-display text-3xl md:text-4xl text-accent tracking-wider flex items-center gap-2">
-            <TrayIcon size={28} weight="duotone" className="shrink-0 relative top-1" />
-            Requests
-          </h1>
-          <p className="font-mono text-xs text-muted mt-2">
-            Submit & review requests{hasLoaded ? ` • ${countLabel}` : ''}
-          </p>
-        </div>
+      <PageHeader
+        icon={TrayIcon}
+        title="Requests"
+        subtitle={`Submit & review requests${hasLoaded ? ` • ${countLabel}` : ''}`}
+      >
         <Button
           variant="primary"
           onClick={() => setShowAddModal(true)}
@@ -130,7 +125,7 @@ export default function RequestsPage() {
         >
           + Request Song
         </Button>
-      </div>
+      </PageHeader>
 
       {/* Tabs + filter */}
       <div className="flex items-center gap-3 mb-4 md:mb-6">

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -30,6 +30,7 @@ import ConfirmModal from '../components/ConfirmModal';
 import FilterChips from '../components/FilterChips';
 import NotificationToast from '../components/NotificationToast';
 import { Button } from '../components/ui/Button';
+import { PageHeader } from '../components/ui/PageHeader';
 import { VirtualSongList } from '../components/VirtualSongList';
 import { useAdminView } from '../context/AdminViewContext';
 import { usePermissions } from '../context/PermissionsContext';
@@ -396,17 +397,11 @@ export default function SongsPage() {
 
   return (
     <div className="p-4 md:p-8">
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-6 md:mb-8">
-        <div>
-          <h1 className="font-display text-3xl md:text-4xl text-accent tracking-wider flex items-center gap-2">
-            <MusicNotesIcon size={28} weight="duotone" className="shrink-0 relative top-1" />
-            Songs
-          </h1>
-          <p className="font-mono text-xs text-muted mt-2">
-            Music library{hasLoaded ? ` • ${total} track${total !== 1 ? 's' : ''}` : ''}
-          </p>
-        </div>
+      <PageHeader
+        icon={MusicNotesIcon}
+        title="Songs"
+        subtitle={`Music library${hasLoaded ? ` • ${total} track${total !== 1 ? 's' : ''}` : ''}`}
+      >
         <span className="relative group">
           <QuestionIcon size={20} weight="duotone" className="text-muted cursor-help" />
           <span className="glass-tooltip absolute right-0 top-full mt-2 w-64 p-3 leading-relaxed">
@@ -415,7 +410,7 @@ export default function SongsPage() {
             permission.
           </span>
         </span>
-      </div>
+      </PageHeader>
 
       {/* Search bar + Sort + View toggle */}
       <div className="flex items-center gap-2 mb-3">

--- a/packages/web/src/pages/TagsPage.tsx
+++ b/packages/web/src/pages/TagsPage.tsx
@@ -7,6 +7,7 @@ import EmptyState from '../components/EmptyState';
 import TagTicker from '../components/TagTicker';
 import { ArtworkImage } from '../components/ui/ArtworkImage';
 import { Button } from '../components/ui/Button';
+import { PageHeader } from '../components/ui/PageHeader';
 import { useTagColors } from '../context/TagsContext';
 import { getTagColorClasses, TAG_COLORS } from '../utils/tagColors';
 
@@ -121,17 +122,11 @@ export default function TagsPage() {
 
   return (
     <div className="p-4 md:p-8 flex flex-col h-full">
-      {/* Page header */}
-      <div className="mb-6 md:mb-8 shrink-0">
-        <h1 className="font-display text-3xl md:text-4xl text-accent tracking-wider flex items-center gap-2">
-          <TagIcon size={28} weight="duotone" className="shrink-0 relative top-1" />
-          Tags
-        </h1>
-        <p className="font-mono text-xs text-muted mt-2">
-          Manage tags & colors
-          {loadingTags ? '' : ` • ${allTags.length} tag${allTags.length !== 1 ? 's' : ''}`}
-        </p>
-      </div>
+      <PageHeader
+        icon={TagIcon}
+        title="Tags"
+        subtitle={`Manage tags & colors${loadingTags ? '' : ` • ${allTags.length} tag${allTags.length !== 1 ? 's' : ''}`}`}
+      />
 
       <div className="flex gap-4 flex-1 min-h-0">
         {/* Left pane: tag list */}


### PR DESCRIPTION
## Summary

Extract the repeated page header pattern (icon + title + subtitle + optional right slot) that appeared in 6 page files into a single `<PageHeader>` component.

## Changes

- Create `packages/web/src/components/ui/PageHeader.tsx` — shared header component with icon, title, subtitle, and optional right-aligned children slot
- Replace inline header markup in `SongsPage`, `PlaylistsPage`, `RequestsPage`, `AudioPage`, `TagsPage`, and `PermissionsPage` with `<PageHeader>`