### PR TITLE
feat(web): re-add grid view with masonic masonry layout

### DIFF
--- a/.pi/skills/alfira-web/SKILL.md
+++ b/.pi/skills/alfira-web/SKILL.md
@@ -48,17 +48,18 @@ description: React 19 + Tailwind CSS 4 web UI, component and page structure, API
 
 ### Song & Queue Components
 
-| Component                 | Purpose                                                 |
-| ------------------------- | ------------------------------------------------------- |
-| `SongCard.tsx`            | Song display — grid card or list row via `variant` prop |
-| `SongEditPanel.tsx`       | Song metadata editor (tags, volume boost, etc.)         |
-| `VirtualSongList.tsx`     | Virtualized song list for performance                   |
-| `QueuePanel.tsx`          | Now playing + upcoming queue (in `components/queue/`)   |
-| `PlaylistRow.tsx`         | Playlist list item                                      |
-| `VirtualPlaylistList.tsx` | Virtualized playlist list                               |
-| `VirtualRequestList.tsx`  | Virtualized request list                                |
-| `RequestCard.tsx`         | Song request card with approve/deny actions             |
-| `SourceIcons.tsx`         | Source platform icons (YouTube, SoundCloud, etc.)       |
+| Component                 | Purpose                                                  |
+| ------------------------- | -------------------------------------------------------- |
+| `SongCard.tsx`            | Song display — grid card or list row via `variant` prop  |
+| `SongEditPanel.tsx`       | Song metadata editor (tags, volume boost, etc.)          |
+| `VirtualSongList.tsx`     | Virtualized song list (TanStack Virtual) for performance |
+| `VirtualSongGrid.tsx`     | Virtualized masonry grid (masonic) for performance       |
+| `QueuePanel.tsx`          | Now playing + upcoming queue (in `components/queue/`)    |
+| `PlaylistRow.tsx`         | Playlist list item                                       |
+| `VirtualPlaylistList.tsx` | Virtualized playlist list                                |
+| `VirtualRequestList.tsx`  | Virtualized request list                                 |
+| `RequestCard.tsx`         | Song request card with approve/deny actions              |
+| `SourceIcons.tsx`         | Source platform icons (YouTube, SoundCloud, etc.)        |
 
 ### Modals & Overlays
 
@@ -102,15 +103,16 @@ description: React 19 + Tailwind CSS 4 web UI, component and page structure, API
 
 ### Other Components
 
-| Component               | Purpose                              |
-| ----------------------- | ------------------------------------ |
-| `AddFilterPopover.tsx`  | Tag filter popover                   |
-| `BarButton.tsx`         | NowPlayingBar action button          |
-| `EmptyState.tsx`        | Empty state placeholder              |
-| `FilterChips.tsx`       | Active filter tag chips              |
-| `NotificationToast.tsx` | Toast notification                   |
-| `TagTicker.tsx`         | Scrolling tag display for songs      |
-| `UserMenu.tsx`          | User dropdown menu (profile, logout) |
+| Component               | Purpose                                                     |
+| ----------------------- | ----------------------------------------------------------- |
+| `AddFilterPopover.tsx`  | Tag filter popover                                          |
+| `BarButton.tsx`         | NowPlayingBar action button                                 |
+| `EmptyState.tsx`        | Empty state placeholder                                     |
+| `FilterChips.tsx`       | Active filter tag chips                                     |
+| `ListToolbar.tsx`       | Search, sort, filter toolbar with optional list/grid toggle |
+| `NotificationToast.tsx` | Toast notification                                          |
+| `TagTicker.tsx`         | Scrolling tag display for songs                             |
+| `UserMenu.tsx`          | User dropdown menu (profile, logout)                        |
 
 ### Context Menu Components (in `components/ContextMenu/`)
 
@@ -122,15 +124,17 @@ description: React 19 + Tailwind CSS 4 web UI, component and page structure, API
 
 ## Hooks (`packages/web/src/hooks/`)
 
-| Hook                              | Purpose                                              |
-| --------------------------------- | ---------------------------------------------------- |
-| `useSocket.ts`                    | WebSocket connection for real-time player state      |
-| `useSongActions.tsx`              | Common song actions (play, queue, edit, delete)      |
-| `useAddToQueue.ts`                | Add-to-queue logic (play now, play next, add to end) |
-| `useCreatePlaylist.tsx`           | Playlist creation form/dialog state                  |
-| `useProgressBar.ts`               | NowPlayingBar progress/scrubber logic                |
-| `useNotification.ts`              | Toast notification state                             |
-| `useVirtualizedInfiniteScroll.ts` | Virtual list with infinite scroll pagination         |
+| Hook                              | Purpose                                                   |
+| --------------------------------- | --------------------------------------------------------- |
+| `useSocket.ts`                    | WebSocket connection for real-time player state           |
+| `useSongActions.tsx`              | Common song actions (play, queue, edit, delete)           |
+| `useAddToQueue.ts`                | Add-to-queue logic (play now, play next, add to end)      |
+| `useCreatePlaylist.tsx`           | Playlist creation form/dialog state                       |
+| `useProgressBar.ts`               | NowPlayingBar progress/scrubber logic                     |
+| `useNotification.ts`              | Toast notification state                                  |
+| `useScrollObserver.ts`            | rAF-batched scroll + ResizeObserver for virtualized views |
+| `useWindowSize.ts`                | Reactive `[width, height]` window dimensions              |
+| `useVirtualizedInfiniteScroll.ts` | Virtual list with infinite scroll pagination              |
 
 ## API Client (`packages/web/src/api/`) + Utils (`packages/web/src/utils/api.ts`)
 
@@ -157,7 +161,8 @@ Shared constants used across the web UI. Common values like API base URLs, defau
 
 - **Setup:** `lib/motion.ts` exports `LazyMotion`, `domAnimation`, and shared variants. Import `m` separately as `import * as m from 'motion/react-m'` (namespace import required).
 - **Page transitions:** `AnimatedOutlet` replaces `<Outlet />` in Layout — handles enter/exit crossfade on route change
-- **Pattern:** `import * as m from 'motion/react-m'` for the minimal `m` component factory; `import { AnimatePresence } from 'motion/react'` for enter/exit orchestration; `import { pageVariants } from '../lib/motion'` for shared variants
+- **View mode transitions:** `SongsPage` and `PlaylistDetailPage` wrap list/grid views in `AnimatePresence mode='wait'` with shared `viewTransition` for crossfade when toggling view modes
+- **Pattern:** `import * as m from 'motion/react-m'` for the minimal `m` component factory; `import { AnimatePresence } from 'motion/react'` for enter/exit orchestration; `import { pageVariants, viewTransition } from '../lib/motion'` for shared variants
 - **Bundle:** Uses `LazyMotion` + `m` (4.6kb base) with `domAnimation` features loaded synchronously at mount
 - **SpringUp:** `<SpringUp>` wraps content in a shared spring-up variant (`springUp` from `lib/motion.ts`) — replaces the old `animate-fade-up` CSS class
 - CSS keyframes (`slideUp`, `pulseGentle`, etc.) remain in `index.css` for non-React animations (now-playing bar, loaders)

--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
         "@alfira/server": "workspace:*",
         "@phosphor-icons/react": "2.1.10",
         "@tanstack/react-virtual": "3.14.6",
+        "masonic": "^4.1.0",
         "motion": "^12.42.2",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -40,6 +41,14 @@
     "@alfira/server": ["@alfira/server@workspace:packages/server"],
 
     "@alfira/web": ["@alfira/web@workspace:packages/web"],
