### PR TITLE
fix(server,web): sort by display name instead of raw title

### DIFF
--- a/packages/server/src/lib/search.ts
+++ b/packages/server/src/lib/search.ts
@@ -29,6 +29,7 @@ export function buildSongOrderBy(
   sortOrder: 'ASC' | 'DESC',
   cols?: {
     title: SqlInterpolatable;
+    nickname: SqlInterpolatable;
     artist: SqlInterpolatable;
     album: SqlInterpolatable;
     duration: SqlInterpolatable;
@@ -37,6 +38,7 @@ export function buildSongOrderBy(
 ): ReturnType<typeof sql> {
   const c = cols ?? {
     title: sql`title`,
+    nickname: sql`nickname`,
     artist: sql`artist`,
     album: sql`album`,
     duration: sql`duration`,
@@ -44,7 +46,7 @@ export function buildSongOrderBy(
   };
   switch (sortField) {
     case 'title':
-      return sql`lower(${c.title}) ${sql.raw(sortOrder)}`;
+      return sql`lower(COALESCE(NULLIF(TRIM(${c.nickname}), ''), ${c.title})) ${sql.raw(sortOrder)}`;
     case 'artist':
       return sql`${c.artist} IS NULL, lower(${c.artist}) ${sql.raw(sortOrder)}`;
     case 'album':

--- a/packages/server/src/routes/playlists.ts
+++ b/packages/server/src/routes/playlists.ts
@@ -238,6 +238,7 @@ async function handleGetPlaylist(
     const orderBy = songSortField
       ? buildSongOrderBy(songSortField, sortOrder, {
           title: tables.song.title,
+          nickname: tables.song.nickname,
           artist: tables.song.artist,
           album: tables.song.album,
           duration: tables.song.duration,

--- a/packages/web/src/hooks/useVirtualizedInfiniteScroll.ts
+++ b/packages/web/src/hooks/useVirtualizedInfiniteScroll.ts
@@ -8,6 +8,12 @@ export interface UseInfiniteScrollOptions<T, A extends unknown[], M = undefined>
   ) => Promise<{ items: T[]; hasMore: boolean; total?: number; metadata?: M }>;
   limit?: number;
   deps?: A;
+  /**
+   * Optional comparator for sorting items after real-time mutations (prepend / updateItem).
+   * Without this, updated items stay at their old array position even when the current
+   * sort order would place them elsewhere.
+   */
+  compareFn?: (a: T, b: T) => number;
 }
 
 export interface UseInfiniteScrollReturn<T, M = undefined> {
@@ -32,6 +38,7 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[], M = undefin
   fetchPage,
   limit = 24,
   deps = [] as unknown as A,
+  compareFn,
 }: UseInfiniteScrollOptions<T, A, M>): UseInfiniteScrollReturn<T, M> {
   const [items, setItems] = useState<T[]>([]);
   const [metadata, setMetadata] = useState<M | undefined>(undefined);
@@ -58,6 +65,9 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[], M = undefin
 
   const depsRef = useRef(deps);
   depsRef.current = deps;
+
+  const compareFnRef = useRef(compareFn);
+  compareFnRef.current = compareFn;
 
   const sentinelRefInternal = useRef<HTMLDivElement | null>(null);
   const observerRef = useRef<IntersectionObserver | null>(null);
@@ -144,15 +154,25 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[], M = undefin
     if (resetInProgressRef.current) return;
     setItems((prev) => {
       if (prev.some((i) => (i as { id: string }).id === (item as { id: string }).id)) return prev;
-      return [item, ...prev];
+      const next = [item, ...prev];
+      if (compareFnRef.current) {
+        next.sort(compareFnRef.current);
+      }
+      return next;
     });
   }, []);
 
   const updateItem = useCallback((item: T) => {
     if (resetInProgressRef.current) return;
-    setItems((prev) =>
-      prev.map((i) => ((i as { id: string }).id === (item as { id: string }).id ? item : i))
-    );
+    setItems((prev) => {
+      const next = prev.map((i) =>
+        (i as { id: string }).id === (item as { id: string }).id ? item : i
+      );
+      if (compareFnRef.current) {
+        next.sort(compareFnRef.current);
+      }
+      return next;
+    });
   }, []);
 
   const removeItem = useCallback((id: string) => {

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -140,6 +140,47 @@ export default function PlaylistDetailPage() {
     return opts;
   }, [search, sort, order, filterTags, filterSources]);
 
+  // ── Comparator for re-sorting after real-time mutations ──────────────
+  type PS = PlaylistDetail['songs'][number];
+  const playlistSongCompareFn = useMemo(() => {
+    const dir = order === 'asc' ? 1 : -1;
+    return (a: PS, b: PS): number => {
+      switch (sort) {
+        case 'title': {
+          // Sort by display name: nickname if set, otherwise title
+          const aName = (a.song.nickname || a.song.title) ?? '';
+          const bName = (b.song.nickname || b.song.title) ?? '';
+          return dir * aName.localeCompare(bName, undefined, { sensitivity: 'base' });
+        }
+        case 'artist': {
+          const aArt = a.song.artist ?? '';
+          const bArt = b.song.artist ?? '';
+          if (!aArt && !bArt) return 0;
+          if (!aArt) return dir;
+          if (!bArt) return -dir;
+          return dir * aArt.localeCompare(bArt, undefined, { sensitivity: 'base' });
+        }
+        case 'album': {
+          const aAlb = a.song.album ?? '';
+          const bAlb = b.song.album ?? '';
+          if (!aAlb && !bAlb) return 0;
+          if (!aAlb) return dir;
+          if (!bAlb) return -dir;
+          return dir * aAlb.localeCompare(bAlb, undefined, { sensitivity: 'base' });
+        }
+        case 'duration':
+          return dir * ((a.song.duration ?? 0) - (b.song.duration ?? 0));
+        case 'createdAt':
+          return (
+            dir * (new Date(a.song.createdAt).getTime() - new Date(b.song.createdAt).getTime())
+          );
+        default:
+          // position — lower position first for asc, higher first for desc
+          return dir * (a.position - b.position);
+      }
+    };
+  }, [sort, order]);
+
   // ── Infinite scroll with metadata ────────────────────────────────────
 
   const {
@@ -185,6 +226,7 @@ export default function PlaylistDetailPage() {
       isAdminView,
       songsOpts,
     ],
+    compareFn: playlistSongCompareFn,
   });
 
   // Derive PlaylistDetail for JSX — metadata from the hook, songs from items

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -134,6 +134,43 @@ export default function SongsPage() {
       });
   }, [isAdminView]);
 
+  // ── Comparator for re-sorting after real-time mutations ──────────────
+  const songCompareFn = useMemo(() => {
+    const dir = order === 'asc' ? 1 : -1;
+    return (a: Song, b: Song): number => {
+      switch (sort) {
+        case 'title': {
+          // Sort by display name: nickname if set, otherwise title
+          const aName = (a.nickname || a.title) ?? '';
+          const bName = (b.nickname || b.title) ?? '';
+          return dir * aName.localeCompare(bName, undefined, { sensitivity: 'base' });
+        }
+        case 'artist': {
+          const aArt = a.artist ?? '';
+          const bArt = b.artist ?? '';
+          // nulls last, regardless of direction
+          if (!aArt && !bArt) return 0;
+          if (!aArt) return dir;
+          if (!bArt) return -dir;
+          return dir * aArt.localeCompare(bArt, undefined, { sensitivity: 'base' });
+        }
+        case 'album': {
+          const aAlb = a.album ?? '';
+          const bAlb = b.album ?? '';
+          if (!aAlb && !bAlb) return 0;
+          if (!aAlb) return dir;
+          if (!bAlb) return -dir;
+          return dir * aAlb.localeCompare(bAlb, undefined, { sensitivity: 'base' });
+        }
+        case 'duration':
+          return dir * ((a.duration ?? 0) - (b.duration ?? 0));
+        default:
+          // createdAt — newest first for desc, oldest first for asc
+          return dir * (new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+      }
+    };
+  }, [sort, order]);
+
   // ── Infinite scroll ─────────────────────────────────────────────────
   const {
     items,
@@ -159,6 +196,7 @@ export default function SongsPage() {
     },
     limit: ITEMS_PER_PAGE,
     deps: [songsOpts],
+    compareFn: songCompareFn,
   });
 
   // ── Real-time socket wiring ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

Title sort now uses the displayed name (nickname if set, otherwise title) instead of the raw title. Also fixes real-time websocket updates so items re-sort into the correct position after mutation.

## Changes

- **server**: `buildSongOrderBy` now sorts by `COALESCE(NULLIF(TRIM(nickname), ''), title)` instead of just `title`, matching what the UI displays
- **web**: `useVirtualizedInfiniteScroll` now accepts an optional `compareFn` and re-sorts after `prepend`/`updateItem` mutations
- **web**: `SongsPage` and `PlaylistDetailPage` pass comparators keyed on the active sort field/order, respecting `nickname || title` for the title sort