### PR TITLE
fix(web): sort options not applying on playlist detail page

### DIFF
--- a/packages/web/src/hooks/useVirtualizedInfiniteScroll.ts
+++ b/packages/web/src/hooks/useVirtualizedInfiniteScroll.ts
@@ -222,7 +222,7 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[], M = undefin
   const depsArray = [...deps, loadPage];
   useEffect(() => {
     isMountedRef.current = true;
-    void loadPage(1, true, deps[0] as string | undefined);
+    void loadPage(1, true);
 
     return () => {
       isMountedRef.current = false;


### PR DESCRIPTION
## Summary

The `useVirtualizedInfiniteScroll` hook's effect was passing only `deps[0]` as a search override when deps changed. On SongsPage (`deps = [songsOpts]`), this happened to work because the first element was the full options object. On PlaylistDetailPage (`deps = [id, isAdminView, songsOpts]`), only the playlist ID was passed — the `isAdminView` boolean and the `songsOpts` (containing sort/order/filters) were silently dropped.

## Changes

- Fixed the effect to call `loadPage(1, true)` without a search override, so it falls back to `depsRef.current` which always has the latest full deps array