### PR TITLE
refactor(web): extract ListToolbar component

### DIFF
--- a/packages/web/src/components/ListToolbar.tsx
+++ b/packages/web/src/components/ListToolbar.tsx
@@ -1,0 +1,322 @@
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  CaretDownIcon,
+  CheckSquareIcon,
+  FunnelIcon,
+  ListIcon,
+  MagnifyingGlassIcon,
+  SortAscendingIcon,
+  SquaresFourIcon,
+} from '@phosphor-icons/react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import AddFilterPopover from './AddFilterPopover';
+import FilterChips from './FilterChips';
+import { Button } from './ui/Button';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface SortOption {
+  value: string;
+  label: string;
+}
+
+export interface ListToolbarProps {
+  // ── Search ──
+  searchValue: string;
+  onSearchChange: (value: string) => void;
+  searchPlaceholder?: string;
+
+  // ── Sort ──
+  sortOptions: SortOption[];
+  sort: string;
+  order: 'asc' | 'desc';
+  onSortChange: (field: string, order: 'asc' | 'desc') => void;
+  /** The default (no-op) sort field. Controls pressed state of the sort button. */
+  defaultSort: string;
+  /**
+   * Sort fields where ascending means A→Z. The arrow icon is flipped for these.
+   * Fields not listed here are treated as numeric/date (asc = lowest first).
+   */
+  textSortFields?: string[];
+
+  // ── Filters ──
+  filterTags: string[];
+  filterSources: string[];
+  onAddTag: (tag: string) => void;
+  onRemoveTag: (tag: string) => void;
+  onAddSource: (source: string) => void;
+  onRemoveSource: (source: string) => void;
+
+  // ── Bulk selection toggle ──
+  showBulkToggle?: boolean;
+  selectionMode?: boolean;
+  onToggleSelectionMode?: () => void;
+
+  // ── View mode toggle (grid / list) ──
+  showViewToggle?: boolean;
+  viewMode?: 'grid' | 'list';
+  onViewModeChange?: (mode: 'grid' | 'list') => void;
+  viewModeStorageKey?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function ListToolbar({
+  searchValue,
+  onSearchChange,
+  searchPlaceholder = 'Search...',
+  sortOptions,
+  sort,
+  order,
+  onSortChange,
+  defaultSort,
+  textSortFields = [],
+  filterTags,
+  filterSources,
+  onAddTag,
+  onRemoveTag,
+  onAddSource,
+  onRemoveSource,
+  showBulkToggle = false,
+  selectionMode = false,
+  onToggleSelectionMode,
+  showViewToggle = false,
+  viewMode = 'grid',
+  onViewModeChange,
+  viewModeStorageKey,
+}: ListToolbarProps) {
+  // ── Search (local mirror + debounce) ─────────────────────────────
+  const [searchInput, setSearchInput] = useState(searchValue);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  // Sync local input ← external value (e.g. browser back/forward on SongsPage)
+  useEffect(() => {
+    setSearchInput(searchValue);
+  }, [searchValue]);
+
+  const handleSearchInputChange = useCallback(
+    (next: string) => {
+      setSearchInput(next);
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        onSearchChange(next);
+      }, 250);
+    },
+    [onSearchChange]
+  );
+
+  // ── Sort dropdown ────────────────────────────────────────────────
+  const [sortOpen, setSortOpen] = useState(false);
+  const sortRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    if (!sortOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (sortRef.current && !sortRef.current.contains(e.target as Node)) {
+        setSortOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [sortOpen]);
+
+  const hasActiveSort = sort !== defaultSort || order !== 'desc';
+
+  const handleSortOptionClick = useCallback(
+    (field: string) => {
+      if (field === sort) {
+        // Toggle order
+        onSortChange(field, order === 'asc' ? 'desc' : 'asc');
+      } else {
+        // New field — determine default order: text fields → asc, numeric/date → desc
+        const newOrder = textSortFields.includes(field) ? 'asc' : 'desc';
+        onSortChange(field, newOrder);
+      }
+      setSortOpen(false);
+    },
+    [sort, order, textSortFields, onSortChange]
+  );
+
+  // Direction arrow: text fields show ↓ when ascending (A→Z = down),
+  // numeric/date fields show ↑ when ascending (lowest first = up).
+  const isTextField = textSortFields.includes(sort);
+  const showDownArrow = isTextField ? order === 'asc' : order !== 'asc';
+
+  // ── Filter popover ───────────────────────────────────────────────
+  const [filterOpen, setFilterOpen] = useState(false);
+  const hasActiveFilters = filterTags.length > 0 || filterSources.length > 0;
+
+  // ── View toggle ──────────────────────────────────────────────────
+  const isGrid = viewMode === 'grid';
+
+  const handleViewModeChange = useCallback(
+    (mode: 'grid' | 'list') => {
+      onViewModeChange?.(mode);
+      if (viewModeStorageKey) {
+        localStorage.setItem(viewModeStorageKey, mode);
+      }
+    },
+    [onViewModeChange, viewModeStorageKey]
+  );
+
+  return (
+    <>
+      {/* ── Toolbar ── */}
+      <div className="flex items-center gap-2 mb-3">
+        {/* Search */}
+        <div className="relative flex-1">
+          <MagnifyingGlassIcon
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-faint w-4 h-4 md:w-3.5 md:h-3.5"
+            weight="duotone"
+          />
+          <input
+            className="input pl-10"
+            placeholder={searchPlaceholder}
+            value={searchInput}
+            onChange={(e) => handleSearchInputChange(e.target.value)}
+          />
+        </div>
+
+        {/* Bulk selection toggle */}
+        {showBulkToggle && (
+          <Button
+            variant="inherit"
+            surface="surface"
+            onClick={onToggleSelectionMode}
+            className={`flex items-center gap-1.5 px-2.5 ${
+              selectionMode ? 'pressed text-accent' : ''
+            }`}
+            title={selectionMode ? 'Exit selection mode' : 'Select items'}
+          >
+            <CheckSquareIcon size={16} weight="duotone" />
+          </Button>
+        )}
+
+        {/* Filter button */}
+        <Button
+          variant="inherit"
+          surface="surface"
+          onClick={() => setFilterOpen(true)}
+          className={`flex items-center gap-1.5 px-2.5 ${
+            hasActiveFilters ? 'pressed text-accent' : ''
+          }`}
+          title={`Filter${hasActiveFilters ? ` (${filterTags.length + filterSources.length} active)` : ''}`}
+        >
+          <FunnelIcon size={16} weight="duotone" />
+        </Button>
+
+        {/* Sort dropdown */}
+        <div className="relative" ref={sortRef}>
+          <Button
+            variant="inherit"
+            surface="surface"
+            onClick={() => setSortOpen((v) => !v)}
+            className={`flex items-center gap-1.5 px-2.5 ${
+              sortOpen || hasActiveSort ? 'pressed text-accent' : ''
+            }`}
+            title={`Sort by ${sortOptions.find((o) => o.value === sort)?.label ?? sort} (${order === 'asc' ? 'ascending' : 'descending'})`}
+          >
+            <SortAscendingIcon size={16} weight="duotone" />
+            <CaretDownIcon size={10} weight="fill" className="text-faint" />
+          </Button>
+
+          {sortOpen && (
+            <div className="absolute right-0 top-full mt-1.5 w-48 glass-popover z-20 py-1 origin-top-right">
+              {sortOptions.map((opt) => {
+                const isActive = sort === opt.value;
+                return (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    className={`w-full flex items-center justify-between px-3 py-2 text-sm font-body transition-colors ${
+                      isActive
+                        ? 'text-accent bg-accent/5'
+                        : 'text-fg hover:bg-surface active:bg-surface/80'
+                    }`}
+                    onClick={() => handleSortOptionClick(opt.value)}
+                  >
+                    <span>{opt.label}</span>
+                    {isActive && (
+                      <button
+                        type="button"
+                        className="cursor-pointer p-0.5 rounded hover:bg-black/10 dark:hover:bg-white/10 transition-colors"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleSortOptionClick(opt.value);
+                        }}
+                        title={order === 'asc' ? 'Switch to descending' : 'Switch to ascending'}
+                      >
+                        {showDownArrow ? (
+                          <ArrowDownIcon size={14} weight="bold" />
+                        ) : (
+                          <ArrowUpIcon size={14} weight="bold" />
+                        )}
+                      </button>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* View toggle */}
+        {showViewToggle && (
+          <div className="flex gap-1 bg-elevated rounded-lg p-1 shrink-0">
+            <button
+              type="button"
+              onClick={() => handleViewModeChange('list')}
+              className={`px-2 py-1.5 rounded-md transition-colors cursor-pointer ${
+                !isGrid ? 'bg-accent text-elevated' : 'text-muted hover:text-fg'
+              }`}
+              title="List view"
+            >
+              <ListIcon size={18} weight="duotone" />
+            </button>
+            <button
+              type="button"
+              onClick={() => handleViewModeChange('grid')}
+              className={`px-2 py-1.5 rounded-md transition-colors cursor-pointer ${
+                isGrid ? 'bg-accent text-elevated' : 'text-muted hover:text-fg'
+              }`}
+              title="Grid view"
+            >
+              <SquaresFourIcon size={18} weight="duotone" />
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* ── Filter chips ── */}
+      {hasActiveFilters && (
+        <div className="mb-2">
+          <FilterChips
+            tags={filterTags}
+            sources={filterSources}
+            onRemoveTag={onRemoveTag}
+            onRemoveSource={onRemoveSource}
+          />
+        </div>
+      )}
+
+      {/* ── Filter popover ── */}
+      {filterOpen && (
+        <AddFilterPopover
+          activeTags={filterTags}
+          activeSources={filterSources}
+          onAddTag={onAddTag}
+          onRemoveTag={onRemoveTag}
+          onAddSource={onAddSource}
+          onRemoveSource={onRemoveSource}
+          onClose={() => setFilterOpen(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -6,25 +6,16 @@ import { useVirtualizedInfiniteScroll } from '../hooks/useVirtualizedInfiniteScr
 type PlaylistDetailMeta = Omit<PlaylistDetail, 'songs'>;
 
 import {
-  ArrowDownIcon,
-  ArrowUpIcon,
   BombIcon,
-  CaretDownIcon,
   CaretLeftIcon,
-  CheckSquareIcon,
-  FunnelIcon,
   GhostIcon,
-  ListIcon,
   LockIcon,
   LockOpenIcon,
-  MagnifyingGlassIcon,
   PencilSimple,
   PlayCircleIcon,
   PlayIcon,
   PlusCircleIcon,
   ShuffleIcon,
-  SortAscendingIcon,
-  SquaresFourIcon,
   TagIcon,
 } from '@phosphor-icons/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -39,7 +30,6 @@ import {
   startPlayback,
   togglePlaylistVisibility,
 } from '../api/api';
-import AddFilterPopover from '../components/AddFilterPopover';
 import AddSongsModal from '../components/AddSongsModal';
 import BulkActionBar from '../components/BulkActionBar';
 import BulkEditModal from '../components/BulkEditModal';
@@ -47,7 +37,8 @@ import ConfirmModal from '../components/ConfirmModal';
 import type { MenuItem } from '../components/ContextMenu';
 import { ContextMenu, ContextMenuTrigger } from '../components/ContextMenu';
 import EmptyState from '../components/EmptyState';
-import FilterChips from '../components/FilterChips';
+import ListToolbar from '../components/ListToolbar';
+
 import NotificationToast from '../components/NotificationToast';
 
 import { Button } from '../components/ui/Button';
@@ -135,9 +126,6 @@ export default function PlaylistDetailPage() {
   const [order, setOrder] = useState('desc');
   const [filterTags, setFilterTags] = useState<string[]>([]);
   const [filterSources, setFilterSources] = useState<string[]>([]);
-  const [sortOpen, setSortOpen] = useState(false);
-  const [filterPopoverOpen, setFilterPopoverOpen] = useState(false);
-  const sortRefEl = useRef<HTMLDivElement>(null);
 
   // Build stable fetch options for the hook
   const songsOpts = useMemo<FetchSongsOptions>(() => {
@@ -151,18 +139,6 @@ export default function PlaylistDetailPage() {
     if (s) opts.source = s;
     return opts;
   }, [search, sort, order, filterTags, filterSources]);
-
-  // Close sort dropdown on outside click
-  useEffect(() => {
-    if (!sortOpen) return;
-    const handler = (e: MouseEvent) => {
-      if (sortRefEl.current && !sortRefEl.current.contains(e.target as Node)) {
-        setSortOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [sortOpen]);
 
   // ── Infinite scroll with metadata ────────────────────────────────────
 
@@ -218,46 +194,6 @@ export default function PlaylistDetailPage() {
   const canEdit = isAdminView || isOwner || hasPermission('songs.edit');
   const canBulk = canEdit;
   const isSmart = !!playlistDetail?.tagNameLower;
-
-  // ── Sort / filter handlers ──────────────────────────────────────────
-
-  const handleOrderToggle = useCallback(() => {
-    setOrder((prev) => (prev === 'asc' ? 'desc' : 'asc'));
-  }, []);
-
-  const handleSortChange = useCallback(
-    (newSort: string) => {
-      if (newSort === sort) {
-        handleOrderToggle();
-      } else {
-        const newOrder =
-          newSort === 'createdAt' || newSort === 'position' || newSort === 'duration'
-            ? 'desc'
-            : 'asc';
-        setSort(newSort);
-        setOrder(newOrder);
-        setSortOpen(false);
-      }
-    },
-    [sort, handleOrderToggle]
-  );
-
-  const handleRemoveTag = useCallback((tag: string) => {
-    setFilterTags((prev) => prev.filter((t) => t !== tag));
-  }, []);
-
-  const handleRemoveSource = useCallback((source: string) => {
-    setFilterSources((prev) => prev.filter((s) => s !== source));
-  }, []);
-
-  const handleAddTag = useCallback((tag: string) => {
-    const normalized = tag.toLowerCase();
-    setFilterTags((prev) => (prev.includes(normalized) ? prev : [...prev, normalized]));
-  }, []);
-
-  const handleAddSource = useCallback((source: string) => {
-    setFilterSources((prev) => (prev.includes(source) ? prev : [...prev, source]));
-  }, []);
 
   // ── Socket: playlist updated (rename, visibility, song count changes) ──
   useEffect(() => {
@@ -675,156 +611,41 @@ export default function PlaylistDetailPage() {
         </div>
       </div>
 
-      {/* Search, sort, filter, and view toggle */}
-      <div className="flex items-center gap-2 mb-3">
-        <div className="relative flex-1">
-          <MagnifyingGlassIcon
-            className="absolute left-3 top-1/2 -translate-y-1/2 text-faint w-4 h-4 md:w-3.5 md:h-3.5"
-            weight="duotone"
-          />
-          <input
-            className="input pl-10"
-            placeholder="Search by title, nickname, artist, album, or tag..."
-            value={search}
-            onChange={(e) => {
-              setSearch(e.target.value);
-            }}
-          />
-        </div>
-
-        {/* Select toggle (only visible to users with bulk permissions) */}
-        {canBulk && (
-          <Button
-            variant="inherit"
-            surface="surface"
-            onClick={() => {
-              if (selectionMode) bulk.clearAll();
-              setSelectionMode((v) => !v);
-            }}
-            className={`flex items-center gap-1.5 px-2.5 ${
-              selectionMode ? 'pressed text-accent' : ''
-            }`}
-            title={selectionMode ? 'Exit selection mode' : 'Select songs'}
-          >
-            <CheckSquareIcon size={16} weight="duotone" />
-          </Button>
-        )}
-
-        {/* Add filter button */}
-        <Button
-          variant="inherit"
-          surface="surface"
-          onClick={() => setFilterPopoverOpen(true)}
-          className={`flex items-center gap-1.5 px-2.5 ${
-            filterTags.length > 0 || filterSources.length > 0 ? 'pressed text-accent' : ''
-          }`}
-          title={`Filter${filterTags.length > 0 || filterSources.length > 0 ? ` (${filterTags.length + filterSources.length} active)` : ''}`}
-        >
-          <FunnelIcon size={16} weight="duotone" />
-        </Button>
-
-        {/* Sort dropdown */}
-        <div className="relative" ref={sortRefEl}>
-          <Button
-            variant="inherit"
-            surface="surface"
-            onClick={() => setSortOpen((v) => !v)}
-            className={`flex items-center gap-1.5 px-2.5 ${
-              sortOpen || sort !== 'position' || order !== 'desc' ? 'pressed text-accent' : ''
-            }`}
-            title={`Sort by ${SORT_OPTIONS.find((o) => o.value === sort)?.label ?? 'Playlist Order'} (${order === 'asc' ? 'ascending' : 'descending'})`}
-          >
-            <SortAscendingIcon size={16} weight="duotone" />
-            <CaretDownIcon size={10} weight="fill" className="text-faint" />
-          </Button>
-
-          {sortOpen && (
-            <div className="absolute right-0 top-full mt-1.5 w-48 glass-popover z-20 py-1 origin-top-right">
-              {SORT_OPTIONS.map((opt) => {
-                const isActive = sort === opt.value;
-                return (
-                  <button
-                    key={opt.value}
-                    type="button"
-                    className={`w-full flex items-center justify-between px-3 py-2 text-sm font-body transition-colors ${
-                      isActive
-                        ? 'text-accent bg-accent/5'
-                        : 'text-fg hover:bg-surface active:bg-surface/80'
-                    }`}
-                    onClick={() => handleSortChange(opt.value)}
-                  >
-                    <span>{opt.label}</span>
-                    {isActive && (
-                      <button
-                        type="button"
-                        className="cursor-pointer p-0.5 rounded hover:bg-black/10 dark:hover:bg-white/10 transition-colors"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleOrderToggle();
-                        }}
-                        title={order === 'asc' ? 'Switch to descending' : 'Switch to ascending'}
-                      >
-                        {(() => {
-                          const isTextField =
-                            sort === 'title' || sort === 'artist' || sort === 'album';
-                          const showDown = isTextField ? order === 'asc' : order !== 'asc';
-                          return showDown ? (
-                            <ArrowDownIcon size={14} weight="bold" />
-                          ) : (
-                            <ArrowUpIcon size={14} weight="bold" />
-                          );
-                        })()}
-                      </button>
-                    )}
-                  </button>
-                );
-              })}
-            </div>
-          )}
-        </div>
-
-        {/* View toggle */}
-        <div className="flex gap-1 bg-elevated rounded-lg p-1 shrink-0">
-          <button
-            type="button"
-            onClick={() => {
-              setViewMode('list');
-              localStorage.setItem('alfira-playlist-detail-view', 'list');
-            }}
-            className={`px-2 py-1.5 rounded-md transition-colors cursor-pointer ${
-              viewMode === 'list' ? 'bg-accent text-elevated' : 'text-muted hover:text-fg'
-            }`}
-            title="List view"
-          >
-            <ListIcon size={18} weight="duotone" />
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              setViewMode('grid');
-              localStorage.setItem('alfira-playlist-detail-view', 'grid');
-            }}
-            className={`px-2 py-1.5 rounded-md transition-colors cursor-pointer ${
-              viewMode === 'grid' ? 'bg-accent text-elevated' : 'text-muted hover:text-fg'
-            }`}
-            title="Grid view"
-          >
-            <SquaresFourIcon size={18} weight="duotone" />
-          </button>
-        </div>
-      </div>
-
-      {/* Active filter chips */}
-      {(filterTags.length > 0 || filterSources.length > 0) && (
-        <div className="mb-2">
-          <FilterChips
-            tags={filterTags}
-            sources={filterSources}
-            onRemoveTag={handleRemoveTag}
-            onRemoveSource={handleRemoveSource}
-          />
-        </div>
-      )}
+      <ListToolbar
+        searchValue={search}
+        onSearchChange={setSearch}
+        searchPlaceholder="Search by title, nickname, artist, album, or tag..."
+        sortOptions={[...SORT_OPTIONS]}
+        sort={sort}
+        order={order as 'asc' | 'desc'}
+        onSortChange={(field, newOrder) => {
+          setSort(field);
+          setOrder(newOrder);
+        }}
+        defaultSort="position"
+        textSortFields={['title', 'artist', 'album']}
+        filterTags={filterTags}
+        filterSources={filterSources}
+        onAddTag={(tag) => {
+          const normalized = tag.toLowerCase();
+          setFilterTags((prev) => (prev.includes(normalized) ? prev : [...prev, normalized]));
+        }}
+        onRemoveTag={(tag) => setFilterTags((prev) => prev.filter((t) => t !== tag))}
+        onAddSource={(s) => setFilterSources((prev) => (prev.includes(s) ? prev : [...prev, s]))}
+        onRemoveSource={(s) => setFilterSources((prev) => prev.filter((x) => x !== s))}
+        showBulkToggle={canBulk}
+        selectionMode={selectionMode}
+        onToggleSelectionMode={() => {
+          if (selectionMode) bulk.clearAll();
+          setSelectionMode((v) => !v);
+        }}
+        showViewToggle
+        viewMode={viewMode}
+        onViewModeChange={(m) => {
+          setViewMode(m);
+          localStorage.setItem('alfira-playlist-detail-view', m);
+        }}
+      />
 
       {/* Song list */}
       {songItems.length === 0 && !isLoading ? (
@@ -950,19 +771,6 @@ export default function PlaylistDetailPage() {
           confirmLabel="Convert"
           onConfirm={() => handleMakeSmart(tagSmartConfirm)}
           onCancel={() => setTagSmartConfirm(null)}
-        />
-      )}
-
-      {/* Add Filter popover */}
-      {filterPopoverOpen && (
-        <AddFilterPopover
-          activeTags={filterTags}
-          activeSources={filterSources}
-          onAddTag={handleAddTag}
-          onRemoveTag={handleRemoveTag}
-          onAddSource={handleAddSource}
-          onRemoveSource={handleRemoveSource}
-          onClose={() => setFilterPopoverOpen(false)}
         />
       )}
 

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -1,19 +1,7 @@
 import type { Playlist, Song } from '@alfira-bot/server/shared';
 import type { FetchSongsOptions } from '@alfira-bot/server/shared/api';
-import {
-  ArrowDownIcon,
-  ArrowUpIcon,
-  CaretDownIcon,
-  CheckSquareIcon,
-  FunnelIcon,
-  ListIcon,
-  MagnifyingGlassIcon,
-  MusicNotesIcon,
-  QuestionIcon,
-  SortAscendingIcon,
-  SquaresFourIcon,
-} from '@phosphor-icons/react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { MusicNotesIcon, QuestionIcon } from '@phosphor-icons/react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
   bulkDeleteSongs,
@@ -23,13 +11,13 @@ import {
   getSongsPage,
   startPlayback,
 } from '../api/api';
-import AddFilterPopover from '../components/AddFilterPopover';
 import BulkActionBar from '../components/BulkActionBar';
 import BulkEditModal from '../components/BulkEditModal';
 import ConfirmModal from '../components/ConfirmModal';
-import FilterChips from '../components/FilterChips';
+import ListToolbar from '../components/ListToolbar';
+
 import NotificationToast from '../components/NotificationToast';
-import { Button } from '../components/ui/Button';
+
 import { PageHeader } from '../components/ui/PageHeader';
 import { VirtualSongList } from '../components/VirtualSongList';
 import { useAdminView } from '../context/AdminViewContext';
@@ -68,13 +56,6 @@ export default function SongsPage() {
   const { notify } = useNotification();
   const handleSetDeleteId = useCallback((id: string | null) => setDeleteId(id), []);
 
-  // Sort dropdown state
-  const [sortOpen, setSortOpen] = useState(false);
-  const sortRef = useRef<HTMLDivElement>(null);
-
-  // Add filter popover state
-  const [filterPopoverOpen, setFilterPopoverOpen] = useState(false);
-
   // Bulk selection
   const bulk = useBulkSelection();
   const [selectionMode, setSelectionMode] = useState(false);
@@ -112,14 +93,6 @@ export default function SongsPage() {
     [searchParams]
   );
 
-  // Local search input mirrors URL param
-  const [searchInput, setSearchInput] = useState(search);
-
-  // Sync search input ← URL (e.g. on browser back/forward)
-  useEffect(() => {
-    setSearchInput(search);
-  }, [search]);
-
   const updateParam = useCallback(
     (key: string, value: string | null) => {
       setSearchParams(
@@ -136,105 +109,6 @@ export default function SongsPage() {
       );
     },
     [setSearchParams]
-  );
-
-  // Debounced search → URL
-  const searchTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const handleSearchChange = useCallback(
-    (value: string) => {
-      setSearchInput(value);
-      if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
-      searchTimerRef.current = setTimeout(() => {
-        updateParam('search', value || null);
-      }, 250);
-    },
-    [updateParam]
-  );
-
-  // ── Sort handlers ───────────────────────────────────────────────────
-  const handleOrderToggle = useCallback(() => {
-    updateParam('order', order === 'asc' ? null : 'asc');
-  }, [order, updateParam]);
-
-  const handleSortChange = useCallback(
-    (newSort: SortField) => {
-      if (newSort === sort) {
-        handleOrderToggle();
-      } else {
-        // When switching to a text field, default to ascending (A-Z).
-        // Update both params atomically — React Router's setSearchParams
-        // sees the same URL for each callback, so two calls would race.
-        const newOrder = newSort === 'createdAt' || newSort === 'duration' ? 'desc' : 'asc';
-        setSearchParams(
-          (prev) => {
-            const next = new URLSearchParams(prev);
-            if (newSort === 'createdAt') {
-              next.delete('sort');
-            } else {
-              next.set('sort', newSort);
-            }
-            if (newOrder === 'asc') {
-              next.set('order', 'asc');
-            } else {
-              next.delete('order');
-            }
-            return next;
-          },
-          { replace: true }
-        );
-      }
-      setSortOpen(false);
-    },
-    [sort, setSearchParams, handleOrderToggle]
-  );
-
-  // Close sort dropdown on outside click
-  useEffect(() => {
-    if (!sortOpen) return;
-    const handler = (e: MouseEvent) => {
-      if (sortRef.current && !sortRef.current.contains(e.target as Node)) {
-        setSortOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [sortOpen]);
-
-  // ── Filter handlers ─────────────────────────────────────────────────
-  const handleRemoveTag = useCallback(
-    (tag: string) => {
-      const next = filterTags.filter((t) => t !== tag);
-      updateParam('tags', next.length > 0 ? next.join(',') : null);
-    },
-    [filterTags, updateParam]
-  );
-
-  const handleRemoveSource = useCallback(
-    (source: string) => {
-      const next = filterSources.filter((s) => s !== source);
-      updateParam('source', next.length > 0 ? next.join(',') : null);
-    },
-    [filterSources, updateParam]
-  );
-
-  const handleAddTag = useCallback(
-    (tag: string) => {
-      // Normalize to lowercase for consistency
-      const normalized = tag.toLowerCase();
-      if (filterTags.includes(normalized)) return;
-      const next = [...filterTags, normalized];
-      updateParam('tags', next.join(','));
-    },
-    [filterTags, updateParam]
-  );
-
-  const handleAddSource = useCallback(
-    (source: string) => {
-      if (filterSources.includes(source)) return;
-      const next = [...filterSources, source];
-      updateParam('source', next.join(','));
-    },
-    [filterSources, updateParam]
   );
 
   // ── Build stable fetch options for the infinite scroll hook ─────────
@@ -393,8 +267,6 @@ export default function SongsPage() {
     [queueState.loopMode, notify]
   );
 
-  const isGrid = viewMode === 'grid';
-
   return (
     <div className="p-4 md:p-8">
       <PageHeader
@@ -412,154 +284,64 @@ export default function SongsPage() {
         </span>
       </PageHeader>
 
-      {/* Search bar + Sort + View toggle */}
-      <div className="flex items-center gap-2 mb-3">
-        <div className="relative flex-1">
-          <MagnifyingGlassIcon
-            className="absolute left-3 top-1/2 -translate-y-1/2 text-faint w-4 h-4 md:w-3.5 md:h-3.5"
-            weight="duotone"
-          />
-          <input
-            className="input pl-10"
-            placeholder="Search by title, nickname, artist, album, or tag..."
-            value={searchInput}
-            onChange={(e) => handleSearchChange(e.target.value)}
-          />
-        </div>
-
-        {/* Select toggle (only visible to users with bulk permissions) */}
-        {canBulk && (
-          <Button
-            variant="inherit"
-            surface="surface"
-            onClick={() => {
-              if (selectionMode) bulk.clearAll();
-              setSelectionMode((v) => !v);
-            }}
-            className={`flex items-center gap-1.5 px-2.5 ${
-              selectionMode ? 'pressed text-accent' : ''
-            }`}
-            title={selectionMode ? 'Exit selection mode' : 'Select songs'}
-          >
-            <CheckSquareIcon size={16} weight="duotone" />
-          </Button>
-        )}
-
-        {/* Add filter button */}
-        <Button
-          variant="inherit"
-          surface="surface"
-          onClick={() => setFilterPopoverOpen(true)}
-          className={`flex items-center gap-1.5 px-2.5 ${
-            filterTags.length > 0 || filterSources.length > 0 ? 'pressed text-accent' : ''
-          }`}
-          title={`Filter${filterTags.length > 0 || filterSources.length > 0 ? ` (${filterTags.length + filterSources.length} active)` : ''}`}
-        >
-          <FunnelIcon size={16} weight="duotone" />
-        </Button>
-
-        {/* Sort dropdown */}
-        <div className="relative" ref={sortRef}>
-          <Button
-            variant="inherit"
-            surface="surface"
-            onClick={() => setSortOpen((v) => !v)}
-            className={`flex items-center gap-1.5 px-2.5 ${
-              sortOpen || sort !== 'createdAt' || order !== 'desc' ? 'pressed text-accent' : ''
-            }`}
-            title={`Sort by ${SORT_OPTIONS.find((o) => o.value === sort)?.label ?? 'Date Added'} (${order === 'asc' ? 'ascending' : 'descending'})`}
-          >
-            <SortAscendingIcon size={16} weight="duotone" />
-            <CaretDownIcon size={10} weight="fill" className="text-faint" />
-          </Button>
-
-          {sortOpen && (
-            <div className="absolute right-0 top-full mt-1.5 w-48 glass-popover z-20 py-1 origin-top-right">
-              {SORT_OPTIONS.map((opt) => {
-                const isActive = sort === opt.value;
-                return (
-                  <button
-                    key={opt.value}
-                    type="button"
-                    className={`w-full flex items-center justify-between px-3 py-2 text-sm font-body transition-colors ${
-                      isActive
-                        ? 'text-accent bg-accent/5'
-                        : 'text-fg hover:bg-surface active:bg-surface/80'
-                    }`}
-                    onClick={() => handleSortChange(opt.value)}
-                  >
-                    <span>{opt.label}</span>
-                    {isActive && (
-                      <button
-                        type="button"
-                        className="cursor-pointer p-0.5 rounded hover:bg-black/10 dark:hover:bg-white/10 transition-colors"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleOrderToggle();
-                        }}
-                        title={order === 'asc' ? 'Switch to descending' : 'Switch to ascending'}
-                      >
-                        {(() => {
-                          const isTextField =
-                            sort === 'title' || sort === 'artist' || sort === 'album';
-                          const showDown = isTextField ? order === 'asc' : order !== 'asc';
-                          return showDown ? (
-                            <ArrowDownIcon size={14} weight="bold" />
-                          ) : (
-                            <ArrowUpIcon size={14} weight="bold" />
-                          );
-                        })()}
-                      </button>
-                    )}
-                  </button>
-                );
-              })}
-            </div>
-          )}
-        </div>
-
-        {/* View toggle */}
-        <div className="flex gap-1 bg-elevated rounded-lg p-1">
-          <button
-            type="button"
-            onClick={() => {
-              setViewMode('list');
-              localStorage.setItem('alfira-library-view', 'list');
-            }}
-            className={`px-3 py-1.5 rounded-md text-sm font-body transition-colors cursor-pointer ${
-              !isGrid ? 'bg-accent text-elevated' : 'text-muted hover:text-fg'
-            }`}
-            title="List view"
-          >
-            <ListIcon size={18} weight="duotone" />
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              setViewMode('grid');
-              localStorage.setItem('alfira-library-view', 'grid');
-            }}
-            className={`px-2 py-1.5 rounded-md transition-colors cursor-pointer ${
-              isGrid ? 'bg-accent text-elevated' : 'text-muted hover:text-fg'
-            }`}
-            title="Grid view"
-          >
-            <SquaresFourIcon size={18} weight="duotone" />
-          </button>
-        </div>
-      </div>
-
-      {/* Active filter chips — only shown when filters are active */}
-      {(filterTags.length > 0 || filterSources.length > 0) && (
-        <div className="mb-2">
-          <FilterChips
-            tags={filterTags}
-            sources={filterSources}
-            onRemoveTag={handleRemoveTag}
-            onRemoveSource={handleRemoveSource}
-          />
-        </div>
-      )}
+      <ListToolbar
+        searchValue={search}
+        onSearchChange={(v) => updateParam('search', v || null)}
+        searchPlaceholder="Search by title, nickname, artist, album, or tag..."
+        sortOptions={SORT_OPTIONS}
+        sort={sort}
+        order={order as 'asc' | 'desc'}
+        onSortChange={(field, newOrder) => {
+          setSearchParams(
+            (prev) => {
+              const next = new URLSearchParams(prev);
+              if (field === 'createdAt') {
+                next.delete('sort');
+              } else {
+                next.set('sort', field);
+              }
+              if (newOrder === 'asc') {
+                next.set('order', 'asc');
+              } else {
+                next.delete('order');
+              }
+              return next;
+            },
+            { replace: true }
+          );
+        }}
+        defaultSort="createdAt"
+        textSortFields={['title', 'artist', 'album']}
+        filterTags={filterTags}
+        filterSources={filterSources}
+        onAddTag={(tag) => {
+          const normalized = tag.toLowerCase();
+          if (filterTags.includes(normalized)) return;
+          updateParam('tags', [...filterTags, normalized].join(','));
+        }}
+        onRemoveTag={(tag) =>
+          updateParam('tags', filterTags.filter((t) => t !== tag).join(',') || null)
+        }
+        onAddSource={(s) => {
+          if (filterSources.includes(s)) return;
+          updateParam('source', [...filterSources, s].join(','));
+        }}
+        onRemoveSource={(s) =>
+          updateParam('source', filterSources.filter((x) => x !== s).join(',') || null)
+        }
+        showBulkToggle={canBulk}
+        selectionMode={selectionMode}
+        onToggleSelectionMode={() => {
+          if (selectionMode) bulk.clearAll();
+          setSelectionMode((v) => !v);
+        }}
+        showViewToggle
+        viewMode={viewMode}
+        onViewModeChange={(m) => {
+          setViewMode(m);
+          localStorage.setItem('alfira-library-view', m);
+        }}
+      />
 
       {/* Content */}
       <VirtualSongList
@@ -592,19 +374,6 @@ export default function SongsPage() {
             : 'Submit a request to add songs'
         }
       />
-
-      {/* ── Add Filter popover ────────────────────────────────── */}
-      {filterPopoverOpen && (
-        <AddFilterPopover
-          activeTags={filterTags}
-          activeSources={filterSources}
-          onAddTag={handleAddTag}
-          onRemoveTag={handleRemoveTag}
-          onAddSource={handleAddSource}
-          onRemoveSource={handleRemoveSource}
-          onClose={() => setFilterPopoverOpen(false)}
-        />
-      )}
 
       {/* Modals */}
       {deleteId && (


### PR DESCRIPTION
## Summary

Extract search, sort, filter, and view-toggle toolbar from `SongsPage` and `PlaylistDetailPage` into a shared `ListToolbar` component, eliminating ~500 lines of duplicated code.

## Changes

- New `ListToolbar` component with configurable search (debounced), sort dropdown, filter chips/popover, bulk selection toggle, and grid/list view toggle
- Refactor `SongsPage` to use `ListToolbar`
- Refactor `PlaylistDetailPage` to use `ListToolbar`