### PR TITLE
fix: drop ws dependency and fix WebSocket double-connect

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,12 +18,10 @@
         "drizzle-orm": "0.45.2",
         "jsonwebtoken": "9.0.3",
         "seyfert": "5.0.0",
-        "ws": "8.21.1",
       },
       "devDependencies": {
         "@types/jsonwebtoken": "9.0.10",
         "@types/node": "25.9.4",
-        "@types/ws": "8.18.1",
         "bun-types": "1.3.14",
         "typescript": "7.0.2",
       },
@@ -55,7 +53,6 @@
     "react-dom": "19.2.7",
     "serialize-javascript": "7.0.4",
     "undici": "6.24.0",
-    "ws": "8.21.0",
   },
   "packages": {
     "@alfira-bot/server": ["@alfira-bot/server@workspace:packages/server"],
@@ -221,8 +218,6 @@
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
-
-    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 
@@ -390,8 +385,6 @@
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
-    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
-
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
@@ -406,15 +399,11 @@
 
     "@types/jsonwebtoken/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
-    "@types/ws/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
-
     "bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "lightningcss/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "@types/jsonwebtoken/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "@types/ws/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
   }

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -16,8 +16,6 @@ Prefer stdlib/native runtime APIs over npm packages. Bun's built-in HTTP, WebSoc
 
 ### Dependencies we keep intentionally
 
-**`ws`** — Bun's global `WebSocket` follows the WHATWG standard (`new WebSocket(url, protocols?)`) which provides no way to set custom HTTP headers on the handshake. The `ws` library supports `new WebSocket(url, { headers })`, which is needed to send `Authorization` and `User-Id` headers when connecting to NodeLink. This is a small (sub-1MB), focused, well-maintained package filling a genuine gap in the WHATWG API.
-
 **`seyfert`** — Handles the Discord gateway protocol: heartbeats, identify, resume, sharding, opcode dispatch, and rate-limit backpressure. The codebase interacts with it at only ~6 call sites, but those are backed by hundreds of lines of non-trivial protocol logic. Reimplementing that correctly would be error-prone and violate the spirit of "better dependencies."
 
 **`jsonwebtoken`** — Bun has Web Crypto API primitives (HMAC-SHA256, base64url) but no built-in JWT encode/decode. Implementing JWT from scratch — with correct expiration, audience, and algorithm handling — would be a net negative in maintenance surface area. This is a focused, zero-dependency library.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "type": "module",
   "scripts": {
-    "dev": "bun run --filter @alfira-bot/server build && docker compose up --build",
+    "dev": "bun run --filter @alfira-bot/server build && docker compose -f docker-compose.dev.yml up --build",
     "web:build": "bun run --filter @alfira-bot/web build",
     "db:migrate": "bun run --filter @alfira-bot/server db:migrate",
     "db:generate": "bun run --filter @alfira-bot/server db:generate",
@@ -30,8 +30,7 @@
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "serialize-javascript": "7.0.4",
-    "undici": "6.24.0",
-    "ws": "8.21.0"
+    "undici": "6.24.0"
   },
   "packageManager": "bun@1.3.11"
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,13 +19,11 @@
   "dependencies": {
     "drizzle-orm": "0.45.2",
     "jsonwebtoken": "9.0.3",
-    "seyfert": "5.0.0",
-    "ws": "8.21.1"
+    "seyfert": "5.0.0"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "9.0.10",
     "@types/node": "25.9.4",
-    "@types/ws": "8.18.1",
     "bun-types": "1.3.14",
     "typescript": "7.0.2"
   }

--- a/packages/server/src/lib/lavalink.ts
+++ b/packages/server/src/lib/lavalink.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from 'node:events';
-import WebSocket from 'ws';
 
 import { logger } from '../shared/logger';
 
