### PR TITLE
refactor(server): extract shared song query builders to lib/search

### DIFF
--- a/packages/server/src/lib/search.ts
+++ b/packages/server/src/lib/search.ts
@@ -2,6 +2,109 @@ import { sql } from 'drizzle-orm';
 import { $client } from '../shared/db';
 
 // ---------------------------------------------------------------------------
+// Song sort fields — shared between songs and playlist detail endpoints.
+// ---------------------------------------------------------------------------
+export const SONG_SORT_FIELDS = ['createdAt', 'title', 'artist', 'album', 'duration'] as const;
+export type SongSortField = (typeof SONG_SORT_FIELDS)[number];
+
+/** Parse a raw sort query param into a SongSortField, or null if unrecognized. */
+export function parseSongSortField(raw: string): SongSortField | null {
+  return (SONG_SORT_FIELDS as readonly string[]).includes(raw) ? (raw as SongSortField) : null;
+}
+
+/**
+ * Build a dynamic ORDER BY clause for song queries.
+ *
+ * Pass column references via the optional `cols` parameter when the query
+ * involves a join (e.g. playlistSong ↔ song).  Omit for single-table queries.
+ *
+ * Column params accept Drizzle column refs (SQLiteColumn / PgColumn) or
+ * raw SQL chunks — anything the `sql` tagged template can interpolate.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: Drizzle column refs are not assignable to SQL<unknown> but are valid sql`` interpolations
+type SqlInterpolatable = any;
+
+export function buildSongOrderBy(
+  sortField: SongSortField,
+  sortOrder: 'ASC' | 'DESC',
+  cols?: {
+    title: SqlInterpolatable;
+    artist: SqlInterpolatable;
+    album: SqlInterpolatable;
+    duration: SqlInterpolatable;
+    createdAt: SqlInterpolatable;
+  }
+): ReturnType<typeof sql> {
+  const c = cols ?? {
+    title: sql`title`,
+    artist: sql`artist`,
+    album: sql`album`,
+    duration: sql`duration`,
+    createdAt: sql`"createdAt"`,
+  };
+  switch (sortField) {
+    case 'title':
+      return sql`lower(${c.title}) ${sql.raw(sortOrder)}`;
+    case 'artist':
+      return sql`${c.artist} IS NULL, lower(${c.artist}) ${sql.raw(sortOrder)}`;
+    case 'album':
+      return sql`${c.album} IS NULL, lower(${c.album}) ${sql.raw(sortOrder)}`;
+    case 'duration':
+      return sql`${c.duration} ${sql.raw(sortOrder)}`;
+    default:
+      return sql`${c.createdAt} ${sql.raw(sortOrder)}`;
+  }
+}
+
+/**
+ * Build WHERE filter clauses for tag AND source OR matching.
+ * Returns undefined when no filters are active.
+ *
+ * Pass column references via the optional `cols` parameter when the query
+ * involves a join (e.g. playlistSong ↔ song).  Omit for single-table queries.
+ *
+ * Column params accept Drizzle column refs (SQLiteColumn / PgColumn) or
+ * raw SQL chunks — anything the `sql` tagged template can interpolate.
+ */
+export function buildSongFilterClause(
+  tags: string[],
+  sources: string[],
+  cols?: {
+    tags: SqlInterpolatable;
+    sourceUrl: SqlInterpolatable;
+  }
+): ReturnType<typeof sql> | undefined {
+  const c = cols ?? { tags: sql`tags`, sourceUrl: sql`"sourceUrl"` };
+  const clauses: ReturnType<typeof sql>[] = [];
+
+  // Tags: AND — song must have every requested tag.
+  // Match JSON-quoted tag name for precision (avoids partial matches like
+  // "rock" matching "bedrock").
+  for (const tag of tags) {
+    clauses.push(sql`lower(${c.tags}) LIKE lower(${`%"${tag}"%`})`);
+  }
+
+  // Sources: OR — song URL can match any of the requested sources.
+  if (sources.length > 0) {
+    const sourceOrs: ReturnType<typeof sql>[] = [];
+    for (const source of sources) {
+      const patterns = SOURCE_LIKE_PATTERNS[source];
+      if (patterns) {
+        for (const pattern of patterns) {
+          sourceOrs.push(sql`${c.sourceUrl} LIKE ${pattern}`);
+        }
+      }
+    }
+    if (sourceOrs.length > 0) {
+      clauses.push(sql`(${sql.join(sourceOrs, sql` OR `)})`);
+    }
+  }
+
+  if (clauses.length === 0) return undefined;
+  return sql.join(clauses, sql` AND `);
+}
+
+// ---------------------------------------------------------------------------
 // Source URL → LIKE patterns for server-side source filtering.
 // Must mirror the web's HOST_TO_SOURCE map in packages/web/src/utils/source.ts.
 // ---------------------------------------------------------------------------

