### PR TITLE
refactor(server): adopt bun native spawn, routes, and strict sqlite mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ENV NODE_ENV=development
 
 EXPOSE 3001
 
-CMD ["bun", "--env-file=.env", "run", "packages/server/src/index.ts"]
+CMD ["bun", "--env-file=.env", "packages/server/src/index.ts"]
 
 # ---------------------------------------------------------------------------
 # Builder stage — builds all packages but does NOT generate a runtime image.

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,4 +1,3 @@
-import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -176,11 +175,27 @@ async function handleHealth(): Promise<Response> {
 }
 
 // ---------------------------------------------------------------------------
+// Route wrapper — creates auth context for Bun's native routes.
+// ---------------------------------------------------------------------------
+
+/** Wrap a routeTable handler for use with Bun.serve({ routes }). */
+function apiRoute(handler: (ctx: RouteContext, request: Request) => Response | Promise<Response>) {
+  return async (request: Request) => {
+    const ctx = createContext(request);
+    return setSecurityHeaders(await handler(ctx, request));
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Main server
 //
 // Created during startup in main() after migrations, DB verification,
-// and NodeLink are ready. A module-level mutable variable is used because
-// the fetch handler closes over `server` for server.upgrade() calls.
+// and NodeLink are ready. Uses Bun's native routes (v1.2.3+) for all
+// API endpoints; the fetch fallback handles WebSocket upgrades and
+// static file / SPA serving.
+//
+// The server instance is stored in a module-level variable so the
+// shutdown handler can call server.stop().
 // ---------------------------------------------------------------------------
 
 let server: ReturnType<typeof Bun.serve>;
@@ -188,33 +203,50 @@ let server: ReturnType<typeof Bun.serve>;
 function startServer(): void {
   server = Bun.serve({
     port: PORT,
-    async fetch(request) {
+    routes: {
+      '/health': async () => setSecurityHeaders(await handleHealth()),
+      '/api/version': () => setSecurityHeaders(json({ version: VERSION })),
+      '/api/tags': apiRoute(handleTags),
+      '/api/tags/*': apiRoute(handleTags),
+      '/api/requests': apiRoute(handleRequests),
+      '/api/requests/*': apiRoute(handleRequests),
+      '/api/songs': apiRoute(handleSongs),
+      '/api/songs/*': apiRoute(handleSongs),
+      '/api/playlists': apiRoute(handlePlaylists),
+      '/api/playlists/*': apiRoute(handlePlaylists),
+      '/api/player': apiRoute(handlePlayer),
+      '/api/player/*': apiRoute(handlePlayer),
+      '/api/settings/compressor': apiRoute(handleCompressor),
+      '/api/settings/compressor/*': apiRoute(handleCompressor),
+      '/api/settings/equalizer': apiRoute(handleEqualizer),
+      '/api/settings/equalizer/*': apiRoute(handleEqualizer),
+      '/api/permissions': apiRoute(handlePermissions),
+      '/api/permissions/*': apiRoute(handlePermissions),
+      '/api/settings/general': apiRoute(handleGeneralSettings),
+      '/api/settings/general/*': apiRoute(handleGeneralSettings),
+      '/api/setup': apiRoute(handleSetup),
+      '/api/setup/*': apiRoute(handleSetup),
+      '/auth': apiRoute(handleAuth),
+      '/auth/*': apiRoute(handleAuth),
+    },
+    fetch(request, server) {
       const url = new URL(request.url);
 
-      // Health check
-      if (url.pathname === '/health') {
-        return setSecurityHeaders(await handleHealth());
-      }
-
-      // Version — public, no auth required
-      if (url.pathname === '/api/version') {
-        return setSecurityHeaders(json({ version: VERSION }));
-      }
-
-      // WebSocket upgrade — auth is handled here before upgrade
+      // WebSocket upgrade — auth is handled here before upgrade.
+      // `server` is passed as the second argument to fetch (Bun 1.2+).
       if (url.pathname === '/ws') {
         const user = getSessionUser(request.headers.get('cookie') || '');
         if (!user) {
           return new Response('Unauthorized', { status: 401 });
         }
-        // server is assigned before requests arrive (in main()).
-        // The closure captures the mutable variable — it's set by then.
-        const success = server?.upgrade(request, { data: { user } });
+        const success = server.upgrade(request, { data: { user } });
         if (success) return undefined;
         return new Response('WebSocket upgrade failed', { status: 500 });
       }
 
-      // Serve built web assets statically (SPA fallback for client-side routing)
+      // Serve built web assets statically (SPA fallback for client-side routing).
+      // API routes are handled by `routes` above; `fetch` only runs for
+      // unmatched paths (static files, SPA, 404s).
       const pathname = url.pathname;
       const ext = pathname.includes('.') ? `.${pathname.split('.').pop()}` : '.html';
       const isAsset =
@@ -227,44 +259,6 @@ function startServer(): void {
         const filePath = `/app/packages/web/dist${url.pathname === '/' ? '/index.html' : url.pathname}`;
         const response = serveStatic(filePath, url.pathname);
         if (response) return response;
-      }
-
-      // Create auth context for all other routes
-      const ctx = createContext(request);
-
-      // Route matching
-      if (url.pathname.startsWith('/api/tags')) {
-        return setSecurityHeaders(await handleTags(ctx, request));
-      }
-      if (url.pathname.startsWith('/api/requests')) {
-        return setSecurityHeaders(await handleRequests(ctx, request));
-      }
-      if (url.pathname.startsWith('/api/songs')) {
-        return setSecurityHeaders(await handleSongs(ctx, request));
-      }
-      if (url.pathname.startsWith('/api/playlists')) {
-        return setSecurityHeaders(await handlePlaylists(ctx, request));
-      }
-      if (url.pathname.startsWith('/api/player')) {
-        return setSecurityHeaders(await handlePlayer(ctx, request));
-      }
-      if (url.pathname.startsWith('/api/settings/compressor')) {
-        return setSecurityHeaders(await handleCompressor(ctx, request));
-      }
-      if (url.pathname.startsWith('/api/settings/equalizer')) {
-        return setSecurityHeaders(await handleEqualizer(ctx, request));
-      }
-      if (url.pathname.startsWith('/api/permissions')) {
-        return setSecurityHeaders(await handlePermissions(ctx, request));
-      }
-      if (url.pathname.startsWith('/api/settings/general')) {
-        return setSecurityHeaders(await handleGeneralSettings(ctx, request));
-      }
-      if (url.pathname.startsWith('/api/setup')) {
-        return setSecurityHeaders(await handleSetup(ctx, request));
-      }
-      if (url.pathname.startsWith('/auth')) {
-        return setSecurityHeaders(await handleAuth(ctx, request));
       }
 
       return (
@@ -363,23 +357,37 @@ function runMigrations(): void {
 // ---------------------------------------------------------------------------
 function startNodeLink(): Promise<void> {
   return new Promise((resolve) => {
-    nodelinkProcess = spawn('/usr/local/bin/bun', ['src/index.ts'], {
+    nodelinkProcess = Bun.spawn(['/usr/local/bin/bun', 'src/index.ts'], {
       cwd: '/usr/local/nodelink',
-      stdio: 'pipe',
+      stdout: 'pipe',
+      stderr: 'pipe',
       env: { ...process.env, NODELINK_AUTHORIZATION: 'nodelink-internal' },
     });
 
-    nodelinkProcess.stdout?.on('data', (data: Buffer) => {
-      logger.debug({ component: 'NodeLink' }, data.toString().trimEnd());
-    });
+    // Fire-and-forget: consume stdout. ReadableStream chunks may contain
+    // partial lines — a long line split across chunks becomes two log
+    // entries, which matches the Node.js EventEmitter behavior this replaces.
+    void (async () => {
+      const decoder = new TextDecoder();
+      for await (const chunk of nodelinkProcess.stdout as ReadableStream<Uint8Array>) {
+        for (const line of decoder.decode(chunk).split('\n')) {
+          const trimmed = line.trimEnd();
+          if (trimmed) logger.debug({ component: 'NodeLink' }, trimmed);
+        }
+      }
+    })();
 
-    nodelinkProcess.stderr?.on('data', (data: Buffer) => {
-      const line = data.toString().trimEnd();
-      // NodeLink runs git commands internally — these fail harmlessly when
-      // there's no .git directory (production container). Suppress the noise.
-      if (line.includes('fatal:')) return;
-      logger.warn({ component: 'NodeLink' }, line);
-    });
+    // Fire-and-forget: consume stderr, suppressing git "fatal:" noise.
+    void (async () => {
+      const decoder = new TextDecoder();
+      for await (const chunk of nodelinkProcess.stderr as ReadableStream<Uint8Array>) {
+        for (const line of decoder.decode(chunk).split('\n')) {
+          const trimmed = line.trimEnd();
+          if (!trimmed || trimmed.includes('fatal:')) continue;
+          logger.warn({ component: 'NodeLink' }, trimmed);
+        }
+      }
+    })();
 
     const checkReady = async () => {
       try {
@@ -471,7 +479,7 @@ main().catch((err) => {
 // Graceful shutdown
 // ---------------------------------------------------------------------------
 let shuttingDown = false;
-let nodelinkProcess: ReturnType<typeof spawn> | undefined;
+let nodelinkProcess: ReturnType<typeof Bun.spawn> | undefined;
 
 function shutdown(signal: string): void {
   if (shuttingDown) return;

--- a/packages/server/src/shared/db/index.ts
+++ b/packages/server/src/shared/db/index.ts
@@ -15,7 +15,7 @@ if (!DATABASE_URL) {
   throw new Error('DATABASE_URL environment variable is not set');
 }
 
-const sqliteDb = new Database(DATABASE_URL, { create: true });
+const sqliteDb = new Database(DATABASE_URL, { create: true, strict: true });
 sqliteDb.exec('PRAGMA journal_mode=WAL;');
 sqliteDb.exec('PRAGMA foreign_keys=ON;');
 export const db = drizzle(sqliteDb, { schema });


### PR DESCRIPTION
## Summary

Modernize Bun API usage across the server package — replace Node.js `spawn` with `Bun.spawn`, adopt Bun 1.2.3+ native `routes` for HTTP dispatch, use the `fetch(server)` second parameter, enable SQLite `strict` mode, and drop redundant `run` from the Docker dev CMD.

## Changes

- Replace `node:child_process` spawn with `Bun.spawn` for NodeLink subprocess
- Replace hand-rolled `if/else-if` route chain with Bun 1.2.3+ native `routes` object (exact + wildcard entries for each API group)
- Use `fetch(request, server)` second parameter for WebSocket upgrades instead of mutable module-level variable
- Enable `strict: true` on SQLite `Database` constructor to catch missing/typo'd parameter names
- Drop redundant `run` keyword from Dockerfile dev CMD (`bun` executes `.ts` files directly)