### PR TITLE
refactor(server): replace jsonwebtoken with bun-native crypto hasher

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,11 +16,9 @@
       "version": "0.1.1",
       "dependencies": {
         "drizzle-orm": "0.45.2",
-        "jsonwebtoken": "9.0.3",
         "seyfert": "5.0.0",
       },
       "devDependencies": {
-        "@types/jsonwebtoken": "9.0.10",
         "@types/node": "25.9.4",
         "bun-types": "1.3.14",
         "typescript": "7.0.2",
@@ -208,10 +206,6 @@
 
     "@tanstack/virtual-core": ["@tanstack/virtual-core@3.17.4", "", {}, "sha512-nGm5KteqxasUdThLc2izl6dHUqLv0LQj7Nuyo5gYalTPf/U8a9ermvsl7reT+6ioBW1l8WfpP/mcU338nLXpqw=="],
 
-    "@types/jsonwebtoken": ["@types/jsonwebtoken@9.0.10", "", { "dependencies": { "@types/ms": "*", "@types/node": "*" } }, "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA=="],
-
-    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
-
     "@types/node": ["@types/node@25.9.4", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g=="],
 
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
@@ -260,8 +254,6 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
-
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
@@ -271,8 +263,6 @@
     "detect-libc": ["detect-libc@1.0.3", "", { "bin": { "detect-libc": "./bin/detect-libc.js" } }, "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="],
 
     "drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
-
-    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.21.6", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ=="],
 
@@ -287,12 +277,6 @@
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
-
-    "jsonwebtoken": ["jsonwebtoken@9.0.3", "", { "dependencies": { "jws": "^4.0.1", "lodash.includes": "^4.3.0", "lodash.isboolean": "^3.0.3", "lodash.isinteger": "^4.0.4", "lodash.isnumber": "^3.0.3", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.once": "^4.0.0", "ms": "^2.1.1", "semver": "^7.5.4" } }, "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g=="],
-
-    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
-
-    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -318,27 +302,11 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
-    "lodash.includes": ["lodash.includes@4.3.0", "", {}, "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="],
-
-    "lodash.isboolean": ["lodash.isboolean@3.0.3", "", {}, "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="],
-
-    "lodash.isinteger": ["lodash.isinteger@4.0.4", "", {}, "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="],
-
-    "lodash.isnumber": ["lodash.isnumber@3.0.3", "", {}, "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="],
-
-    "lodash.isplainobject": ["lodash.isplainobject@4.0.6", "", {}, "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="],
-
-    "lodash.isstring": ["lodash.isstring@4.0.1", "", {}, "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="],
-
-    "lodash.once": ["lodash.once@4.1.1", "", {}, "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="],
-
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
-
-    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
@@ -360,11 +328,7 @@
 
     "react-router-dom": ["react-router-dom@7.18.1", "", { "dependencies": { "react-router": "7.18.1" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg=="],
 
-    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
-
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
-
-    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
@@ -396,13 +360,9 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "@types/jsonwebtoken/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
-
     "bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "lightningcss/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
-
-    "@types/jsonwebtoken/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
   }

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -18,8 +18,6 @@ Prefer stdlib/native runtime APIs over npm packages. Bun's built-in HTTP, WebSoc
 
 **`seyfert`** — Handles the Discord gateway protocol: heartbeats, identify, resume, sharding, opcode dispatch, and rate-limit backpressure. The codebase interacts with it at only ~6 call sites, but those are backed by hundreds of lines of non-trivial protocol logic. Reimplementing that correctly would be error-prone and violate the spirit of "better dependencies."
 
-**`jsonwebtoken`** — Bun has Web Crypto API primitives (HMAC-SHA256, base64url) but no built-in JWT encode/decode. Implementing JWT from scratch — with correct expiration, audience, and algorithm handling — would be a net negative in maintenance surface area. This is a focused, zero-dependency library.
-
 ---
 
 ## 3. Single-process simplicity by design

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -18,11 +18,9 @@
   },
   "dependencies": {
     "drizzle-orm": "0.45.2",
-    "jsonwebtoken": "9.0.3",
     "seyfert": "5.0.0"
   },
   "devDependencies": {
-    "@types/jsonwebtoken": "9.0.10",
     "@types/node": "25.9.4",
     "bun-types": "1.3.14",
     "typescript": "7.0.2"

--- a/packages/server/src/lib/jwt.ts
+++ b/packages/server/src/lib/jwt.ts
@@ -1,0 +1,99 @@
+/**
+ * Minimal JWT implementation using Bun.CryptoHasher for HMAC-SHA256 (HS256).
+ * Replaces the `jsonwebtoken` npm package.
+ *
+ * Only supports HS256 — the only algorithm this project uses.
+ */
+
+// Standard JWT header for HS256
+const JWT_HEADER = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'; // base64url({"alg":"HS256","typ":"JWT"})
+
+/** Encode a string as base64url (RFC 7515). */
+function base64url(input: string): string {
+  // Bun's btoa uses standard base64. Convert to base64url.
+  return btoa(input).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/** Decode a base64url string. */
+function base64urlDecode(input: string): string {
+  // Restore padding and convert to standard base64, then decode.
+  const base64 = input.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
+  return atob(padded);
+}
+
+/** Parse an expiresIn string like "1h", "30d", "15m" to seconds. */
+function parseExpiresIn(expiresIn: string): number {
+  const match = expiresIn.match(/^(\d+)([smhd])$/);
+  if (!match || !match[1] || !match[2]) throw new Error(`Invalid expiresIn format: ${expiresIn}`);
+  const num = parseInt(match[1], 10);
+  const unit = match[2];
+  const multipliers: Record<string, number> = { s: 1, m: 60, h: 3600, d: 86400 };
+  return num * (multipliers[unit] ?? 1);
+}
+
+/** Compute HMAC-SHA256 of data using the given key. */
+function hmacSha256(key: string, data: string): Uint8Array {
+  const hasher = new Bun.CryptoHasher('sha256', key);
+  hasher.update(data);
+  return hasher.digest();
+}
+
+/**
+ * Sign a payload and return a JWT string.
+ *
+ * The payload must be a plain object (no functions, no circular refs).
+ * iat and exp are added automatically.
+ */
+export function sign(
+  payload: Record<string, unknown>,
+  secret: string,
+  options: { expiresIn: string }
+): string {
+  const now = Math.floor(Date.now() / 1000);
+  const exp = now + parseExpiresIn(options.expiresIn);
+
+  const payloadWithClaims = {
+    ...payload,
+    iat: now,
+    exp,
+  };
+
+  const data = `${JWT_HEADER}.${base64url(JSON.stringify(payloadWithClaims))}`;
+  const signature = base64url(String.fromCharCode(...hmacSha256(secret, data)));
+
+  return `${data}.${signature}`;
+}
+
+/**
+ * Verify a JWT token and return the decoded payload.
+ * Returns null if the token is invalid, expired, or has a bad signature.
+ */
+export function verify<T = Record<string, unknown>>(token: string, secret: string): T | null {
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+
+  const headerB64 = parts[0] as string;
+  const payloadB64 = parts[1] as string;
+  const signatureB64 = parts[2] as string;
+
+  // Verify the signature
+  const data = `${headerB64}.${payloadB64}`;
+  const expectedSig = base64url(String.fromCharCode(...hmacSha256(secret, data)));
+  if (signatureB64 !== expectedSig) return null;
+
+  // Decode and parse the payload
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(base64urlDecode(payloadB64));
+  } catch {
+    return null;
+  }
+
+  // Check expiration
+  if (typeof payload.exp === 'number' && payload.exp < Math.floor(Date.now() / 1000)) {
+    return null;
+  }
+
+  return payload as T;
+}

--- a/packages/server/src/middleware/requireAuth.ts
+++ b/packages/server/src/middleware/requireAuth.ts
@@ -1,4 +1,4 @@
-import jwt from 'jsonwebtoken';
+import { verify } from '../lib/jwt';
 import type { User } from '../shared';
 
 /**
@@ -9,9 +9,5 @@ export function verifySessionToken(token: string): User | null {
   const { JWT_SECRET } = process.env;
   if (!JWT_SECRET) return null;
 
-  try {
-    return jwt.verify(token, JWT_SECRET) as User;
-  } catch {
-    return null;
-  }
+  return verify<User>(token, JWT_SECRET);
 }

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 import { and, eq, lt } from 'drizzle-orm';
-import jwt from 'jsonwebtoken';
+import { sign, verify } from '../lib/jwt';
 import type { RouteContext } from '../index';
 import { getGuildId } from '../lib/config';
 import { json } from '../lib/json';
@@ -112,15 +112,11 @@ function generateAccessToken(payload: {
   isSetupAdmin?: boolean;
   roles?: string[];
 }): string {
-  return jwt.sign(payload, JWT_SECRET_, {
-    expiresIn: ACCESS_TOKEN_EXPIRES_IN,
-  } as jwt.SignOptions);
+  return sign(payload, JWT_SECRET_, { expiresIn: ACCESS_TOKEN_EXPIRES_IN });
 }
 
 function generateRefreshToken(discordId: string): string {
-  return jwt.sign({ discordId, type: 'refresh' }, JWT_SECRET_, {
-    expiresIn: REFRESH_TOKEN_EXPIRES_IN,
-  } as jwt.SignOptions);
+  return sign({ discordId, type: 'refresh' }, JWT_SECRET_, { expiresIn: REFRESH_TOKEN_EXPIRES_IN });
 }
 
 function buildCookieHeader(
@@ -512,16 +508,14 @@ async function handleRefresh(
   }
 
   // 1. Verify the refresh token signature and expiration.
-  let decoded: { discordId: string; type: string };
-  try {
-    decoded = jwt.verify(refreshToken, JWT_SECRET_) as { discordId: string; type: string };
-    if (decoded.type !== 'refresh') {
-      logger.warn({ decodedType: decoded.type }, 'Auth refresh failed: invalid token type');
-      return json({ error: 'Invalid token type.' }, 401);
-    }
-  } catch (err) {
-    logger.warn({ err: (err as Error).message }, 'Auth refresh failed: JWT verification');
+  const decoded = verify<{ discordId: string; type: string }>(refreshToken, JWT_SECRET_);
+  if (!decoded) {
+    logger.warn('Auth refresh failed: JWT verification');
     return json({ error: 'Invalid or expired refresh token.' }, 401);
+  }
+  if (decoded.type !== 'refresh') {
+    logger.warn({ decodedType: decoded.type }, 'Auth refresh failed: invalid token type');
+    return json({ error: 'Invalid token type.' }, 401);
   }
 
   // 2. Check if the refresh token exists in the database (not revoked).


### PR DESCRIPTION
## Summary

Replaces the `jsonwebtoken` npm package and its transitive dependencies with a ~95-line JWT utility built on `Bun.CryptoHasher` (HMAC-SHA256). Only HS256 is needed — the only algorithm the project uses.

## Changes

- **Add** `packages/server/src/lib/jwt.ts` — `sign()` and `verify()` using Bun's native crypto hasher
- **Update** `middleware/requireAuth.ts` — swap `jwt.verify` for the new `verify<User>` (returns null instead of throwing)
- **Update** `routes/auth.ts` — swap all 3 `jwt.sign` calls and 1 `jwt.verify` call
- **Remove** `jsonwebtoken` and `@types/jsonwebtoken` from `package.json`
- **Update** `docs/philosophy.md` — remove now-stale jsonwebtoken justification