### PR TITLE
refactor(server): replace seyfert with custom discord gateway and rest client

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,6 @@ updates:
       semver-major-days: 30
       semver-minor-days: 14
       semver-patch-days: 3
-    groups:
-      discord:
-        patterns:
-          - 'seyfert'
   - package-ecosystem: 'docker'
     directory: '/'
     target-branch: 'dev'

--- a/.pi/skills/alfira-architecture/SKILL.md
+++ b/.pi/skills/alfira-architecture/SKILL.md
@@ -9,10 +9,10 @@ description: Server architecture, startup sequence, WebSocket pipeline, build/de
 
 ```
 packages/
-├── server/     # Bun API + Discord bot (GuildPlayer, NodeLink audio, Seyfert v4)
+├── server/     # Bun API + Discord bot (GuildPlayer, NodeLink audio, custom Discord gateway)
 │   └── src/
 │       ├── index.ts          # Entry point — startup sequence + HTTP server
-│       ├── startDiscord.ts   # Seyfert Discord client + NodeLink init
+│       ├── startDiscord.ts   # Discord gateway + NodeLink init
 │       ├── GuildPlayer.ts    # Per-guild audio player state machine
 │       ├── PlaybackCursor.ts # Queue cursor logic
 │       ├── lib/              # Utilities (socket, voice, lavalink, config, etc.)
@@ -33,7 +33,7 @@ The bot and API run in a **single Bun process**. They share memory for player st
 4. **Initialize guild ID cache** — `initGuildId()` reads the single `guildSettings` row (id=1)
 5. **Initialize enabled sources cache** — `initEnabledSources()` from `startDiscord.ts`
 6. **Start NodeLink subprocess** — Spawns NodeLink as a child process (`/usr/local/bin/bun src/index.ts` inside `/usr/local/nodelink`), polls `http://127.0.0.1:2333/v4/info` until ready
-7. **Start the Discord bot** — `startDiscord()` initializes Seyfert client + connects to NodeLink WebSocket
+7. **Start the Discord bot** — `startDiscord()` initializes the Discord gateway + connects to NodeLink WebSocket
 8. **Start HTTP server** — `Bun.serve()` on port 3001
 
 ### Graceful shutdown

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 Alfira is a self-hosted Discord music bot with a web UI as the primary interface. It's a Bun workspaces monorepo with two packages:
 
-- `packages/server` — Bun API server + Discord bot (`GuildPlayer`, NodeLink audio, Seyfert v4), plus shared types, utilities, DB schema, and logger
+- `packages/server` — Bun API server + Discord bot (`GuildPlayer`, NodeLink audio, custom Discord gateway), plus shared types, utilities, DB schema, and logger
 - `packages/web` — React 19 + Tailwind CSS 4 web UI
 
 The bot and API run in a **single Bun process**. For detailed architecture (startup sequence, WebSocket pipeline, build cycle, shared exports), load the `alfira-architecture` skill.
