### PR TITLE
docs(docs): update tooling references from biome to oxlint/oxfmt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ The bot and API run in a **single Bun process**. For detailed architecture (star
 | API       | Bun native HTTP + WebSocket |
 | Database  | SQLite + Drizzle ORM        |
 | Frontend  | React 19 + Tailwind CSS 4   |
-| Linting   | Biome                       |
+| Linting   | oxlint + oxfmt              |
 
 ## Development Commands
 
@@ -49,7 +49,7 @@ bun run format
 
 ## Code Style
 
-- Biome for linting and formatting
+- oxlint + oxfmt for linting and formatting
 - Run `bun run check` before committing
 - CI runs `bun run lint` — code must pass before merging
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ docker compose up --build
 
 ## Code Quality
 
-The project uses [Biome](https://biomejs.dev/) for linting and formatting.
+The project uses [oxlint](https://oxc.rs/) and [oxfmt](https://oxc.rs/) for linting and formatting.
 
 ```bash
 # Lint + format check with auto-fix (recommended before committing)
@@ -63,13 +63,13 @@ bun run lint:fix
 bun run format
 ```
 
-CI runs `bun run lint` in the typecheck workflow — your code must pass before merging. See the [Biome Setup](docs/biome-setup.md) doc for configuration details.
+CI runs `bun run lint` in the typecheck workflow — your code must pass before merging.
 
 ## Editor Tooling
 
 The repo includes preconfigured settings for a couple of tools (optional — use whatever you prefer):
 
-- **Zed** (`.zed/`) — Biome integration, TypeScript inlay hints, Markdown formatting, and task shortcuts for common dev commands
+- **Zed** (`.zed/`) — oxlint/oxfmt integration, TypeScript inlay hints, Markdown formatting, and task shortcuts for common dev commands
 - **Pi** (`.pi/`) — Prompt templates and extensions for the project's development pipeline (plan, verify, submit, release)
 
 If you use Zed or Pi, you'll get a pre-tuned experience out of the box. Nothing is enforced — these are just defaults for convenience.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ See the **[Installation Guide](docs/installation.md)** for full details.
 | **[Installation Guide](docs/installation.md)** | Setup, environment variables, Docker commands |
 | **[Philosophy](docs/philosophy.md)**           | Design principles guiding the project         |
 | **[Tech Stack](docs/tech-stack.md)**           | Technology stack and project structure        |
-| **[Biome Setup](docs/biome-setup.md)**         | Editor setup for Biome linting and formatting |
 | **[Troubleshooting](docs/troubleshooting.md)** | Common issues and solutions                   |
 
 ## License


### PR DESCRIPTION
## Summary

Replace stale Biome references in project documentation with oxlint/oxfmt, reflecting the actual tooling currently in use.

## Changes

- Update tech stack table and code style section in AGENTS.md to reference oxlint + oxfmt
- Update Code Quality section in CONTRIBUTING.md with correct oxlint/oxfmt URLs and remove dead link to docs/biome-setup.md
- Update Zed editor tooling description from Biome to oxlint/oxfmt
- Remove stale Biome Setup row from README.md docs table