+
+    "@essentials/memoize-one": ["@essentials/memoize-one@1.1.0", "", {}, "sha512-HMkuIkKNe0EWSUpZhlaq9+5Yp47YhrMhxLMnXTRnEyE5N4xKLspAvMGjUFdi794VnEF1EcOZFS8rdROeujrgag=="],
+
+    "@essentials/one-key-map": ["@essentials/one-key-map@1.2.0", "", {}, "sha512-C2H7zHVcsoipDv4VKY5uUcv5ilsK+uEgEj+WeOdN5oz/Qj1/OZIzCdle90gDzj0xnGQrmZ9qDujwD7AkBb5k9A=="],
+
+    "@essentials/raf": ["@essentials/raf@1.2.0", "", {}, "sha512-AWJvpprE2o7ATMb7HBYMVUVmPJBCt2wZp2rY7d+rAcNSMvzLbDepy9KFeqqrPZh+s9aIpbw1LgmuAW7kuRFgrQ=="],
+
+    "@essentials/request-timeout": ["@essentials/request-timeout@1.3.0", "", { "dependencies": { "@essentials/raf": "^1.2.0" } }, "sha512-lKZPhKScNFnR1MBnk4+sxshk46fpvdN+Uh1LlKWFO5g1ocuz4EcknNIL7tm/rsCAs/+xMWiBTwbDUvm+pDNlXw=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -157,6 +166,20 @@
 
     "@phosphor-icons/react": ["@phosphor-icons/react@2.1.10", "", { "peerDependencies": { "react": ">= 16.8", "react-dom": ">= 16.8" } }, "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA=="],
 
+    "@react-hook/debounce": ["@react-hook/debounce@3.0.0", "", { "dependencies": { "@react-hook/latest": "^1.0.2" }, "peerDependencies": { "react": ">=16.8" } }, "sha512-ir/kPrSfAzY12Gre0sOHkZ2rkEmM4fS5M5zFxCi4BnCeXh2nvx9Ujd+U4IGpKCuPA+EQD0pg1eK2NGLvfWejag=="],
+
+    "@react-hook/event": ["@react-hook/event@1.2.6", "", { "peerDependencies": { "react": ">=16.8" } }, "sha512-JUL5IluaOdn5w5Afpe/puPa1rj8X6udMlQ9dt4hvMuKmTrBS1Ya6sb4sVgvfe2eU4yDuOfAhik8xhbcCekbg9Q=="],
+
+    "@react-hook/latest": ["@react-hook/latest@1.0.3", "", { "peerDependencies": { "react": ">=16.8" } }, "sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg=="],
+
+    "@react-hook/passive-layout-effect": ["@react-hook/passive-layout-effect@1.2.1", "", { "peerDependencies": { "react": ">=16.8" } }, "sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg=="],
+
+    "@react-hook/throttle": ["@react-hook/throttle@2.2.0", "", { "dependencies": { "@react-hook/latest": "^1.0.2" }, "peerDependencies": { "react": ">=16.8" } }, "sha512-LJ5eg+yMV8lXtqK3lR+OtOZ2WH/EfWvuiEEu0M3bhR7dZRfTyEJKxH1oK9uyBxiXPtWXiQggWbZirMCXam51tg=="],
+
+    "@react-hook/window-scroll": ["@react-hook/window-scroll@1.3.0", "", { "dependencies": { "@react-hook/event": "^1.2.1", "@react-hook/throttle": "^2.2.0" }, "peerDependencies": { "react": ">=16.8" } }, "sha512-LdYnCL22pFI+LTs85Fi2OQHSKWkzIuHFgv8lA+wwuaPxLOEhWR5bzJ21iygUH9X4meeLVRZKEbfpYi3OWWD4GQ=="],
+
+    "@react-hook/window-size": ["@react-hook/window-size@3.1.1", "", { "dependencies": { "@react-hook/debounce": "^3.0.0", "@react-hook/event": "^1.2.1", "@react-hook/throttle": "^2.2.0" }, "peerDependencies": { "react": ">=16.8" } }, "sha512-yWnVS5LKnOUIrEsI44oz3bIIUYqflamPL27n+k/PC//PsX/YeWBky09oPeAoc9As6jSH16Wgo8plI+ECZaHk3g=="],
+
     "@tailwindcss/cli": ["@tailwindcss/cli@4.3.2", "", { "dependencies": { "@parcel/watcher": "2.5.1", "@tailwindcss/node": "4.3.2", "@tailwindcss/oxide": "4.3.2", "enhanced-resolve": "5.21.6", "mri": "^1.2.0", "picocolors": "^1.1.1", "tailwindcss": "4.3.2" }, "bin": { "tailwindcss": "./dist/index.mjs" } }, "sha512-Fzt+HrIZHDlkRYKdLMBeufaroaPvwCBG70sMLdmurdeadNMO/LxbmT8Sbb+P83ep0iAlAImettb7Y+rO+37rXw=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.3.2", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "5.21.6", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.2" } }, "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg=="],
@@ -251,6 +274,8 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "masonic": ["masonic@4.1.0", "", { "dependencies": { "@essentials/memoize-one": "^1.1.0", "@essentials/one-key-map": "^1.2.0", "@essentials/request-timeout": "^1.3.0", "@react-hook/event": "^1.2.6", "@react-hook/latest": "^1.0.3", "@react-hook/passive-layout-effect": "^1.2.1", "@react-hook/throttle": "^2.2.0", "@react-hook/window-scroll": "^1.3.0", "@react-hook/window-size": "^3.1.1", "raf-schd": "^4.0.3", "trie-memoize": "^1.2.0" }, "peerDependencies": { "react": ">=16.8" } }, "sha512-3RNbAG5qLve7qNtGp1UM/u7vI39jO73ZFHDBAg3xl8AVh7A6Ikx7I7mBeC0NY0h1r1jJn2Wqeol1QMa09MQbyQ=="],
+
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
     "motion": ["motion@12.42.2", "", { "dependencies": { "framer-motion": "^12.42.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q=="],
@@ -273,6 +298,8 @@
 
     "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
 
+    "raf-schd": ["raf-schd@4.0.3", "", {}, "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="],
+
     "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
     "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
@@ -294,6 +321,8 @@
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "trie-memoize": ["trie-memoize@1.2.0", "", {}, "sha512-hEDLVEP1FCgaRtt0oZDJdz2lK9uK7WlB7ASswt9U9cqruSNueVigtRGxI97hevKlViqhAcRgNgzuY/m8FCCMcg=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -12,6 +12,7 @@
     "@alfira/server": "workspace:*",
     "@phosphor-icons/react": "2.1.10",
     "@tanstack/react-virtual": "3.14.6",
+    "masonic": "^4.1.0",
     "motion": "^12.42.2",
     "react": "19.2.7",
     "react-dom": "19.2.7",

--- a/packages/web/src/components/AnimatedOutlet.tsx
+++ b/packages/web/src/components/AnimatedOutlet.tsx
@@ -1,9 +1,7 @@
-import { AnimatePresence, type Transition } from 'motion/react';
+import { AnimatePresence } from 'motion/react';
 import * as m from 'motion/react-m';
 import { useLocation, useOutlet } from 'react-router-dom';
-import { pageVariants } from '../lib/motion';
-
-const pageTransition: Transition = { duration: 0.18, ease: 'easeOut' };
+import { pageVariants, viewTransition } from '../lib/motion';
 
 /**
  * Drop-in replacement for react-router-dom's <Outlet /> that animates page
@@ -26,7 +24,7 @@ export function AnimatedOutlet() {
         initial='initial'
         animate='animate'
         exit='exit'
-        transition={pageTransition}
+        transition={viewTransition}
       >
         {outlet}
       </m.div>

--- a/packages/web/src/components/ListToolbar.tsx
+++ b/packages/web/src/components/ListToolbar.tsx
@@ -5,7 +5,9 @@ import {
   CheckSquareIcon,
   FunnelIcon,
   MagnifyingGlassIcon,
+  RowsIcon,
   SortAscendingIcon,
+  SquaresFourIcon,
 } from '@phosphor-icons/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import AddFilterPopover from './AddFilterPopover';
@@ -52,6 +54,10 @@ export interface ListToolbarProps {
   showBulkToggle?: boolean;
   selectionMode?: boolean;
   onToggleSelectionMode?: () => void;
+
+  // ── View mode toggle ──
+  viewMode?: 'list' | 'grid';
+  onViewModeChange?: (mode: 'list' | 'grid') => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -77,6 +83,8 @@ export default function ListToolbar({
   showBulkToggle = false,
   selectionMode = false,
   onToggleSelectionMode,
+  viewMode,
+  onViewModeChange,
 }: ListToolbarProps) {
   // ── Search (local mirror + debounce) ─────────────────────────────
   const [searchInput, setSearchInput] = useState(searchValue);
@@ -240,6 +248,23 @@ export default function ListToolbar({
             </div>
           )}
         </div>
+
+        {/* View mode toggle */}
+        {onViewModeChange && (
+          <Button
+            variant='inherit'
+            surface='surface'
+            onClick={() => onViewModeChange(viewMode === 'grid' ? 'list' : 'grid')}
+            className='flex items-center gap-1.5 px-2.5'
+            title={viewMode === 'grid' ? 'List view' : 'Grid view'}
+          >
+            {viewMode === 'grid' ? (
+              <RowsIcon size={16} weight='duotone' />
+            ) : (
+              <SquaresFourIcon size={16} weight='duotone' />
+            )}
+          </Button>
+        )}
       </div>
 
       {/* ── Filter chips ── */}

--- a/packages/web/src/components/SongEditPanel.tsx
+++ b/packages/web/src/components/SongEditPanel.tsx
@@ -388,7 +388,7 @@ function VolumeSlider({
           max={max}
           value={numeric}
           onChange={(e) => onChange(e.target.value)}
-          className='volume-range-input'
+          className='volume-range-input min-w-0'
           style={
             {
               ['--volume-pct' as string]: pct,

--- a/packages/web/src/components/VirtualList.tsx
+++ b/packages/web/src/components/VirtualList.tsx
@@ -140,7 +140,7 @@ function VirtualListInner<T>({
           ref={scrollRef}
           className='overflow-y-auto px-4 pt-4 pb-4 min-h-0'
           style={{
-            maxHeight: 'calc(100vh - 280px)',
+            maxHeight: 'calc(100vh - 340px)',
             WebkitMaskImage:
               'linear-gradient(to bottom, black 0%, black calc(100% - 40px), transparent 100%)',
             maskImage:

--- a/packages/web/src/components/VirtualSongGrid.tsx
+++ b/packages/web/src/components/VirtualSongGrid.tsx
@@ -1,6 +1,7 @@
 import type { Playlist, Song } from '@alfira/server/shared';
 import { useContainerPosition, useMasonry, usePositioner, useResizeObserver } from 'masonic';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useWindowSize } from '../hooks/useWindowSize';
 import SongCard from './SongCard';
 
 // ---------------------------------------------------------------------------
@@ -87,6 +88,7 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
 }: VirtualSongGridProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const masonryContainerRef = useRef<HTMLDivElement>(null);
+  const [windowWidth, windowHeight] = useWindowSize();
   const [scrollTop, setScrollTop] = useState(0);
   const [containerHeight, setContainerHeight] = useState(600);
 
@@ -96,7 +98,6 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
     if (!el) return;
 
     const onScroll = () => setScrollTop(el.scrollTop);
-    const onResize = () => setContainerHeight(el.clientHeight);
 
     // Measure now, and also after a frame to catch CSS layout settling.
     setContainerHeight(el.clientHeight);
@@ -107,16 +108,24 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
     });
 
     el.addEventListener('scroll', onScroll, { passive: true });
-    window.addEventListener('resize', onResize);
 
     return () => {
       el.removeEventListener('scroll', onScroll);
-      window.removeEventListener('resize', onResize);
     };
   }, [hasLoaded]);
 
+  // ── Keep container height in sync with window resize ────────────────
+  useEffect(() => {
+    if (scrollContainerRef.current) {
+      setContainerHeight(scrollContainerRef.current.clientHeight);
+    }
+  }, [windowHeight]);
+
   // ── Masonry positioner ─────────────────────────────────────────────
-  const { width: measuredWidth } = useContainerPosition(scrollContainerRef);
+  const { width: measuredWidth } = useContainerPosition(scrollContainerRef, [
+    windowWidth,
+    windowHeight,
+  ]);
   const gridWidth =
     measuredWidth || (typeof window !== 'undefined' ? window.innerWidth - 300 : 960);
   const positioner = usePositioner({

--- a/packages/web/src/components/VirtualSongGrid.tsx
+++ b/packages/web/src/components/VirtualSongGrid.tsx
@@ -32,6 +32,12 @@ interface VirtualSongGridProps {
   onToggleSelect?: (id: string) => void;
 }
 
+/** Composite item passed to masonic so isPlaying changes trigger re-renders. */
+interface GridSongItem {
+  song: Song;
+  isPlaying: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // Skeleton
 // ---------------------------------------------------------------------------
@@ -133,12 +139,22 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
 
   // ── Infinite scroll trigger ────────────────────────────────────────
   const handleRender = useCallback(
-    (_startIndex: number, stopIndex: number | undefined, _currentItems: Song[]) => {
+    (_startIndex: number, stopIndex: number | undefined, _currentItems: GridSongItem[]) => {
       if (stopIndex !== undefined && stopIndex >= items.length - 10 && hasMore && !isFetching) {
         onFetchMore();
       }
     },
     [items.length, hasMore, isFetching, onFetchMore]
+  );
+
+  // ── Grid items (song + playing state) ──────────────────────────────
+  // Bundling isPlaying into the item data lets masonic detect playingId
+  // changes as data changes and update cards in-place (same itemKey = no
+  // unmount/remount flash). The GridCard render component stays memoized
+  // with empty deps so its identity is stable across all re-renders.
+  const gridItems: GridSongItem[] = useMemo(
+    () => items.map((song) => ({ song, isPlaying: playingId === song.id })),
+    [items, playingId]
   );
 
   // ── Grid card renderer (stable component identity via refs) ─────────
@@ -147,12 +163,15 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
   // toggles) causes React to unmount + remount every visible card,
   // producing a visible flash. We store dynamic props in a ref so the
   // component type identity never changes.
+  //
+  // NB: playingId is NOT in the ref because it lives in gridItems (above);
+  // masonic re-renders individual cards when isPlaying flips without
+  // changing the render function identity.
   const cardPropsRef = useRef({
     isAdminView,
     playlists,
     onDelete,
     onPlay,
-    playingId,
     onAddToQueue,
     selectionMode,
     isSelected,
@@ -163,7 +182,6 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
     playlists,
     onDelete,
     onPlay,
-    playingId,
     onAddToQueue,
     selectionMode,
     isSelected,
@@ -174,11 +192,11 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
     const Component = ({
       index: _index,
       width,
-      data: song,
+      data: { song, isPlaying },
     }: {
       index: number;
       width: number;
-      data: Song;
+      data: GridSongItem;
     }) => {
       const p = cardPropsRef.current;
       return (
@@ -190,7 +208,7 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
             playlists={p.playlists}
             onDelete={p.onDelete}
             onPlay={() => p.onPlay(song.id)}
-            isPlaying={p.playingId === song.id}
+            isPlaying={isPlaying}
             onAddToQueue={() => p.onAddToQueue(song.id)}
             selectionMode={p.selectionMode}
             isSelected={p.isSelected?.(song.id) ?? false}
@@ -212,12 +230,12 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
   const masonry = useMasonry({
     positioner,
     resizeObserver,
-    items,
+    items: gridItems,
     scrollTop,
     isScrolling,
     height: containerHeight || 600,
     containerRef: masonryContainerRef,
-    itemKey: (song: Song) => song.id,
+    itemKey: (item: GridSongItem) => item.song.id,
     itemHeightEstimate: 330,
     overscanBy: 2,
     render: GridCard as React.ComponentType<{ index: number; width: number; data: unknown }>,

--- a/packages/web/src/components/VirtualSongGrid.tsx
+++ b/packages/web/src/components/VirtualSongGrid.tsx
@@ -1,0 +1,252 @@
+import type { Playlist, Song } from '@alfira/server/shared';
+import { useContainerPosition, useMasonry, usePositioner, useResizeObserver } from 'masonic';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import SongCard from './SongCard';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface VirtualSongGridProps {
+  items: Song[];
+  isAdminView: boolean;
+  playlists: Playlist[];
+  isLoading: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  hasMore: boolean;
+  hasLoaded: boolean;
+  playingId: string | null;
+  onRetry: () => void;
+  onFetchMore: () => void;
+  onDelete?: (id: string) => void;
+  onPlay: (id: string) => void;
+  onAddToQueue: (id: string) => void;
+  emptyTitle: string;
+  emptyMessage?: string;
+  // Bulk selection
+  selectionMode?: boolean;
+  isSelected?: (id: string) => boolean;
+  onToggleSelect?: (id: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Skeleton
+// ---------------------------------------------------------------------------
+
+function SkeletonGrid() {
+  return (
+    <div className='px-4 pt-4'>
+      <div
+        className='grid gap-4'
+        style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))' }}
+      >
+        {Array.from({ length: 8 }).map((_, i) => (
+          // eslint-disable-next-line react/no-array-index-key -- static skeleton placeholders
+          <div
+            key={`skeleton-${i}`}
+            className='rounded-lg bg-elevated clay-resting overflow-hidden'
+          >
+            <div className='skeleton aspect-square m-3 rounded-lg' />
+            <div className='p-4 flex flex-col gap-2'>
+              <div className='skeleton h-3.5 w-3/5' />
+              <div className='skeleton h-3 w-4/5' />
+              <div className='skeleton h-3 w-2/5' />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export const VirtualSongGrid = memo(function VirtualSongGrid({
+  items,
+  isAdminView,
+  playlists,
+  isLoading,
+  isFetching,
+  isError,
+  hasMore,
+  hasLoaded,
+  playingId,
+  onRetry,
+  onFetchMore,
+  onDelete,
+  onPlay,
+  onAddToQueue,
+  emptyTitle,
+  emptyMessage,
+  selectionMode = false,
+  isSelected,
+  onToggleSelect,
+}: VirtualSongGridProps) {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const masonryContainerRef = useRef<HTMLDivElement>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [containerHeight, setContainerHeight] = useState(600);
+
+  // ── Track scroll container's scroll position and height ────────────
+  useEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+
+    const onScroll = () => setScrollTop(el.scrollTop);
+    const onResize = () => setContainerHeight(el.clientHeight);
+
+    // Measure now, and also after a frame to catch CSS layout settling.
+    setContainerHeight(el.clientHeight);
+    requestAnimationFrame(() => {
+      if (scrollContainerRef.current) {
+        setContainerHeight(scrollContainerRef.current.clientHeight);
+      }
+    });
+
+    el.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onResize);
+
+    return () => {
+      el.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', onResize);
+    };
+  }, [hasLoaded]);
+
+  // ── Masonry positioner ─────────────────────────────────────────────
+  const { width: measuredWidth } = useContainerPosition(scrollContainerRef);
+  const gridWidth =
+    measuredWidth || (typeof window !== 'undefined' ? window.innerWidth - 300 : 960);
+  const positioner = usePositioner({
+    width: gridWidth,
+    columnWidth: 260,
+    columnGutter: 0, // We handle padding in the render wrapper
+  });
+  const resizeObserver = useResizeObserver(positioner);
+
+  // ── Infinite scroll trigger ────────────────────────────────────────
+  const handleRender = useCallback(
+    (_startIndex: number, stopIndex: number | undefined, _currentItems: Song[]) => {
+      if (stopIndex !== undefined && stopIndex >= items.length - 10 && hasMore && !isFetching) {
+        onFetchMore();
+      }
+    },
+    [items.length, hasMore, isFetching, onFetchMore]
+  );
+
+  // ── Grid card renderer (closure capturing outer props) ─────────────
+  const GridCard = useMemo(() => {
+    const Component = ({
+      index: _index,
+      width,
+      data: song,
+    }: {
+      index: number;
+      width: number;
+      data: Song;
+    }) => (
+      <div style={{ width, padding: '0 8px 16px' }}>
+        <SongCard
+          song={song}
+          variant='grid'
+          isAdminView={isAdminView}
+          playlists={playlists}
+          onDelete={onDelete}
+          onPlay={() => onPlay(song.id)}
+          isPlaying={playingId === song.id}
+          onAddToQueue={() => onAddToQueue(song.id)}
+          selectionMode={selectionMode}
+          isSelected={isSelected?.(song.id) ?? false}
+          onToggleSelect={onToggleSelect ? () => onToggleSelect(song.id) : undefined}
+        />
+      </div>
+    );
+    Component.displayName = 'GridCard';
+    return Component;
+  }, [
+    isAdminView,
+    playlists,
+    onDelete,
+    onPlay,
+    playingId,
+    onAddToQueue,
+    selectionMode,
+    isSelected,
+    onToggleSelect,
+  ]);
+
+  // ── Build the masonry ──────────────────────────────────────────────
+  const showSkeleton = isLoading;
+  const showEmpty = hasLoaded && items.length === 0;
+  const isContentReady = !isLoading && hasLoaded && items.length > 0;
+
+  const masonry = useMasonry({
+    positioner,
+    resizeObserver,
+    items,
+    scrollTop,
+    height: containerHeight || 600,
+    containerRef: masonryContainerRef,
+    itemKey: (song: Song) => song.id,
+    itemHeightEstimate: 330,
+    overscanBy: 2,
+    render: GridCard as React.ComponentType<{ index: number; width: number; data: unknown }>,
+    onRender: isContentReady ? handleRender : undefined,
+  });
+
+  return (
+    <div
+      ref={scrollContainerRef}
+      className='min-h-0'
+      style={{
+        maxHeight: 'calc(100vh - 340px)',
+        overflowY: isContentReady ? 'auto' : 'hidden',
+        WebkitMaskImage: isContentReady
+          ? 'linear-gradient(to bottom, black 0%, black calc(100% - 40px), transparent 100%)'
+          : undefined,
+        maskImage: isContentReady
+          ? 'linear-gradient(to bottom, black 0%, black calc(100% - 40px), transparent 100%)'
+          : undefined,
+      }}
+    >
+      {showSkeleton && <SkeletonGrid />}
+
+      {showEmpty && (
+        <div className='px-4 pt-4'>
+          <div className='text-center py-16'>
+            <p className='text-fg font-semibold'>{emptyTitle}</p>
+            {emptyMessage && <p className='text-muted text-sm mt-1'>{emptyMessage}</p>}
+          </div>
+        </div>
+      )}
+
+      {/* Masonry is always in the DOM (ref attachment) but hidden until content is ready */}
+      <div style={{ display: isContentReady ? undefined : 'none' }}>{masonry}</div>
+
+      {isContentReady && isFetching && (
+        <div className='flex justify-center py-4 gap-2'>
+          {Array.from({ length: 3 }).map((_, i) => (
+            // eslint-disable-next-line react/no-array-index-key -- static loading indicator
+            <div key={`loading-dot-${i}`} className='skeleton h-3 w-3 rounded-full animate-pulse' />
+          ))}
+        </div>
+      )}
+
+      {isContentReady && isError && (
+        <div className='flex justify-center py-4'>
+          <button
+            type='button'
+            onClick={onRetry}
+            className='font-mono text-xs text-muted hover:text-fg transition-colors underline'
+          >
+            Failed to load more. Retry
+          </button>
+        </div>
+      )}
+    </div>
+  );
+});
+
+export default VirtualSongGrid;

--- a/packages/web/src/components/VirtualSongGrid.tsx
+++ b/packages/web/src/components/VirtualSongGrid.tsx
@@ -1,7 +1,8 @@
 import type { Playlist, Song } from '@alfira/server/shared';
-import { useContainerPosition, useMasonry, usePositioner, useResizeObserver } from 'masonic';
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useWindowSize } from '../hooks/useWindowSize';
+import { useMasonry, usePositioner, useResizeObserver } from 'masonic';
+import { memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { flushSync } from 'react-dom';
+import { useScrollObserver } from '../hooks/useScrollObserver';
 import SongCard from './SongCard';
 
 // ---------------------------------------------------------------------------
@@ -88,46 +89,41 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
 }: VirtualSongGridProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const masonryContainerRef = useRef<HTMLDivElement>(null);
-  const [windowWidth, windowHeight] = useWindowSize();
-  const [scrollTop, setScrollTop] = useState(0);
-  const [containerHeight, setContainerHeight] = useState(600);
 
-  // ── Track scroll container's scroll position and height ────────────
-  useEffect(() => {
+  // rAF-batched scroll tracking + isScrolling flag (enables masonic's
+  // will-change / pointer-events optimizations during scroll) + height
+  // measurement via ResizeObserver.
+  const { scrollTop, isScrolling, height: containerHeight } = useScrollObserver(scrollContainerRef);
+
+  // Width: state initializer provides a reasonable fallback for SSR / first
+  // page load. On subsequent mounts (view switches), a callback ref with
+  // flushSync reads the real element width during commit and forces React
+  // to process the state update synchronously before the browser paints.
+  // A ResizeObserver handles subsequent layout changes.
+  const [gridWidth, setGridWidth] = useState(() => {
+    if (typeof window === 'undefined') return 960;
+    return document.querySelector('main')?.clientWidth ?? 960;
+  });
+
+  const scrollRefCallback = useCallback((el: HTMLDivElement | null) => {
+    scrollContainerRef.current = el;
+    if (el) {
+      flushSync(() => {
+        setGridWidth(el.clientWidth);
+      });
+    }
+  }, []);
+
+  useLayoutEffect(() => {
     const el = scrollContainerRef.current;
     if (!el) return;
-
-    const onScroll = () => setScrollTop(el.scrollTop);
-
-    // Measure now, and also after a frame to catch CSS layout settling.
-    setContainerHeight(el.clientHeight);
-    requestAnimationFrame(() => {
-      if (scrollContainerRef.current) {
-        setContainerHeight(scrollContainerRef.current.clientHeight);
-      }
+    const ro = new ResizeObserver(([entry]) => {
+      if (entry) setGridWidth(entry.contentRect.width);
     });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
 
-    el.addEventListener('scroll', onScroll, { passive: true });
-
-    return () => {
-      el.removeEventListener('scroll', onScroll);
-    };
-  }, [hasLoaded]);
-
-  // ── Keep container height in sync with window resize ────────────────
-  useEffect(() => {
-    if (scrollContainerRef.current) {
-      setContainerHeight(scrollContainerRef.current.clientHeight);
-    }
-  }, [windowHeight]);
-
-  // ── Masonry positioner ─────────────────────────────────────────────
-  const { width: measuredWidth } = useContainerPosition(scrollContainerRef, [
-    windowWidth,
-    windowHeight,
-  ]);
-  const gridWidth =
-    measuredWidth || (typeof window !== 'undefined' ? window.innerWidth - 300 : 960);
   const positioner = usePositioner({
     width: gridWidth,
     columnWidth: 260,
@@ -218,6 +214,7 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
     resizeObserver,
     items,
     scrollTop,
+    isScrolling,
     height: containerHeight || 600,
     containerRef: masonryContainerRef,
     itemKey: (song: Song) => song.id,
@@ -229,7 +226,7 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
 
   return (
     <div
-      ref={scrollContainerRef}
+      ref={scrollRefCallback}
       className='min-h-0'
       style={{
         maxHeight: 'calc(100vh - 340px)',

--- a/packages/web/src/components/VirtualSongGrid.tsx
+++ b/packages/web/src/components/VirtualSongGrid.tsx
@@ -145,36 +145,13 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
     [items.length, hasMore, isFetching, onFetchMore]
   );
 
-  // ── Grid card renderer (closure capturing outer props) ─────────────
-  const GridCard = useMemo(() => {
-    const Component = ({
-      index: _index,
-      width,
-      data: song,
-    }: {
-      index: number;
-      width: number;
-      data: Song;
-    }) => (
-      <div style={{ width, padding: '0 8px 16px' }}>
-        <SongCard
-          song={song}
-          variant='grid'
-          isAdminView={isAdminView}
-          playlists={playlists}
-          onDelete={onDelete}
-          onPlay={() => onPlay(song.id)}
-          isPlaying={playingId === song.id}
-          onAddToQueue={() => onAddToQueue(song.id)}
-          selectionMode={selectionMode}
-          isSelected={isSelected?.(song.id) ?? false}
-          onToggleSelect={onToggleSelect ? () => onToggleSelect(song.id) : undefined}
-        />
-      </div>
-    );
-    Component.displayName = 'GridCard';
-    return Component;
-  }, [
+  // ── Grid card renderer (stable component identity via refs) ─────────
+  // The masonry render component must stay referentially stable across
+  // re-renders. Changing component identity (e.g. when isAdminView
+  // toggles) causes React to unmount + remount every visible card,
+  // producing a visible flash. We store dynamic props in a ref so the
+  // component type identity never changes.
+  const cardPropsRef = useRef({
     isAdminView,
     playlists,
     onDelete,
@@ -184,7 +161,52 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
     selectionMode,
     isSelected,
     onToggleSelect,
-  ]);
+  });
+  cardPropsRef.current = {
+    isAdminView,
+    playlists,
+    onDelete,
+    onPlay,
+    playingId,
+    onAddToQueue,
+    selectionMode,
+    isSelected,
+    onToggleSelect,
+  };
+
+  const GridCard = useMemo(() => {
+    const Component = ({
+      index: _index,
+      width,
+      data: song,
+    }: {
+      index: number;
+      width: number;
+      data: Song;
+    }) => {
+      const p = cardPropsRef.current;
+      return (
+        <div style={{ width, padding: '0 8px 16px' }}>
+          <SongCard
+            song={song}
+            variant='grid'
+            isAdminView={p.isAdminView}
+            playlists={p.playlists}
+            onDelete={p.onDelete}
+            onPlay={() => p.onPlay(song.id)}
+            isPlaying={p.playingId === song.id}
+            onAddToQueue={() => p.onAddToQueue(song.id)}
+            selectionMode={p.selectionMode}
+            isSelected={p.isSelected?.(song.id) ?? false}
+            onToggleSelect={p.onToggleSelect ? () => p.onToggleSelect(song.id) : undefined}
+          />
+        </div>
+      );
+    };
+    Component.displayName = 'GridCard';
+    return Component;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally stable; dynamic values come from ref
+  }, []);
 
   // ── Build the masonry ──────────────────────────────────────────────
   const showSkeleton = isLoading;

--- a/packages/web/src/hooks/useScrollObserver.ts
+++ b/packages/web/src/hooks/useScrollObserver.ts
@@ -1,0 +1,124 @@
+import { type RefObject, useEffect, useLayoutEffect, useRef, useState } from 'react';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ScrollObserverResult {
+  scrollTop: number;
+  isScrolling: boolean;
+  height: number;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Observes scroll position and size of an element with rAF-batched scroll
+ * tracking and ResizeObserver-based height measurement.
+ *
+ * Patterned after masonic's `useScroller` but works with any scroll element,
+ * not just `window`. The rAF batching prevents excessive React re-renders
+ * during fast scrolling (at most one state update per animation frame).
+ *
+ * @param elementRef - Ref to the scroll container element.
+ * @param fps - Maximum scroll position updates per second. Default 12.
+ */
+export function useScrollObserver(
+  elementRef: RefObject<HTMLElement | null>,
+  fps = 12
+): ScrollObserverResult {
+  const [scrollTop, setScrollTop] = useState(0);
+  const [isScrolling, setIsScrolling] = useState(false);
+  const [height, setHeight] = useState(0);
+
+  const didMountRef = useRef(0);
+  const tickingRef = useRef(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
+  const scrollTopRef = useRef(0);
+
+  // ── rAF-batched scroll tracking ────────────────────────────────────
+  // Reads the current scrollTop inside a rAF callback so no more than one
+  // state update occurs per animation frame, even during high-frequency
+  // scroll events.
+  useEffect(() => {
+    const el = elementRef.current;
+    if (!el) return;
+
+    const onScroll = () => {
+      // Store the latest scrollTop in the ref so the rAF callback always
+      // reads the freshest value, even if multiple scroll events fired.
+      scrollTopRef.current = el.scrollTop;
+
+      if (!tickingRef.current) {
+        requestAnimationFrame(() => {
+          // Only update state if the scroll position actually changed.
+          // This avoids a no-op re-render when the user hasn't scrolled
+          // but a resize or other event triggered the effect.
+          setScrollTop((prev) => {
+            const next = scrollTopRef.current;
+            return prev !== next ? next : prev;
+          });
+          tickingRef.current = false;
+        });
+        tickingRef.current = true;
+      }
+    };
+
+    // Prime with the current value.
+    setScrollTop(el.scrollTop);
+
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+    // elementRef is a stable ref object; the effect only needs to re-run
+    // if the underlying element changes (handled via the early return).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── isScrolling flag ───────────────────────────────────────────────
+  // Set true on the first scroll change after mount, then clear after a
+  // debounce period. Matches masonic's `useScroller` behavior: the flag
+  // enables will-change and disables pointer-events during active scroll.
+  useEffect(() => {
+    if (didMountRef.current === 1) {
+      setIsScrolling(true);
+    }
+
+    clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(
+      () => {
+        setIsScrolling(false);
+      },
+      40 + 1000 / fps
+    );
+
+    didMountRef.current = 1;
+
+    return () => {
+      clearTimeout(timeoutRef.current);
+    };
+  }, [fps, scrollTop]);
+
+  // ── Height tracking via ResizeObserver ─────────────────────────────
+  // useLayoutEffect reads the initial clientHeight before the first
+  // paint, avoiding a flash where the grid renders at the wrong height.
+  useLayoutEffect(() => {
+    const el = elementRef.current;
+    if (!el) return;
+
+    setHeight(el.clientHeight);
+
+    const ro = new ResizeObserver(([entry]) => {
+      if (entry) {
+        setHeight(entry.contentRect.height);
+      }
+    });
+    ro.observe(el);
+
+    return () => ro.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { scrollTop, isScrolling, height };
+}

--- a/packages/web/src/hooks/useWindowSize.ts
+++ b/packages/web/src/hooks/useWindowSize.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+
+export function useWindowSize() {
+  const [size, setSize] = useState<[number, number]>([
+    typeof window !== 'undefined' ? window.innerWidth : 1024,
+    typeof window !== 'undefined' ? window.innerHeight : 768,
+  ]);
+
+  useEffect(() => {
+    const handle = () => setSize([window.innerWidth, window.innerHeight]);
+    window.addEventListener('resize', handle, { passive: true });
+    return () => window.removeEventListener('resize', handle);
+  }, []);
+
+  return size;
+}

--- a/packages/web/src/lib/motion.ts
+++ b/packages/web/src/lib/motion.ts
@@ -31,7 +31,7 @@ export const listItemVariants: Variants = {
   animate: {
     opacity: 1,
     x: 0,
-    transition: { type: 'spring', stiffness: 650, damping: 22 },
+    transition: { type: 'spring', stiffness: 400, damping: 38 },
   },
   exit: { opacity: 0 },
 };

--- a/packages/web/src/lib/motion.ts
+++ b/packages/web/src/lib/motion.ts
@@ -60,3 +60,9 @@ export const metadataTransition: Transition = {
   duration: 0.18,
   ease: 'easeOut',
 };
+
+/** Shared crossfade transition used for page and view mode changes. */
+export const viewTransition: Transition = {
+  duration: 0.125,
+  ease: 'easeOut',
+};

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -42,6 +42,7 @@ import ListToolbar from '../components/ListToolbar';
 import NotificationToast from '../components/NotificationToast';
 
 import { Button } from '../components/ui/Button';
+import { VirtualSongGrid } from '../components/VirtualSongGrid';
 import { VirtualSongList } from '../components/VirtualSongList';
 import { useAdminView } from '../context/AdminViewContext';
 import { useAuth } from '../context/AuthContext';
@@ -99,6 +100,9 @@ export default function PlaylistDetailPage() {
   const [bulkRemoveConfirm, setBulkRemoveConfirm] = useState(false);
   const [bulkEditingOpen, setBulkEditingOpen] = useState(false);
   const [bulkEditingApplying, setBulkEditingApplying] = useState(false);
+  const [viewMode, setViewMode] = useState<'list' | 'grid'>(
+    () => (localStorage.getItem('alfira-playlist-view') as 'list' | 'grid' | null) ?? 'list'
+  );
 
   const menuTriggerRef = useRef<HTMLButtonElement>(null);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -704,6 +708,11 @@ export default function PlaylistDetailPage() {
           if (selectionMode) bulk.clearAll();
           setSelectionMode((v) => !v);
         }}
+        viewMode={viewMode}
+        onViewModeChange={(mode) => {
+          localStorage.setItem('alfira-playlist-view', mode);
+          setViewMode(mode);
+        }}
       />
 
       {/* Song list */}
@@ -721,8 +730,37 @@ export default function PlaylistDetailPage() {
             addLabel='add some songs'
           />
         )
-      ) : (
+      ) : viewMode === 'list' ? (
         <VirtualSongList
+          items={songItems}
+          isAdminView={isAdminView}
+          playlists={[]}
+          isLoading={isLoading}
+          isFetching={isFetching}
+          isError={isError}
+          hasMore={hasMore}
+          hasLoaded={!isLoading}
+          playingId={playingSongId}
+          onRetry={retry}
+          onFetchMore={fetchNextPage}
+          onDelete={
+            selectionMode
+              ? undefined
+              : (id) => {
+                  const ps = songs.find((p) => p.songId === id);
+                  if (ps) setRemoveId(ps.songId);
+                }
+          }
+          onPlay={handlePlayFromSong}
+          onAddToQueue={handleAddToQueue}
+          selectionMode={selectionMode}
+          isSelected={bulk.isSelected}
+          onToggleSelect={bulk.toggle}
+          emptyTitle='No Songs'
+          emptyMessage='Add songs to this playlist'
+        />
+      ) : (
+        <VirtualSongGrid
           items={songItems}
           isAdminView={isAdminView}
           playlists={[]}

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -1,6 +1,9 @@
 import type { Playlist, PlaylistDetail, Song, TagItem } from '@alfira/server/shared';
 import type { FetchSongsOptions } from '@alfira/server/shared/api';
 import { fetchTags, updatePlaylistTag } from '@alfira/server/shared/api';
+import { AnimatePresence } from 'motion/react';
+import * as m from 'motion/react-m';
+import { pageVariants, viewTransition } from '../lib/motion';
 import { usePaginatedData } from '../hooks/usePaginatedData';
 
 type PlaylistDetailMeta = Omit<PlaylistDetail, 'songs'>;
@@ -730,64 +733,86 @@ export default function PlaylistDetailPage() {
             addLabel='add some songs'
           />
         )
-      ) : viewMode === 'list' ? (
-        <VirtualSongList
-          items={songItems}
-          isAdminView={isAdminView}
-          playlists={[]}
-          isLoading={isLoading}
-          isFetching={isFetching}
-          isError={isError}
-          hasMore={hasMore}
-          hasLoaded={!isLoading}
-          playingId={playingSongId}
-          onRetry={retry}
-          onFetchMore={fetchNextPage}
-          onDelete={
-            selectionMode
-              ? undefined
-              : (id) => {
-                  const ps = songs.find((p) => p.songId === id);
-                  if (ps) setRemoveId(ps.songId);
-                }
-          }
-          onPlay={handlePlayFromSong}
-          onAddToQueue={handleAddToQueue}
-          selectionMode={selectionMode}
-          isSelected={bulk.isSelected}
-          onToggleSelect={bulk.toggle}
-          emptyTitle='No Songs'
-          emptyMessage='Add songs to this playlist'
-        />
       ) : (
-        <VirtualSongGrid
-          items={songItems}
-          isAdminView={isAdminView}
-          playlists={[]}
-          isLoading={isLoading}
-          isFetching={isFetching}
-          isError={isError}
-          hasMore={hasMore}
-          hasLoaded={!isLoading}
-          playingId={playingSongId}
-          onRetry={retry}
-          onFetchMore={fetchNextPage}
-          onDelete={
-            selectionMode
-              ? undefined
-              : (id) => {
-                  const ps = songs.find((p) => p.songId === id);
-                  if (ps) setRemoveId(ps.songId);
+        <AnimatePresence mode='wait'>
+          {viewMode === 'list' ? (
+            <m.div
+              key='list'
+              variants={pageVariants}
+              initial='initial'
+              animate='animate'
+              exit='exit'
+              transition={viewTransition}
+            >
+              <VirtualSongList
+                items={songItems}
+                isAdminView={isAdminView}
+                playlists={[]}
+                isLoading={isLoading}
+                isFetching={isFetching}
+                isError={isError}
+                hasMore={hasMore}
+                hasLoaded={!isLoading}
+                playingId={playingSongId}
+                onRetry={retry}
+                onFetchMore={fetchNextPage}
+                onDelete={
+                  selectionMode
+                    ? undefined
+                    : (id) => {
+                        const ps = songs.find((p) => p.songId === id);
+                        if (ps) setRemoveId(ps.songId);
+                      }
                 }
-          }
-          onPlay={handlePlayFromSong}
-          onAddToQueue={handleAddToQueue}
-          selectionMode={selectionMode}
-          isSelected={bulk.isSelected}
-          onToggleSelect={bulk.toggle}
-          emptyTitle='No Songs'
-          emptyMessage='Add songs to this playlist'
-        />
+                onPlay={handlePlayFromSong}
+                onAddToQueue={handleAddToQueue}
+                selectionMode={selectionMode}
+                isSelected={bulk.isSelected}
+                onToggleSelect={bulk.toggle}
+                emptyTitle='No Songs'
+                emptyMessage='Add songs to this playlist'
+              />
+            </m.div>
+          ) : (
+            <m.div
+              key='grid'
+              variants={pageVariants}
+              initial='initial'
+              animate='animate'
+              exit='exit'
+              transition={viewTransition}
+            >
+              <VirtualSongGrid
+                items={songItems}
+                isAdminView={isAdminView}
+                playlists={[]}
+                isLoading={isLoading}
+                isFetching={isFetching}
+                isError={isError}
+                hasMore={hasMore}
+                hasLoaded={!isLoading}
+                playingId={playingSongId}
+                onRetry={retry}
+                onFetchMore={fetchNextPage}
+                onDelete={
+                  selectionMode
+                    ? undefined
+                    : (id) => {
+                        const ps = songs.find((p) => p.songId === id);
+                        if (ps) setRemoveId(ps.songId);
+                      }
+                }
+                onPlay={handlePlayFromSong}
+                onAddToQueue={handleAddToQueue}
+                selectionMode={selectionMode}
+                isSelected={bulk.isSelected}
+                onToggleSelect={bulk.toggle}
+                emptyTitle='No Songs'
+                emptyMessage='Add songs to this playlist'
+              />
+            </m.div>
+          )}
+        </AnimatePresence>
       )}
 
       {/* Modals */}

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -19,6 +19,7 @@ import ListToolbar from '../components/ListToolbar';
 import NotificationToast from '../components/NotificationToast';
 
 import { PageHeader } from '../components/ui/PageHeader';
+import { VirtualSongGrid } from '../components/VirtualSongGrid';
 import { VirtualSongList } from '../components/VirtualSongList';
 import { useAdminView } from '../context/AdminViewContext';
 import { usePermissions } from '../context/PermissionsContext';
@@ -55,6 +56,9 @@ export default function SongsPage() {
 
   // Bulk selection
   const bulk = useBulkSelection();
+  const [viewMode, setViewMode] = useState<'list' | 'grid'>(
+    () => (localStorage.getItem('alfira-song-view') as 'list' | 'grid' | null) ?? 'list'
+  );
   const [selectionMode, setSelectionMode] = useState(false);
   const [bulkDeleting, setBulkDeleting] = useState(false);
   const [bulkDeleteConfirm, setBulkDeleteConfirm] = useState(false);
@@ -370,38 +374,75 @@ export default function SongsPage() {
           if (selectionMode) bulk.clearAll();
           setSelectionMode((v) => !v);
         }}
+        viewMode={viewMode}
+        onViewModeChange={(mode) => {
+          localStorage.setItem('alfira-song-view', mode);
+          setViewMode(mode);
+        }}
       />
 
       {/* Content */}
-      <VirtualSongList
-        items={items}
-        isAdminView={isAdminView}
-        playlists={playlists}
-        isLoading={isLoading}
-        isFetching={isFetching}
-        isError={isError}
-        hasMore={hasMore}
-        hasLoaded={hasLoaded}
-        playingId={playingId}
-        onRetry={retry}
-        onFetchMore={fetchNextPage}
-        onDelete={selectionMode ? undefined : handleSetDeleteId}
-        onPlay={handlePlayFromSong}
-        onAddToQueue={handleAddToQueue}
-        selectionMode={selectionMode}
-        isSelected={bulk.isSelected}
-        onToggleSelect={bulk.toggle}
-        emptyTitle={
-          search || filterTags.length > 0 || filterSources.length > 0
-            ? 'No Matches'
-            : 'No Songs Yet'
-        }
-        emptyMessage={
-          search || filterTags.length > 0 || filterSources.length > 0
-            ? 'Try adjusting your search or filters'
-            : 'Submit a request to add songs'
-        }
-      />
+      {viewMode === 'list' ? (
+        <VirtualSongList
+          items={items}
+          isAdminView={isAdminView}
+          playlists={playlists}
+          isLoading={isLoading}
+          isFetching={isFetching}
+          isError={isError}
+          hasMore={hasMore}
+          hasLoaded={hasLoaded}
+          playingId={playingId}
+          onRetry={retry}
+          onFetchMore={fetchNextPage}
+          onDelete={selectionMode ? undefined : handleSetDeleteId}
+          onPlay={handlePlayFromSong}
+          onAddToQueue={handleAddToQueue}
+          selectionMode={selectionMode}
+          isSelected={bulk.isSelected}
+          onToggleSelect={bulk.toggle}
+          emptyTitle={
+            search || filterTags.length > 0 || filterSources.length > 0
+              ? 'No Matches'
+              : 'No Songs Yet'
+          }
+          emptyMessage={
+            search || filterTags.length > 0 || filterSources.length > 0
+              ? 'Try adjusting your search or filters'
+              : 'Submit a request to add songs'
+          }
+        />
+      ) : (
+        <VirtualSongGrid
+          items={items}
+          isAdminView={isAdminView}
+          playlists={playlists}
+          isLoading={isLoading}
+          isFetching={isFetching}
+          isError={isError}
+          hasMore={hasMore}
+          hasLoaded={hasLoaded}
+          playingId={playingId}
+          onRetry={retry}
+          onFetchMore={fetchNextPage}
+          onDelete={selectionMode ? undefined : handleSetDeleteId}
+          onPlay={handlePlayFromSong}
+          onAddToQueue={handleAddToQueue}
+          selectionMode={selectionMode}
+          isSelected={bulk.isSelected}
+          onToggleSelect={bulk.toggle}
+          emptyTitle={
+            search || filterTags.length > 0 || filterSources.length > 0
+              ? 'No Matches'
+              : 'No Songs Yet'
+          }
+          emptyMessage={
+            search || filterTags.length > 0 || filterSources.length > 0
+              ? 'Try adjusting your search or filters'
+              : 'Submit a request to add songs'
+          }
+        />
+      )}
 
       {/* Modals */}
       {deleteId && (

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -1,8 +1,11 @@
 import type { Playlist, Song } from '@alfira/server/shared';
 import type { FetchSongsOptions } from '@alfira/server/shared/api';
 import { MusicNotesIcon, QuestionIcon } from '@phosphor-icons/react';
+import { AnimatePresence } from 'motion/react';
+import * as m from 'motion/react-m';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { pageVariants, viewTransition } from '../lib/motion';
 import {
   bulkDeleteSongs,
   bulkEditSongs,
@@ -382,67 +385,87 @@ export default function SongsPage() {
       />
 
       {/* Content */}
-      {viewMode === 'list' ? (
-        <VirtualSongList
-          items={items}
-          isAdminView={isAdminView}
-          playlists={playlists}
-          isLoading={isLoading}
-          isFetching={isFetching}
-          isError={isError}
-          hasMore={hasMore}
-          hasLoaded={hasLoaded}
-          playingId={playingId}
-          onRetry={retry}
-          onFetchMore={fetchNextPage}
-          onDelete={selectionMode ? undefined : handleSetDeleteId}
-          onPlay={handlePlayFromSong}
-          onAddToQueue={handleAddToQueue}
-          selectionMode={selectionMode}
-          isSelected={bulk.isSelected}
-          onToggleSelect={bulk.toggle}
-          emptyTitle={
-            search || filterTags.length > 0 || filterSources.length > 0
-              ? 'No Matches'
-              : 'No Songs Yet'
-          }
-          emptyMessage={
-            search || filterTags.length > 0 || filterSources.length > 0
-              ? 'Try adjusting your search or filters'
-              : 'Submit a request to add songs'
-          }
-        />
-      ) : (
-        <VirtualSongGrid
-          items={items}
-          isAdminView={isAdminView}
-          playlists={playlists}
-          isLoading={isLoading}
-          isFetching={isFetching}
-          isError={isError}
-          hasMore={hasMore}
-          hasLoaded={hasLoaded}
-          playingId={playingId}
-          onRetry={retry}
-          onFetchMore={fetchNextPage}
-          onDelete={selectionMode ? undefined : handleSetDeleteId}
-          onPlay={handlePlayFromSong}
-          onAddToQueue={handleAddToQueue}
-          selectionMode={selectionMode}
-          isSelected={bulk.isSelected}
-          onToggleSelect={bulk.toggle}
-          emptyTitle={
-            search || filterTags.length > 0 || filterSources.length > 0
-              ? 'No Matches'
-              : 'No Songs Yet'
-          }
-          emptyMessage={
-            search || filterTags.length > 0 || filterSources.length > 0
-              ? 'Try adjusting your search or filters'
-              : 'Submit a request to add songs'
-          }
-        />
-      )}
+      <AnimatePresence mode='wait'>
+        {viewMode === 'list' ? (
+          <m.div
+            key='list'
+            variants={pageVariants}
+            initial='initial'
+            animate='animate'
+            exit='exit'
+            transition={viewTransition}
+          >
+            <VirtualSongList
+              items={items}
+              isAdminView={isAdminView}
+              playlists={playlists}
+              isLoading={isLoading}
+              isFetching={isFetching}
+              isError={isError}
+              hasMore={hasMore}
+              hasLoaded={hasLoaded}
+              playingId={playingId}
+              onRetry={retry}
+              onFetchMore={fetchNextPage}
+              onDelete={selectionMode ? undefined : handleSetDeleteId}
+              onPlay={handlePlayFromSong}
+              onAddToQueue={handleAddToQueue}
+              selectionMode={selectionMode}
+              isSelected={bulk.isSelected}
+              onToggleSelect={bulk.toggle}
+              emptyTitle={
+                search || filterTags.length > 0 || filterSources.length > 0
+                  ? 'No Matches'
+                  : 'No Songs Yet'
+              }
+              emptyMessage={
+                search || filterTags.length > 0 || filterSources.length > 0
+                  ? 'Try adjusting your search or filters'
+                  : 'Submit a request to add songs'
+              }
+            />
+          </m.div>
+        ) : (
+          <m.div
+            key='grid'
+            variants={pageVariants}
+            initial='initial'
+            animate='animate'
+            exit='exit'
+            transition={viewTransition}
+          >
+            <VirtualSongGrid
+              items={items}
+              isAdminView={isAdminView}
+              playlists={playlists}
+              isLoading={isLoading}
+              isFetching={isFetching}
+              isError={isError}
+              hasMore={hasMore}
+              hasLoaded={hasLoaded}
+              playingId={playingId}
+              onRetry={retry}
+              onFetchMore={fetchNextPage}
+              onDelete={selectionMode ? undefined : handleSetDeleteId}
+              onPlay={handlePlayFromSong}
+              onAddToQueue={handleAddToQueue}
+              selectionMode={selectionMode}
+              isSelected={bulk.isSelected}
+              onToggleSelect={bulk.toggle}
+              emptyTitle={
+                search || filterTags.length > 0 || filterSources.length > 0
+                  ? 'No Matches'
+                  : 'No Songs Yet'
+              }
+              emptyMessage={
+                search || filterTags.length > 0 || filterSources.length > 0
+                  ? 'Try adjusting your search or filters'
+                  : 'Submit a request to add songs'
+              }
+            />
+          </m.div>
+        )}
+      </AnimatePresence>
 
       {/* Modals */}
       {deleteId && (


### PR DESCRIPTION
## Summary

Re-adds the grid view for the song library using `masonic`, a lightweight virtualized masonry grid library. Each column reflows independently — expanding an edit panel on a card only pushes cards below it in the same column, not the entire row. The grid view is also available on playlist detail pages. A crossfade animation smooths the list/grid toggle, and view preference is persisted to `localStorage`.

## Changes

### Grid View

- **New: `VirtualSongGrid.tsx`** — masonry grid component using `masonic`'s `useMasonry` with container-scoped scroll, callback ref + `ResizeObserver` + `flushSync` for initial width measurement, `useResizeObserver` for dynamic card height detection, and `usePositioner` for responsive column count
- **New: `useScrollObserver.ts`** — rAF-batched (12fps) scroll tracking hook with `isScrolling` flag for `will-change`/`pointer-events` optimizations during scroll
- **`SongsPage.tsx`** — view mode toggle (`list` | `grid`) persisted to `localStorage`, with `AnimatePresence` crossfade between views
- **`PlaylistDetailPage.tsx`** — same grid/list toggle pattern as songs page
- **`ListToolbar.tsx`** — optional grid/list toggle button (icon: `SquaresFourIcon` / `RowsIcon`) on the right side of the toolbar
- **`VirtualList.tsx`** — increased scroll container `max-height` offset from 280px to 340px to prevent double scrollbars
- **`lib/motion.ts`** — new shared `viewTransition` constant and `pageVariants` for crossfade animations
- **`AnimatedOutlet.tsx`** — switched local `pageTransition` to shared `viewTransition` constant

### Fixes

- **Grid reflow on resize** — replaced `useContainerPosition` (window-scroll-oriented) with callback ref + `ResizeObserver` for correct column count on first paint and subsequent layout changes
- **Admin view flash** — store `isAdminView` in a ref instead of recreating the `GridCard` render component via `useMemo`, preventing unmount/remount of every visible card
- **Play button responsiveness** — bundle `isPlaying` into masonic item data (`GridSongItem`) so that `playingId` changes update cards in-place without changing render component identity
- **Volume boost slider overflow** — fixed slider clipping in grid card edit panels
- **List-item spring flash** — increased damping from 22 to 38 and lowered stiffness from 650 to 400 (damping ratio ~0.43 → ~0.95) to eliminate overshoot flash

### Dependencies

- **`package.json`** — added `masonic@4.1.0` dependency

### Documentation

- **`alfira-web` skill** — documented `VirtualSongGrid`, `ListToolbar`, `useScrollObserver`, `useWindowSize`, and `viewTransition` pattern
