### PR TITLE
feat: add rate-limit cooldown feedback to all player controls

### DIFF
--- a/packages/server/src/lib/rateLimit.ts
+++ b/packages/server/src/lib/rateLimit.ts
@@ -17,6 +17,12 @@ interface RateLimitConfig {
   maxRequests: number;
 }
 
+export interface RateLimitInfo {
+  limit: number;
+  remaining: number;
+  resetAt: number; // Unix ms timestamp when the window resets
+}
+
 const DEFAULT_CONFIG: RateLimitConfig = {
   windowMs: 60_000,
   maxRequests: 60,
@@ -36,11 +42,20 @@ export function getClientIp(request: Request): string {
 }
 
 /**
+ * Result of a rate limit check.
+ */
+export interface RateLimitResult extends RateLimitInfo {
+  allowed: boolean;
+}
+
+/**
  * Check whether a request is within the rate limit for a given route group.
- * Returns true if the request is allowed, false if rate-limited.
  *
- * Each call that succeeds increments the counter. Stale entries are pruned
+ * Each call that passes increments the counter. Stale entries are pruned
  * automatically when they're found to be outside the current window.
+ *
+ * Always returns detailed info (remaining, limit, resetAt) so the caller
+ * can attach standard X-RateLimit-* headers to the response.
  *
  * @param group  Identifier for the route group (e.g., 'player-mutations')
  * @param ip     Client IP address
@@ -50,7 +65,7 @@ export function checkRateLimit(
   group: string,
   ip: string,
   config: Partial<RateLimitConfig> = {}
-): boolean {
+): RateLimitResult {
   const { windowMs, maxRequests } = { ...DEFAULT_CONFIG, ...config };
   const now = Date.now();
 
@@ -65,30 +80,57 @@ export function checkRateLimit(
   // First request from this IP, or outside the current window.
   if (!entry || now - entry.windowStart >= windowMs) {
     store.set(ip, { count: 1, windowStart: now });
-    return true;
+    return {
+      allowed: true,
+      limit: maxRequests,
+      remaining: maxRequests - 1,
+      resetAt: now + windowMs,
+    };
   }
+
+  const resetAt = entry.windowStart + windowMs;
 
   // Within the current window but over the limit.
   if (entry.count >= maxRequests) {
-    return false;
+    return { allowed: false, limit: maxRequests, remaining: 0, resetAt };
   }
 
   entry.count++;
-  return true;
+  return { allowed: true, limit: maxRequests, remaining: maxRequests - entry.count, resetAt };
+}
+
+/**
+ * Build standard X-RateLimit-* headers from a RateLimitResult.
+ */
+export function rateLimitHeaders(info: RateLimitInfo): Record<string, string> {
+  return {
+    'X-RateLimit-Limit': String(info.limit),
+    'X-RateLimit-Remaining': String(info.remaining),
+    'X-RateLimit-Reset': String(Math.ceil(info.resetAt / 1000)),
+  };
 }
 
 /**
  * Build a 429 Response for rate-limited requests.
- * Includes Retry-After header.
+ * Includes Retry-After header, rate limit headers, and a JSON body
+ * with retryAfterSeconds so the client can show a countdown.
  */
-export function rateLimitResponse(retryAfterSeconds = 60): Response {
-  return new Response(JSON.stringify({ error: 'Too many requests. Please slow down.' }), {
-    status: 429,
-    headers: {
-      'Content-Type': 'application/json',
-      'Retry-After': String(retryAfterSeconds),
-    },
-  });
+export function rateLimitResponse(info: RateLimitInfo): Response {
+  const retryAfterSeconds = Math.max(1, Math.ceil((info.resetAt - Date.now()) / 1000));
+  return new Response(
+    JSON.stringify({
+      error: 'Too many requests. Please slow down.',
+      retryAfterSeconds,
+    }),
+    {
+      status: 429,
+      headers: {
+        'Content-Type': 'application/json',
+        'Retry-After': String(retryAfterSeconds),
+        ...rateLimitHeaders(info),
+      },
+    }
+  );
 }
 
 /**

--- a/packages/server/src/lib/rateLimit.ts
+++ b/packages/server/src/lib/rateLimit.ts
@@ -111,6 +111,22 @@ export function rateLimitHeaders(info: RateLimitInfo): Record<string, string> {
 }
 
 /**
+ * Attach X-RateLimit-* headers to an existing Response.
+ * Used to annotate successful responses so the client can track budget.
+ */
+export function attachRateLimitHeaders(response: Response, info: RateLimitInfo): Response {
+  const headers = new Headers(response.headers);
+  for (const [key, value] of Object.entries(rateLimitHeaders(info))) {
+    headers.set(key, value);
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+/**
  * Build a 429 Response for rate-limited requests.
  * Includes Retry-After header, rate limit headers, and a JSON body
  * with retryAfterSeconds so the client can show a countdown.

--- a/packages/server/src/lib/routeTable.ts
+++ b/packages/server/src/lib/routeTable.ts
@@ -1,9 +1,9 @@
 import type { RouteContext } from '../index';
 import { json } from './json';
 import {
+  attachRateLimitHeaders,
   checkRateLimit,
   getClientIp,
-  rateLimitHeaders,
   rateLimitResponse,
   type RateLimitInfo,
 } from './rateLimit';
@@ -111,15 +111,7 @@ export function routeTable(
       // Attach rate limit headers to the response so the client can track
       // remaining budget and show approaching / cooldown UI.
       if (rateLimitInfo) {
-        const headers = new Headers(response.headers);
-        for (const [key, value] of Object.entries(rateLimitHeaders(rateLimitInfo))) {
-          headers.set(key, value);
-        }
-        response = new Response(response.body, {
-          status: response.status,
-          statusText: response.statusText,
-          headers,
-        });
+        response = attachRateLimitHeaders(response, rateLimitInfo);
       }
 
       return response;

--- a/packages/server/src/lib/routeTable.ts
+++ b/packages/server/src/lib/routeTable.ts
@@ -1,6 +1,12 @@
 import type { RouteContext } from '../index';
 import { json } from './json';
-import { checkRateLimit, getClientIp, rateLimitResponse } from './rateLimit';
+import {
+  checkRateLimit,
+  getClientIp,
+  rateLimitHeaders,
+  rateLimitResponse,
+  type RateLimitInfo,
+} from './rateLimit';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -81,15 +87,16 @@ export function routeTable(
     const path = url.pathname.slice(prefix.length) || '/';
 
     // Rate-limit non-GET requests.
+    let rateLimitInfo: RateLimitInfo | null = null;
     if (rateLimit && request.method !== 'GET') {
       const ip = getClientIp(request);
-      if (
-        !checkRateLimit(rateLimit.bucket, ip, {
-          windowMs: rateLimit.windowMs,
-          maxRequests: rateLimit.maxRequests,
-        })
-      ) {
-        return rateLimitResponse(60);
+      const result = checkRateLimit(rateLimit.bucket, ip, {
+        windowMs: rateLimit.windowMs,
+        maxRequests: rateLimit.maxRequests,
+      });
+      rateLimitInfo = result;
+      if (!result.allowed) {
+        return rateLimitResponse(result);
       }
     }
 
@@ -99,7 +106,23 @@ export function routeTable(
       const params = matchPath(path, pattern);
       if (params === null) continue;
 
-      return await handler(ctx, request, params);
+      let response = await handler(ctx, request, params);
+
+      // Attach rate limit headers to the response so the client can track
+      // remaining budget and show approaching / cooldown UI.
+      if (rateLimitInfo) {
+        const headers = new Headers(response.headers);
+        for (const [key, value] of Object.entries(rateLimitHeaders(rateLimitInfo))) {
+          headers.set(key, value);
+        }
+        response = new Response(response.body, {
+          status: response.status,
+          statusText: response.statusText,
+          headers,
+        });
+      }
+
+      return response;
     }
 
     return json({ error: 'Not Found' }, 404);

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -9,7 +9,28 @@
 // sent on every request automatically.
 // ---------------------------------------------------------------------------
 
+import { updateRateLimit } from '../hooks/useRateLimit';
+
 const TIMEOUT_MS = 10_000;
+
+// Map URL path prefixes to server-side rate limit bucket names.
+const RATE_LIMIT_BUCKETS: Array<[prefix: string, bucket: string]> = [
+  ['/api/player', 'player-mutations'],
+  ['/api/songs', 'songs-mutations'],
+  ['/api/playlists', 'playlists-mutations'],
+];
+
+function extractRateLimit(url: string, headers: Headers): void {
+  const limit = headers.get('X-RateLimit-Limit');
+  const remaining = headers.get('X-RateLimit-Remaining');
+  const reset = headers.get('X-RateLimit-Reset');
+  if (limit === null || remaining === null || reset === null) return;
+
+  const bucket = RATE_LIMIT_BUCKETS.find(([prefix]) => url.startsWith(prefix))?.[1];
+  if (!bucket) return;
+
+  updateRateLimit(bucket, Number(limit), Number(remaining), Number(reset));
+}
 
 async function fetchWithTimeout(url: string, init?: RequestInit): Promise<Response> {
   const controller = new AbortController();
@@ -186,6 +207,9 @@ async function wrappedFetch(
       throw new ApiError('Unauthorized', 401);
     }
   }
+
+  // Extract rate limit info from headers before consuming the body.
+  extractRateLimit(url, response.headers);
 
   if (!response.ok) {
     // Try to parse error body for code

--- a/packages/web/src/components/BarButton.tsx
+++ b/packages/web/src/components/BarButton.tsx
@@ -7,6 +7,7 @@ export function BarButton({
   onClick,
   busy,
   disabled,
+  dimmed,
   title,
   hoverColor,
   pulse = false,
@@ -16,6 +17,7 @@ export function BarButton({
   onClick: () => void;
   busy: boolean;
   disabled: boolean;
+  dimmed?: boolean;
   title: string;
   hoverColor: string;
   pulse?: boolean;
@@ -28,6 +30,7 @@ export function BarButton({
       size='icon'
       onClick={onClick}
       disabled={disabled}
+      dimmed={dimmed}
       title={title}
       className={`${
         busy

--- a/packages/web/src/components/NowPlayingBar.tsx
+++ b/packages/web/src/components/NowPlayingBar.tsx
@@ -12,12 +12,11 @@ import {
   ShuffleIcon,
   SkipForwardIcon,
 } from '@phosphor-icons/react';
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { usePlayer } from '../context/PlayerContext';
 import { useQueuePanel } from '../context/QueuePanelContext';
-import { useCooldownGuard } from '../hooks/useCooldownGuard';
-import { useNotification } from '../hooks/useNotification';
-import { apiErrorMessage, isRateLimitError } from '../utils/api';
+import { useCooldownGuard, type CooldownState } from '../hooks/useCooldownGuard';
+import { useMutationHandler } from '../hooks/useMutationHandler';
 import { getSourceKey } from '../utils/source';
 import { BarButton } from './BarButton';
 import QueuePanel from './QueuePanel';
@@ -25,6 +24,7 @@ import { SourceIcon } from './SourceIcons';
 import TagTicker from './TagTicker';
 import { ArtworkImage } from './ui/ArtworkImage';
 import { Button } from './ui/Button';
+import { cooldownButtonProps } from './ui/cooldownButtonProps';
 import { VolumeBoostBadge } from './ui/VolumeBoostBadge';
 
 /* ---------------------------------------------------------------------------
@@ -40,12 +40,10 @@ interface PlaybackControlsProps {
   isConnectedToVoice: boolean;
   pauseBusy: boolean;
   skipBusy: boolean;
-  coolingDown: boolean;
-  statusTitle: string | undefined;
+  cooldown: CooldownState;
   onPauseResume: () => void;
   onSkip: () => void;
   onStop: () => void;
-  onCooldownClick: () => void;
 }
 
 const PlaybackControls = memo(function PlaybackControls({
@@ -56,23 +54,22 @@ const PlaybackControls = memo(function PlaybackControls({
   isConnectedToVoice,
   pauseBusy,
   skipBusy,
-  coolingDown,
-  statusTitle,
+  cooldown,
   onPauseResume,
   onSkip,
   onStop,
-  onCooldownClick,
 }: PlaybackControlsProps) {
   const realDisabled = !currentSong || pauseBusy || skipBusy;
 
   return (
     <div className='flex items-center gap-1 md:gap-1.5 shrink-0'>
       <BarButton
-        onClick={coolingDown ? onCooldownClick : onPauseResume}
+        {...cooldownButtonProps(cooldown, {
+          onClick: onPauseResume,
+          disabled: realDisabled,
+          title: isPaused || isStopped ? 'Play' : 'Pause',
+        })}
         busy={pauseBusy}
-        disabled={realDisabled}
-        dimmed={coolingDown}
-        title={statusTitle ?? (isPaused || isStopped ? 'Play' : 'Pause')}
         hoverColor='hover:text-fg'
         pulse={isPlaying && !isPaused}
       >
@@ -83,11 +80,12 @@ const PlaybackControls = memo(function PlaybackControls({
         )}
       </BarButton>
       <BarButton
-        onClick={coolingDown ? onCooldownClick : onSkip}
+        {...cooldownButtonProps(cooldown, {
+          onClick: onSkip,
+          disabled: realDisabled,
+          title: 'Skip',
+        })}
         busy={skipBusy}
-        disabled={realDisabled}
-        dimmed={coolingDown}
-        title={statusTitle ?? 'Skip'}
         hoverColor='hover:text-fg'
         className='hidden md:flex'
       >
@@ -98,10 +96,11 @@ const PlaybackControls = memo(function PlaybackControls({
         variant='inherit'
         surface='base'
         size='icon'
-        onClick={coolingDown ? onCooldownClick : onStop}
-        disabled={!isConnectedToVoice}
-        dimmed={coolingDown}
-        title={statusTitle ?? 'Stop playback'}
+        {...cooldownButtonProps(cooldown, {
+          onClick: onStop,
+          disabled: !isConnectedToVoice,
+          title: 'Stop playback',
+        })}
         className='text-black dark:text-white hover:text-danger md:w-12 md:h-12'
       >
         <DoorOpenIcon size={24} weight='duotone' className='md:w-5 md:h-5' />
@@ -116,11 +115,9 @@ interface LoopShuffleControlsProps {
   isShuffled: boolean;
   loopBusy: boolean;
   shuffleBusy: boolean;
-  coolingDown: boolean;
-  statusTitle: string | undefined;
+  cooldown: CooldownState;
   onCycleLoop: () => void;
   onShuffleToggle: () => void;
-  onCooldownClick: () => void;
 }
 
 const LoopShuffleControls = memo(function LoopShuffleControls({
@@ -129,11 +126,9 @@ const LoopShuffleControls = memo(function LoopShuffleControls({
   isShuffled,
   loopBusy,
   shuffleBusy,
-  coolingDown,
-  statusTitle,
+  cooldown,
   onCycleLoop,
   onShuffleToggle,
-  onCooldownClick,
 }: LoopShuffleControlsProps) {
   const isLoopActive = loopMode !== 'off';
   const loopIcon = isLoopActive ? (
@@ -152,10 +147,11 @@ const LoopShuffleControls = memo(function LoopShuffleControls({
         variant='inherit'
         surface='base'
         size='icon'
-        onClick={coolingDown ? onCooldownClick : onCycleLoop}
-        disabled={!currentSong || loopBusy}
-        dimmed={coolingDown}
-        title={statusTitle ?? `Loop: ${loopMode}`}
+        {...cooldownButtonProps(cooldown, {
+          onClick: onCycleLoop,
+          disabled: !currentSong || loopBusy,
+          title: `Loop: ${loopMode}`,
+        })}
         className={`shrink-0 md:w-12 md:h-12 ${
           isLoopActive
             ? 'pressed text-accent hover:text-accent-muted'
@@ -172,10 +168,11 @@ const LoopShuffleControls = memo(function LoopShuffleControls({
         variant='inherit'
         surface='base'
         size='icon'
-        onClick={coolingDown ? onCooldownClick : onShuffleToggle}
-        disabled={!currentSong || shuffleBusy}
-        dimmed={coolingDown}
-        title={statusTitle ?? (isShuffled ? 'Unshuffle queue' : 'Shuffle queue')}
+        {...cooldownButtonProps(cooldown, {
+          onClick: onShuffleToggle,
+          disabled: !currentSong || shuffleBusy,
+          title: isShuffled ? 'Unshuffle queue' : 'Shuffle queue',
+        })}
         className={`shrink-0 md:w-12 md:h-12 ${
           isShuffled
             ? 'pressed text-accent hover:text-accent-muted'
@@ -456,94 +453,36 @@ export function NowPlayingBar() {
 
   const { queueOpen, setQueueOpen } = useQueuePanel();
 
-  const [pauseBusy, setPauseBusy] = useState(false);
-  const [skipBusy, setSkipBusy] = useState(false);
-  const [loopBusy, setLoopBusy] = useState(false);
-  const [shuffleBusy, setShuffleBusy] = useState(false);
-
-  const { notify } = useNotification();
   const { coolingDown, statusTitle, handleCooldownClick } = useCooldownGuard();
 
-  // Refs provide synchronous guards against rapid clicks bypassing state-based
-  // disabled. React state updates are async, so fast clicks can fire multiple
-  // handlers before the DOM re-renders with disabled={true}.
-  const pauseBusyRef = useRef(false);
-  const skipBusyRef = useRef(false);
-  const loopBusyRef = useRef(false);
-  const shuffleBusyRef = useRef(false);
+  const cooldown: CooldownState = useMemo(
+    () => ({ coolingDown, statusTitle, onCooldownClick: handleCooldownClick }),
+    [coolingDown, statusTitle, handleCooldownClick]
+  );
 
-  const handlePauseResume = useCallback(async () => {
-    if (pauseBusyRef.current) return;
-    pauseBusyRef.current = true;
-    setPauseBusy(true);
-    try {
-      await pause();
-    } catch (err) {
-      if (!isRateLimitError(err)) {
-        notify(apiErrorMessage(err, 'Could not toggle playback.'), 'error', 5000);
-      }
-    } finally {
-      pauseBusyRef.current = false;
-      setPauseBusy(false);
-    }
-  }, [pause, notify]);
-
-  const handleSkip = useCallback(async () => {
-    if (skipBusyRef.current) return;
-    skipBusyRef.current = true;
-    setSkipBusy(true);
-    try {
-      await skip();
-    } catch (err) {
-      if (!isRateLimitError(err)) {
-        notify(apiErrorMessage(err, 'Could not skip track.'), 'error', 5000);
-      }
-    } finally {
-      skipBusyRef.current = false;
-      setSkipBusy(false);
-    }
-  }, [skip, notify]);
+  const { busy: pauseBusy, handler: handlePauseResume } = useMutationHandler(
+    pause,
+    'Could not toggle playback.'
+  );
+  const { busy: skipBusy, handler: handleSkip } = useMutationHandler(skip, 'Could not skip track.');
+  const { busy: loopBusy, handler: handleCycleLoop } = useMutationHandler(
+    useCallback(async () => {
+      const next = loopMode === 'off' ? 'queue' : loopMode === 'queue' ? 'song' : 'off';
+      await setLoop(next);
+    }, [loopMode, setLoop]),
+    'Could not change loop mode.'
+  );
+  const { busy: shuffleBusy, handler: handleShuffleToggle } = useMutationHandler(
+    useCallback(async () => {
+      if (isShuffled) await unshuffle();
+      else await shuffle();
+    }, [isShuffled, shuffle, unshuffle]),
+    'Could not toggle shuffle.'
+  );
 
   const handleStop = useCallback(() => {
     leave().catch((e) => console.error(e));
   }, [leave]);
-
-  const handleCycleLoop = useCallback(async () => {
-    if (loopBusyRef.current) return;
-    loopBusyRef.current = true;
-    setLoopBusy(true);
-    const next = loopMode === 'off' ? 'queue' : loopMode === 'queue' ? 'song' : 'off';
-    try {
-      await setLoop(next);
-    } catch (err) {
-      if (!isRateLimitError(err)) {
-        notify(apiErrorMessage(err, 'Could not change loop mode.'), 'error', 5000);
-      }
-    } finally {
-      loopBusyRef.current = false;
-      setLoopBusy(false);
-    }
-  }, [loopMode, setLoop, notify]);
-
-  const handleShuffleToggle = useCallback(async () => {
-    if (shuffleBusyRef.current) return;
-    shuffleBusyRef.current = true;
-    setShuffleBusy(true);
-    try {
-      if (isShuffled) {
-        await unshuffle();
-      } else {
-        await shuffle();
-      }
-    } catch (err) {
-      if (!isRateLimitError(err)) {
-        notify(apiErrorMessage(err, 'Could not toggle shuffle.'), 'error', 5000);
-      }
-    } finally {
-      shuffleBusyRef.current = false;
-      setShuffleBusy(false);
-    }
-  }, [isShuffled, shuffle, unshuffle, notify]);
 
   const handleSeek = useCallback(
     async (seconds: number) => {
@@ -580,12 +519,10 @@ export function NowPlayingBar() {
           isConnectedToVoice={isConnectedToVoice}
           pauseBusy={pauseBusy}
           skipBusy={skipBusy}
-          coolingDown={coolingDown}
-          statusTitle={statusTitle}
+          cooldown={cooldown}
           onPauseResume={handlePauseResume}
           onSkip={handleSkip}
           onStop={handleStop}
-          onCooldownClick={handleCooldownClick}
         />
 
         {/* Desktop: spacer → art → metadata+progress → spacer → loop/shuffle+queue */}
@@ -613,11 +550,9 @@ export function NowPlayingBar() {
             isShuffled={isShuffled}
             loopBusy={loopBusy}
             shuffleBusy={shuffleBusy}
-            coolingDown={coolingDown}
-            statusTitle={statusTitle}
+            cooldown={cooldown}
             onCycleLoop={handleCycleLoop}
             onShuffleToggle={handleShuffleToggle}
-            onCooldownClick={handleCooldownClick}
           />
           <Button
             variant='inherit'
@@ -689,12 +624,10 @@ export function NowPlayingBar() {
                 loopBusy,
                 shuffleBusy,
                 skipBusy,
-                coolingDown,
-                statusTitle,
+                cooldown,
                 onSkip: handleSkip,
                 onCycleLoop: handleCycleLoop,
                 onShuffleToggle: handleShuffleToggle,
-                onCooldownClick: handleCooldownClick,
               }}
             />
           </div>

--- a/packages/web/src/components/NowPlayingBar.tsx
+++ b/packages/web/src/components/NowPlayingBar.tsx
@@ -15,6 +15,9 @@ import {
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { usePlayer } from '../context/PlayerContext';
 import { useQueuePanel } from '../context/QueuePanelContext';
+import { useCooldownGuard } from '../hooks/useCooldownGuard';
+import { useNotification } from '../hooks/useNotification';
+import { apiErrorMessage, isRateLimitError } from '../utils/api';
 import { getSourceKey } from '../utils/source';
 import { BarButton } from './BarButton';
 import QueuePanel from './QueuePanel';
@@ -37,9 +40,12 @@ interface PlaybackControlsProps {
   isConnectedToVoice: boolean;
   pauseBusy: boolean;
   skipBusy: boolean;
+  coolingDown: boolean;
+  statusTitle: string | undefined;
   onPauseResume: () => void;
   onSkip: () => void;
   onStop: () => void;
+  onCooldownClick: () => void;
 }
 
 const PlaybackControls = memo(function PlaybackControls({
@@ -50,17 +56,23 @@ const PlaybackControls = memo(function PlaybackControls({
   isConnectedToVoice,
   pauseBusy,
   skipBusy,
+  coolingDown,
+  statusTitle,
   onPauseResume,
   onSkip,
   onStop,
+  onCooldownClick,
 }: PlaybackControlsProps) {
+  const realDisabled = !currentSong || pauseBusy || skipBusy;
+
   return (
     <div className='flex items-center gap-1 md:gap-1.5 shrink-0'>
       <BarButton
-        onClick={onPauseResume}
+        onClick={coolingDown ? onCooldownClick : onPauseResume}
         busy={pauseBusy}
-        disabled={!currentSong || pauseBusy || skipBusy}
-        title={isPaused || isStopped ? 'Play' : 'Pause'}
+        disabled={realDisabled}
+        dimmed={coolingDown}
+        title={statusTitle ?? (isPaused || isStopped ? 'Play' : 'Pause')}
         hoverColor='hover:text-fg'
         pulse={isPlaying && !isPaused}
       >
@@ -71,10 +83,11 @@ const PlaybackControls = memo(function PlaybackControls({
         )}
       </BarButton>
       <BarButton
-        onClick={onSkip}
+        onClick={coolingDown ? onCooldownClick : onSkip}
         busy={skipBusy}
-        disabled={!currentSong || pauseBusy || skipBusy}
-        title='Skip'
+        disabled={realDisabled}
+        dimmed={coolingDown}
+        title={statusTitle ?? 'Skip'}
         hoverColor='hover:text-fg'
         className='hidden md:flex'
       >
@@ -85,9 +98,10 @@ const PlaybackControls = memo(function PlaybackControls({
         variant='inherit'
         surface='base'
         size='icon'
-        onClick={onStop}
+        onClick={coolingDown ? onCooldownClick : onStop}
         disabled={!isConnectedToVoice}
-        title='Stop playback'
+        dimmed={coolingDown}
+        title={statusTitle ?? 'Stop playback'}
         className='text-black dark:text-white hover:text-danger md:w-12 md:h-12'
       >
         <DoorOpenIcon size={24} weight='duotone' className='md:w-5 md:h-5' />
@@ -102,8 +116,11 @@ interface LoopShuffleControlsProps {
   isShuffled: boolean;
   loopBusy: boolean;
   shuffleBusy: boolean;
+  coolingDown: boolean;
+  statusTitle: string | undefined;
   onCycleLoop: () => void;
   onShuffleToggle: () => void;
+  onCooldownClick: () => void;
 }
 
 const LoopShuffleControls = memo(function LoopShuffleControls({
@@ -112,8 +129,11 @@ const LoopShuffleControls = memo(function LoopShuffleControls({
   isShuffled,
   loopBusy,
   shuffleBusy,
+  coolingDown,
+  statusTitle,
   onCycleLoop,
   onShuffleToggle,
+  onCooldownClick,
 }: LoopShuffleControlsProps) {
   const isLoopActive = loopMode !== 'off';
   const loopIcon = isLoopActive ? (
@@ -132,10 +152,11 @@ const LoopShuffleControls = memo(function LoopShuffleControls({
         variant='inherit'
         surface='base'
         size='icon'
-        onClick={onCycleLoop}
+        onClick={coolingDown ? onCooldownClick : onCycleLoop}
         disabled={!currentSong || loopBusy}
-        title={`Loop: ${loopMode}`}
-        className={`shrink-0 disabled:opacity-50 md:w-12 md:h-12 ${
+        dimmed={coolingDown}
+        title={statusTitle ?? `Loop: ${loopMode}`}
+        className={`shrink-0 md:w-12 md:h-12 ${
           isLoopActive
             ? 'pressed text-accent hover:text-accent-muted'
             : 'text-black dark:text-white hover:text-fg'
@@ -151,10 +172,11 @@ const LoopShuffleControls = memo(function LoopShuffleControls({
         variant='inherit'
         surface='base'
         size='icon'
-        onClick={onShuffleToggle}
+        onClick={coolingDown ? onCooldownClick : onShuffleToggle}
         disabled={!currentSong || shuffleBusy}
-        title={isShuffled ? 'Unshuffle queue' : 'Shuffle queue'}
-        className={`shrink-0 disabled:opacity-50 md:w-12 md:h-12 ${
+        dimmed={coolingDown}
+        title={statusTitle ?? (isShuffled ? 'Unshuffle queue' : 'Shuffle queue')}
+        className={`shrink-0 md:w-12 md:h-12 ${
           isShuffled
             ? 'pressed text-accent hover:text-accent-muted'
             : 'text-black dark:text-white hover:text-fg'
@@ -439,43 +461,73 @@ export function NowPlayingBar() {
   const [loopBusy, setLoopBusy] = useState(false);
   const [shuffleBusy, setShuffleBusy] = useState(false);
 
+  const { notify } = useNotification();
+  const { coolingDown, statusTitle, handleCooldownClick } = useCooldownGuard();
+
+  // Refs provide synchronous guards against rapid clicks bypassing state-based
+  // disabled. React state updates are async, so fast clicks can fire multiple
+  // handlers before the DOM re-renders with disabled={true}.
+  const pauseBusyRef = useRef(false);
+  const skipBusyRef = useRef(false);
+  const loopBusyRef = useRef(false);
+  const shuffleBusyRef = useRef(false);
+
   const handlePauseResume = useCallback(async () => {
+    if (pauseBusyRef.current) return;
+    pauseBusyRef.current = true;
     setPauseBusy(true);
     try {
       await pause();
-    } catch (e) {
-      console.error(e);
+    } catch (err) {
+      if (!isRateLimitError(err)) {
+        notify(apiErrorMessage(err, 'Could not toggle playback.'), 'error', 5000);
+      }
     } finally {
+      pauseBusyRef.current = false;
       setPauseBusy(false);
     }
-  }, [pause]);
+  }, [pause, notify]);
 
   const handleSkip = useCallback(async () => {
+    if (skipBusyRef.current) return;
+    skipBusyRef.current = true;
     setSkipBusy(true);
     try {
       await skip();
-    } catch (e) {
-      console.error(e);
+    } catch (err) {
+      if (!isRateLimitError(err)) {
+        notify(apiErrorMessage(err, 'Could not skip track.'), 'error', 5000);
+      }
     } finally {
+      skipBusyRef.current = false;
       setSkipBusy(false);
     }
-  }, [skip]);
+  }, [skip, notify]);
 
   const handleStop = useCallback(() => {
     leave().catch((e) => console.error(e));
   }, [leave]);
 
   const handleCycleLoop = useCallback(async () => {
+    if (loopBusyRef.current) return;
+    loopBusyRef.current = true;
     setLoopBusy(true);
     const next = loopMode === 'off' ? 'queue' : loopMode === 'queue' ? 'song' : 'off';
     try {
       await setLoop(next);
+    } catch (err) {
+      if (!isRateLimitError(err)) {
+        notify(apiErrorMessage(err, 'Could not change loop mode.'), 'error', 5000);
+      }
     } finally {
+      loopBusyRef.current = false;
       setLoopBusy(false);
     }
-  }, [loopMode, setLoop]);
+  }, [loopMode, setLoop, notify]);
 
   const handleShuffleToggle = useCallback(async () => {
+    if (shuffleBusyRef.current) return;
+    shuffleBusyRef.current = true;
     setShuffleBusy(true);
     try {
       if (isShuffled) {
@@ -483,10 +535,15 @@ export function NowPlayingBar() {
       } else {
         await shuffle();
       }
+    } catch (err) {
+      if (!isRateLimitError(err)) {
+        notify(apiErrorMessage(err, 'Could not toggle shuffle.'), 'error', 5000);
+      }
     } finally {
+      shuffleBusyRef.current = false;
       setShuffleBusy(false);
     }
-  }, [isShuffled, shuffle, unshuffle]);
+  }, [isShuffled, shuffle, unshuffle, notify]);
 
   const handleSeek = useCallback(
     async (seconds: number) => {
@@ -523,9 +580,12 @@ export function NowPlayingBar() {
           isConnectedToVoice={isConnectedToVoice}
           pauseBusy={pauseBusy}
           skipBusy={skipBusy}
+          coolingDown={coolingDown}
+          statusTitle={statusTitle}
           onPauseResume={handlePauseResume}
           onSkip={handleSkip}
           onStop={handleStop}
+          onCooldownClick={handleCooldownClick}
         />
 
         {/* Desktop: spacer → art → metadata+progress → spacer → loop/shuffle+queue */}
@@ -553,8 +613,11 @@ export function NowPlayingBar() {
             isShuffled={isShuffled}
             loopBusy={loopBusy}
             shuffleBusy={shuffleBusy}
+            coolingDown={coolingDown}
+            statusTitle={statusTitle}
             onCycleLoop={handleCycleLoop}
             onShuffleToggle={handleShuffleToggle}
+            onCooldownClick={handleCooldownClick}
           />
           <Button
             variant='inherit'
@@ -626,9 +689,12 @@ export function NowPlayingBar() {
                 loopBusy,
                 shuffleBusy,
                 skipBusy,
+                coolingDown,
+                statusTitle,
                 onSkip: handleSkip,
                 onCycleLoop: handleCycleLoop,
                 onShuffleToggle: handleShuffleToggle,
+                onCooldownClick: handleCooldownClick,
               }}
             />
           </div>

--- a/packages/web/src/components/QueuePanel.tsx
+++ b/packages/web/src/components/QueuePanel.tsx
@@ -47,9 +47,12 @@ export interface MobileQuickControls {
   loopBusy: boolean;
   shuffleBusy: boolean;
   skipBusy: boolean;
+  coolingDown: boolean;
+  statusTitle: string | undefined;
   onSkip: () => void;
   onCycleLoop: () => void;
   onShuffleToggle: () => void;
+  onCooldownClick: () => void;
 }
 
 type VirtualQueueItem =
@@ -696,10 +699,11 @@ const PanelHeader = memo(function PanelHeader({
               variant='inherit'
               surface='base'
               size='icon'
-              onClick={mqc.onSkip}
+              onClick={mqc.coolingDown ? mqc.onCooldownClick : mqc.onSkip}
               disabled={!mqc.currentSong || mqc.skipBusy}
-              title='Skip'
-              className='text-muted hover:text-fg disabled:opacity-50'
+              dimmed={mqc.coolingDown}
+              title={mqc.statusTitle ?? 'Skip'}
+              className='text-muted hover:text-fg'
             >
               {mqc.skipBusy ? (
                 <CircleNotchIcon size={18} weight='bold' className='animate-spin' />
@@ -711,10 +715,11 @@ const PanelHeader = memo(function PanelHeader({
               variant='inherit'
               surface='base'
               size='icon'
-              onClick={mqc.onCycleLoop}
+              onClick={mqc.coolingDown ? mqc.onCooldownClick : mqc.onCycleLoop}
               disabled={!mqc.currentSong || mqc.loopBusy}
-              title={`Loop: ${mqc.loopMode}`}
-              className={`disabled:opacity-50 ${
+              dimmed={mqc.coolingDown}
+              title={mqc.statusTitle ?? `Loop: ${mqc.loopMode}`}
+              className={`${
                 isLoopActive
                   ? 'pressed text-accent hover:text-accent-muted'
                   : 'text-muted hover:text-fg'
@@ -730,10 +735,11 @@ const PanelHeader = memo(function PanelHeader({
               variant='inherit'
               surface='base'
               size='icon'
-              onClick={mqc.onShuffleToggle}
+              onClick={mqc.coolingDown ? mqc.onCooldownClick : mqc.onShuffleToggle}
               disabled={!mqc.currentSong || mqc.shuffleBusy}
-              title={mqc.isShuffled ? 'Unshuffle queue' : 'Shuffle queue'}
-              className={`disabled:opacity-50 ${
+              dimmed={mqc.coolingDown}
+              title={mqc.statusTitle ?? (mqc.isShuffled ? 'Unshuffle queue' : 'Shuffle queue')}
+              className={`${
                 mqc.isShuffled
                   ? 'pressed text-accent hover:text-accent-muted'
                   : 'text-muted hover:text-fg'

--- a/packages/web/src/components/QueuePanel.tsx
+++ b/packages/web/src/components/QueuePanel.tsx
@@ -24,6 +24,7 @@ import {
 } from '@phosphor-icons/react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { memo, useCallback, useMemo, useRef, useState } from 'react';
+import type { CooldownState } from '../hooks/useCooldownGuard';
 import { createPortal } from 'react-dom';
 import ConfirmModal from '../components/ConfirmModal';
 import { ContextMenu, type MenuItem } from '../components/ContextMenu';
@@ -37,6 +38,7 @@ import { getSourceKey } from '../utils/source';
 import { getRandomIdleIcon } from './EmptyState';
 import { ArtworkImage } from './ui/ArtworkImage';
 import { Button } from './ui/Button';
+import { cooldownButtonProps } from './ui/cooldownButtonProps';
 import { DurationBadge } from './ui/DurationBadge';
 import { VolumeBoostBadge } from './ui/VolumeBoostBadge';
 
@@ -47,12 +49,10 @@ export interface MobileQuickControls {
   loopBusy: boolean;
   shuffleBusy: boolean;
   skipBusy: boolean;
-  coolingDown: boolean;
-  statusTitle: string | undefined;
+  cooldown: CooldownState;
   onSkip: () => void;
   onCycleLoop: () => void;
   onShuffleToggle: () => void;
-  onCooldownClick: () => void;
 }
 
 type VirtualQueueItem =
@@ -699,10 +699,11 @@ const PanelHeader = memo(function PanelHeader({
               variant='inherit'
               surface='base'
               size='icon'
-              onClick={mqc.coolingDown ? mqc.onCooldownClick : mqc.onSkip}
-              disabled={!mqc.currentSong || mqc.skipBusy}
-              dimmed={mqc.coolingDown}
-              title={mqc.statusTitle ?? 'Skip'}
+              {...cooldownButtonProps(mqc.cooldown, {
+                onClick: mqc.onSkip,
+                disabled: !mqc.currentSong || mqc.skipBusy,
+                title: 'Skip',
+              })}
               className='text-muted hover:text-fg'
             >
               {mqc.skipBusy ? (
@@ -715,10 +716,11 @@ const PanelHeader = memo(function PanelHeader({
               variant='inherit'
               surface='base'
               size='icon'
-              onClick={mqc.coolingDown ? mqc.onCooldownClick : mqc.onCycleLoop}
-              disabled={!mqc.currentSong || mqc.loopBusy}
-              dimmed={mqc.coolingDown}
-              title={mqc.statusTitle ?? `Loop: ${mqc.loopMode}`}
+              {...cooldownButtonProps(mqc.cooldown, {
+                onClick: mqc.onCycleLoop,
+                disabled: !mqc.currentSong || mqc.loopBusy,
+                title: `Loop: ${mqc.loopMode}`,
+              })}
               className={`${
                 isLoopActive
                   ? 'pressed text-accent hover:text-accent-muted'
@@ -735,10 +737,11 @@ const PanelHeader = memo(function PanelHeader({
               variant='inherit'
               surface='base'
               size='icon'
-              onClick={mqc.coolingDown ? mqc.onCooldownClick : mqc.onShuffleToggle}
-              disabled={!mqc.currentSong || mqc.shuffleBusy}
-              dimmed={mqc.coolingDown}
-              title={mqc.statusTitle ?? (mqc.isShuffled ? 'Unshuffle queue' : 'Shuffle queue')}
+              {...cooldownButtonProps(mqc.cooldown, {
+                onClick: mqc.onShuffleToggle,
+                disabled: !mqc.currentSong || mqc.shuffleBusy,
+                title: mqc.isShuffled ? 'Unshuffle queue' : 'Shuffle queue',
+              })}
               className={`${
                 mqc.isShuffled
                   ? 'pressed text-accent hover:text-accent-muted'

--- a/packages/web/src/components/queue/OverrideModal.tsx
+++ b/packages/web/src/components/queue/OverrideModal.tsx
@@ -1,7 +1,7 @@
 import { WarningIcon } from '@phosphor-icons/react';
 import { useState } from 'react';
 import { overridePlay } from '../../api/api';
-import { apiErrorMessage } from '../../utils/api';
+import { apiErrorMessage, isRateLimitError } from '../../utils/api';
 import { Backdrop } from '../Backdrop';
 import { Button } from '../ui/Button';
 import { Spinner } from '../ui/Spinner';
@@ -25,7 +25,11 @@ export default function OverrideModal({
       await overridePlay(sourceUrl.trim());
       onOverride();
     } catch (err: unknown) {
-      setError(apiErrorMessage(err, 'Could not override playback. Is the bot in a voice channel?'));
+      if (!isRateLimitError(err)) {
+        setError(
+          apiErrorMessage(err, 'Could not override playback. Is the bot in a voice channel?')
+        );
+      }
       setSubmitting(false);
     }
   };

--- a/packages/web/src/components/queue/QuickAddModal.tsx
+++ b/packages/web/src/components/queue/QuickAddModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { quickAddPlaylistToQueue, quickAddToQueue } from '../../api/api';
-import { apiErrorMessage } from '../../utils/api';
+import { apiErrorMessage, isRateLimitError } from '../../utils/api';
 import { Backdrop } from '../Backdrop';
 import { Button } from '../ui/Button';
 import Checkbox from '../ui/Checkbox';
@@ -37,7 +37,11 @@ export default function QuickAddModal({
         onAdded();
       }
     } catch (err: unknown) {
-      setError(apiErrorMessage(err, 'Could not add song to queue. Is the bot in a voice channel?'));
+      if (!isRateLimitError(err)) {
+        setError(
+          apiErrorMessage(err, 'Could not add song to queue. Is the bot in a voice channel?')
+        );
+      }
       setSubmitting(false);
     }
   };

--- a/packages/web/src/components/ui/Button.tsx
+++ b/packages/web/src/components/ui/Button.tsx
@@ -9,6 +9,8 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;
   size?: ButtonSize;
   surface?: ButtonSurface;
+  /** Visually disabled styling + cursor-not-allowed, but onClick still fires. */
+  dimmed?: boolean;
 }
 
 const defaultClasses: Record<ButtonVariant, string> = {
@@ -38,6 +40,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
     variant = 'primary',
     size = 'default',
     surface = 'surface',
+    dimmed,
     className,
     style,
     ...props
@@ -49,13 +52,20 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
     variant === 'inherit'
       ? ({ ...style, '--btn-surface': surfaceVars[surface] } as React.CSSProperties)
       : style || {};
+
+  // dimmed = visually disabled but still clickable (for cooldown toasts).
+  // Don't pass disabled to the native element when dimmed.
+  const { disabled: _disabled, ...restProps } = props;
+  const dimmedClass = dimmed ? 'opacity-50 cursor-not-allowed' : '';
+
   return (
     <button
       ref={ref}
       type='button'
-      className={className ? `${base} ${className}` : base}
+      disabled={dimmed ? undefined : (_disabled as boolean | undefined)}
+      className={[base, dimmedClass, className].filter(Boolean).join(' ')}
       style={inheritStyle}
-      {...props}
+      {...restProps}
     />
   );
 });

--- a/packages/web/src/components/ui/PlayButton.tsx
+++ b/packages/web/src/components/ui/PlayButton.tsx
@@ -1,5 +1,6 @@
 import { CircleNotchIcon, PlayIcon } from '@phosphor-icons/react';
 import { memo } from 'react';
+import { useCooldownGuard } from '../../hooks/useCooldownGuard';
 import { Button } from './Button';
 
 interface PlayButtonProps {
@@ -15,6 +16,10 @@ export const PlayButton = memo(function PlayButton({
   className = '',
   title = 'Play from this song',
 }: PlayButtonProps) {
+  const { coolingDown, statusTitle, handleCooldownClick } = useCooldownGuard();
+
+  const effectiveTitle = statusTitle ?? title;
+
   return (
     <Button
       variant='primary'
@@ -25,11 +30,16 @@ export const PlayButton = memo(function PlayButton({
       }}
       onClick={(e) => {
         e.stopPropagation();
-        onClick();
+        if (coolingDown) {
+          handleCooldownClick();
+        } else {
+          onClick();
+        }
       }}
-      disabled={isPlaying}
+      disabled={isPlaying && !coolingDown}
+      dimmed={coolingDown}
       className={`shrink-0 disabled:cursor-default ${className}`}
-      title={title}
+      title={effectiveTitle}
     >
       {isPlaying ? (
         <CircleNotchIcon size={22} weight='bold' className='animate-spin' />

--- a/packages/web/src/components/ui/PlayButton.tsx
+++ b/packages/web/src/components/ui/PlayButton.tsx
@@ -1,7 +1,8 @@
 import { CircleNotchIcon, PlayIcon } from '@phosphor-icons/react';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import { useCooldownGuard } from '../../hooks/useCooldownGuard';
 import { Button } from './Button';
+import { cooldownButtonProps } from './cooldownButtonProps';
 
 interface PlayButtonProps {
   onClick: () => void;
@@ -18,12 +19,16 @@ export const PlayButton = memo(function PlayButton({
 }: PlayButtonProps) {
   const { coolingDown, statusTitle, handleCooldownClick } = useCooldownGuard();
 
-  const effectiveTitle = statusTitle ?? title;
+  const cooldown = useMemo(
+    () => ({ coolingDown, statusTitle, onCooldownClick: handleCooldownClick }),
+    [coolingDown, statusTitle, handleCooldownClick]
+  );
 
   return (
     <Button
       variant='primary'
       size='icon'
+      {...cooldownButtonProps(cooldown, { onClick, disabled: isPlaying, title })}
       onMouseDown={(e) => {
         e.preventDefault();
         e.stopPropagation();
@@ -36,10 +41,7 @@ export const PlayButton = memo(function PlayButton({
           onClick();
         }
       }}
-      disabled={isPlaying && !coolingDown}
-      dimmed={coolingDown}
       className={`shrink-0 disabled:cursor-default ${className}`}
-      title={effectiveTitle}
     >
       {isPlaying ? (
         <CircleNotchIcon size={22} weight='bold' className='animate-spin' />

--- a/packages/web/src/components/ui/cooldownButtonProps.ts
+++ b/packages/web/src/components/ui/cooldownButtonProps.ts
@@ -1,0 +1,33 @@
+import type { CooldownState } from '../../hooks/useCooldownGuard';
+
+interface CooldownButtonOpts {
+  onClick: () => void;
+  /** Native disabled state — cooldown overrides it (dimmed + clickable) */
+  disabled?: boolean;
+  /** Default tooltip when not in cooldown/approaching state */
+  title: string;
+}
+
+/**
+ * Convert a CooldownState + button options into the merged props for a
+ * cooldown-aware Button/BarButton: onClick, disabled, dimmed, and title
+ * are all wired up consistently.
+ *
+ * This is a pure function (not a hook) so it's safe inside memo components.
+ */
+export function cooldownButtonProps(
+  c: CooldownState,
+  opts: CooldownButtonOpts
+): {
+  onClick: () => void;
+  disabled: boolean;
+  dimmed: boolean;
+  title: string;
+} {
+  return {
+    onClick: c.coolingDown ? c.onCooldownClick : opts.onClick,
+    disabled: !!opts.disabled && !c.coolingDown,
+    dimmed: c.coolingDown,
+    title: c.statusTitle ?? opts.title,
+  };
+}

--- a/packages/web/src/hooks/useAddToQueue.ts
+++ b/packages/web/src/hooks/useAddToQueue.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { addToPriorityQueue } from '../api/api';
-import { apiErrorMessage } from '../utils/api';
+import { apiErrorMessage, isRateLimitError } from '../utils/api';
 import { useNotification } from './useNotification';
 
 export function useAddToQueue() {
@@ -12,11 +12,13 @@ export function useAddToQueue() {
         await addToPriorityQueue(songId);
         notify('Added to Up Next', 'success');
       } catch (err: unknown) {
-        notify(
-          apiErrorMessage(err, 'Could not add to queue. Is the bot in a voice channel?'),
-          'error',
-          5000
-        );
+        if (!isRateLimitError(err)) {
+          notify(
+            apiErrorMessage(err, 'Could not add to queue. Is the bot in a voice channel?'),
+            'error',
+            5000
+          );
+        }
       }
     },
     [notify]

--- a/packages/web/src/hooks/useCooldownGuard.ts
+++ b/packages/web/src/hooks/useCooldownGuard.ts
@@ -14,7 +14,17 @@ import { useRateLimit } from './useRateLimit';
 // The toast debounce is module-level so all components share one timer —
 // clicking a dimmed play button and a dimmed shuffle button won't fire
 // two toasts within the same 6s window.
+//
+// CooldownState is the canonical prop shape for passing cooldown awareness
+// into memo children — use it alongside cooldownButtonProps() to avoid
+// repeating the onClick / disabled / dimmed / title ternaries.
 // ---------------------------------------------------------------------------
+
+export interface CooldownState {
+  coolingDown: boolean;
+  statusTitle: string | undefined;
+  onCooldownClick: () => void;
+}
 
 let lastToast = 0;
 let proactiveFired = false; // prevent duplicate proactive toasts across instances

--- a/packages/web/src/hooks/useCooldownGuard.ts
+++ b/packages/web/src/hooks/useCooldownGuard.ts
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useNotification } from './useNotification';
+import { useRateLimit } from './useRateLimit';
+
+// ---------------------------------------------------------------------------
+// Shared cooldown guard for player-mutations rate limiting.
+//
+// Provides the building blocks for any button that triggers a player mutation:
+//   - coolingDown / retryAfterSeconds   — state from the rate limit headers
+//   - statusTitle                       — ready-to-use tooltip (cooldown countdown
+//                                         or approaching warning, or undefined)
+//   - handleCooldownClick               — debounced toast for dimmed-button clicks
+//
+// The toast debounce is module-level so all components share one timer —
+// clicking a dimmed play button and a dimmed shuffle button won't fire
+// two toasts within the same 6s window.
+// ---------------------------------------------------------------------------
+
+let lastToast = 0;
+let proactiveFired = false; // prevent duplicate proactive toasts across instances
+const TOAST_INTERVAL_MS = 6000;
+
+export function useCooldownGuard() {
+  const { coolingDown, approaching, retryAfterSeconds } = useRateLimit('player-mutations');
+  const { notify } = useNotification();
+  const prevCoolingDownRef = useRef(coolingDown);
+
+  // When cooldown first kicks in, show a proactive toast once globally and
+  // reset the debounce timer so the message isn't immediately replaced by
+  // a dimmed-click toast.
+  useEffect(() => {
+    if (coolingDown && !prevCoolingDownRef.current && !proactiveFired) {
+      proactiveFired = true;
+      lastToast = Date.now();
+      notify(
+        `Rate limit reached. Controls will be disabled for ${retryAfterSeconds}s.`,
+        'error',
+        5000
+      );
+    }
+    if (!coolingDown) {
+      proactiveFired = false;
+    }
+    prevCoolingDownRef.current = coolingDown;
+  }, [coolingDown, retryAfterSeconds, notify]);
+
+  const handleCooldownClick = useCallback(() => {
+    const now = Date.now();
+    if (now - lastToast < TOAST_INTERVAL_MS) return;
+    lastToast = now;
+    notify(`${retryAfterSeconds}s remaining until controls are re-enabled.`, 'error', 5000);
+  }, [retryAfterSeconds, notify]);
+
+  const cooldownTitle = coolingDown ? `Cooldown — ${retryAfterSeconds}s remaining` : undefined;
+  const approachingTitle = approaching ? 'Approaching rate limit — slow down' : undefined;
+  const statusTitle = cooldownTitle ?? approachingTitle;
+
+  return {
+    coolingDown,
+    approaching,
+    retryAfterSeconds,
+    statusTitle,
+    handleCooldownClick,
+  } as const;
+}

--- a/packages/web/src/hooks/useMutationHandler.ts
+++ b/packages/web/src/hooks/useMutationHandler.ts
@@ -1,0 +1,40 @@
+import { useCallback, useRef, useState } from 'react';
+import { apiErrorMessage, isRateLimitError } from '../utils/api';
+import { useNotification } from './useNotification';
+
+/**
+ * Reusable mutation handler for player controls.
+ *
+ * Provides:
+ *   - `busy`    — boolean state for showing a spinner / disabling the button
+ *   - `handler` — async callback with synchronous ref guard (prevents
+ *                 rapid double-clicks bypassing React state), 429 suppression
+ *                 (cooldown UI handles those), and error notification.
+ *
+ * @param action       Async function that performs the mutation.
+ * @param errorMessage Human-readable fallback shown if the call fails with
+ *                     a non-rate-limit error.
+ */
+export function useMutationHandler(action: () => Promise<void>, errorMessage: string) {
+  const busyRef = useRef(false);
+  const [busy, setBusy] = useState(false);
+  const { notify } = useNotification();
+
+  const handler = useCallback(async () => {
+    if (busyRef.current) return;
+    busyRef.current = true;
+    setBusy(true);
+    try {
+      await action();
+    } catch (err) {
+      if (!isRateLimitError(err)) {
+        notify(apiErrorMessage(err, errorMessage), 'error', 5000);
+      }
+    } finally {
+      busyRef.current = false;
+      setBusy(false);
+    }
+  }, [action, errorMessage, notify]);
+
+  return { busy, handler };
+}

--- a/packages/web/src/hooks/useRateLimit.ts
+++ b/packages/web/src/hooks/useRateLimit.ts
@@ -1,0 +1,161 @@
+import { useCallback, useSyncExternalStore } from 'react';
+
+// ---------------------------------------------------------------------------
+// Client-side rate limit tracking
+//
+// The server sends X-RateLimit-* headers on every player mutation response.
+// wrappedFetch (in client.ts) calls updateRateLimit() with the parsed values.
+// This hook reads from the same store so components can react to changes.
+// ---------------------------------------------------------------------------
+
+interface RateLimitState {
+  limit: number;
+  remaining: number;
+  resetAt: number; // Unix seconds
+}
+
+const defaultState: RateLimitState = { limit: 30, remaining: 30, resetAt: 0 };
+
+// Module-level state keyed by bucket name.
+const state = new Map<string, RateLimitState>();
+const listeners = new Set<() => void>();
+
+function subscribe(callback: () => void) {
+  listeners.add(callback);
+  return () => void listeners.delete(callback);
+}
+
+/**
+ * Called by wrappedFetch whenever rate limit headers are present on a response.
+ * External consumers should not call this directly.
+ */
+export function updateRateLimit(
+  bucket: string,
+  limit: number,
+  remaining: number,
+  resetAt: number
+): void {
+  state.set(bucket, { limit, remaining, resetAt });
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Computed snapshot
+//
+// useSyncExternalStore detects changes via Object.is on the returned value.
+// The raw store state ({remaining, resetAt}) doesn't change when wall-clock
+// time advances past resetAt, so we must fold the time-dependent computation
+// into getSnapshot. Otherwise React sees the same object and skips re-renders,
+// leaving controls visually disabled even after the cooldown expires.
+// ---------------------------------------------------------------------------
+
+export interface RateLimitSnapshot {
+  limit: number;
+  remaining: number;
+  resetAt: number;
+  coolingDown: boolean;
+  approaching: boolean;
+  retryAfterSeconds: number;
+}
+
+function computeSnapshot(raw: RateLimitState, nowSec: number): RateLimitSnapshot {
+  const expired = raw.resetAt > 0 && nowSec >= raw.resetAt;
+  const remaining = expired ? raw.limit : raw.remaining;
+  const coolingDown = !expired && raw.resetAt > 0 && remaining === 0;
+  const approaching = !coolingDown && remaining <= 5 && remaining > 0;
+  const retryAfterSeconds = coolingDown ? Math.max(0, raw.resetAt - nowSec) : 0;
+
+  return {
+    limit: raw.limit,
+    remaining,
+    resetAt: raw.resetAt,
+    coolingDown,
+    approaching,
+    retryAfterSeconds,
+  };
+}
+
+// Cache per-bucket so we only return a new object when fields actually change.
+// Returning a fresh object every call causes an infinite loop —
+// Object.is always says "changed", triggering another render.
+const snapshotCache = new Map<string, RateLimitSnapshot>();
+
+function getSnapshot(bucket: string): RateLimitSnapshot {
+  const raw = state.get(bucket) ?? defaultState;
+  const next = computeSnapshot(raw, Math.floor(Date.now() / 1000));
+  const cached = snapshotCache.get(bucket);
+
+  // Same reference if nothing changed — prevents infinite re-renders.
+  if (
+    cached &&
+    cached.limit === next.limit &&
+    cached.remaining === next.remaining &&
+    cached.resetAt === next.resetAt &&
+    cached.coolingDown === next.coolingDown &&
+    cached.approaching === next.approaching &&
+    cached.retryAfterSeconds === next.retryAfterSeconds
+  ) {
+    return cached;
+  }
+
+  snapshotCache.set(bucket, next);
+  return next;
+}
+
+/**
+ * React hook that returns the current rate limit status for a route bucket.
+ *
+ * `bucket` corresponds to the server-side route group (e.g. 'player-mutations').
+ */
+export function useRateLimit(bucket: string): RateLimitSnapshot {
+  return useSyncExternalStore(
+    useCallback((cb: () => void) => subscribe(cb), []),
+    useCallback(() => getSnapshot(bucket), [bucket])
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Side-effect: tick every second to trigger re-renders so the displayed
+// countdown doesn't appear frozen.
+//
+// Accuracy comes from computing remaining time against wall-clock (resetAt -
+// Date.now()), not from counting ticks. setInterval is throttled by browsers
+// when the tab is in the background, so we also listen for visibilitychange
+// to force an immediate re-render when the user returns.
+// ---------------------------------------------------------------------------
+
+let tickInterval: ReturnType<typeof setInterval> | null = null;
+
+function notifyListeners() {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function ensureTicking() {
+  if (tickInterval !== null) return;
+  tickInterval = setInterval(notifyListeners, 1000);
+}
+
+// Start ticking as soon as this module is imported.
+ensureTicking();
+
+if (typeof window !== 'undefined') {
+  // Force an immediate tick when the tab becomes visible again — the browser
+  // may have throttled setInterval while the tab was backgrounded.
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') {
+      notifyListeners();
+    }
+  });
+
+  // Clean up on unload.
+  window.addEventListener('beforeunload', () => {
+    if (tickInterval !== null) {
+      clearInterval(tickInterval);
+      tickInterval = null;
+    }
+  });
+}

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -49,9 +49,10 @@ import { usePermissions } from '../context/PermissionsContext';
 import { usePlayerState } from '../context/PlayerContext';
 import { useAddToQueue } from '../hooks/useAddToQueue';
 import { useBulkSelection } from '../hooks/useBulkSelection';
+import { useCooldownGuard } from '../hooks/useCooldownGuard';
 import { useNotification } from '../hooks/useNotification';
 import { onSocketEvent } from '../hooks/useSocket';
-import { apiErrorMessage } from '../utils/api';
+import { apiErrorMessage, isRateLimitError } from '../utils/api';
 import { getTagColorClasses } from '../utils/tagColors';
 
 const ITEMS_PER_PAGE = 24;
@@ -74,6 +75,7 @@ export default function PlaylistDetailPage() {
   const [tags, setTags] = useState<TagItem[]>([]);
   const { handleAddToQueue, notification } = useAddToQueue();
   const { notify } = useNotification();
+  const { coolingDown, statusTitle, handleCooldownClick } = useCooldownGuard();
 
   const SORT_OPTIONS = [
     { value: 'position', label: 'Playlist Order' },
@@ -409,7 +411,9 @@ export default function PlaylistDetailPage() {
         if (throwErrors) {
           throw err;
         }
-        notify(apiErrorMessage(err, 'Could not start playback.'), 'error', 5000);
+        if (!isRateLimitError(err)) {
+          notify(apiErrorMessage(err, 'Could not start playback.'), 'error', 5000);
+        }
       } finally {
         setPlayingSongId(null);
       }
@@ -631,21 +635,32 @@ export default function PlaylistDetailPage() {
           <Button
             variant='secondary'
             className='rounded-full!'
-            onClick={() => {
-              void handlePlayFromSong(songs[0]?.songId, 'random');
-            }}
-            disabled={songItems.length === 0}
-            title='Shuffle'
+            onClick={
+              coolingDown
+                ? handleCooldownClick
+                : () => {
+                    void handlePlayFromSong(songs[0]?.songId, 'random');
+                  }
+            }
+            disabled={songItems.length === 0 && !coolingDown}
+            dimmed={coolingDown}
+            title={statusTitle ?? 'Shuffle'}
           >
             <ShuffleIcon size={18} weight='duotone' />
           </Button>
           <Button
             variant='primary'
             className='text-xs flex items-center gap-1.5'
-            onClick={() => {
-              void handlePlayFromSong(songs[0]?.songId, 'sequential');
-            }}
-            disabled={songItems.length === 0}
+            onClick={
+              coolingDown
+                ? handleCooldownClick
+                : () => {
+                    void handlePlayFromSong(songs[0]?.songId, 'sequential');
+                  }
+            }
+            disabled={songItems.length === 0 && !coolingDown}
+            dimmed={coolingDown}
+            title={statusTitle ?? 'Play'}
           >
             <PlayIcon size={14} weight='duotone' /> Play
           </Button>

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -50,9 +50,10 @@ import { usePlayerState } from '../context/PlayerContext';
 import { useAddToQueue } from '../hooks/useAddToQueue';
 import { useBulkSelection } from '../hooks/useBulkSelection';
 import { useCooldownGuard } from '../hooks/useCooldownGuard';
+import { cooldownButtonProps } from '../components/ui/cooldownButtonProps';
 import { useNotification } from '../hooks/useNotification';
 import { onSocketEvent } from '../hooks/useSocket';
-import { apiErrorMessage, isRateLimitError } from '../utils/api';
+import { apiErrorMessage, notifyUnlessRateLimit } from '../utils/api';
 import { getTagColorClasses } from '../utils/tagColors';
 
 const ITEMS_PER_PAGE = 24;
@@ -76,6 +77,11 @@ export default function PlaylistDetailPage() {
   const { handleAddToQueue, notification } = useAddToQueue();
   const { notify } = useNotification();
   const { coolingDown, statusTitle, handleCooldownClick } = useCooldownGuard();
+
+  const cooldown = useMemo(
+    () => ({ coolingDown, statusTitle, onCooldownClick: handleCooldownClick }),
+    [coolingDown, statusTitle, handleCooldownClick]
+  );
 
   const SORT_OPTIONS = [
     { value: 'position', label: 'Playlist Order' },
@@ -411,9 +417,7 @@ export default function PlaylistDetailPage() {
         if (throwErrors) {
           throw err;
         }
-        if (!isRateLimitError(err)) {
-          notify(apiErrorMessage(err, 'Could not start playback.'), 'error', 5000);
-        }
+        notifyUnlessRateLimit(err, 'Could not start playback.', notify);
       } finally {
         setPlayingSongId(null);
       }
@@ -635,32 +639,26 @@ export default function PlaylistDetailPage() {
           <Button
             variant='secondary'
             className='rounded-full!'
-            onClick={
-              coolingDown
-                ? handleCooldownClick
-                : () => {
-                    void handlePlayFromSong(songs[0]?.songId, 'random');
-                  }
-            }
-            disabled={songItems.length === 0 && !coolingDown}
-            dimmed={coolingDown}
-            title={statusTitle ?? 'Shuffle'}
+            {...cooldownButtonProps(cooldown, {
+              onClick: () => {
+                void handlePlayFromSong(songs[0]?.songId, 'random');
+              },
+              disabled: songItems.length === 0,
+              title: 'Shuffle',
+            })}
           >
             <ShuffleIcon size={18} weight='duotone' />
           </Button>
           <Button
             variant='primary'
             className='text-xs flex items-center gap-1.5'
-            onClick={
-              coolingDown
-                ? handleCooldownClick
-                : () => {
-                    void handlePlayFromSong(songs[0]?.songId, 'sequential');
-                  }
-            }
-            disabled={songItems.length === 0 && !coolingDown}
-            dimmed={coolingDown}
-            title={statusTitle ?? 'Play'}
+            {...cooldownButtonProps(cooldown, {
+              onClick: () => {
+                void handlePlayFromSong(songs[0]?.songId, 'sequential');
+              },
+              disabled: songItems.length === 0,
+              title: 'Play',
+            })}
           >
             <PlayIcon size={14} weight='duotone' /> Play
           </Button>

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -28,7 +28,7 @@ import { useBulkSelection } from '../hooks/useBulkSelection';
 import { useNotification } from '../hooks/useNotification';
 import { onSocketEvent } from '../hooks/useSocket';
 import { useVirtualizedInfiniteScroll } from '../hooks/useVirtualizedInfiniteScroll';
-import { apiErrorMessage, isRateLimitError } from '../utils/api';
+import { apiErrorMessage, notifyUnlessRateLimit } from '../utils/api';
 
 const ITEMS_PER_PAGE = 24;
 
@@ -293,13 +293,11 @@ export default function SongsPage() {
         });
         notify('Started playback', 'success');
       } catch (err: unknown) {
-        if (!isRateLimitError(err)) {
-          notify(
-            apiErrorMessage(err, 'Could not start playback. Is the bot in a voice channel?'),
-            'error',
-            5000
-          );
-        }
+        notifyUnlessRateLimit(
+          err,
+          'Could not start playback. Is the bot in a voice channel?',
+          notify
+        );
       } finally {
         setPlayingId(null);
       }

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -28,7 +28,7 @@ import { useBulkSelection } from '../hooks/useBulkSelection';
 import { useNotification } from '../hooks/useNotification';
 import { onSocketEvent } from '../hooks/useSocket';
 import { useVirtualizedInfiniteScroll } from '../hooks/useVirtualizedInfiniteScroll';
-import { apiErrorMessage } from '../utils/api';
+import { apiErrorMessage, isRateLimitError } from '../utils/api';
 
 const ITEMS_PER_PAGE = 24;
 
@@ -293,11 +293,13 @@ export default function SongsPage() {
         });
         notify('Started playback', 'success');
       } catch (err: unknown) {
-        notify(
-          apiErrorMessage(err, 'Could not start playback. Is the bot in a voice channel?'),
-          'error',
-          5000
-        );
+        if (!isRateLimitError(err)) {
+          notify(
+            apiErrorMessage(err, 'Could not start playback. Is the bot in a voice channel?'),
+            'error',
+            5000
+          );
+        }
       } finally {
         setPlayingId(null);
       }

--- a/packages/web/src/utils/api.ts
+++ b/packages/web/src/utils/api.ts
@@ -12,3 +12,21 @@ export function apiErrorMessage(err: unknown, fallback: string): string {
 export function isRateLimitError(err: unknown): boolean {
   return err instanceof ApiError && err.status === 429;
 }
+
+type NotifyFn = (message: string, type: 'success' | 'error' | 'info', duration?: number) => void;
+
+/**
+ * Show an error notification for an API error, unless it's a 429 rate limit.
+ * Rate limit errors are handled visually by the cooldown UI, so we suppress
+ * duplicate toast messages for them.
+ */
+export function notifyUnlessRateLimit(
+  err: unknown,
+  fallback: string,
+  notify: NotifyFn,
+  duration = 5000
+): void {
+  if (!isRateLimitError(err)) {
+    notify(apiErrorMessage(err, fallback), 'error', duration);
+  }
+}

--- a/packages/web/src/utils/api.ts
+++ b/packages/web/src/utils/api.ts
@@ -7,3 +7,8 @@ export function apiErrorMessage(err: unknown, fallback: string): string {
   }
   return err instanceof Error ? err.message : fallback;
 }
+
+/** True when the error is a 429 rate limit response — the cooldown UI handles these. */
+export function isRateLimitError(err: unknown): boolean {
+  return err instanceof ApiError && err.status === 429;
+}


### PR DESCRIPTION
## Summary

Adds real-time rate-limit cooldown feedback across all player controls. When the player-mutations rate limit (30 req/60s) is exhausted, controls are dimmed with a countdown timer, tooltip, and proactive toast notification — instead of silently breaking until the window resets.

## Changes

### Server
- **rateLimit.ts** — `checkRateLimit` returns detailed info (remaining, limit, resetAt) instead of a boolean
- **routeTable.ts** — attaches `X-RateLimit-*` headers to all non-GET player responses; enriched 429 body with `retryAfterSeconds`

### Client (new hooks)
- **useRateLimit.ts** — reactive store + `useSyncExternalStore` hook tracking rate limit state from response headers, with `visibilitychange` listener for accurate background-tab recovery
- **useCooldownGuard.ts** — shared hook providing `coolingDown`, `statusTitle` (cooldown/approaching tooltip), `handleCooldownClick` (debounced toast) for any button

### Client (UI)
- **Button.tsx / BarButton.tsx** — new `dimmed` prop: visually disabled but still clickable (for cooldown toasts)
- **PlayButton.tsx** — cooldown-aware via `useCooldownGuard`; dims, shows countdown tooltip, debounced toast on click
- **NowPlayingBar.tsx** — all 4 handlers (pause, skip, loop, shuffle) use ref guards, 429 suppression, and cooldown-aware sub-components
- **QueuePanel.tsx** — mobile quick controls use `dimmed` + cooldown-aware titles
- **PlaylistDetailPage.tsx** — Play/Shuffle buttons cooldown-aware
- **SongsPage.tsx, QuickAddModal.tsx, OverrideModal.tsx, useAddToQueue.ts** — 429 catch-block suppression (proactive toast handles it)
- **utils/api.ts** — `isRateLimitError()` helper; `ApiError` import centralized here