### PR TITLE
fix(server): cache guild member fetches to avoid Discord rate limits

### DIFF
--- a/.pi/skills/alfira-web/SKILL.md
+++ b/.pi/skills/alfira-web/SKILL.md
@@ -84,21 +84,21 @@ description: React 19 + Tailwind CSS 4 web UI, component and page structure, API
 
 ### Utility UI Components (in `components/ui/`)
 
-| Component               | Purpose                      |
-| ----------------------- | ---------------------------- |
-| `Button.tsx`            | Reusable button component    |
-| `Card.tsx`              | Reusable card wrapper        |
-| `Checkbox.tsx`          | Reusable checkbox            |
-| `DurationBadge.tsx`     | Formatted duration display   |
-| `ErrorBanner.tsx`       | Error message banner         |
-| `PlayButton.tsx`        | Play action button           |
-| `RoleComboBox.tsx`      | Role selection dropdown      |
-| `ArtworkImage.tsx`      | Lazy-loaded artwork with fallback |
-| `PageHeader.tsx`        | Consistent page header           |
-| `Spinner.tsx`           | Loading spinner                   |
+| Component               | Purpose                                    |
+| ----------------------- | ------------------------------------------ |
+| `Button.tsx`            | Reusable button component                  |
+| `Card.tsx`              | Reusable card wrapper                      |
+| `Checkbox.tsx`          | Reusable checkbox                          |
+| `DurationBadge.tsx`     | Formatted duration display                 |
+| `ErrorBanner.tsx`       | Error message banner                       |
+| `PlayButton.tsx`        | Play action button                         |
+| `RoleComboBox.tsx`      | Role selection dropdown                    |
+| `ArtworkImage.tsx`      | Lazy-loaded artwork with fallback          |
+| `PageHeader.tsx`        | Consistent page header                     |
+| `Spinner.tsx`           | Loading spinner                            |
 | `SpringUp.tsx`          | Spring-up mount animation wrapper (motion) |
-| `VirtualListFooter.tsx` | Footer for virtualized lists      |
-| `VolumeBoostBadge.tsx`  | Volume boost indicator            |
+| `VirtualListFooter.tsx` | Footer for virtualized lists               |
+| `VolumeBoostBadge.tsx`  | Volume boost indicator                     |
 
 ### Other Components
 

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -2,16 +2,16 @@
 
 ## Overview
 
-| Component    | Technology                                       |
-| ------------ | ------------------------------------------------ |
-| **Runtime**  | Bun                                              |
-| **Language** | TypeScript                                       |
-| **Discord**  | Custom gateway (WebSocket) + REST                |
-| **Audio**    | NodeLink (Lavalink v4) — direct WebSocket + REST |
-| **API**      | Bun native HTTP + WebSocket                      |
-| **Database** | SQLite + Drizzle ORM                             |
+| Component    | Technology                                             |
+| ------------ | ------------------------------------------------------ |
+| **Runtime**  | Bun                                                    |
+| **Language** | TypeScript                                             |
+| **Discord**  | Custom gateway (WebSocket) + REST                      |
+| **Audio**    | NodeLink (Lavalink v4) — direct WebSocket + REST       |
+| **API**      | Bun native HTTP + WebSocket                            |
+| **Database** | SQLite + Drizzle ORM                                   |
 | **Frontend** | React 19 + Tailwind CSS 4 + motion (framer-motion v12) |
-| **Logging**  | Custom (shared/logger)                           |
+| **Logging**  | Custom (shared/logger)                                 |
 
 ## Architecture
 

--- a/packages/server/src/lib/discordRest.ts
+++ b/packages/server/src/lib/discordRest.ts
@@ -37,6 +37,62 @@ async function discordFetch(path: string): Promise<Response> {
 }
 
 // ---------------------------------------------------------------------------
