### PR TITLE
feat(web): add motion-powered animations

### DIFF
--- a/.pi/skills/alfira-web/SKILL.md
+++ b/.pi/skills/alfira-web/SKILL.md
@@ -9,6 +9,7 @@ description: React 19 + Tailwind CSS 4 web UI, component and page structure, API
 
 - **Framework:** React 19
 - **Styling:** Tailwind CSS 4
+- **Animation:** motion (framer-motion v12) via `LazyMotion` + `m` for minimal bundle
 - **Bundler:** Bun (builds to `packages/web/dist/`)
 - **Build command:** `bun run web:build`
 
@@ -39,6 +40,7 @@ description: React 19 + Tailwind CSS 4 web UI, component and page structure, API
 | Component            | Purpose                                              |
 | -------------------- | ---------------------------------------------------- |
 | `Layout.tsx`         | App shell with sidebar nav + NowPlayingBar           |
+| `AnimatedOutlet.tsx` | Page transition wrapper (motion AnimatePresence)     |
 | `MobileNav.tsx`      | Mobile navigation bar                                |
 | `NowPlayingBar.tsx`  | Persistent bottom bar with playback controls         |
 | `ProtectedRoute.tsx` | Auth guard wrapper                                   |
@@ -147,6 +149,14 @@ Connects to `/ws` for real-time player state updates. Used primarily by the now-
 ## Constants (`packages/web/src/constants.ts`)
 
 Shared constants used across the web UI. Common values like API base URLs, default settings, etc.
+
+## Animations (motion)
+
+- **Setup:** `lib/motion.ts` exports `LazyMotion`, `domAnimation`, and shared variants. Import `m` separately as `import * as m from 'motion/react-m'` (namespace import required).
+- **Page transitions:** `AnimatedOutlet` replaces `<Outlet />` in Layout — handles enter/exit crossfade on route change
+- **Pattern:** `import * as m from 'motion/react-m'` for the minimal `m` component factory; `import { AnimatePresence } from 'motion/react'` for enter/exit orchestration; `import { pageVariants } from '../lib/motion'` for shared variants
+- **Bundle:** Uses `LazyMotion` + `m` (4.6kb base) with `domAnimation` features loaded synchronously at mount
+- CSS keyframes (`fadeUp`, `slideUp`, etc.) remain in `index.css` for non-React animations (modals, loaders)
 
 ## Tailwind CSS 4 Conventions
 

--- a/.pi/skills/alfira-web/SKILL.md
+++ b/.pi/skills/alfira-web/SKILL.md
@@ -93,9 +93,12 @@ description: React 19 + Tailwind CSS 4 web UI, component and page structure, API
 | `ErrorBanner.tsx`       | Error message banner         |
 | `PlayButton.tsx`        | Play action button           |
 | `RoleComboBox.tsx`      | Role selection dropdown      |
-| `Spinner.tsx`           | Loading spinner              |
-| `VirtualListFooter.tsx` | Footer for virtualized lists |
-| `VolumeBoostBadge.tsx`  | Volume boost indicator       |
+| `ArtworkImage.tsx`      | Lazy-loaded artwork with fallback |
+| `PageHeader.tsx`        | Consistent page header           |
+| `Spinner.tsx`           | Loading spinner                   |
+| `SpringUp.tsx`          | Spring-up mount animation wrapper (motion) |
+| `VirtualListFooter.tsx` | Footer for virtualized lists      |
+| `VolumeBoostBadge.tsx`  | Volume boost indicator            |
 
 ### Other Components
 
@@ -156,7 +159,8 @@ Shared constants used across the web UI. Common values like API base URLs, defau
 - **Page transitions:** `AnimatedOutlet` replaces `<Outlet />` in Layout — handles enter/exit crossfade on route change
 - **Pattern:** `import * as m from 'motion/react-m'` for the minimal `m` component factory; `import { AnimatePresence } from 'motion/react'` for enter/exit orchestration; `import { pageVariants } from '../lib/motion'` for shared variants
 - **Bundle:** Uses `LazyMotion` + `m` (4.6kb base) with `domAnimation` features loaded synchronously at mount
-- CSS keyframes (`fadeUp`, `slideUp`, etc.) remain in `index.css` for non-React animations (modals, loaders)
+- **SpringUp:** `<SpringUp>` wraps content in a shared spring-up variant (`springUp` from `lib/motion.ts`) — replaces the old `animate-fade-up` CSS class
+- CSS keyframes (`slideUp`, `pulseGentle`, etc.) remain in `index.css` for non-React animations (now-playing bar, loaders)
 
 ## Tailwind CSS 4 Conventions
 

--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
         "@alfira/server": "workspace:*",
         "@phosphor-icons/react": "2.1.10",
         "@tanstack/react-virtual": "3.14.6",