--- a/packages/server/src/routes/playlists.ts
+++ b/packages/server/src/routes/playlists.ts
@@ -6,30 +6,18 @@ import { parsePagination } from '../lib/pagination';
 import { canAccessPlaylist } from '../lib/playlistAccess';
 import { checkGuards } from '../lib/routeGuards';
 import { routeTable } from '../lib/routeTable';
-import { buildSongSearchClause, SOURCE_LIKE_PATTERNS } from '../lib/search';
+import {
+  buildSongFilterClause,
+  buildSongOrderBy,
+  buildSongSearchClause,
+  parseSongSortField,
+} from '../lib/search';
 import { emitPlaylistUpdated } from '../lib/socket';
 import { syncPlaylistToTag } from '../lib/syncPlaylistToTag';
 import { validatePlaylistName } from '../lib/validation';
 import { db, tables } from '../shared/db';
 
 const { playlist: playlistTable, playlistSong: playlistSongTable } = tables;
-
-function buildSongOrderBy(field: string, direction: 'ASC' | 'DESC'): ReturnType<typeof sql> {
-  switch (field) {
-    case 'title':
-      return sql`lower(${tables.song.title}) ${sql.raw(direction)}`;
-    case 'artist':
-      return sql`${tables.song.artist} IS NULL, lower(${tables.song.artist}) ${sql.raw(direction)}`;
-    case 'album':
-      return sql`${tables.song.album} IS NULL, lower(${tables.song.album}) ${sql.raw(direction)}`;
-    case 'duration':
-      return sql`${tables.song.duration} ${sql.raw(direction)}`;
-    case 'createdAt':
-      return sql`${tables.song.createdAt} ${sql.raw(direction)}`;
-    default:
-      return sql`${tables.song.createdAt} ${sql.raw(direction)}`;
-  }
-}
 
 async function getPlaylistSongCount(playlistId: string): Promise<number> {
   const result = await db
@@ -281,32 +269,26 @@ async function handleGetPlaylist(
       if (searchClause) songFilterClauses.push(searchClause);
     }
 
-    for (const tag of filterTags) {
-      songFilterClauses.push(sql`lower(${tables.song.tags}) LIKE lower(${`%"${tag}"%`})`);
-    }
-
-    if (filterSources.length > 0) {
-      const sourceOrs: ReturnType<typeof sql>[] = [];
-      for (const source of filterSources) {
-        const patterns = SOURCE_LIKE_PATTERNS[source];
-        if (patterns) {
-          for (const pattern of patterns) {
-            sourceOrs.push(sql`${tables.song.sourceUrl} LIKE ${pattern}`);
-          }
-        }
-      }
-      if (sourceOrs.length > 0) {
-        songFilterClauses.push(sql`(${sql.join(sourceOrs, sql` OR `)})`);
-      }
-    }
+    const tagSourceFilter = buildSongFilterClause(filterTags, filterSources, {
+      tags: tables.song.tags,
+      sourceUrl: tables.song.sourceUrl,
+    });
+    if (tagSourceFilter) songFilterClauses.push(tagSourceFilter);
 
     const joinWhere = and(
       eq(playlistSongTable.playlistId, id),
       ...(songFilterClauses.length > 0 ? [sql.join(songFilterClauses, sql` AND `)] : [])
     );
 
-    const orderBy = wantsCustomSort
-      ? buildSongOrderBy(sortField, sortOrder)
+    const songSortField = wantsCustomSort ? parseSongSortField(sortField) : null;
+    const orderBy = songSortField
+      ? buildSongOrderBy(songSortField, sortOrder, {
+          title: tables.song.title,
+          artist: tables.song.artist,
+          album: tables.song.album,
+          duration: tables.song.duration,
+          createdAt: tables.song.createdAt,
+        })
       : playlistSongTable.position;
 
     const [rows, countResult] = await Promise.all([

--- a/packages/server/src/routes/songs.ts
+++ b/packages/server/src/routes/songs.ts
@@ -6,7 +6,12 @@ import { json } from '../lib/json';
 import { parsePagination } from '../lib/pagination';
 import { checkGuards } from '../lib/routeGuards';
 import { routeTable } from '../lib/routeTable';
-import { buildSongSearchClause, SOURCE_LIKE_PATTERNS } from '../lib/search';
+import {
+  buildSongFilterClause,
+  buildSongOrderBy,
+  buildSongSearchClause,
+  parseSongSortField,
+} from '../lib/search';
 import { formatSong } from '../lib/serialization';
 import { emitSongDeleted, emitSongUpdated } from '../lib/socket';
 import { reSyncPlaylistsForTags } from '../lib/syncPlaylistToTag';
@@ -22,65 +27,6 @@ import { db, tables } from '../shared/db';
 import { getPlayer } from '../startDiscord';
 
 const { song: songTable } = tables;
-
-const ALLOWED_SORTS = ['createdAt', 'title', 'artist', 'album', 'duration'] as const;
-type SortField = (typeof ALLOWED_SORTS)[number];
-
-// ---------------------------------------------------------------------------
-// Build a dynamic ORDER BY clause from sort field + direction.
-// ---------------------------------------------------------------------------
-function buildOrderByClause(
-  sortField: SortField,
-  sortOrder: 'ASC' | 'DESC'
-): ReturnType<typeof sql> {
-  switch (sortField) {
-    case 'title':
-      return sql`lower(title) ${sql.raw(sortOrder)}`;
-    case 'artist':
-      return sql`artist IS NULL, lower(artist) ${sql.raw(sortOrder)}`;
-    case 'album':
-      return sql`album IS NULL, lower(album) ${sql.raw(sortOrder)}`;
-    case 'duration':
-      return sql`duration ${sql.raw(sortOrder)}`;
-    default:
-      return sql`"createdAt" ${sql.raw(sortOrder)}`;
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Build additional filter clauses for tags (AND) and sources (OR).
-// Returns a SQL fragment that can be AND-ed with the search clause, or
-// undefined when no filters are active.
-// ---------------------------------------------------------------------------
-function buildFilterClause(tags: string[], sources: string[]): ReturnType<typeof sql> | undefined {
-  const clauses: ReturnType<typeof sql>[] = [];
-
-  // Tags: AND — song must have every requested tag
-  for (const tag of tags) {
-    // Match JSON-quoted tag name for precision (avoids partial matches like
-    // "rock" matching "bedrock").
-    clauses.push(sql`lower(tags) LIKE lower(${`%"${tag}"%`})`);
-  }
-
-  // Sources: OR — song URL can match any of the requested sources
-  if (sources.length > 0) {
-    const sourceOrs: ReturnType<typeof sql>[] = [];
-    for (const source of sources) {
-      const patterns = SOURCE_LIKE_PATTERNS[source];
-      if (patterns) {
-        for (const pattern of patterns) {
-          sourceOrs.push(sql`"sourceUrl" LIKE ${pattern}`);
-        }
-      }
-    }
-    if (sourceOrs.length > 0) {
-      clauses.push(sql`(${sql.join(sourceOrs, sql` OR `)})`);
-    }
-  }
-
-  if (clauses.length === 0) return undefined;
-  return sql.join(clauses, sql` AND `);
-}
 
 // ---------------------------------------------------------------------------
 // POST /api/songs/bulk-delete — delete multiple songs at once.
@@ -314,9 +260,7 @@ async function handleGetSongs(ctx: RouteContext, request: Request): Promise<Resp
 
   // Sort
   const sortRaw = url.searchParams.get('sort') ?? 'createdAt';
-  const sortField: SortField = (ALLOWED_SORTS as readonly string[]).includes(sortRaw)
-    ? (sortRaw as SortField)
-    : 'createdAt';
+  const sortField = parseSongSortField(sortRaw) ?? 'createdAt';
   const sortOrder = url.searchParams.get('order') === 'asc' ? 'ASC' : 'DESC';
 
   // Filters
@@ -337,7 +281,7 @@ async function handleGetSongs(ctx: RouteContext, request: Request): Promise<Resp
 
   // Build WHERE clause — search text + tag/source filters
   const searchClause = buildSongSearchClause(search || undefined);
-  const filterClause = buildFilterClause(filterTags, filterSources);
+  const filterClause = buildSongFilterClause(filterTags, filterSources);
 
   let where: ReturnType<typeof sql> | undefined;
   if (searchClause && filterClause) {
@@ -348,7 +292,7 @@ async function handleGetSongs(ctx: RouteContext, request: Request): Promise<Resp
     where = filterClause;
   }
 
-  const orderBy = buildOrderByClause(sortField, sortOrder);
+  const orderBy = buildSongOrderBy(sortField, sortOrder);
 
   const [songs, countResult] = await Promise.all([
     db.select().from(songTable).where(where).orderBy(orderBy).offset(skip).limit(limit),


### PR DESCRIPTION
## Summary

Move duplicated song sorting and filtering SQL builders from `routes/songs.ts` and `routes/playlists.ts` into `lib/search.ts`, giving the codebase a single source of truth for valid sort fields, ORDER BY generation, and tag/source filter clause construction.

## Changes

- **`lib/search.ts`** — add `SONG_SORT_FIELDS`, `SongSortField`, `parseSongSortField()`, `buildSongOrderBy()`, and `buildSongFilterClause()` with optional column overrides for join queries
- **`routes/songs.ts`** — remove local `ALLOWED_SORTS`, `buildOrderByClause`, `buildFilterClause`; use shared functions instead
- **`routes/playlists.ts`** — remove local `buildSongOrderBy`; replace inline filter SQL building with `buildSongFilterClause()`