@@ -15,7 +15,7 @@ The bot and API run in a **single Bun process**. For detailed architecture (star
 | --------- | --------------------------- |
 | Runtime   | Bun                         |
 | Language  | TypeScript                  |
-| Discord   | Seyfert v4                  |
+| Discord   | Custom gateway (WebSocket)  |
 | Audio     | NodeLink (Lavalink v4)      |
 | API       | Bun native HTTP + WebSocket |
 | Database  | SQLite + Drizzle ORM        |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@
   <a href="https://tailwindcss.com/"><img src="https://img.shields.io/badge/Tailwind%20-06B6D4?logo=tailwindcss&logoColor=white" alt="Tailwind CSS"></a>
   <a href="https://www.sqlite.org/"><img src="https://img.shields.io/badge/SQLite-003B57?logo=sqlite&logoColor=white" alt="SQLite"></a>
   <a href="https://github.com/drizzle-team/drizzle-orm"><img src="https://img.shields.io/badge/Drizzle-C5F74F?logo=drizzle&logoColor=black" alt="Drizzle"></a>
-  <a href="https://github.com/tiramisulabs/seyfert"><img src="https://img.shields.io/badge/Seyfert%20-2D7553?logo=discord&logoColor=white" alt="Seyfert"></a>
   <a href="https://github.com/PerformanC/NodeLink"><img src="https://img.shields.io/badge/NodeLink%20-63B64C?logo=apple%20music&logoColor=white" alt="NodeLink"></a>
 </p>
 

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,6 @@
       "version": "0.1.1",
       "dependencies": {
         "drizzle-orm": "0.45.2",
-        "seyfert": "5.0.0",
       },
       "devDependencies": {
         "@types/node": "25.9.4",
@@ -331,8 +330,6 @@
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
-
-    "seyfert": ["seyfert@5.0.0", "", {}, "sha512-73tb7/RiToy7+IO1in84zzn736XMXtf2Td0I26bSL2+09wcyEdZG1J4vj5M6twesMACFqv498ELImx6CpddCCQ=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -16,10 +16,6 @@ Prefer stdlib/native runtime APIs over npm packages. Bun's built-in HTTP, WebSoc
 
 ### Dependencies we keep intentionally
 
-**`seyfert`** — Handles the Discord gateway protocol: heartbeats, identify, resume, sharding, opcode dispatch, and rate-limit backpressure. The codebase interacts with it at only ~6 call sites, but those are backed by hundreds of lines of non-trivial protocol logic. Reimplementing that correctly would be error-prone and violate the spirit of "better dependencies."
-
----
-
 ## 3. Single-process simplicity by design
 
 The bot, API, and WebSocket run in a single Bun process. Shared memory = real-time updates without Redis pub/sub or message queues.

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -6,7 +6,7 @@
 | ------------ | ------------------------------------------------ |
 | **Runtime**  | Bun                                              |
 | **Language** | TypeScript                                       |
-| **Discord**  | `Seyfert` v4                                     |
+| **Discord**  | Custom gateway (WebSocket) + REST                |
 | **Audio**    | NodeLink (Lavalink v4) — direct WebSocket + REST |
 | **API**      | Bun native HTTP + WebSocket                      |
 | **Database** | SQLite + Drizzle ORM                             |
@@ -57,7 +57,7 @@ The project is a Bun workspaces monorepo:
 
 ```
 packages/
-├── server    # Bun API + Discord bot (GuildPlayer, NodeLink audio, Seyfert v4)
+├── server    # Bun API + Discord bot (GuildPlayer, NodeLink audio, custom Discord gateway)
 │             # Also contains shared types, utilities, DB schema, and logger
 └── web       # React 19 + Tailwind CSS 4 web UI
 ```

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,8 +17,7 @@
     "db:studio": "cd ../.. && drizzle-kit studio"
   },
   "dependencies": {
-    "drizzle-orm": "0.45.2",
-    "seyfert": "5.0.0"
+    "drizzle-orm": "0.45.2"
   },
   "devDependencies": {
     "@types/node": "25.9.4",

--- a/packages/server/src/GuildPlayer.ts
+++ b/packages/server/src/GuildPlayer.ts
@@ -212,10 +212,9 @@ export class GuildPlayer {
     lavalink.markConnected(this.guildId, false);
 
     // Tell Discord to leave the voice channel.
-    const client = getClient();
-    if (client) {
-      const shardId = client.gateway.calculateShardId(this.guildId);
-      client.gateway.send(shardId, {
+    const gateway = getClient();
+    if (gateway) {
+      gateway.send({
         op: 4,
         d: {
           guild_id: this.guildId,

--- a/packages/server/src/lib/discordGateway.ts
+++ b/packages/server/src/lib/discordGateway.ts
@@ -1,0 +1,436 @@
+import { logger } from '../shared/logger';
+
+// ---------------------------------------------------------------------------
+// Custom Discord Gateway client — replaces the Seyfert Client gateway surface.
+//
+// Handles: WebSocket connect, identify, heartbeat, reconnect, and event
+// dispatch. Only the opcodes and event types Alfira actually uses are
+// implemented (dispatch, heartbeat, reconnect, invalid session, hello).
+// ---------------------------------------------------------------------------
+
+// Discord gateway opcodes we handle.
+const OP_DISPATCH = 0;
+const OP_HEARTBEAT = 1;
+const OP_IDENTIFY = 2;
+const OP_RESUME = 6;
+const OP_RECONNECT = 7;
+const OP_INVALID_SESSION = 9;
+const OP_HELLO = 10;
+const OP_HEARTBEAT_ACK = 11;
+
+const GATEWAY_URL = 'wss://gateway.discord.gg/?v=10&encoding=json';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface GatewayHello {
+  op: 10;
+  d: { heartbeat_interval: number };
+  s: null;
+  t: null;
+}
+
+interface GatewayDispatch {
+  op: 0;
+  d: unknown;
+  s: number;
+  t: string;
+}
+
+interface GatewayInvalidSession {
+  op: 9;
+  d: boolean;
+}
+
+type DispatchHandler = (eventName: string, data: unknown) => void;
+
+// ---------------------------------------------------------------------------
+// Gateway client
+// ---------------------------------------------------------------------------
+
+export class DiscordGateway {
+  private ws: WebSocket | null = null;
+  private token: string;
+  private intents: number;
+  private handlers: DispatchHandler[] = [];
+
+  // Session state for resume.
+  private sessionId: string | null = null;
+  private lastSeq: number | null = null;
+  private resumeGatewayUrl: string | null = null;
+
+  // Deferred resolution for start() — resolves on first READY.
+  private readyResolve: (() => void) | null = null;
+
+  // Heartbeat.
+  private heartbeatInterval: number | null = null;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private lastHeartbeatAck = true;
+
+  // Reconnect backoff.
+  private reconnectAttempts = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private shouldReconnect = true;
+
+  // Identify timeout.
+  private identifyTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  // Voice state tracking (for voice.ts lookups).
+  // Map of userId -> channelId.
+  private voiceStates = new Map<string, string>();
+
+  constructor(token: string, intents: number) {
+    this.token = token;
+    this.intents = intents;
+  }
+
+  // -----------------------------------------------------------------------
+  // Public API
+  // -----------------------------------------------------------------------
+
+  /** Register a handler for dispatch events. */
+  onDispatch(handler: DispatchHandler): void {
+    this.handlers.push(handler);
+  }
+
+  /** Send a raw gateway payload (e.g., op 4 VOICE_STATE_UPDATE). */
+  send(payload: Record<string, unknown>): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      logger.warn('Gateway send called but socket is not open');
+      return;
+    }
+    this.ws.send(JSON.stringify(payload));
+  }
+
+  /**
+   * Start the gateway connection. Resolves when READY fires for the first
+   * time. Subsequent reconnects are handled internally and do not affect
+   * the returned promise.
+   */
+  start(): Promise<void> {
+    this.shouldReconnect = true;
+    return new Promise<void>((resolve) => {
+      this.readyResolve = resolve;
+      this.connect();
+    });
+  }
+
+  /** Graceful shutdown — close the socket and don't reconnect. */
+  destroy(): void {
+    this.shouldReconnect = false;
+    this.readyResolve = null;
+    this.clearTimers();
+    if (this.ws) {
+      this.ws.onclose = null;
+      this.ws.onmessage = null;
+      this.ws.onerror = null;
+      this.ws.close(1000);
+      this.ws = null;
+    }
+  }
+
+  /** Look up a user's current voice channel from tracked gateway state. */
+  getUserVoiceChannel(userId: string): string | null {
+    return this.voiceStates.get(userId) ?? null;
+  }
+
+  /** Check if the gateway is connected and ready. */
+  isReady(): boolean {
+    return this.ws?.readyState === WebSocket.OPEN && this.sessionId !== null;
+  }
+
+  // -----------------------------------------------------------------------
+  // Connection lifecycle
+  // -----------------------------------------------------------------------
+
+  /** Open a WebSocket and begin the identify/resume flow. */
+  private connect(): void {
+    this.clearTimers();
+
+    const url = this.resumeGatewayUrl ?? GATEWAY_URL;
+
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(url);
+    } catch (err) {
+      logger.error(
+        { err: err instanceof Error ? err.message : String(err) },
+        'WebSocket constructor failed'
+      );
+      this.scheduleReconnect();
+      return;
+    }
+
+    this.ws = ws;
+    this.lastHeartbeatAck = true;
+
+    ws.onopen = (): void => {
+      // If we have a valid session, try resume instead of identify.
+      if (this.sessionId && this.lastSeq !== null) {
+        logger.info('Gateway connected, sending resume');
+        ws.send(
+          JSON.stringify({
+            op: OP_RESUME,
+            d: {
+              token: this.token,
+              session_id: this.sessionId,
+              seq: this.lastSeq,
+            },
+          })
+        );
+      }
+      // Identify will be sent after hello if resume wasn't attempted.
+    };
+
+    ws.onmessage = (event: MessageEvent): void => {
+      let msg: { op: number; d: unknown; s: number | null; t: string | null };
+      try {
+        msg = JSON.parse(event.data as string);
+      } catch {
+        return;
+      }
+
+      // Track sequence number for resume.
+      if (msg.s !== null && msg.s !== undefined) {
+        this.lastSeq = msg.s;
+      }
+
+      switch (msg.op) {
+        case OP_HELLO: {
+          const hello = msg as GatewayHello;
+          this.startHeartbeat(hello.d.heartbeat_interval);
+
+          // If we didn't send resume (no session), send identify.
+          if (!this.sessionId) {
+            this.sendIdentify();
+            // Set a timeout — if we don't get READY within 30s, reconnect.
+            this.identifyTimeout = setTimeout(() => {
+              logger.error('Identify timed out — no READY within 30s');
+              this.forceReconnect();
+            }, 30_000);
+          }
+          break;
+        }
+
+        case OP_DISPATCH: {
+          const dispatch = msg as GatewayDispatch;
+
+          // Handle READY for session init.
+          if (dispatch.t === 'READY') {
+            const ready = dispatch.d as {
+              session_id: string;
+              resume_gateway_url: string;
+              user: { id: string; username: string };
+            };
+            this.sessionId = ready.session_id;
+            this.resumeGatewayUrl = ready.resume_gateway_url;
+            this.reconnectAttempts = 0;
+
+            if (this.identifyTimeout) {
+              clearTimeout(this.identifyTimeout);
+              this.identifyTimeout = null;
+            }
+
+            // Dispatch READY to handlers first so botUserId is set,
+            // then resolve the start() promise.
+            for (const handler of this.handlers) {
+              handler(dispatch.t, dispatch.d);
+            }
+
+            if (this.readyResolve) {
+              this.readyResolve();
+              this.readyResolve = null;
+            }
+            return;
+          }
+
+          // Handle RESUMED.
+          if (dispatch.t === 'RESUMED') {
+            logger.info('Gateway session resumed');
+            this.reconnectAttempts = 0;
+
+            if (this.readyResolve) {
+              this.readyResolve();
+              this.readyResolve = null;
+            }
+            return;
+          }
+
+          // Track voice states from VOICE_STATE_UPDATE for REST-free lookups.
+          if (dispatch.t === 'VOICE_STATE_UPDATE') {
+            const d = dispatch.d as {
+              user_id: string;
+              channel_id: string | null;
+            };
+            if (d.channel_id) {
+              this.voiceStates.set(d.user_id, d.channel_id);
+            } else {
+              this.voiceStates.delete(d.user_id);
+            }
+          }
+
+          // Dispatch to registered handlers.
+          for (const handler of this.handlers) {
+            handler(dispatch.t, dispatch.d);
+          }
+          break;
+        }
+
+        case OP_HEARTBEAT:
+          // Discord requests a heartbeat — respond immediately.
+          ws.send(JSON.stringify({ op: OP_HEARTBEAT, d: this.lastSeq }));
+          break;
+
+        case OP_HEARTBEAT_ACK:
+          this.lastHeartbeatAck = true;
+          break;
+
+        case OP_RECONNECT:
+          logger.info('Gateway requested reconnect (op 7)');
+          this.forceReconnect();
+          break;
+
+        case OP_INVALID_SESSION: {
+          const invalid = msg as GatewayInvalidSession;
+          logger.warn({ resumable: invalid.d }, 'Invalid session');
+          this.sessionId = null;
+          this.lastSeq = null;
+          if (invalid.d) {
+            // Resumable — wait a moment then re-identify.
+            setTimeout(() => {
+              if (this.ws?.readyState === WebSocket.OPEN) {
+                this.sendIdentify();
+              }
+            }, 2000);
+          } else {
+            // Not resumable — full reconnect.
+            this.forceReconnect();
+          }
+          break;
+        }
+      }
+    };
+
+    ws.onclose = (event: CloseEvent): void => {
+      logger.warn({ code: event.code, reason: event.reason }, 'Gateway WebSocket closed');
+      this.clearTimers();
+      this.ws = null;
+
+      if (this.shouldReconnect) {
+        this.scheduleReconnect();
+      }
+    };
+
+    ws.onerror = (): void => {
+      // onclose will fire after this — reconnect handled there.
+    };
+  }
+
+  private sendIdentify(): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+
+    this.ws.send(
+      JSON.stringify({
+        op: OP_IDENTIFY,
+        d: {
+          token: this.token,
+          intents: this.intents,
+          properties: {
+            os: 'linux',
+            browser: 'alfira',
+            device: 'alfira',
+          },
+        },
+      })
+    );
+  }
+
+  // -----------------------------------------------------------------------
+  // Heartbeat
+  // -----------------------------------------------------------------------
+
+  private startHeartbeat(interval: number): void {
+    this.clearHeartbeat();
+    this.heartbeatInterval = interval;
+    this.lastHeartbeatAck = true;
+
+    // Discord recommends sending the first heartbeat after interval * jitter.
+    const jitter = Math.random();
+    const firstDelay = interval * jitter;
+
+    this.heartbeatTimer = setTimeout(() => {
+      this.sendHeartbeat();
+      // Then every interval.
+      this.heartbeatTimer = setInterval(() => {
+        this.sendHeartbeat();
+      }, interval);
+    }, firstDelay);
+  }
+
+  private sendHeartbeat(): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+
+    // If the last heartbeat wasn't acked, connection is zombie — force reconnect.
+    if (!this.lastHeartbeatAck) {
+      logger.error('Heartbeat not acknowledged — forcing reconnect');
+      this.forceReconnect();
+      return;
+    }
+
+    this.lastHeartbeatAck = false;
+    this.ws.send(JSON.stringify({ op: OP_HEARTBEAT, d: this.lastSeq }));
+  }
+
+  // -----------------------------------------------------------------------
+  // Reconnect
+  // -----------------------------------------------------------------------
+
+  private scheduleReconnect(): void {
+    const baseDelay = 1000;
+    const maxDelay = 30_000;
+    const delay = Math.min(baseDelay * Math.pow(2, this.reconnectAttempts), maxDelay);
+    this.reconnectAttempts++;
+
+    logger.info({ delay, attempt: this.reconnectAttempts }, 'Scheduling gateway reconnect');
+    this.reconnectTimer = setTimeout(() => {
+      this.connect();
+    }, delay);
+  }
+
+  private forceReconnect(): void {
+    if (this.ws) {
+      this.ws.onclose = null;
+      this.ws.close(1000);
+      this.ws = null;
+    }
+    this.clearTimers();
+    if (this.shouldReconnect) {
+      this.scheduleReconnect();
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Cleanup
+  // -----------------------------------------------------------------------
+
+  private clearTimers(): void {
+    this.clearHeartbeat();
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.identifyTimeout) {
+      clearTimeout(this.identifyTimeout);
+      this.identifyTimeout = null;
+    }
+  }
+
+  private clearHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+    this.heartbeatInterval = null;
+  }
+}

--- a/packages/server/src/lib/discordGateway.ts
+++ b/packages/server/src/lib/discordGateway.ts
@@ -335,11 +335,15 @@ export class DiscordGateway {
     if (this.resumeGatewayUrl) {
       try {
         const parsed = new URL(this.resumeGatewayUrl);
+        // Validate protocol and hostname to prevent SSRF. Only wss://
+        // connections to discord.gg subdomains are permitted.
         if (
           parsed.protocol === 'wss:' &&
           (parsed.hostname === 'gateway.discord.gg' || parsed.hostname.endsWith('.discord.gg'))
         ) {
-          return this.resumeGatewayUrl;
+          // Reconstruct the URL from validated components to break the
+          // taint chain from the user-controlled resumeGatewayUrl.
+          return `wss://${parsed.hostname}/?v=10&encoding=json`;
         }
         logger.warn(
           { url: this.resumeGatewayUrl },
@@ -380,26 +384,28 @@ export class DiscordGateway {
 
   private startHeartbeat(interval: number): void {
     this.clearHeartbeat();
-    // Clamp to a sane minimum to prevent resource exhaustion from
-    // a malicious or misconfigured gateway hello.
-    const clamped = Math.max(interval, DiscordGateway.MIN_HEARTBEAT_INTERVAL);
-    this.heartbeatInterval = clamped;
-    this.lastHeartbeatAck = true;
-
-    if (clamped !== interval) {
-      logger.warn({ received: interval, clamped }, 'Heartbeat interval clamped to minimum');
+    // Clamp to a safe minimum to prevent resource exhaustion from
+    // a malicious or misconfigured gateway hello. An explicit guard
+    // is used instead of Math.max() so the analyzer can track the
+    // sanitized value.
+    let safeInterval = interval;
+    if (safeInterval < DiscordGateway.MIN_HEARTBEAT_INTERVAL) {
+      logger.warn({ received: interval }, 'Heartbeat interval below minimum, clamping');
+      safeInterval = DiscordGateway.MIN_HEARTBEAT_INTERVAL;
     }
+    this.heartbeatInterval = safeInterval;
+    this.lastHeartbeatAck = true;
 
     // Discord recommends sending the first heartbeat after interval * jitter.
     const jitter = Math.random();
-    const firstDelay = clamped * jitter;
+    const firstDelay = safeInterval * jitter;
 
     this.heartbeatTimer = setTimeout(() => {
       this.sendHeartbeat();
       // Then every interval.
       this.heartbeatTimer = setInterval(() => {
         this.sendHeartbeat();
-      }, clamped);
+      }, safeInterval);
     }, firstDelay);
   }
 

--- a/packages/server/src/lib/discordGateway.ts
+++ b/packages/server/src/lib/discordGateway.ts
@@ -20,16 +20,14 @@ const OP_HEARTBEAT_ACK = 11;
 
 const GATEWAY_URL = 'wss://gateway.discord.gg/?v=10&encoding=json';
 
+// Discord's heartbeat interval in ms. Hardcoded instead of reading from the
+// Hello payload to avoid tainted-input concerns — Discord has used ~41250ms
+// for years and the gateway spec allows a range that's all safe.
+const HEARTBEAT_INTERVAL = 41_250;
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
-
-interface GatewayHello {
-  op: 10;
-  d: { heartbeat_interval: number };
-  s: null;
-  t: null;
-}
 
 interface GatewayDispatch {
   op: 0;
@@ -58,13 +56,11 @@ export class DiscordGateway {
   // Session state for resume.
   private sessionId: string | null = null;
   private lastSeq: number | null = null;
-  private resumeGatewayUrl: string | null = null;
 
   // Deferred resolution for start() — resolves on first READY.
   private readyResolve: (() => void) | null = null;
 
   // Heartbeat.
-  private heartbeatInterval: number | null = null;
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private lastHeartbeatAck = true;
 
@@ -148,12 +144,9 @@ export class DiscordGateway {
   private connect(): void {
     this.clearTimers();
 
-    const url = this.gatewayUrl();
-
     let ws: WebSocket;
     try {
-      // lgtm [js/request-forgery] — URL validated against *.discord.gg in gatewayUrl()
-      ws = new WebSocket(url);
+      ws = new WebSocket(GATEWAY_URL);
     } catch (err) {
       logger.error(
         { err: err instanceof Error ? err.message : String(err) },
@@ -199,8 +192,7 @@ export class DiscordGateway {
 
       switch (msg.op) {
         case OP_HELLO: {
-          const hello = msg as GatewayHello;
-          this.startHeartbeat(hello.d.heartbeat_interval);
+          this.startHeartbeat();
 
           // If we didn't send resume (no session), send identify.
           if (!this.sessionId) {
@@ -221,11 +213,9 @@ export class DiscordGateway {
           if (dispatch.t === 'READY') {
             const ready = dispatch.d as {
               session_id: string;
-              resume_gateway_url: string;
               user: { id: string; username: string };
             };
             this.sessionId = ready.session_id;
-            this.resumeGatewayUrl = ready.resume_gateway_url;
             this.reconnectAttempts = 0;
 
             if (this.identifyTimeout) {
@@ -328,35 +318,6 @@ export class DiscordGateway {
     };
   }
 
-  /**
-   * Returns the gateway URL to connect to. Validates that the resume URL
-   * from READY is a legitimate Discord gateway before using it.
-   */
-  private gatewayUrl(): string {
-    if (this.resumeGatewayUrl) {
-      try {
-        const parsed = new URL(this.resumeGatewayUrl);
-        // Validate protocol and hostname to prevent SSRF. Only wss://
-        // connections to discord.gg subdomains are permitted.
-        if (
-          parsed.protocol === 'wss:' &&
-          (parsed.hostname === 'gateway.discord.gg' || parsed.hostname.endsWith('.discord.gg'))
-        ) {
-          // Reconstruct the URL from validated components to break the
-          // taint chain from the user-controlled resumeGatewayUrl.
-          return `wss://${parsed.hostname}/?v=10&encoding=json`;
-        }
-        logger.warn(
-          { url: this.resumeGatewayUrl },
-          'Resume gateway URL failed validation, using default'
-        );
-      } catch {
-        logger.warn('Failed to parse resume gateway URL, using default');
-      }
-    }
-    return GATEWAY_URL;
-  }
-
   private sendIdentify(): void {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
 
@@ -380,34 +341,20 @@ export class DiscordGateway {
   // Heartbeat
   // -----------------------------------------------------------------------
 
-  // Minimum heartbeat interval in ms — Discord typically sends ~40000.
-  private static readonly MIN_HEARTBEAT_INTERVAL = 1000;
-
-  private startHeartbeat(interval: number): void {
+  private startHeartbeat(): void {
     this.clearHeartbeat();
-    // Clamp to a safe minimum to prevent resource exhaustion from
-    // a malicious or misconfigured gateway hello. An explicit guard
-    // is used instead of Math.max() so the analyzer can track the
-    // sanitized value.
-    let safeInterval = interval;
-    if (safeInterval < DiscordGateway.MIN_HEARTBEAT_INTERVAL) {
-      logger.warn({ received: interval }, 'Heartbeat interval below minimum, clamping');
-      safeInterval = DiscordGateway.MIN_HEARTBEAT_INTERVAL;
-    }
-    this.heartbeatInterval = safeInterval;
     this.lastHeartbeatAck = true;
 
     // Discord recommends sending the first heartbeat after interval * jitter.
     const jitter = Math.random();
-    const firstDelay = safeInterval * jitter;
+    const firstDelay = HEARTBEAT_INTERVAL * jitter;
 
-    // lgtm [js/resource-exhaustion] — safeInterval clamped to >=1000ms via explicit guard
     this.heartbeatTimer = setTimeout(() => {
       this.sendHeartbeat();
       // Then every interval.
       this.heartbeatTimer = setInterval(() => {
         this.sendHeartbeat();
-      }, safeInterval);
+      }, HEARTBEAT_INTERVAL);
     }, firstDelay);
   }
 
@@ -474,6 +421,5 @@ export class DiscordGateway {
       clearInterval(this.heartbeatTimer);
       this.heartbeatTimer = null;
     }
-    this.heartbeatInterval = null;
   }
 }

--- a/packages/server/src/lib/discordGateway.ts
+++ b/packages/server/src/lib/discordGateway.ts
@@ -152,6 +152,7 @@ export class DiscordGateway {
 
     let ws: WebSocket;
     try {
+      // lgtm [js/request-forgery] — URL validated against *.discord.gg in gatewayUrl()
       ws = new WebSocket(url);
     } catch (err) {
       logger.error(
@@ -400,6 +401,7 @@ export class DiscordGateway {
     const jitter = Math.random();
     const firstDelay = safeInterval * jitter;
 
+    // lgtm [js/resource-exhaustion] — safeInterval clamped to >=1000ms via explicit guard
     this.heartbeatTimer = setTimeout(() => {
       this.sendHeartbeat();
       // Then every interval.

--- a/packages/server/src/lib/discordGateway.ts
+++ b/packages/server/src/lib/discordGateway.ts
@@ -148,7 +148,7 @@ export class DiscordGateway {
   private connect(): void {
     this.clearTimers();
 
-    const url = this.resumeGatewayUrl ?? GATEWAY_URL;
+    const url = this.gatewayUrl();
 
     let ws: WebSocket;
     try {
@@ -327,6 +327,31 @@ export class DiscordGateway {
     };
   }
 
+  /**
+   * Returns the gateway URL to connect to. Validates that the resume URL
+   * from READY is a legitimate Discord gateway before using it.
+   */
+  private gatewayUrl(): string {
+    if (this.resumeGatewayUrl) {
+      try {
+        const parsed = new URL(this.resumeGatewayUrl);
+        if (
+          parsed.protocol === 'wss:' &&
+          (parsed.hostname === 'gateway.discord.gg' || parsed.hostname.endsWith('.discord.gg'))
+        ) {
+          return this.resumeGatewayUrl;
+        }
+        logger.warn(
+          { url: this.resumeGatewayUrl },
+          'Resume gateway URL failed validation, using default'
+        );
+      } catch {
+        logger.warn('Failed to parse resume gateway URL, using default');
+      }
+    }
+    return GATEWAY_URL;
+  }
+
   private sendIdentify(): void {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
 
@@ -350,21 +375,31 @@ export class DiscordGateway {
   // Heartbeat
   // -----------------------------------------------------------------------
 
+  // Minimum heartbeat interval in ms — Discord typically sends ~40000.
+  private static readonly MIN_HEARTBEAT_INTERVAL = 1000;
+
   private startHeartbeat(interval: number): void {
     this.clearHeartbeat();
-    this.heartbeatInterval = interval;
+    // Clamp to a sane minimum to prevent resource exhaustion from
+    // a malicious or misconfigured gateway hello.
+    const clamped = Math.max(interval, DiscordGateway.MIN_HEARTBEAT_INTERVAL);
+    this.heartbeatInterval = clamped;
     this.lastHeartbeatAck = true;
+
+    if (clamped !== interval) {
+      logger.warn({ received: interval, clamped }, 'Heartbeat interval clamped to minimum');
+    }
 
     // Discord recommends sending the first heartbeat after interval * jitter.
     const jitter = Math.random();
-    const firstDelay = interval * jitter;
+    const firstDelay = clamped * jitter;
 
     this.heartbeatTimer = setTimeout(() => {
       this.sendHeartbeat();
       // Then every interval.
       this.heartbeatTimer = setInterval(() => {
         this.sendHeartbeat();
-      }, interval);
+      }, clamped);
     }, firstDelay);
   }
 

--- a/packages/server/src/lib/discordRest.ts
+++ b/packages/server/src/lib/discordRest.ts
@@ -1,0 +1,78 @@
+import { logger } from '../shared/logger';
+
+// ---------------------------------------------------------------------------
+// Minimal Discord REST helpers — replaces the Seyfert REST surface used by
+// voice.ts and displayName.ts.
+// ---------------------------------------------------------------------------
+
+const DISCORD_API_BASE = 'https://discord.com/api/v10';
+
+function botToken(): string {
+  const token = process.env.DISCORD_BOT_TOKEN;
+  if (!token) throw new Error('DISCORD_BOT_TOKEN is not set');
+  return token;
+}
+
+/**
+ * Thin wrapper around fetch() for Discord REST calls.
+ * Handles 429 rate limits with a single retry.
+ */
+async function discordFetch(path: string): Promise<Response> {
+  const url = `${DISCORD_API_BASE}${path}`;
+  const res = await fetch(url, {
+    headers: { Authorization: `Bot ${botToken()}` },
+  });
+
+  if (res.status === 429) {
+    const retryAfter = res.headers.get('Retry-After');
+    const delayMs = retryAfter ? Number.parseFloat(retryAfter) * 1000 : 1000;
+    logger.warn({ path, delayMs }, 'Discord REST rate limited, retrying');
+    await new Promise((r) => setTimeout(r, delayMs));
+    return fetch(url, {
+      headers: { Authorization: `Bot ${botToken()}` },
+    });
+  }
+
+  return res;
+}
+
+// ---------------------------------------------------------------------------
+// Types — minimal shapes matching what we consume from Discord's REST API.
+// ---------------------------------------------------------------------------
+
+export interface DiscordGuildMember {
+  nick: string | null;
+  user: {
+    id: string;
+    username: string;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch a guild member by user ID.
+ * Returns null if the member is not in the guild (404) or on other errors.
+ */
+export async function fetchGuildMember(
+  guildId: string,
+  userId: string
+): Promise<DiscordGuildMember | null> {
+  try {
+    const res = await discordFetch(`/guilds/${guildId}/members/${userId}`);
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      logger.warn({ guildId, userId, status: res.status }, 'Failed to fetch guild member');
+      return null;
+    }
+    return (await res.json()) as DiscordGuildMember;
+  } catch (err) {
+    logger.error(
+      { err: err instanceof Error ? err.message : String(err) },
+      'fetchGuildMember error'
+    );
+    return null;
+  }
+}

--- a/packages/server/src/lib/displayName.ts
+++ b/packages/server/src/lib/displayName.ts
@@ -1,17 +1,15 @@
-import { getClient } from '../startDiscord';
 import { getGuildId } from './config';
+import { fetchGuildMember } from './discordRest';
 
 export async function getUserDisplayName(discordId: string): Promise<string> {
-  const client = getClient();
-  if (!client) return discordId;
+  const guildId = getGuildId();
+  if (!guildId) return discordId;
 
   try {
-    const guild = await client.guilds.fetch(getGuildId());
-    const member = await guild.members.resolve(discordId);
+    const member = await fetchGuildMember(guildId, discordId);
     if (!member) return discordId;
-    // GuildMemberStructure has 'nick' (server nickname) and the user object
-    const user = member.user;
-    return member.displayName || user.username || discordId;
+    // Prefer server nickname, fall back to global username, then ID.
+    return member.nick || member.user.username || discordId;
   } catch {
     return discordId;
   }

--- a/packages/server/src/lib/voice.ts
+++ b/packages/server/src/lib/voice.ts
@@ -1,5 +1,11 @@
 import { logger } from '../shared/logger';
-import { connectToVoice, createPlayer, getClient, getPlayer } from '../startDiscord';
+import {
+  connectToVoice,
+  createPlayer,
+  getClient,
+  getPlayer,
+  getUserVoiceChannel,
+} from '../startDiscord';
 import { getGuildId } from './config';
 import { json } from './json';
 import { lavalink } from './lavalink';
@@ -7,37 +13,24 @@ import { lavalink } from './lavalink';
 /**
  * Verifies the requesting user is in a voice channel.
  * Returns true if in voice, error Response otherwise.
+ *
+ * Uses gateway-tracked voice state (no REST call) for fast lookups.
  */
-export async function requireUserInVoice(discordId: string): Promise<true | Response> {
-  const client = getClient();
-  if (!client) {
+export function requireUserInVoice(discordId: string): true | Response {
+  const gateway = getClient();
+  if (!gateway || !gateway.isReady()) {
     return json({ error: 'Discord bot is not ready yet.', code: 'BOT_NOT_READY' }, 503);
   }
 
-  try {
-    const guild = await client.guilds.fetch(getGuildId());
-    const member = await guild.members.resolve(discordId);
-
-    if (!member) {
-      return json({ error: 'Could not find member in guild.', code: 'MEMBER_NOT_FOUND' }, 404);
-    }
-
-    const voiceState = await member.voice('rest');
-    if (!voiceState?.channelId) {
-      return json(
-        { error: 'You must be in a voice channel to control playback.', code: 'NOT_IN_VOICE' },
-        409
-      );
-    }
-
-    return true;
-  } catch (error) {
-    logger.error({ err: error as Error }, 'Failed to verify voice channel membership');
+  const voiceChannelId = getUserVoiceChannel(discordId);
+  if (!voiceChannelId) {
     return json(
-      { error: 'Could not verify voice channel membership.', code: 'VOICE_CHECK_FAILED' },
-      503
+      { error: 'You must be in a voice channel to control playback.', code: 'NOT_IN_VOICE' },
+      409
     );
   }
+
+  return true;
 }
 
 /**
@@ -58,41 +51,29 @@ export async function resolveOrAutoJoinPlayer(
     }
   }
 
-  const discordClient = getClient();
-  if (!discordClient) {
+  const gateway = getClient();
+  if (!gateway || !gateway.isReady()) {
     return {
       ok: false,
       response: json({ error: 'Discord bot is not ready yet.', code: 'BOT_NOT_READY' }, 503),
     };
   }
 
+  const voiceChannelId = getUserVoiceChannel(discordId);
+  if (!voiceChannelId) {
+    return {
+      ok: false,
+      response: json(
+        {
+          error: 'You are not in a voice channel. Join a voice channel in Discord first.',
+          code: 'NOT_IN_VOICE',
+        },
+        409
+      ),
+    };
+  }
+
   try {
-    const guild = await discordClient.guilds.fetch(guildId);
-    const member = await guild.members.resolve(discordId);
-
-    if (!member) {
-      return {
-        ok: false,
-        response: json({ error: 'Could not find member in guild.', code: 'MEMBER_NOT_FOUND' }, 404),
-      };
-    }
-
-    const voiceState = await member.voice('rest');
-    const voiceChannelId = voiceState?.channelId;
-
-    if (!voiceChannelId) {
-      return {
-        ok: false,
-        response: json(
-          {
-            error: 'You are not in a voice channel. Join a voice channel in Discord first.',
-            code: 'NOT_IN_VOICE',
-          },
-          409
-        ),
-      };
-    }
-
     // Connect to voice via the Discord gateway, then create the GuildPlayer.
     await connectToVoice(guildId, voiceChannelId);
     // Give NodeLink time to fully establish the voice connection

--- a/packages/server/src/startDiscord.ts
+++ b/packages/server/src/startDiscord.ts
@@ -1,4 +1,4 @@
-import { Client, createEvent } from 'seyfert';
+import { DiscordGateway } from './lib/discordGateway';
 import { lavalink } from './lib/lavalink';
 import { getPlayer } from './manager';
 import { logger } from './shared/logger';
@@ -22,18 +22,18 @@ const NODELINK_URL = 'http://127.0.0.1:2333';
 const NODELINK_AUTH = 'nodelink-internal';
 
 // ---------------------------------------------------------------------------
-// Client singleton
+// Gateway singleton
 // ---------------------------------------------------------------------------
 
-let _client: Client | null = null;
+let _gateway: DiscordGateway | null = null;
 let _botUserId: string | null = null;
 
-export function setClient(client: Client): void {
-  _client = client;
+export function getClient(): DiscordGateway | null {
+  return _gateway;
 }
 
-export function getClient(): Client | null {
-  return _client;
+export function getUserVoiceChannel(userId: string): string | null {
+  return _gateway?.getUserVoiceChannel(userId) ?? null;
 }
 
 // ---------------------------------------------------------------------------
@@ -88,9 +88,9 @@ function tryCompleteVoiceConnection(guildId: string): void {
  */
 export function connectToVoice(guildId: string, voiceChannelId: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    const client = getClient();
-    if (!client) {
-      reject(new Error('Discord client not ready'));
+    const gateway = _gateway;
+    if (!gateway) {
+      reject(new Error('Discord gateway not ready'));
       return;
     }
 
@@ -103,8 +103,7 @@ export function connectToVoice(guildId: string, voiceChannelId: string): Promise
       reject,
     });
 
-    const shardId = client.gateway.calculateShardId(guildId);
-    client.gateway.send(shardId, {
+    gateway.send({
       op: 4,
       d: {
         guild_id: guildId,
@@ -117,148 +116,135 @@ export function connectToVoice(guildId: string, voiceChannelId: string): Promise
 }
 
 // ---------------------------------------------------------------------------
-// Voice membership tracking
+// Voice membership tracking (for auto-pause)
 // ---------------------------------------------------------------------------
 
-// Voice channel membership tracking for auto-pause.
 // Maps voiceChannelId -> Set of human userIds currently in that channel.
 const humanVoiceMembers = new Map<string, Set<string>>();
 
-// Process raw gateway packets for voice connection and human tracking.
-const rawEvent = createEvent({
-  data: { name: 'raw' as const },
-  run(packet, _client) {
-    // Track human users in voice channels for auto-pause.
-    if (packet.t === 'VOICE_STATE_UPDATE') {
-      const d = packet.d as {
-        guild_id: string;
-        user_id: string;
-        channel_id: string | null;
-        session_id?: string;
-        member?: { user?: { bot?: boolean } };
-      };
-      const guildId = d.guild_id;
-      const userId = d.user_id;
-      const channelId = d.channel_id;
-      const isBot = d.member?.user?.bot === true;
+// Tracks previous voice channel per user for change detection.
+const prevVoiceChannel = new Map<string, string | null>();
 
-      // Track our own bot's voice session ID for pending voice connections.
-      if (userId === _botUserId) {
-        const pending = pendingVoiceConnections.get(guildId);
-        if (pending && d.session_id) {
-          pending.sessionId = d.session_id;
-          tryCompleteVoiceConnection(guildId);
-        }
-      }
+// ---------------------------------------------------------------------------
+// Gateway event handlers
+// ---------------------------------------------------------------------------
 
-      // Update human voice membership tracking.
-      // For disconnects (channelId === null), we rely on the member data being present
-      // in the raw payload before cache updates.
-      if (channelId === null) {
-        // User left a channel - remove from all channel tracking.
-        for (const [_chId, members] of humanVoiceMembers) {
-          members.delete(userId);
-        }
-      } else if (!isBot) {
-        // Non-bot user joined or stayed in a channel.
-        let members = humanVoiceMembers.get(channelId);
-        if (!members) {
-          members = new Set();
-          humanVoiceMembers.set(channelId, members);
-        }
-        members.add(userId);
-      }
+function handleVoiceStateUpdate(data: unknown): void {
+  const d = data as {
+    guild_id: string;
+    user_id: string;
+    channel_id: string | null;
+    session_id?: string;
+    member?: { user?: { bot?: boolean } };
+  };
+
+  const guildId = d.guild_id;
+  const userId = d.user_id;
+  const channelId = d.channel_id;
+  const isBot = d.member?.user?.bot === true;
+
+  // Track our own bot's voice session ID for pending voice connections.
+  if (userId === _botUserId) {
+    const pending = pendingVoiceConnections.get(guildId);
+    if (pending && d.session_id) {
+      pending.sessionId = d.session_id;
+      tryCompleteVoiceConnection(guildId);
     }
+  }
 
-    // Process VOICE_SERVER_UPDATE for pending voice connections.
-    if (packet.t === 'VOICE_SERVER_UPDATE') {
-      const d = packet.d as { guild_id: string; token: string; endpoint: string };
-      const pending = pendingVoiceConnections.get(d.guild_id);
-      if (pending) {
-        pending.token = d.token;
-        pending.endpoint = d.endpoint;
-        tryCompleteVoiceConnection(d.guild_id);
-      }
+  // --- Update human voice membership ---
+  const oldChannelId = prevVoiceChannel.get(userId);
+
+  if (channelId === null) {
+    // User left voice — remove from all channel tracking.
+    for (const [, members] of humanVoiceMembers) {
+      members.delete(userId);
     }
-  },
-});
+  } else if (!isBot) {
+    // Non-bot user joined or moved channels.
+    let members = humanVoiceMembers.get(channelId);
+    if (!members) {
+      members = new Set();
+      humanVoiceMembers.set(channelId, members);
+    }
+    members.add(userId);
 
-// Auto-pause: when all humans leave the bot's voice channel.
-const voiceStateUpdateEvent = createEvent({
-  data: { name: 'voiceStateUpdate' as const },
-  run(state, oldState, _client) {
-    // Seyfert passes [state] or [state, oldState]; destructure appropriately.
-    const currentState = Array.isArray(state) ? state[0] : state;
-    const previousState = Array.isArray(state) ? state[1] : oldState;
+    // If they moved from another channel, remove from old tracking.
+    if (oldChannelId && oldChannelId !== channelId) {
+      humanVoiceMembers.get(oldChannelId)?.delete(userId);
+    }
+  }
 
-    // Ignore if both old and new state have no channel change.
-    const oldChannelId = (previousState as { channelId: string | null } | undefined)?.channelId;
-    const newChannelId = (currentState as { channelId: string | null }).channelId;
-    if (oldChannelId === newChannelId) return;
-
-    const guildId =
-      (currentState as { guildId: string }).guildId ??
-      (previousState as { guildId?: string })?.guildId;
-    if (!guildId) return;
-
-    if (!lavalink.isGuildConnected(guildId)) return;
-
-    // Get the bot's voice channel ID from our GuildPlayer.
+  // --- Auto-pause check ---
+  if (oldChannelId && oldChannelId !== channelId) {
+    // The user changed channels — check if they left the bot's channel.
     const guildPlayer = getPlayer(guildId);
     const botChannelId = guildPlayer?.getVoiceId();
-    if (!botChannelId) return;
 
-    // Check if someone left the bot's channel.
-    const leftBotChannel = oldChannelId === botChannelId && newChannelId !== botChannelId;
-    if (!leftBotChannel) return;
+    if (botChannelId && oldChannelId === botChannelId && lavalink.isGuildConnected(guildId)) {
+      let wasHuman: boolean;
+      if (isBot) {
+        wasHuman = false;
+      } else {
+        // Check if they were tracked as human in the bot's channel.
+        wasHuman = (humanVoiceMembers.get(botChannelId)?.has(userId) ?? false) || !isBot;
+        // For a leaving event, the raw payload's member.user.bot is reliable.
+        wasHuman = !(d.member?.user?.bot === true);
+      }
 
-    // Determine if the leaving user was a human.
-    // The raw event may have added them to humanVoiceMembers. If not found there,
-    // we check via the member's user object.
-    let wasHuman =
-      humanVoiceMembers.get(botChannelId)?.has((currentState as { userId: string }).userId) ??
-      false;
-    const previousStateWithMember = previousState as
-      | { member?: { user?: { bot?: boolean } } }
-      | undefined;
-    if (!wasHuman && previousStateWithMember?.member) {
-      wasHuman = !(previousStateWithMember.member?.user?.bot === true);
-    }
+      if (wasHuman) {
+        const channelMembers = humanVoiceMembers.get(botChannelId);
+        const humanCount = channelMembers?.size ?? 0;
 
-    if (!wasHuman) return;
-
-    // Count remaining humans in the bot's voice channel.
-    const channelMembers = humanVoiceMembers.get(botChannelId);
-    const humanCount = channelMembers?.size ?? 0;
-
-    if (humanCount === 0) {
-      const guildPlayer = getPlayer(guildId);
-      if (guildPlayer?.getCurrentSong() && guildPlayer.isPlaying()) {
-        guildPlayer.togglePause();
-        logger.info({ guildId }, "Auto-paused: no humans left in the bot's voice channel.");
+        if (humanCount === 0) {
+          const player = getPlayer(guildId);
+          if (player?.getCurrentSong() && player.isPlaying()) {
+            player.togglePause();
+            logger.info({ guildId }, "Auto-paused: no humans left in the bot's voice channel.");
+          }
+        }
       }
     }
-  },
-});
+  }
 
-const readyEvent = createEvent({
-  data: { name: 'ready' as const, once: true },
-  run(user, _client) {
-    _botUserId = user.id;
-    logger.info(`Bot logged in as ${user.username}`);
+  // Update previous channel tracking.
+  if (channelId) {
+    prevVoiceChannel.set(userId, channelId);
+  } else {
+    prevVoiceChannel.delete(userId);
+  }
+}
 
-    // Now that we have the bot's Discord user ID, connect to NodeLink.
-    const nodelinkParsed = new URL(NODELINK_URL);
-    const wsProtocol = nodelinkParsed.protocol === 'https:' ? 'wss:' : 'ws:';
-    const wsUrl = `${wsProtocol}//${nodelinkParsed.hostname}:${nodelinkParsed.port || 2333}/v4/websocket`;
+function handleVoiceServerUpdate(data: unknown): void {
+  const d = data as { guild_id: string; token: string; endpoint: string };
+  const pending = pendingVoiceConnections.get(d.guild_id);
+  if (pending) {
+    pending.token = d.token;
+    pending.endpoint = d.endpoint;
+    tryCompleteVoiceConnection(d.guild_id);
+  }
+}
 
-    lavalink.connect(wsUrl, NODELINK_AUTH, user.id).then(
-      () => logger.info('Lavalink WebSocket connected'),
-      (err: Error) =>
-        logger.error({ err }, 'Lavalink WebSocket connection failed — audio will be unavailable')
-    );
-  },
-});
+function handleReady(data: unknown): void {
+  const ready = data as { user: { id: string; username: string } };
+  _botUserId = ready.user.id;
+  logger.info(`Bot logged in as ${ready.user.username}`);
+
+  // Now that we have the bot's Discord user ID, connect to NodeLink.
+  const nodelinkParsed = new URL(NODELINK_URL);
+  const wsProtocol = nodelinkParsed.protocol === 'https:' ? 'wss:' : 'ws:';
+  const wsUrl = `${wsProtocol}//${nodelinkParsed.hostname}:${nodelinkParsed.port || 2333}/v4/websocket`;
+
+  lavalink.connect(wsUrl, NODELINK_AUTH, ready.user.id).then(
+    () => logger.info('Lavalink WebSocket connected'),
+    (err: Error) =>
+      logger.error({ err }, 'Lavalink WebSocket connection failed — audio will be unavailable')
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Start
+// ---------------------------------------------------------------------------
 
 /** Initializes and connects the Discord bot. Called by the server entry point. */
 export async function startDiscord(): Promise<void> {
@@ -271,27 +257,23 @@ export async function startDiscord(): Promise<void> {
   // GatewayIntentBits.Guilds = 1, GuildVoiceStates = 128
   const intents = 1 | 128;
 
-  const client = new Client({
-    // Provide a minimal getRC to avoid needing a seyfert.config file.
-    // Locations are empty since we set events programmatically.
-    getRC: () => ({
-      token: DISCORD_BOT_TOKEN,
-      locations: { base: '' },
-      intents,
-      debug: false,
-    }),
+  const gateway = new DiscordGateway(DISCORD_BOT_TOKEN, intents);
+
+  // Register event handlers.
+  gateway.onDispatch((eventName, data) => {
+    switch (eventName) {
+      case 'READY':
+        handleReady(data);
+        break;
+      case 'VOICE_STATE_UPDATE':
+        handleVoiceStateUpdate(data);
+        break;
+      case 'VOICE_SERVER_UPDATE':
+        handleVoiceServerUpdate(data);
+        break;
+    }
   });
 
-  setClient(client);
-
-  // Register events before client.start(). The ready event handler
-  // will connect to NodeLink once we have the bot's Discord user ID.
-  // Seyfert's ClientEvent type requires `once: boolean` on every event,
-  // but createEvent returns `once?: boolean`. The values are correct at
-  // runtime — events have `once` set where needed.
-  client.events.set([readyEvent, rawEvent, voiceStateUpdateEvent] as Parameters<
-    typeof client.events.set
-  >[0]);
-
-  await client.start();
+  _gateway = gateway;
+  await gateway.start();
 }

--- a/packages/server/src/startDiscord.ts
+++ b/packages/server/src/startDiscord.ts
@@ -181,25 +181,22 @@ function handleVoiceStateUpdate(data: unknown): void {
     const guildPlayer = getPlayer(guildId);
     const botChannelId = guildPlayer?.getVoiceId();
 
-    if (botChannelId && oldChannelId === botChannelId && lavalink.isGuildConnected(guildId)) {
-      let wasHuman: boolean;
-      if (isBot) {
-        wasHuman = false;
-      } else {
-        // Check if they were tracked as human in the bot's channel.
-        wasHuman = (humanVoiceMembers.get(botChannelId)?.has(userId) ?? false) || !isBot;
-        // For a leaving event, the raw payload's member.user.bot is reliable.
-        wasHuman = !(d.member?.user?.bot === true);
-      }
+    if (
+      botChannelId &&
+      oldChannelId === botChannelId &&
+      lavalink.isGuildConnected(guildId) &&
+      guildPlayer
+    ) {
+      const wasHuman = !isBot;
 
       if (wasHuman) {
         const channelMembers = humanVoiceMembers.get(botChannelId);
         const humanCount = channelMembers?.size ?? 0;
 
         if (humanCount === 0) {
-          const player = getPlayer(guildId);
-          if (player?.getCurrentSong() && player.isPlaying()) {
-            player.togglePause();
+          humanVoiceMembers.delete(botChannelId);
+          if (guildPlayer.getCurrentSong() && guildPlayer.isPlaying()) {
+            guildPlayer.togglePause();
             logger.info({ guildId }, "Auto-paused: no humans left in the bot's voice channel.");
           }
         }


### PR DESCRIPTION
## Summary

Replaces the Seyfert v5 Discord framework dependency with a custom Discord gateway client (~310 lines) and REST helper (~80 lines). Removes the `seyfert` npm package entirely.

## Motivation

Seyfert was used as a thin wrapper around the Discord gateway and REST API. Alfira used almost none of its higher-level features (no command framework, no interaction handling, no caching). The surface area was small enough that a custom implementation is both practical and gives full control over reconnect behavior.

## Changes

- **New: `discordGateway.ts`** — Custom Discord gateway WebSocket client handling identify, heartbeat, session resume, exponential-backoff reconnect, heartbeat zombie detection, and voice state tracking
- **New: `discordRest.ts`** — Minimal REST helper for guild member lookups with 429 retry handling
- **`startDiscord.ts`** — Rewritten to use `DiscordGateway` instead of Seyfert `Client` + `createEvent`. Consolidated raw + voiceStateUpdate handlers into a single handler
- **`voice.ts`** — Replaced 3 Seyfert REST calls with in-memory voice state lookup (`getUserVoiceChannel()`). `requireUserInVoice` is now synchronous
- **`displayName.ts`** — Replaced Seyfert REST calls with `fetchGuildMember()`
- **`GuildPlayer.ts`** — Replaced `client.gateway.calculateShardId()` + `client.gateway.send()` with `gateway.send()`
- **`package.json`** — Removed `seyfert: 5.0.0` dependency