+        "motion": "^12.42.2",
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "react-router-dom": "7.18.1",
@@ -212,6 +213,8 @@
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
+    "framer-motion": ["framer-motion@12.42.2", "", { "dependencies": { "motion-dom": "^12.42.2", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw=="],
+
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
@@ -250,6 +253,12 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
+    "motion": ["motion@12.42.2", "", { "dependencies": { "framer-motion": "^12.42.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q=="],
+
+    "motion-dom": ["motion-dom@12.42.2", "", { "dependencies": { "motion-utils": "^12.39.0" } }, "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA=="],
+
+    "motion-utils": ["motion-utils@12.39.0", "", {}, "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ=="],
+
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
@@ -285,6 +294,8 @@
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -10,7 +10,7 @@
 | **Audio**    | NodeLink (Lavalink v4) — direct WebSocket + REST |
 | **API**      | Bun native HTTP + WebSocket                      |
 | **Database** | SQLite + Drizzle ORM                             |
-| **Frontend** | React 19 + Tailwind CSS 4                        |
+| **Frontend** | React 19 + Tailwind CSS 4 + motion (framer-motion v12) |
 | **Logging**  | Custom (shared/logger)                           |
 
 ## Architecture

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -12,6 +12,7 @@
     "@alfira/server": "workspace:*",
     "@phosphor-icons/react": "2.1.10",
     "@tanstack/react-virtual": "3.14.6",
+    "motion": "^12.42.2",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-router-dom": "7.18.1"

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { Navigate, Route, Routes } from 'react-router-dom';
 import Layout from './components/Layout';
 import ProtectedRoute from './components/ProtectedRoute';
+import { LazyMotion, domAnimation } from './lib/motion';
 import SettingsPage from './components/settings/SettingsPage';
 import { AdminViewProvider } from './context/AdminViewContext';
 import { AuthProvider } from './context/AuthContext';
@@ -23,54 +24,56 @@ import TagsPage from './pages/TagsPage';
 
 export default function App() {
   return (
-    <ThemeProvider>
-      <TagsProvider>
-        <AuthProvider>
-          <AdminViewProvider>
-            <PermissionsProvider>
-              <NotificationProvider>
-                <SongEditProvider>
-                  <SongMenuProvider>
-                    <Routes>
-                      <Route path='/login' element={<LoginPage />} />
-                      <Route
-                        path='/setup'
-                        element={
-                          <ProtectedRoute>
-                            <SetupWizard />
-                          </ProtectedRoute>
-                        }
-                      />
-                      <Route
-                        path='/'
-                        element={
-                          <ProtectedRoute>
-                            {/* PlayerProvider lives inside ProtectedRoute so it only polls while a user is authenticated. */}
-                            <PlayerProvider>
-                              <Layout />
-                            </PlayerProvider>
-                          </ProtectedRoute>
-                        }
-                      >
-                        <Route index element={<Navigate to='/songs' replace />} />
-                        <Route path='songs' element={<SongsPage />} />
-                        <Route path='playlists' element={<PlaylistsPage />} />
-                        <Route path='playlists/:id' element={<PlaylistDetailPage />} />
-                        <Route path='settings' element={<SettingsPage />} />
-                        <Route path='audio' element={<AudioPage />} />
-                        <Route path='tags' element={<TagsPage />} />
-                        <Route path='permissions' element={<PermissionsPage />} />
-                        <Route path='requests' element={<RequestsPage />} />
-                      </Route>
-                      <Route path='*' element={<Navigate to='/' replace />} />
-                    </Routes>
-                  </SongMenuProvider>
-                </SongEditProvider>
-              </NotificationProvider>
-            </PermissionsProvider>
-          </AdminViewProvider>
-        </AuthProvider>
-      </TagsProvider>
-    </ThemeProvider>
+    <LazyMotion features={domAnimation}>
+      <ThemeProvider>
+        <TagsProvider>
+          <AuthProvider>
+            <AdminViewProvider>
+              <PermissionsProvider>
+                <NotificationProvider>
+                  <SongEditProvider>
+                    <SongMenuProvider>
+                      <Routes>
+                        <Route path='/login' element={<LoginPage />} />
+                        <Route
+                          path='/setup'
+                          element={
+                            <ProtectedRoute>
+                              <SetupWizard />
+                            </ProtectedRoute>
+                          }
+                        />
+                        <Route
+                          path='/'
+                          element={
+                            <ProtectedRoute>
+                              {/* PlayerProvider lives inside ProtectedRoute so it only polls while a user is authenticated. */}
+                              <PlayerProvider>
+                                <Layout />
+                              </PlayerProvider>
+                            </ProtectedRoute>
+                          }
+                        >
+                          <Route index element={<Navigate to='/songs' replace />} />
+                          <Route path='songs' element={<SongsPage />} />
+                          <Route path='playlists' element={<PlaylistsPage />} />
+                          <Route path='playlists/:id' element={<PlaylistDetailPage />} />
+                          <Route path='settings' element={<SettingsPage />} />
+                          <Route path='audio' element={<AudioPage />} />
+                          <Route path='tags' element={<TagsPage />} />
+                          <Route path='permissions' element={<PermissionsPage />} />
+                          <Route path='requests' element={<RequestsPage />} />
+                        </Route>
+                        <Route path='*' element={<Navigate to='/' replace />} />
+                      </Routes>
+                    </SongMenuProvider>
+                  </SongEditProvider>
+                </NotificationProvider>
+              </PermissionsProvider>
+            </AdminViewProvider>
+          </AuthProvider>
+        </TagsProvider>
+      </ThemeProvider>
+    </LazyMotion>
   );
 }

--- a/packages/web/src/components/AddFilterPopover.tsx
+++ b/packages/web/src/components/AddFilterPopover.tsx
@@ -4,6 +4,7 @@ import { type TagItem, useTagColors } from '../context/TagsContext';
 import { getTagColorClasses } from '../utils/tagColors';
 import { Backdrop } from './Backdrop';
 import { SourceIcon } from './SourceIcons';
+import { SpringUp } from './ui/SpringUp';
 
 // ---------------------------------------------------------------------------
 // Available sources — must mirror the server's SOURCE_LIKE_PATTERNS and the
@@ -83,7 +84,7 @@ export default function AddFilterPopover({
 
   return (
     <Backdrop onClose={onClose}>
-      <div className='w-full max-w-sm glass-modal flex flex-col max-h-[70vh] animate-fade-up'>
+      <SpringUp className='w-full max-w-sm glass-modal flex flex-col max-h-[70vh]'>
         <div className='p-4 border-b border-border flex items-center justify-between'>
           <h3 className='font-body font-semibold text-sm text-fg'>Filters</h3>
           <button
@@ -180,7 +181,7 @@ export default function AddFilterPopover({
             </div>
           </div>
         </div>
-      </div>
+      </SpringUp>
     </Backdrop>
   );
 }

--- a/packages/web/src/components/AddSongModal.tsx
+++ b/packages/web/src/components/AddSongModal.tsx
@@ -9,6 +9,7 @@ import { ArtworkImage } from './ui/ArtworkImage';
 import { Button } from './ui/Button';
 import Checkbox from './ui/Checkbox';
 import { Spinner } from './ui/Spinner';
+import { SpringUp } from './ui/SpringUp';
 
 type Step = 'url' | 'metadata';
 
@@ -194,7 +195,7 @@ export default function AddSongModal({
 
   return (
     <Backdrop onClose={onClose}>
-      <div className='p-5 md:p-6 w-full max-w-md mx-4 glass-modal animate-fade-up'>
+      <SpringUp className='p-5 md:p-6 w-full max-w-md mx-4 glass-modal'>
         <h2 className='font-display text-2xl md:text-3xl text-fg tracking-wider mb-1'>
           Request Song
         </h2>
@@ -450,7 +451,7 @@ export default function AddSongModal({
         )}
 
         {successMsg && <p className='font-mono text-xs text-success mt-3'>{successMsg}</p>}
-      </div>
+      </SpringUp>
     </Backdrop>
   );
 }

--- a/packages/web/src/components/AddSongsModal.tsx
+++ b/packages/web/src/components/AddSongsModal.tsx
@@ -6,6 +6,7 @@ import { addSongToPlaylist, getSongsPage } from '../api/api';
 import { Backdrop } from './Backdrop';
 import { ArtworkImage } from './ui/ArtworkImage';
 import { Button } from './ui/Button';
+import { SpringUp } from './ui/SpringUp';
 
 const PAGE_SIZE = 30;
 
@@ -127,7 +128,7 @@ export default function AddSongsModal({
 
   return (
     <Backdrop onClose={onClose}>
-      <div className='w-full max-w-lg glass-modal flex flex-col max-h-[80vh] animate-fade-up'>
+      <SpringUp className='w-full max-w-lg glass-modal flex flex-col max-h-[80vh]'>
         <div className='p-4 md:p-5 border-b border-border'>
           <h2 className='font-display text-2xl md:text-3xl text-fg tracking-wider'>Add Songs</h2>
           <p className='font-mono text-xs text-muted mt-0.5'>to "{playlist.name}"</p>
@@ -191,7 +192,7 @@ export default function AddSongsModal({
             {hasAddedNew ? 'Done' : 'Close'}
           </Button>
         </div>
-      </div>
+      </SpringUp>
     </Backdrop>
   );
 }

--- a/packages/web/src/components/AnimatedOutlet.tsx
+++ b/packages/web/src/components/AnimatedOutlet.tsx
@@ -1,0 +1,35 @@
+import { AnimatePresence, type Transition } from 'motion/react';
+import * as m from 'motion/react-m';
+import { useLocation, useOutlet } from 'react-router-dom';
+import { pageVariants } from '../lib/motion';
+
+const pageTransition: Transition = { duration: 0.18, ease: 'easeOut' };
+
+/**
+ * Drop-in replacement for react-router-dom's <Outlet /> that animates page
+ * transitions using motion's AnimatePresence.
+ *
+ * Each route change triggers a quick crossfade + vertical slide. The exiting
+ * page fades out while the entering page fades in and slides up slightly.
+ */
+export function AnimatedOutlet() {
+  const outlet = useOutlet();
+  const location = useLocation();
+
+  if (!outlet) return null;
+
+  return (
+    <AnimatePresence mode='wait'>
+      <m.div
+        key={location.pathname}
+        variants={pageVariants}
+        initial='initial'
+        animate='animate'
+        exit='exit'
+        transition={pageTransition}
+      >
+        {outlet}
+      </m.div>
+    </AnimatePresence>
+  );
+}

--- a/packages/web/src/components/BulkActionBar.tsx
+++ b/packages/web/src/components/BulkActionBar.tsx
@@ -1,5 +1,6 @@
 import { TagIcon, TrashIcon, XIcon } from '@phosphor-icons/react';
 import { Button } from './ui/Button';
+import { SpringUp } from './ui/SpringUp';
 
 interface BulkActionBarProps {
   count: number;
@@ -34,7 +35,7 @@ export default function BulkActionBar({
 
   return (
     <div className='fixed bottom-20 md:bottom-18 left-0 right-0 z-50 flex justify-center pb-4 md:pb-6 pointer-events-none'>
-      <div className='pointer-events-auto flex items-center gap-3 px-4 py-3 bg-elevated border border-border rounded-xl shadow-2xl animate-fade-up'>
+      <SpringUp className='pointer-events-auto flex items-center gap-3 px-4 py-3 bg-elevated border border-border rounded-xl shadow-2xl'>
         <span className='text-sm font-mono text-fg tabular-nums'>
           {count} / {totalCount} selected
         </span>
@@ -81,7 +82,7 @@ export default function BulkActionBar({
         >
           <XIcon size={16} weight='bold' />
         </button>
-      </div>
+      </SpringUp>
     </div>
   );
 }

--- a/packages/web/src/components/BulkEditModal.tsx
+++ b/packages/web/src/components/BulkEditModal.tsx
@@ -5,6 +5,7 @@ import { useTagColors } from '../context/TagsContext';
 import { getTagColorClasses } from '../utils/tagColors';
 import { Backdrop } from './Backdrop';
 import { Button } from './ui/Button';
+import { SpringUp } from './ui/SpringUp';
 
 interface BulkEditModalProps {
   count: number;
@@ -195,8 +196,8 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
   return (
     <Backdrop onClose={onClose}>
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- modal container, keyboard not applicable */}
-      <div
-        className='w-full max-w-md mx-4 p-6 glass-modal animate-fade-up max-h-[85vh] overflow-y-auto'
+      <SpringUp
+        className='w-full max-w-md mx-4 p-6 glass-modal max-h-[85vh] overflow-y-auto'
         onClick={(e) => e.stopPropagation()}
       >
         <h2 className='font-display text-lg text-fg mb-1'>Edit {count} songs</h2>
@@ -463,7 +464,7 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
             {isApplying ? 'Applying...' : `Apply to ${count} songs`}
           </Button>
         </div>
-      </div>
+      </SpringUp>
     </Backdrop>
   );
 }

--- a/packages/web/src/components/ConfirmModal.tsx
+++ b/packages/web/src/components/ConfirmModal.tsx
@@ -1,6 +1,7 @@
 import type React from 'react';
 import { Backdrop } from './Backdrop';
 import { Button } from './ui/Button';
+import { SpringUp } from './ui/SpringUp';
 
 interface ConfirmModalProps {
   title: string;
@@ -19,7 +20,7 @@ export default function ConfirmModal({
 }: ConfirmModalProps) {
   return (
     <Backdrop onClose={onCancel}>
-      <div className='p-5 md:p-6 w-full max-w-sm mx-4 glass-modal animate-fade-up'>
+      <SpringUp className='p-5 md:p-6 w-full max-w-sm mx-4 glass-modal'>
         <h2 className='font-display text-2xl md:text-3xl text-fg tracking-wider mb-1'>{title}</h2>
         <p className='font-body text-sm text-muted mb-4 md:mb-6'>{message}</p>
         <div className='flex gap-2 justify-end'>
@@ -30,7 +31,7 @@ export default function ConfirmModal({
             {confirmLabel}
           </Button>
         </div>
-      </div>
+      </SpringUp>
     </Backdrop>
   );
 }

--- a/packages/web/src/components/ContextMenu/EditSubmenuPanel.tsx
+++ b/packages/web/src/components/ContextMenu/EditSubmenuPanel.tsx
@@ -1,6 +1,7 @@
 import { CaretLeftIcon } from '@phosphor-icons/react';
 import { useEffect, useRef } from 'react';
 import type { MenuItem } from '../ContextMenu';
+import { SpringUp } from '../ui/SpringUp';
 
 interface EditSubmenuPanelProps {
   config: NonNullable<MenuItem['editSubmenu']>;
@@ -12,13 +13,13 @@ export function EditSubmenuPanel({ config, onBack, onSave }: EditSubmenuPanelPro
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    // Delay focus to let the fade-up animation start (element is opacity:0 initially)
+    // Delay focus to let the spring-up animation start.
     const timer = setTimeout(() => inputRef.current?.focus(), 50);
     return () => clearTimeout(timer);
   }, []);
 
   return (
-    <div className='animate-fade-up'>
+    <SpringUp>
       <div className='flex items-center gap-2 px-3 py-2 border-b border-border'>
         <button
           type='button'
@@ -62,6 +63,6 @@ export function EditSubmenuPanel({ config, onBack, onSave }: EditSubmenuPanelPro
           </button>
         </div>
       </div>
-    </div>
+    </SpringUp>
   );
 }

--- a/packages/web/src/components/ContextMenu/SubmenuPanel.tsx
+++ b/packages/web/src/components/ContextMenu/SubmenuPanel.tsx
@@ -1,5 +1,6 @@
 import { CaretLeftIcon } from '@phosphor-icons/react';
 import type { SubmenuConfig } from '../ContextMenu';
+import { SpringUp } from '../ui/SpringUp';
 
 interface SubmenuPanelProps {
   config: SubmenuConfig;
@@ -9,7 +10,7 @@ interface SubmenuPanelProps {
 
 export function SubmenuPanel({ config, onBack, onSelect }: SubmenuPanelProps) {
   return (
-    <div className='animate-fade-up'>
+    <SpringUp>
       <div className='flex items-center gap-2 px-3 py-2 border-b border-border'>
         <button
           type='button'
@@ -45,6 +46,6 @@ export function SubmenuPanel({ config, onBack, onSelect }: SubmenuPanelProps) {
           ))
         )}
       </div>
-    </div>
+    </SpringUp>
   );
 }

--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import { CaretLeftIcon, CraneTowerIcon, GuitarIcon, LinkBreakIcon } from '@phosphor-icons/react';
 import { useEffect, useState } from 'react';
-import { NavLink, Outlet, useNavigate } from 'react-router-dom';
+import { NavLink, useNavigate } from 'react-router-dom';
+import { AnimatedOutlet } from './AnimatedOutlet';
 import { ADMIN_NAV_ITEMS, NAV_ITEMS } from '../constants';
 import { useAdminView } from '../context/AdminViewContext';
 import { useAuth } from '../context/AuthContext';
@@ -245,7 +246,7 @@ function QueueLayout() {
     <>
       <div className='flex-1 flex flex-col min-w-0 pt-14 md:pt-0 overflow-hidden'>
         <main className='flex-1 overflow-y-auto pb-22 md:pb-20'>
-          <Outlet />
+          <AnimatedOutlet />
         </main>
         <NowPlayingBar />
       </div>

--- a/packages/web/src/components/MobileNav.tsx
+++ b/packages/web/src/components/MobileNav.tsx
@@ -12,6 +12,7 @@ import { useAdminView } from '../context/AdminViewContext';
 import { useAuth } from '../context/AuthContext';
 import SettingsMenu from './SettingsMenu';
 import { Button } from './ui/Button';
+import { SpringUp } from './ui/SpringUp';
 
 export default function MobileNav() {
   const { user, logout } = useAuth();
@@ -109,15 +110,17 @@ export default function MobileNav() {
 
       {/* Backdrop overlay */}
       {isOpen && (
-        <button
-          type='button'
-          aria-label='Close navigation menu'
-          className='md:hidden fixed inset-0 z-50 bg-black/60 backdrop-blur-sm animate-fade-up'
-          onClick={() => setIsOpen(false)}
-          onKeyDown={(e) => {
-            if (e.key === 'Escape' || e.key === 'Enter') setIsOpen(false);
-          }}
-        />
+        <SpringUp className='md:hidden fixed inset-0 z-50'>
+          <button
+            type='button'
+            aria-label='Close navigation menu'
+            className='bg-black/60 backdrop-blur-sm absolute inset-0'
+            onClick={() => setIsOpen(false)}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape' || e.key === 'Enter') setIsOpen(false);
+            }}
+          />
+        </SpringUp>
       )}
 
       {/* Slide-out drawer */}

--- a/packages/web/src/components/NotificationToast.tsx
+++ b/packages/web/src/components/NotificationToast.tsx
@@ -1,4 +1,5 @@
 import type { Notification } from '../hooks/useNotification';
+import { SpringUp } from './ui/SpringUp';
 
 interface NotificationToastProps {
   notification: Notification;
@@ -7,14 +8,14 @@ interface NotificationToastProps {
 
 export default function NotificationToast({ notification, lift }: NotificationToastProps) {
   return (
-    <div
-      className={`fixed ${lift ? 'bottom-48 md:bottom-40' : 'bottom-24'} left-1/2 -translate-x-1/2 z-50 px-4 py-3 glass-toast font-mono text-xs animate-fade-up ${
+    <SpringUp
+      className={`fixed ${lift ? 'bottom-48 md:bottom-40' : 'bottom-24'} left-1/2 -translate-x-1/2 z-50 px-4 py-3 glass-toast font-mono text-xs ${
         notification.type === 'success'
           ? 'bg-accent/15 border-accent/40 text-accent'
           : 'bg-danger/15 border-danger/40 text-danger'
       }`}
     >
       {notification.message}
-    </div>
+    </SpringUp>
   );
 }

--- a/packages/web/src/components/QueuePanel.tsx
+++ b/packages/web/src/components/QueuePanel.tsx
@@ -25,7 +25,7 @@ import {
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { memo, useCallback, useMemo, useRef, useState } from 'react';
 import { AnimatePresence, type Transition } from 'motion/react';
-import * as motionM from 'motion/react-m';
+import * as m from 'motion/react-m';
 import { queueItemVariants } from '../lib/motion';
 import type { CooldownState } from '../hooks/useCooldownGuard';
 import { createPortal } from 'react-dom';
@@ -301,7 +301,7 @@ export default function QueuePanel({
       <div className='p-4 space-y-4 shrink-0'>
         <AnimatePresence mode='wait'>
           {currentSong ? (
-            <motionM.div
+            <m.div
               key={currentSong.id}
               variants={queueItemVariants}
               initial='initial'
@@ -314,9 +314,9 @@ export default function QueuePanel({
                 elapsed={elapsed}
                 registerProgress={registerProgress}
               />
-            </motionM.div>
+            </m.div>
           ) : (
-            <motionM.div
+            <m.div
               key='idle'
               variants={queueItemVariants}
               initial='initial'
@@ -325,7 +325,7 @@ export default function QueuePanel({
               transition={{ duration: 0.2, ease: 'easeOut' } as Transition}
             >
               <IdleCard />
-            </motionM.div>
+            </m.div>
           )}
         </AnimatePresence>
 
@@ -409,7 +409,7 @@ export default function QueuePanel({
                     transform: `translateY(${virtualRow.start}px)`,
                   }}
                 >
-                  <motionM.div
+                  <m.div
                     initial='initial'
                     animate='animate'
                     variants={queueItemVariants}
@@ -429,7 +429,7 @@ export default function QueuePanel({
                       onMoveToTop={handleMoveToTop}
                       onMoveToBottom={handleMoveToBottom}
                     />
-                  </motionM.div>
+                  </m.div>
                 </div>
               );
             })}

--- a/packages/web/src/components/QueuePanel.tsx
+++ b/packages/web/src/components/QueuePanel.tsx
@@ -24,6 +24,9 @@ import {
 } from '@phosphor-icons/react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { memo, useCallback, useMemo, useRef, useState } from 'react';
+import { AnimatePresence, type Transition } from 'motion/react';
+import * as motionM from 'motion/react-m';
+import { queueItemVariants } from '../lib/motion';
 import type { CooldownState } from '../hooks/useCooldownGuard';
 import { createPortal } from 'react-dom';
 import ConfirmModal from '../components/ConfirmModal';
@@ -296,15 +299,35 @@ export default function QueuePanel({
 
       {/* Fixed content: Now Playing */}
       <div className='p-4 space-y-4 shrink-0'>
-        {currentSong ? (
-          <NowPlayingCard
-            song={currentSong}
-            elapsed={elapsed}
-            registerProgress={registerProgress}
-          />
-        ) : (
-          <IdleCard />
-        )}
+        <AnimatePresence mode='wait'>
+          {currentSong ? (
+            <motionM.div
+              key={currentSong.id}
+              variants={queueItemVariants}
+              initial='initial'
+              animate='animate'
+              exit='exit'
+              transition={{ duration: 0.2, ease: 'easeOut' } as Transition}
+            >
+              <NowPlayingCard
+                song={currentSong}
+                elapsed={elapsed}
+                registerProgress={registerProgress}
+              />
+            </motionM.div>
+          ) : (
+            <motionM.div
+              key='idle'
+              variants={queueItemVariants}
+              initial='initial'
+              animate='animate'
+              exit='exit'
+              transition={{ duration: 0.2, ease: 'easeOut' } as Transition}
+            >
+              <IdleCard />
+            </motionM.div>
+          )}
+        </AnimatePresence>
 
         {/* Empty state */}
         {virtualItems.length === 0 && (
@@ -386,20 +409,27 @@ export default function QueuePanel({
                     transform: `translateY(${virtualRow.start}px)`,
                   }}
                 >
-                  <QueueSongItem
-                    song={item.song}
-                    index={item.listIndex}
-                    variant={item.variant}
-                    canManage={canManage}
-                    targetQueue={item.variant === 'priority' ? priorityQueue : queue}
-                    onRemove={handleRemove}
-                    onPromote={handlePromote}
-                    onDemote={handleDemote}
-                    onMoveUp={handleMoveUp}
-                    onMoveDown={handleMoveDown}
-                    onMoveToTop={handleMoveToTop}
-                    onMoveToBottom={handleMoveToBottom}
-                  />
+                  <motionM.div
+                    initial='initial'
+                    animate='animate'
+                    variants={queueItemVariants}
+                    transition={{ duration: 0.2, ease: 'easeOut' } as Transition}
+                  >
+                    <QueueSongItem
+                      song={item.song}
+                      index={item.listIndex}
+                      variant={item.variant}
+                      canManage={canManage}
+                      targetQueue={item.variant === 'priority' ? priorityQueue : queue}
+                      onRemove={handleRemove}
+                      onPromote={handlePromote}
+                      onDemote={handleDemote}
+                      onMoveUp={handleMoveUp}
+                      onMoveDown={handleMoveDown}
+                      onMoveToTop={handleMoveToTop}
+                      onMoveToBottom={handleMoveToBottom}
+                    />
+                  </motionM.div>
                 </div>
               );
             })}

--- a/packages/web/src/components/VirtualSongList.tsx
+++ b/packages/web/src/components/VirtualSongList.tsx
@@ -1,6 +1,32 @@
 import type { Playlist, Song } from '@alfira/server/shared';
 import { memo } from 'react';
+import type { Transition, Variants } from 'motion/react';
+import * as motionM from 'motion/react-m';
 import SongCard from './SongCard';
+
+/** Parent orchestrates staggered children. */
+const gridVariants: Variants = {
+  hidden: {},
+  show: {
+    transition: {
+      staggerChildren: 0.04,
+    },
+  },
+};
+
+/** Each card springs up with a gentle bounce. */
+const cardVariants: Variants = {
+  hidden: { opacity: 0, y: 24 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      type: 'spring',
+      stiffness: 300,
+      damping: 24,
+    } as Transition,
+  },
+};
 import VirtualListShell from './VirtualListShell';
 
 interface VirtualSongListProps {
@@ -109,6 +135,10 @@ export const VirtualSongList = memo(function VirtualSongList({
 }: VirtualSongListProps) {
   const isGrid = viewMode === 'grid';
 
+  const gridClass = isGrid
+    ? 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-[repeat(auto-fill,minmax(270px,1fr))] gap-3 md:gap-4 items-start'
+    : 'flex flex-col gap-1.5';
+
   return (
     <VirtualListShell
       isLoading={isLoading}
@@ -124,30 +154,26 @@ export const VirtualSongList = memo(function VirtualSongList({
       emptyMessage={emptyMessage}
       endSpacer
     >
-      <div
-        className={
-          isGrid
-            ? 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-[repeat(auto-fill,minmax(270px,1fr))] gap-3 md:gap-4 items-start'
-            : 'flex flex-col gap-1.5'
-        }
-      >
+      <motionM.div className={gridClass} initial='hidden' animate='show' variants={gridVariants}>
         {items.map((song) => (
-          <SongCard
-            key={song.id}
-            song={song}
-            variant={viewMode === 'grid' ? 'grid' : 'list'}
-            isAdminView={isAdminView}
-            playlists={playlists}
-            onDelete={onDelete}
-            onPlay={() => onPlay(song.id)}
-            isPlaying={playingId === song.id}
-            onAddToQueue={() => onAddToQueue(song.id)}
-            selectionMode={selectionMode}
-            isSelected={isSelected?.(song.id) ?? false}
-            onToggleSelect={onToggleSelect ? () => onToggleSelect(song.id) : undefined}
-          />
+          <motionM.div key={song.id} variants={cardVariants}>
+            <SongCard
+              key={song.id}
+              song={song}
+              variant={viewMode === 'grid' ? 'grid' : 'list'}
+              isAdminView={isAdminView}
+              playlists={playlists}
+              onDelete={onDelete}
+              onPlay={() => onPlay(song.id)}
+              isPlaying={playingId === song.id}
+              onAddToQueue={() => onAddToQueue(song.id)}
+              selectionMode={selectionMode}
+              isSelected={isSelected?.(song.id) ?? false}
+              onToggleSelect={onToggleSelect ? () => onToggleSelect(song.id) : undefined}
+            />
+          </motionM.div>
         ))}
-      </div>
+      </motionM.div>
     </VirtualListShell>
   );
 });

--- a/packages/web/src/components/VirtualSongList.tsx
+++ b/packages/web/src/components/VirtualSongList.tsx
@@ -1,19 +1,8 @@
 import type { Playlist, Song } from '@alfira/server/shared';
 import { memo } from 'react';
-import type { Variants } from 'motion/react';
 import * as motionM from 'motion/react-m';
 import SongCard from './SongCard';
-import { springUp } from '../lib/motion';
-
-/** Parent orchestrates staggered children. */
-const gridVariants: Variants = {
-  hidden: {},
-  show: {
-    transition: {
-      staggerChildren: 0.04,
-    },
-  },
-};
+import { springUpStaggered } from '../lib/motion';
 import VirtualListShell from './VirtualListShell';
 
 interface VirtualSongListProps {
@@ -141,9 +130,15 @@ export const VirtualSongList = memo(function VirtualSongList({
       emptyMessage={emptyMessage}
       endSpacer
     >
-      <motionM.div className={gridClass} initial='hidden' animate='show' variants={gridVariants}>
-        {items.map((song) => (
-          <motionM.div key={song.id} variants={springUp}>
+      <div className={gridClass}>
+        {items.map((song, index) => (
+          <motionM.div
+            key={song.id}
+            initial='hidden'
+            animate='show'
+            variants={springUpStaggered}
+            custom={index % 24}
+          >
             <SongCard
               key={song.id}
               song={song}
@@ -160,7 +155,7 @@ export const VirtualSongList = memo(function VirtualSongList({
             />
           </motionM.div>
         ))}
-      </motionM.div>
+      </div>
     </VirtualListShell>
   );
 });

--- a/packages/web/src/components/VirtualSongList.tsx
+++ b/packages/web/src/components/VirtualSongList.tsx
@@ -1,8 +1,9 @@
 import type { Playlist, Song } from '@alfira/server/shared';
 import { memo } from 'react';
-import type { Transition, Variants } from 'motion/react';
+import type { Variants } from 'motion/react';
 import * as motionM from 'motion/react-m';
 import SongCard from './SongCard';
+import { springUp } from '../lib/motion';
 
 /** Parent orchestrates staggered children. */
 const gridVariants: Variants = {
@@ -11,20 +12,6 @@ const gridVariants: Variants = {
     transition: {
       staggerChildren: 0.04,
     },
-  },
-};
-
-/** Each card springs up with a gentle bounce. */
-const cardVariants: Variants = {
-  hidden: { opacity: 0, y: 24 },
-  show: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      type: 'spring',
-      stiffness: 300,
-      damping: 24,
-    } as Transition,
   },
 };
 import VirtualListShell from './VirtualListShell';
@@ -156,7 +143,7 @@ export const VirtualSongList = memo(function VirtualSongList({
     >
       <motionM.div className={gridClass} initial='hidden' animate='show' variants={gridVariants}>
         {items.map((song) => (
-          <motionM.div key={song.id} variants={cardVariants}>
+          <motionM.div key={song.id} variants={springUp}>
             <SongCard
               key={song.id}
               song={song}

--- a/packages/web/src/components/VirtualSongList.tsx
+++ b/packages/web/src/components/VirtualSongList.tsx
@@ -2,7 +2,6 @@ import type { Playlist, Song } from '@alfira/server/shared';
 import { memo } from 'react';
 import * as m from 'motion/react-m';
 import SongCard from './SongCard';
-import { springUpStaggered } from '../lib/motion';
 import VirtualListShell from './VirtualListShell';
 
 interface VirtualSongListProps {
@@ -134,10 +133,14 @@ export const VirtualSongList = memo(function VirtualSongList({
         {items.map((song, index) => (
           <m.div
             key={song.id}
-            initial='hidden'
-            animate='show'
-            variants={springUpStaggered}
-            custom={index % 24}
+            initial={{ opacity: 0, y: 24 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{
+              type: 'spring',
+              stiffness: 300,
+              damping: 24,
+              delay: (index % 24) * 0.04,
+            }}
           >
             <SongCard
               key={song.id}

--- a/packages/web/src/components/VirtualSongList.tsx
+++ b/packages/web/src/components/VirtualSongList.tsx
@@ -1,6 +1,6 @@
 import type { Playlist, Song } from '@alfira/server/shared';
 import { memo } from 'react';
-import * as motionM from 'motion/react-m';
+import * as m from 'motion/react-m';
 import SongCard from './SongCard';
 import { springUpStaggered } from '../lib/motion';
 import VirtualListShell from './VirtualListShell';
@@ -132,7 +132,7 @@ export const VirtualSongList = memo(function VirtualSongList({
     >
       <div className={gridClass}>
         {items.map((song, index) => (
-          <motionM.div
+          <m.div
             key={song.id}
             initial='hidden'
             animate='show'
@@ -153,7 +153,7 @@ export const VirtualSongList = memo(function VirtualSongList({
               isSelected={isSelected?.(song.id) ?? false}
               onToggleSelect={onToggleSelect ? () => onToggleSelect(song.id) : undefined}
             />
-          </motionM.div>
+          </m.div>
         ))}
       </div>
     </VirtualListShell>

--- a/packages/web/src/components/queue/OverrideModal.tsx
+++ b/packages/web/src/components/queue/OverrideModal.tsx
@@ -5,6 +5,7 @@ import { apiErrorMessage, isRateLimitError } from '../../utils/api';
 import { Backdrop } from '../Backdrop';
 import { Button } from '../ui/Button';
 import { Spinner } from '../ui/Spinner';
+import { SpringUp } from '../ui/SpringUp';
 
 export default function OverrideModal({
   onClose,
@@ -36,7 +37,7 @@ export default function OverrideModal({
 
   return (
     <Backdrop onClose={onClose}>
-      <div className='p-5 md:p-6 w-full max-w-sm mx-4 glass-modal animate-fade-up'>
+      <SpringUp className='p-5 md:p-6 w-full max-w-sm mx-4 glass-modal'>
         <h2 className='font-display text-2xl md:text-3xl text-fg tracking-wider mb-1'>Override</h2>
         <p className='font-mono text-xs text-danger mb-4 md:mb-6'>
           <WarningIcon size={14} weight='duotone' className='inline mr-1' /> This will stop current
@@ -95,7 +96,7 @@ export default function OverrideModal({
             {submitting ? 'Overriding...' : 'Override & Play'}
           </Button>
         </div>
-      </div>
+      </SpringUp>
     </Backdrop>
   );
 }

--- a/packages/web/src/components/queue/QuickAddModal.tsx
+++ b/packages/web/src/components/queue/QuickAddModal.tsx
@@ -5,6 +5,7 @@ import { Backdrop } from '../Backdrop';
 import { Button } from '../ui/Button';
 import Checkbox from '../ui/Checkbox';
 import { Spinner } from '../ui/Spinner';
+import { SpringUp } from '../ui/SpringUp';
 
 export default function QuickAddModal({
   onClose,
@@ -48,7 +49,7 @@ export default function QuickAddModal({
 
   return (
     <Backdrop onClose={onClose}>
-      <div className='p-5 md:p-6 w-full max-w-sm mx-4 glass-modal animate-fade-up'>
+      <SpringUp className='p-5 md:p-6 w-full max-w-sm mx-4 glass-modal'>
         <h2 className='font-display text-2xl md:text-3xl text-fg tracking-wider mb-1'>Quick Add</h2>
         <p className='font-mono text-xs text-muted mb-4 md:mb-6'>
           add a url to Up Next without saving to library
@@ -118,7 +119,7 @@ export default function QuickAddModal({
             {submitting ? 'Adding...' : importFullPlaylist ? 'Add Playlist' : 'Add to Up Next'}
           </Button>
         </div>
-      </div>
+      </SpringUp>
     </Backdrop>
   );
 }

--- a/packages/web/src/components/ui/Card.tsx
+++ b/packages/web/src/components/ui/Card.tsx
@@ -1,4 +1,5 @@
 import { type HTMLAttributes, memo } from 'react';
+import { SpringUp } from './SpringUp';
 
 interface CardProps extends HTMLAttributes<HTMLDivElement> {
   /** Enables hover/active clay transitions */
@@ -17,16 +18,21 @@ export const Card = memo(function Card({
   const hoverClasses = hoverable
     ? 'hover:clay-raised hover:-translate-y-px [&:active:not(:has(button:active))]:clay-flat [&:active:not(:has(button:active))]:translate-y-0'
     : '';
-  const animateClasses = animate ? 'animate-fade-up opacity-0' : '';
 
-  return (
+  const card = (
     <div
-      className={`bg-elevated clay-resting transition-all duration-100 ${hoverClasses} ${animateClasses} ${className}`}
+      className={`bg-elevated clay-resting transition-all duration-100 ${hoverClasses} ${className}`}
       {...rest}
     >
       {children}
     </div>
   );
+
+  if (animate) {
+    return <SpringUp>{card}</SpringUp>;
+  }
+
+  return card;
 });
 
 export default Card;

--- a/packages/web/src/components/ui/SpringUp.tsx
+++ b/packages/web/src/components/ui/SpringUp.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import * as motionM from 'motion/react-m';
+import * as m from 'motion/react-m';
 import { springUp } from '../../lib/motion';
 
 interface SpringUpProps {
@@ -13,8 +13,8 @@ interface SpringUpProps {
  */
 export function SpringUp({ children, className }: SpringUpProps) {
   return (
-    <motionM.div initial='hidden' animate='show' variants={springUp} className={className}>
+    <m.div initial='hidden' animate='show' variants={springUp} className={className}>
       {children}
-    </motionM.div>
+    </m.div>
   );
 }

--- a/packages/web/src/components/ui/SpringUp.tsx
+++ b/packages/web/src/components/ui/SpringUp.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from 'react';
+import * as motionM from 'motion/react-m';
+import { springUp } from '../../lib/motion';
+
+interface SpringUpProps {
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * Wraps children in a motion.div that springs up on mount.
+ * Uses shared spring variants from lib/motion.ts.
+ */
+export function SpringUp({ children, className }: SpringUpProps) {
+  return (
+    <motionM.div initial='hidden' animate='show' variants={springUp} className={className}>
+      {children}
+    </motionM.div>
+  );
+}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -41,26 +41,6 @@
   src: url(/fonts/jetbrains-mono-500-latin.woff2) format('woff2');
 }
 
-@keyframes fadeUp {
-  0% {
-    opacity: 0;
-    transform: translateY(12px);
-  }
-  100% {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@keyframes slideInRight {
-  0% {
-    transform: translateX(100%);
-  }
-  100% {
-    transform: translateX(0);
-  }
-}
-
 @keyframes slideUp {
   0% {
     transform: translateY(100%);
@@ -523,8 +503,6 @@
   --font-body: 'Chiron GoRound TC', regular;
   --font-mono: 'JetBrains Mono', monospace;
   /* Animations */
-  --animate-fade-up: fadeUp 0.3s ease forwards;
-  --animate-slide-in-right: slideInRight 0.3s ease forwards;
   --animate-slide-up: slideUp 0.3s ease forwards;
   --animate-pulse-gentle: pulseGentle 2.4s ease-in-out infinite;
   /* Clay radius tokens — consistent "pebble" proportions */
@@ -1335,7 +1313,7 @@
 
 /* Glass popover — unified styling for dropdowns, context menus, etc. */
 @utility glass-popover {
-  @apply glass-panel rounded-2xl border border-accent/30 clay-floating overflow-hidden animate-fade-up;
+  @apply glass-panel rounded-2xl border border-accent/30 clay-floating overflow-hidden;
 }
 
 /* Glass hover tooltip — for .group hover-revealed help text */

--- a/packages/web/src/lib/motion.ts
+++ b/packages/web/src/lib/motion.ts
@@ -1,0 +1,13 @@
+import { LazyMotion, domAnimation, type Variants } from 'motion/react';
+
+/**
+ * Shared page transition variants.
+ * Subtle upward fade — quick enough to feel responsive, slow enough to register.
+ */
+export const pageVariants: Variants = {
+  initial: { opacity: 0, y: 6 },
+  animate: { opacity: 1, y: 0 },
+  exit: { opacity: 0 },
+};
+
+export { LazyMotion, domAnimation };

--- a/packages/web/src/lib/motion.ts
+++ b/packages/web/src/lib/motion.ts
@@ -10,4 +10,14 @@ export const pageVariants: Variants = {
   exit: { opacity: 0 },
 };
 
+/**
+ * Queue item enter/exit variants.
+ * Slides in from the right on enter, fades out on exit.
+ */
+export const queueItemVariants: Variants = {
+  initial: { opacity: 0, x: 12 },
+  animate: { opacity: 1, x: 0 },
+  exit: { opacity: 0, x: -8 },
+};
+
 export { LazyMotion, domAnimation };

--- a/packages/web/src/lib/motion.ts
+++ b/packages/web/src/lib/motion.ts
@@ -21,3 +21,13 @@ export const queueItemVariants: Variants = {
 };
 
 export { LazyMotion, domAnimation };
+
+/** Spring-up variant — gentle bounce for cards, modals, and overlays. */
+export const springUp: Variants = {
+  hidden: { opacity: 0, y: 24 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: { type: 'spring', stiffness: 300, damping: 24 },
+  },
+};

--- a/packages/web/src/lib/motion.ts
+++ b/packages/web/src/lib/motion.ts
@@ -31,3 +31,18 @@ export const springUp: Variants = {
     transition: { type: 'spring', stiffness: 300, damping: 24 },
   },
 };
+
+/**
+ * Spring-up variant with per-item stagger via the custom prop.
+ * Pass the 0-based index as custom — each item delays by index * 40ms.
+ *
+ * Usage: custom={index % pageSize}
+ */
+export const springUpStaggered: Variants = {
+  hidden: { opacity: 0, y: 24 },
+  show: (i: number) => ({
+    opacity: 1,
+    y: 0,
+    transition: { type: 'spring', stiffness: 300, damping: 24, delay: i * 0.04 },
+  }),
+};

--- a/packages/web/src/lib/motion.ts
+++ b/packages/web/src/lib/motion.ts
@@ -31,18 +31,3 @@ export const springUp: Variants = {
     transition: { type: 'spring', stiffness: 300, damping: 24 },
   },
 };
-
-/**
- * Spring-up variant with per-item stagger via the custom prop.
- * Pass the 0-based index as custom — each item delays by index * 40ms.
- *
- * Usage: custom={index % pageSize}
- */
-export const springUpStaggered: Variants = {
-  hidden: { opacity: 0, y: 24 },
-  show: (i: number) => ({
-    opacity: 1,
-    y: 0,
-    transition: { type: 'spring', stiffness: 300, damping: 24, delay: i * 0.04 },
-  }),
-};

--- a/packages/web/src/pages/LoginPage.tsx
+++ b/packages/web/src/pages/LoginPage.tsx
@@ -2,6 +2,7 @@ import { DiscordLogoIcon } from '@phosphor-icons/react';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
+import { SpringUp } from '../components/ui/SpringUp';
 
 export default function LoginPage() {
   const { user, loading } = useAuth();
@@ -38,7 +39,7 @@ export default function LoginPage() {
       />
 
       {/* Card */}
-      <div className='relative z-10 w-full max-w-sm mx-4 animate-fade-up'>
+      <SpringUp className='relative z-10 w-full max-w-sm mx-4'>
         <div className='p-6 md:p-8 glass-modal'>
           {/* Logo */}
           <div className='mb-6 md:mb-8 text-center'>
@@ -66,7 +67,7 @@ export default function LoginPage() {
         <p className='text-center font-mono text-[10px] text-faint mt-6 tracking-widest uppercase'>
           access is restricted to server members
         </p>
-      </div>
+      </SpringUp>
     </div>
   );
 }

--- a/packages/web/src/pages/PlaylistsPage.tsx
+++ b/packages/web/src/pages/PlaylistsPage.tsx
@@ -8,6 +8,7 @@ import { Backdrop } from '../components/Backdrop';
 import NotificationToast from '../components/NotificationToast';
 import { Button } from '../components/ui/Button';
 import { PageHeader } from '../components/ui/PageHeader';
+import { SpringUp } from '../components/ui/SpringUp';
 import { VirtualPlaylistList } from '../components/VirtualPlaylistList';
 import { useAdminView } from '../context/AdminViewContext';
 import { CreatePlaylistSubmitButton, useCreatePlaylist } from '../hooks/useCreatePlaylist';
@@ -129,51 +130,50 @@ function CreatePlaylistModal({ onClose }: { onClose: () => void }) {
 
   return (
     <Backdrop onClose={onClose}>
-      <form
-        action={formAction}
-        className='p-5 md:p-6 w-full max-w-sm mx-4 glass-modal animate-fade-up'
-      >
-        <h2 className='font-display text-2xl md:text-3xl text-fg tracking-wider mb-1'>
-          New Playlist
-        </h2>
-        <p className='font-mono text-xs text-muted mb-4 md:mb-6'>choose a name</p>
-        <input
-          name='name'
-          className='input mb-3'
-          placeholder='My Playlist'
-          value={name}
-          onChange={(e) => {
-            setName(e.target.value);
-          }}
-          onKeyDown={(e) => {
-            if (e.key === 'Escape') onClose();
-          }}
-          required
-        />
-        <div className='mb-3'>
-          <p className='font-mono text-xs text-muted mb-1.5'>track a tag (optional)</p>
-          <select
-            name='tagNameLower'
-            className='input w-full'
-            value={selectedTag}
-            onChange={(e) => setSelectedTag(e.target.value)}
-          >
-            <option value=''>None (manual playlist)</option>
-            {tags.map((tag) => (
-              <option key={tag.nameLower} value={tag.nameLower}>
-                {tag.canonicalName}
-              </option>
-            ))}
-          </select>
-        </div>
-        {state?.error && <p className='font-mono text-xs text-danger mb-3'>{state.error}</p>}
-        <div className='flex gap-2 justify-end'>
-          <Button variant='inherit' type='button' onClick={onClose} surface='surface'>
-            Cancel
-          </Button>
-          <CreatePlaylistSubmitButton disabled={!name.trim()}>Create</CreatePlaylistSubmitButton>
-        </div>
-      </form>
+      <SpringUp className='p-5 md:p-6 w-full max-w-sm mx-4 glass-modal'>
+        <form action={formAction}>
+          <h2 className='font-display text-2xl md:text-3xl text-fg tracking-wider mb-1'>
+            New Playlist
+          </h2>
+          <p className='font-mono text-xs text-muted mb-4 md:mb-6'>choose a name</p>
+          <input
+            name='name'
+            className='input mb-3'
+            placeholder='My Playlist'
+            value={name}
+            onChange={(e) => {
+              setName(e.target.value);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') onClose();
+            }}
+            required
+          />
+          <div className='mb-3'>
+            <p className='font-mono text-xs text-muted mb-1.5'>track a tag (optional)</p>
+            <select
+              name='tagNameLower'
+              className='input w-full'
+              value={selectedTag}
+              onChange={(e) => setSelectedTag(e.target.value)}
+            >
+              <option value=''>None (manual playlist)</option>
+              {tags.map((tag) => (
+                <option key={tag.nameLower} value={tag.nameLower}>
+                  {tag.canonicalName}
+                </option>
+              ))}
+            </select>
+          </div>
+          {state?.error && <p className='font-mono text-xs text-danger mb-3'>{state.error}</p>}
+          <div className='flex gap-2 justify-end'>
+            <Button variant='inherit' type='button' onClick={onClose} surface='surface'>
+              Cancel
+            </Button>
+            <CreatePlaylistSubmitButton disabled={!name.trim()}>Create</CreatePlaylistSubmitButton>
+          </div>
+        </form>
+      </SpringUp>
     </Backdrop>
   );
 }


### PR DESCRIPTION
## Summary

Replace CSS keyframe animations with motion (framer-motion v12) across the web UI. Spring physics give a polished, bouncy finish that CSS can't match. All fade-up animations now share a single `springUp` variant in `lib/motion.ts`.

## Changes

- **Page transitions** — `AnimatedOutlet` wraps route changes in `AnimatePresence` with crossfade + slide
- **Queue panel** — now-playing card animates on song change; queue items slide in on mount
- **Song list** — spring-staggered card entrance with parent-orchestrated `staggerChildren`
- **SpringUp migration** — all 12 `animate-fade-up` CSS usages replaced with reusable `<SpringUp>` wrapper
- **Dependency** — added `motion` via `LazyMotion` + `m` pattern for minimal bundle
- **Cleanup** — removed unused CSS keyframes (`fadeUp`, `slideInRight`) and animation tokens