### PR TITLE
fix(server): cache discord roles and channels to prevent rate-limiting timeouts

### DIFF
--- a/packages/server/src/lib/discordRoles.ts
+++ b/packages/server/src/lib/discordRoles.ts
@@ -1,0 +1,71 @@
+import type { SetupRole } from '../shared/types';
+import { logger } from '../shared/logger';
+
+const DISCORD_API = 'https://discord.com/api/v10';
+
+export function botHeaders(): Record<string, string> {
+  const token = process.env.DISCORD_BOT_TOKEN;
+  if (!token) throw new Error('DISCORD_BOT_TOKEN not set');
+  return { Authorization: `Bot ${token}` };
+}
+
+// ---------------------------------------------------------------------------
+// In-memory cache for Discord guild roles.
+// Prevents rate limiting when the frontend fetches roles on every settings /
+// permissions page visit. Entries expire after 60 seconds.
+// ---------------------------------------------------------------------------
+const CACHE_TTL_MS = 60_000;
+
+interface CacheEntry {
+  data: SetupRole[];
+  expiresAt: number;
+}
+
+// Keyed by guild ID — the setup wizard may query multiple guilds before
+// one is selected, and the settings + permissions pages query the configured
+// guild afterward.
+const rolesCache = new Map<string, CacheEntry>();
+
+/**
+ * Fetch the roles for a Discord guild, filtering out @everyone and managed
+ * (bot-integration) roles. Results are cached for 60 seconds.
+ */
+export async function fetchGuildRoles(guildId: string): Promise<SetupRole[]> {
+  // Serve from cache if available and not expired.
+  const cached = rolesCache.get(guildId);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.data;
+  }
+
+  try {
+    const res = await fetch(`${DISCORD_API}/guilds/${guildId}/roles`, {
+      headers: botHeaders(),
+    });
+
+    if (!res.ok) {
+      logger.error({ guildId, status: res.status }, 'Failed to fetch guild roles from Discord');
+      return [];
+    }
+
+    const roles = (await res.json()) as Array<{
+      id: string;
+      name: string;
+      color: number;
+      managed: boolean;
+    }>;
+
+    const result: SetupRole[] = roles
+      .filter((r) => r.id !== guildId && !r.managed)
+      .map((r) => ({
+        id: r.id,
+        name: r.name,
+        color: r.color,
+      }));
+
+    rolesCache.set(guildId, { data: result, expiresAt: Date.now() + CACHE_TTL_MS });
+    return result;
+  } catch (err) {
+    logger.error({ err }, 'Error fetching guild roles');
+    return [];
+  }
+}

--- a/packages/server/src/routes/permissions.ts
+++ b/packages/server/src/routes/permissions.ts
@@ -1,55 +1,12 @@
 import { eq, inArray } from 'drizzle-orm';
 import type { RouteContext } from '../index';
 import { getGuildId } from '../lib/config';
+import { fetchGuildRoles } from '../lib/discordRoles';
 import { json } from '../lib/json';
 import { checkGuards } from '../lib/routeGuards';
 import { routeTable } from '../lib/routeTable';
 import { PERMISSION_CATEGORIES, PERMISSION_LABELS, type PermissionAction } from '../shared';
 import { db, tables } from '../shared/db';
-import { logger } from '../shared/logger';
-import type { SetupRole } from '../shared/types';
-
-const DISCORD_API = 'https://discord.com/api/v10';
-
-function botHeaders(): Record<string, string> {
-  const token = process.env.DISCORD_BOT_TOKEN;
-  if (!token) throw new Error('DISCORD_BOT_TOKEN not set');
-  return { Authorization: `Bot ${token}` };
-}
-
-async function fetchGuildRoles(): Promise<SetupRole[]> {
-  const guildId = getGuildId();
-  if (!guildId) return [];
-
-  try {
-    const res = await fetch(`${DISCORD_API}/guilds/${guildId}/roles`, {
-      headers: botHeaders(),
-    });
-
-    if (!res.ok) {
-      logger.error({ guildId, status: res.status }, 'Failed to fetch guild roles for permissions');
-      return [];
-    }
-
-    const roles = (await res.json()) as Array<{
-      id: string;
-      name: string;
-      color: number;
-      managed: boolean;
-    }>;
-
-    return roles
-      .filter((r) => r.id !== guildId && !r.managed)
-      .map((r) => ({
-        id: r.id,
-        name: r.name,
-        color: r.color,
-      }));
-  } catch (err) {
-    logger.error({ err }, 'Error fetching guild roles for permissions');
-    return [];
-  }
-}
 
 // ---------------------------------------------------------------------------
 // GET /api/permissions