@@ -137,27 +136,28 @@ class LavalinkSocket extends EventEmitter<LavalinkEvents> {
     if (this._userId) headers['User-Id'] = this._userId;
     headers['Client-Name'] = 'Alfira';
 
-    const ws = new WebSocket(this.url, { headers });
+    // Bun extends WebSocket constructor with { headers } option
+    const ws = new WebSocket(this.url, { headers } as never);
     this.ws = ws;
 
-    ws.on('open', () => {
+    ws.addEventListener('open', () => {
       logger.info({ url: this.url }, 'Lavalink WebSocket open');
       this.reconnectAttempt = 0;
     });
 
-    ws.on('message', (data: Buffer) => {
+    ws.addEventListener('message', (event: MessageEvent) => {
       let msg: LavalinkMessage;
       try {
-        msg = JSON.parse(data.toString()) as LavalinkMessage;
+        msg = JSON.parse(event.data as string) as LavalinkMessage;
       } catch {
-        logger.warn({ raw: data.toString().slice(0, 200) }, 'Lavalink: unparseable message');
+        logger.warn({ raw: String(event.data).slice(0, 200) }, 'Lavalink: unparseable message');
         return;
       }
       this.dispatch(msg);
     });
 
-    ws.on('close', (code: number) => {
-      logger.warn({ code }, 'Lavalink WebSocket closed');
+    ws.addEventListener('close', (event: CloseEvent) => {
+      logger.warn({ code: event.code }, 'Lavalink WebSocket closed');
       this.ws = null;
       this._sessionId = null;
 
@@ -171,8 +171,8 @@ class LavalinkSocket extends EventEmitter<LavalinkEvents> {
       }
     });
 
-    ws.on('error', (err: Error) => {
-      logger.error({ err }, 'Lavalink WebSocket error');
+    ws.addEventListener('error', (event: Event) => {
+      logger.error({ event }, 'Lavalink WebSocket error');
     });
   }
 

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -6,7 +6,7 @@
     "ignoreDeprecations": "7.0",
     "rootDir": "./src",
     "paths": { "*": ["./*"] },
-    "lib": ["ESNext"],
+    "lib": ["ESNext", "DOM"],
     "types": ["bun-types", "node"],
     "outDir": "./dist",
     "strict": true,

--- a/packages/web/src/hooks/useSocket.ts
+++ b/packages/web/src/hooks/useSocket.ts
@@ -16,6 +16,7 @@ type ConnectionStatus = 'connected' | 'disconnected' | 'reconnecting';
 let ws: WebSocket | null = null;
 let connectionStatus: ConnectionStatus = 'disconnected';
 let reconnectAttempt = 0;
+let intentionalClose = false;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- internal storage holds callbacks of varying types
 const eventListeners = new Map<string, Set<(...args: any[]) => void>>();
 const statusListeners = new Set<() => void>();
@@ -39,6 +40,7 @@ function scheduleReconnect() {
 }
 
 function connect() {
+  intentionalClose = false;
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
   ws = new WebSocket(`${protocol}//${window.location.host}/ws`);
 
@@ -49,7 +51,9 @@ function connect() {
 
   ws.addEventListener('close', () => {
     setStatus('disconnected');
-    scheduleReconnect();
+    if (!intentionalClose) {
+      scheduleReconnect();
+    }
   });
 
   ws.addEventListener('error', () => {
@@ -96,6 +100,7 @@ export function useConnectionStatus(): ConnectionStatus {
 }
 
 export function disposeSocket(): void {
+  intentionalClose = true;
   if (ws) {
     ws.close();
     ws = null;

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,4 +1,3 @@
-import { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
@@ -15,9 +14,7 @@ if (!rootElement) {
 }
 
 ReactDOM.createRoot(rootElement).render(
-  <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
-  </StrictMode>
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>
 );


### PR DESCRIPTION
## Summary

Replaced the `ws` npm package with Bun's native WebSocket client for the NodeLink connection, and fixed a double WebSocket connection bug that prevented player bar updates from appearing in the web UI.

## Changes

- **Drop `ws` dependency** — Replaced with Bun's native `WebSocket` client in `lavalink.ts`. Bun supports custom headers via `new WebSocket(url, { headers })` making the npm package unnecessary. Added `"DOM"` to `tsconfig.json` `lib` for `MessageEvent`/`CloseEvent` types.
- **Fix double WebSocket connection** — Removed `<StrictMode>` from `main.tsx` which caused mount/unmount/remount cycles in the Docker dev environment, creating duplicate WebSocket connections that raced with `player:update` events.
- **Add `intentionalClose` guard** — `disposeSocket()` now prevents the close event handler from scheduling a reconnect.
- **Fix `bun dev`** — Points to `docker-compose.dev.yml` instead of the production compose file.
- **Update docs** — Removed outdated `ws` justification from `philosophy.md`.