### PR TITLE
docs: update verify steps and CI references after tsc removal

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@ Closes #
 ## Checklist
 
 - [ ] `bun run check` passes
-- [ ] TypeScript compiles (`bunx tsc --noEmit -p packages/server/tsconfig.json`)
+- [ ] Server and web build (`bun run --filter @alfira/server build && bun run --filter @alfira/web build`)
 - [ ] Manual testing done (describe below)
 - [ ] Documentation updated if needed
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ Every change follows this pipeline. The agent should guide the user through each
 1. **Discuss** — Talk through the problem and explore approaches. Ask clarifying questions before proposing solutions.
 2. **`/plan`** — Before writing any code, produce a written plan: goal, scope (files touched), ordered implementation steps, risks, and verification checklist. Get user agreement on the plan before proceeding.
 3. **Implement** — Follow the plan one step at a time. After each step, confirm it works before moving on. If the plan needs adjustment mid-implementation, say so and update it.
-4. **`/verify`** — The gate before `/submit`. Run `bun run check`, TypeScript compilation (`bunx tsc --noEmit`), review the full diff, and check for untracked files. Report pass/fail for each check. Do not proceed if anything fails.
+4. **`/verify`** — The gate before `/submit`. Run `bun run check`, then `bun run --filter @alfira/server build && bun run --filter @alfira/web build` to verify both packages compile. Review the full diff and check for untracked files. Report pass/fail for each check. Do not proceed if anything fails.
 5. **`/submit`** — Create a feature branch from `dev`, commit with a semantic message, push, and open a PR targeting `dev`.
 6. **Review & Merge** — Address review feedback. CI must pass. Merge to `dev`.
 7. **`/release`** — Batch accumulated `dev` changes into a release PR targeting `main`. Show pending commits, determine version if applicable, open the PR with a changelog.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ bun run lint:fix
 bun run format
 ```
 
-CI runs `bun run lint` in the typecheck workflow — your code must pass before merging.
+CI runs `bun run lint` and `bun run build` for both packages — your code must pass before merging.
 
 ## Editor Tooling
 

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -107,7 +107,7 @@ Four GitHub Actions workflows run on the repository:
 
 | Workflow             | Trigger                                               | Purpose                                                           |
 | -------------------- | ----------------------------------------------------- | ----------------------------------------------------------------- |
-| **ci.yml**           | All PRs, pushes to `main` and `dev`                   | Lint with oxlint + typecheck all packages + Trivy vuln scan       |
+| **ci.yml**           | All PRs, pushes to `main` and `dev`                   | Lint with oxlint + build all packages + Trivy vuln scan           |
 | **codeql.yml**       | All PRs, pushes to `main` and `dev`, weekly schedule  | CodeQL security analysis                                          |
 | **docker-build.yml** | All PRs, pushes to `main` and `dev` (ignores `docs/`) | Build Docker images; publish to GHCR on `main`                    |
 | **release.yml**      | Pushes of `v*` tags                                   | Build multi-arch Docker image, push to GHCR, draft GitHub release |


### PR DESCRIPTION
## Summary

Updates documentation that still referenced `tsc` and typecheck after the build system switch to `bun build`.

## Changes

- **AGENTS.md**: Replace `tsc --noEmit` with `bun build` in the `/verify` step
- **PR template**: Replace `tsc` checklist item with `bun build`
- **tech-stack.md**: `typecheck` → `build` in CI workflow table
- **CONTRIBUTING.md**: Update CI workflow description