@@ -62,9 +19,11 @@ async function handleGetPermissions(
   const guards = await checkGuards(ctx, { admin: true });
   if (guards instanceof Response) return guards;
 
+  const guildId = getGuildId();
+
   const [allRows, roles, settingsRow] = await Promise.all([
     db.select().from(tables.rolePermission),
-    fetchGuildRoles(),
+    guildId ? fetchGuildRoles(guildId) : [],
     db
       .select({ adminRoleIds: tables.guildSettings.adminRoleIds })
       .from(tables.guildSettings)

--- a/packages/server/src/routes/setup.ts
+++ b/packages/server/src/routes/setup.ts
@@ -1,20 +1,29 @@
 import { eq } from 'drizzle-orm';
 import type { RouteContext } from '../index';
 import { refreshGuildId } from '../lib/config';
+import { botHeaders, fetchGuildRoles } from '../lib/discordRoles';
 import { json } from '../lib/json';
 import { checkGuards } from '../lib/routeGuards';
 import { routeTable } from '../lib/routeTable';
-import type { SetupChannel, SetupGuild, SetupRole } from '../shared';
+import type { SetupChannel, SetupGuild } from '../shared';
 import { db, tables } from '../shared/db';
 import { logger } from '../shared/logger';
 
 const DISCORD_API = 'https://discord.com/api/v10';
 
-function botHeaders(): Record<string, string> {
-  const token = process.env.DISCORD_BOT_TOKEN;
-  if (!token) throw new Error('DISCORD_BOT_TOKEN not set');
-  return { Authorization: `Bot ${token}` };
+// ---------------------------------------------------------------------------
+// In-memory cache for Discord channels.
+// Prevents rate limiting when the frontend fetches these on every settings
+// page visit. Entries expire after 60 seconds.
+// ---------------------------------------------------------------------------
+const CACHE_TTL_MS = 60_000;
+
+interface CacheEntry<T> {
+  data: T;
+  expiresAt: number;
 }
+
+const channelsCache = new Map<string, CacheEntry<SetupChannel[]>>();
 
 // ---------------------------------------------------------------------------
 // GET /api/setup/status
@@ -131,37 +140,8 @@ async function handleGetRoles(
     return json({ error: 'guildId query parameter is required.' }, 400);
   }
 
-  try {
-    const res = await fetch(`${DISCORD_API}/guilds/${guildId}/roles`, {
-      headers: botHeaders(),
-    });
-
-    if (!res.ok) {
-      logger.error({ guildId, status: res.status }, 'Failed to fetch guild roles from Discord');
-      return json({ error: 'Could not fetch roles from Discord.' }, 502);
-    }
-
-    const roles = (await res.json()) as Array<{
-      id: string;
-      name: string;
-      color: number;
-      managed: boolean;
-    }>;
-
-    // Filter out @everyone (id matches guildId) and managed roles (bot integrations).
-    const result: SetupRole[] = roles
-      .filter((r) => r.id !== guildId && !r.managed)
-      .map((r) => ({
-        id: r.id,
-        name: r.name,
-        color: r.color,
-      }));
-
-    return json({ roles: result });
-  } catch (err) {
-    logger.error({ err }, 'Error fetching guild roles');
-    return json({ error: 'Could not fetch roles.' }, 502);
-  }
+  const roles = await fetchGuildRoles(guildId);
+  return json({ roles });
 }
 
 // ---------------------------------------------------------------------------
@@ -180,6 +160,12 @@ async function handleGetChannels(
   const guildId = url.searchParams.get('guildId');
   if (!guildId) {
     return json({ error: 'guildId query parameter is required.' }, 400);
+  }
+
+  // Serve from cache if available and not expired.
+  const cached = channelsCache.get(guildId);
+  if (cached && cached.expiresAt > Date.now()) {
+    return json({ channels: cached.data });
   }
 
   try {
@@ -206,6 +192,7 @@ async function handleGetChannels(
         name: c.name,
       }));
 
+    channelsCache.set(guildId, { data: result, expiresAt: Date.now() + CACHE_TTL_MS });
     return json({ channels: result });
   } catch (err) {
     logger.error({ err }, 'Error fetching guild channels');

--- a/packages/web/src/components/settings/AdminSection.tsx
+++ b/packages/web/src/components/settings/AdminSection.tsx
@@ -53,9 +53,11 @@ export default function AdminSection() {
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
+    let cancelled = false;
     async function load() {
       try {
         const settings = await fetchGeneralSettings();
+        if (cancelled) return;
         setSaved(settings);
         setAdminRoleIds(settings.adminRoleIds);
         setTimeoutMinutes(settings.voiceIdleTimeoutMinutes);
@@ -73,16 +75,21 @@ export default function AdminSection() {
             fetchSetupRoles(settings.guildId),
             fetchSetupChannels(settings.guildId),
           ]);
+          if (cancelled) return;
           setRoles(rolesRes.roles);
           setChannels(channelsRes.channels);
         }
       } catch {
+        if (cancelled) return;
         setError('Could not load settings.');
       } finally {
-        setLoaded(true);
+        if (!cancelled) setLoaded(true);
       }
     }
     load();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const hasChanges = saved

--- a/packages/web/src/pages/PermissionsPage.tsx
+++ b/packages/web/src/pages/PermissionsPage.tsx
@@ -69,17 +69,23 @@ export default function PermissionsPage() {
 
   // Load ------------------------------------------------------------------
   useEffect(() => {
+    let cancelled = false;
     async function load() {
       try {
         const result = await fetchPermissions();
+        if (cancelled) return;
         setData(result);
         setMapping(result.mapping);
         setSavedMapping(result.mapping);
       } catch {
+        if (cancelled) return;
         setError('Could not load permissions.');
       }
     }
     load();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // Has changes? (strip empty arrays before comparing — toggling on then off


### PR DESCRIPTION
## Summary

Navigating between Settings and other pages repeatedly caused Discord roles to time out after a few round-trips. Each settings page visit hit Discord's API directly for roles and channels — after 3–4 rapid visits, Discord rate-limited the bot and the client's 10s timeout fired.

## Changes

- **New: `lib/discordRoles.ts`** — shared utility with `botHeaders()` and cached `fetchGuildRoles(guildId)` (60s TTL, filters @everyone/managed roles)
- **`setup.ts`** — refactored `handleGetRoles` to use shared module; added 60s cache for channels
- **`permissions.ts`** — refactored `fetchGuildRoles` to use shared module (drops ~55 lines of duplicate code)
- **`AdminSection.tsx`** — added unmount cleanup to prevent stale state updates
- **`PermissionsPage.tsx`** — added unmount cleanup to prevent stale state updates