### PR TITLE
fix(web): fix nested button hydration and font preload warnings

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -129,6 +129,7 @@ export default defineConfig({
       rules: {
         'jsx-a11y/no-static-element-interactions': 'off',
         'jsx-a11y/click-events-have-key-events': 'off',
+        'jsx-a11y/prefer-tag-over-role': 'off',
       },
     },
 

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -24,29 +24,10 @@
       href="/fonts/chiron-go-round-tc-400-latin.woff2"
       as="font"
       type="font/woff2"
-      crossorigin
     />
-    <link
-      rel="preload"
-      href="/fonts/jetbrains-mono-400-latin.woff2"
-      as="font"
-      type="font/woff2"
-      crossorigin
-    />
-    <link
-      rel="preload"
-      href="/fonts/cherry-bomb-one-400-latin.woff2"
-      as="font"
-      type="font/woff2"
-      crossorigin
-    />
-    <link
-      rel="preload"
-      href="/fonts/jetbrains-mono-500-latin.woff2"
-      as="font"
-      type="font/woff2"
-      crossorigin
-    />
+    <link rel="preload" href="/fonts/jetbrains-mono-400-latin.woff2" as="font" type="font/woff2" />
+    <link rel="preload" href="/fonts/cherry-bomb-one-400-latin.woff2" as="font" type="font/woff2" />
+    <link rel="preload" href="/fonts/jetbrains-mono-500-latin.woff2" as="font" type="font/woff2" />
   </head>
   <body>
     <div id="root"></div>

--- a/packages/web/src/components/SongCard.tsx
+++ b/packages/web/src/components/SongCard.tsx
@@ -214,8 +214,9 @@ const SongCardInner = ({
       data-song-id={song.id}
       data-song-edit-container
     >
-      <button
-        type='button'
+      <div
+        role='button'
+        tabIndex={canEdit || selectionMode ? 0 : -1}
         className='flex items-center gap-3 md:gap-4 px-4 py-4 w-full text-left bg-transparent border-0'
         onClick={handleListClick}
         onKeyDown={(e) => {
@@ -296,7 +297,7 @@ const SongCardInner = ({
             triggerRef={triggerRef}
           />
         )}
-      </button>
+      </div>
 
       {/* Inline edit panel */}
       <div className={`expand-panel ${isOpen ? 'expanded' : ''}`}>


### PR DESCRIPTION
## Summary

Fixes four browser console warnings/errors in the web UI.

## Changes

- **Fix nested `<button>` hydration error**: Changed the outer row wrapper in SongCard list variant from `<button>` to `<div role="button">` with conditional `tabIndex` to avoid nesting PlayButton and ContextMenuTrigger buttons inside another button
- **Fix font preload `crossorigin` mismatch**: Removed `crossorigin` attribute from font preload `<link>` tags in index.html — same-origin fonts don't need CORS, and the mismatch caused preloaded resources not to be consumed
- **Suppress `prefer-tag-over-role` lint warning**: Added the rule to the existing SongCard oxlint override since we intentionally use `role="button"` on a `<div>` to avoid invalid nested buttons