### PR TITLE
chore(deps): remove unused undici override

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -52,7 +52,6 @@
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "serialize-javascript": "7.0.4",
-    "undici": "6.24.0",
   },
   "packages": {
     "@alfira-bot/server": ["@alfira-bot/server@workspace:packages/server"],

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "lodash": "4.17.23",
     "react": "19.2.7",
     "react-dom": "19.2.7",
-    "serialize-javascript": "7.0.4",
-    "undici": "6.24.0"
+    "serialize-javascript": "7.0.4"
   },
   "packageManager": "bun@1.3.11"
 }


### PR DESCRIPTION
## Summary

Remove the unused `undici` version override from `package.json`. Seyfert 5.0.0 uses Bun's native `fetch` directly — the override was a leftover from the Seyfert v4 era when `@discordjs/rest` (which depended on undici) was in use.

## Changes

- Remove `undici` from `overrides` in `package.json`
- Update `bun.lock` (undici no longer installed)