### PR TITLE
chore(ci): point dependabot at dev instead of main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: 'npm'
     directory: '/'
+    target-branch: 'dev'
     schedule:
       interval: 'weekly'
     cooldown:
@@ -15,12 +16,14 @@ updates:
           - 'seyfert'
   - package-ecosystem: 'docker'
     directory: '/'
+    target-branch: 'dev'
     schedule:
       interval: 'weekly'
     cooldown:
       default-days: 7
   - package-ecosystem: 'github-actions'
     directory: '/'
+    target-branch: 'dev'
     schedule:
       interval: 'weekly'
     cooldown:


### PR DESCRIPTION
Dependabot reads its config from the default branch, so this needs to be on main to take effect.