### PR TITLE
chore(web): add sourcemaps and explicit no-emit to build

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "bunx @tailwindcss/cli -i ./src/index.css -o ./public/index.css --watch & bun run src/server.ts",
     "build:css": "bunx @tailwindcss/cli -i ./src/index.css -o ./dist/index.css --minify",
-    "build": "tsc && bun run build:css && bun build ./src/main.tsx --outdir=./dist --minify && cp ./index.html ./dist/ && sed -i 's|/src/main.tsx|/main.js|g' ./dist/index.html && sed -i 's|/src/index.css|/index.css|g' ./dist/index.html && cp -r ./public/* ./dist/"
+    "build": "tsc --noEmit && bun run build:css && bun build ./src/main.tsx --outdir=./dist --minify --sourcemap=external && cp ./index.html ./dist/ && sed -i 's|/src/main.tsx|/main.js|g' ./dist/index.html && sed -i 's|/src/index.css|/index.css|g' ./dist/index.html && cp -r ./public/* ./dist/"
   },
   "dependencies": {
     "@alfira-bot/server": "workspace:*",


### PR DESCRIPTION
## Summary

Hardens the web package build script with two improvements:

- Makes `tsc --noEmit` explicit (tsconfig already had `noEmit: true`, but relying on it alone is fragile)
- Adds `--sourcemap=external` to `bun build` for production debugging (separate `.map` files, only downloaded when DevTools is open)

## Changes

- `packages/web/package.json`: add `--noEmit` flag to `tsc` step and `--sourcemap=external` to `bun build` step