+// Concurrency limiter — prevents bursting Discord's rate limits when many
+// guild member requests fire at once (e.g. resolving display names for a
+// page of songs).
+// ---------------------------------------------------------------------------
+
+class ConcurrencyLimiter {
+  private running = 0;
+  private queue: (() => void)[] = [];
+
+  constructor(private max: number) {}
+
+  acquire(): Promise<void> {
+    if (this.running < this.max) {
+      this.running++;
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      this.queue.push(resolve);
+    });
+  }
+
+  release(): void {
+    this.running--;
+    const next = this.queue.shift();
+    if (next) {
+      this.running++;
+      next();
+    }
+  }
+}
+
+const memberFetchLimiter = new ConcurrencyLimiter(4);
+
+// ---------------------------------------------------------------------------
+// In-memory cache for guild member fetches.
+// Display names / nicknames rarely change, so a 5-minute TTL avoids hitting
+// Discord's tight rate limit on GET /guilds/{id}/members/{id} on every
+// page navigation. 404s are cached for 1 minute to avoid re-querying users
+// who are not in the guild. Errors are not cached.
+// ---------------------------------------------------------------------------
+
+const MEMBER_CACHE_TTL_MS = 5 * 60 * 1000;
+const NOT_FOUND_CACHE_TTL_MS = 60 * 1000;
+
+interface CacheEntry<T> {
+  data: T;
+  expiresAt: number;
+}
+
+const memberCache = new Map<string, CacheEntry<DiscordGuildMember | null>>();
+
+// In-flight request deduplication: if two callers ask for the same member
+// concurrently, they share one promise.
+const inflightRequests = new Map<string, Promise<DiscordGuildMember | null>>();
+
+// ---------------------------------------------------------------------------
 // Types — minimal shapes matching what we consume from Discord's REST API.
 // ---------------------------------------------------------------------------
 
@@ -54,25 +110,66 @@ export interface DiscordGuildMember {
 
 /**
  * Fetch a guild member by user ID.
- * Returns null if the member is not in the guild (404) or on other errors.
+ * Results are cached for 5 minutes (404s for 1 minute). In-flight requests
+ * for the same user are deduplicated. Concurrency is limited to avoid
+ * Discord rate limits.
  */
 export async function fetchGuildMember(
   guildId: string,
   userId: string
 ): Promise<DiscordGuildMember | null> {
+  const cacheKey = `${guildId}:${userId}`;
+
+  // Check cache.
+  const cached = memberCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.data;
+  }
+
+  // Deduplicate in-flight requests.
+  const inflight = inflightRequests.get(cacheKey);
+  if (inflight) return inflight;
+
+  const promise = doFetchGuildMember(guildId, userId, cacheKey);
+  inflightRequests.set(cacheKey, promise);
+
+  try {
+    return await promise;
+  } finally {
+    inflightRequests.delete(cacheKey);
+  }
+}
+
+async function doFetchGuildMember(
+  guildId: string,
+  userId: string,
+  cacheKey: string
+): Promise<DiscordGuildMember | null> {
+  await memberFetchLimiter.acquire();
   try {
     const res = await discordFetch(`/guilds/${guildId}/members/${userId}`);
-    if (res.status === 404) return null;
-    if (!res.ok) {
-      logger.warn({ guildId, userId, status: res.status }, 'Failed to fetch guild member');
+
+    if (res.status === 404) {
+      memberCache.set(cacheKey, { data: null, expiresAt: Date.now() + NOT_FOUND_CACHE_TTL_MS });
       return null;
     }
-    return (await res.json()) as DiscordGuildMember;
+
+    if (!res.ok) {
+      logger.warn({ guildId, userId, status: res.status }, 'Failed to fetch guild member');
+      // Don't cache errors — they may be transient.
+      return null;
+    }
+
+    const member = (await res.json()) as DiscordGuildMember;
+    memberCache.set(cacheKey, { data: member, expiresAt: Date.now() + MEMBER_CACHE_TTL_MS });
+    return member;
   } catch (err) {
     logger.error(
       { err: err instanceof Error ? err.message : String(err) },
       'fetchGuildMember error'
     );
     return null;
+  } finally {
+    memberFetchLimiter.release();
   }
 }


### PR DESCRIPTION
## Summary

Every page navigation in the web UI (songs, playlists, request history) triggered concurrent Discord REST calls to `GET /guilds/{id}/members/{id}` for each unique user ID, easily hitting Discord's tight rate limit and producing repeated warnings.

## Changes

- **In-memory cache** — successful results cached 5 min, 404s cached 1 min
- **In-flight request deduplication** — concurrent callers for the same user share one promise
- **Concurrency limiter** — max 4 simultaneous Discord calls, queuing the rest

The public API (`fetchGuildMember`) is unchanged — all callers in `displayName.ts`, `songs.ts`, `playlists.ts`, and `requests.ts` get the fix transparently.