### PR TITLE
fix(web): sort options not applying on playlist detail page (#664)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Songs now sort by display name instead of raw title, matching the displayed value (#654).
+- Sort options now correctly apply on the playlist detail page (#664).
 - Removed broken `softprops/action-gh-release` step from the release workflow (#617).
 
 ### Dependencies

--- a/packages/web/src/hooks/useVirtualizedInfiniteScroll.ts
+++ b/packages/web/src/hooks/useVirtualizedInfiniteScroll.ts
@@ -222,7 +222,7 @@ export function useVirtualizedInfiniteScroll<T, A extends unknown[], M = undefin
   const depsArray = [...deps, loadPage];
   useEffect(() => {
     isMountedRef.current = true;
-    void loadPage(1, true, deps[0] as string | undefined);
+    void loadPage(1, true);
 
     return () => {
       isMountedRef.current = false;


### PR DESCRIPTION
Hotfix cherry-picked from dev for v0.1.1 release.\n\n- Fixes sort options not applying on playlist detail page\n- Updates changelog