### PR TITLE
fix(server): fix gapless playback silence between tracks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,13 @@ ARG GIT_HASH
 ENV GIT_HASH=${GIT_HASH}
 RUN apk add --no-cache git
 WORKDIR /usr/local/nodelink
-ARG NODELINK_VERSION=v3.7.0
-RUN git clone --depth 1 --branch ${NODELINK_VERSION} https://github.com/PerformanC/NodeLink.git . && \
+# Pinned to dev @ e524ed7 (2025-07-17) — fixes gapless encoder silence present in v3.7.0.
+# Update periodically; when stable, pin a specific commit.
+ARG NODELINK_VERSION=e524ed7f38c01e0fc8f031134c86ee87e0bc7ffa
+RUN git init . && \
+    git remote add origin https://github.com/PerformanC/NodeLink.git && \
+    git fetch --depth 1 origin ${NODELINK_VERSION} && \
+    git checkout FETCH_HEAD && \
     bun install && \
     bun run build && \
     rm -rf .git

--- a/packages/server/src/GuildPlayer.ts
+++ b/packages/server/src/GuildPlayer.ts
@@ -40,10 +40,7 @@ export class GuildPlayer {
   // Gapless preloading via NodeLink's nextTrack.
   // When enabled, the next track is preloaded into NodeLink so that a
   // gapless TrackEndEvent can transition without a cold-start load.
-  // NodeLink v3.7.0 had a bug (~3s silence) in its gapless pipeline;
-  // if the encoder issue recurs, set this to false and fall back to
-  // cold-start loading for each track.
-  // See: https://github.com/PerformanC/NodeLink/issues (TBD)
+  // Disable if a future NodeLink update regresses the gapless pipeline.
   private static readonly ENABLE_GAPLESS_PRELOAD = true;
 
   // Called when the voice session is torn down so the manager Map can
@@ -170,6 +167,11 @@ export class GuildPlayer {
       // 'replaced' fires when a new track replaces the current one (normal).
       // 'stopped' fires when we explicitly stop/clear.
       if (reason === 'replaced' || reason === 'stopped') return;
+
+      logger.debug(
+        { guildId: this.guildId, reason, track: this.currentSong?.title },
+        'TrackEndEvent received'
+      );
 
       // NodeLink auto-started the next track via gapless preload — flag
       // this so playSong skips the expensive load-and-play path.
@@ -772,6 +774,13 @@ export class GuildPlayer {
       this.consecutiveFailures = 0;
       this.trackStartedAt = Date.now();
       this.pausedAt = null;
+
+      // Fire gapless preload before broadcast so NodeLink has maximum
+      // time to fetch + decode the next track.
+      if (GuildPlayer.ENABLE_GAPLESS_PRELOAD) {
+        this.preloadNextTrack(sessionId);
+      }
+
       this.broadcast();
       const t3 = Date.now();
 
@@ -787,10 +796,6 @@ export class GuildPlayer {
         'playSong: gapless timings'
       );
 
-      // Gapless preload for the next track.
-      if (GuildPlayer.ENABLE_GAPLESS_PRELOAD) {
-        this.preloadNextTrack(sessionId);
-      }
       return;
     }
 
@@ -826,53 +831,54 @@ export class GuildPlayer {
 
     const volume = 100 + (next.volumeBoost ?? 0);
 
-    await updateNodeLinkPlayer(this.guildId, sessionId, {
+    // Build a single PATCH payload combining track, volume, and any
+    // active filters — same pattern as the gapless path above.  One
+    // round-trip instead of three, and filters aren't overwritten.
+    const patch: Record<string, unknown> = {
       track: { encoded: trackData.track },
       volume,
-    });
-    const tCold3 = Date.now();
+    };
 
-    // Apply compressor filter if enabled (shared path).
     if (settings?.enabled) {
       try {
-        await updateNodeLinkPlayer(this.guildId, sessionId, {
-          filters: buildCompressorFilter(settings),
-        });
+        const compressorFilter = buildCompressorFilter(settings);
+        patch.filters = { ...(patch.filters as Record<string, unknown>), ...compressorFilter };
       } catch (err) {
-        logger.error(
-          { err, guildId: this.guildId },
-          'Failed to apply compressor filter on playback start'
-        );
+        logger.error({ err, guildId: this.guildId }, 'Failed to build compressor filter');
       }
     }
 
-    // Apply equalizer filter if any band is non-neutral (shared path).
     const eqBands = eqBandsFromRow(settings);
     if (eqBands.some((b) => b !== 50)) {
       try {
         const equalizerFilter = buildEqualizerFilter(eqBands);
-        await updateNodeLinkPlayer(this.guildId, sessionId, {
-          filters: {
-            equalizer: equalizerFilter,
-          },
-        });
+        patch.filters = {
+          ...(patch.filters as Record<string, unknown>),
+          equalizer: equalizerFilter,
+        };
       } catch (err) {
-        logger.error(
-          { err, guildId: this.guildId },
-          'Failed to apply equalizer filter on playback start'
-        );
+        logger.error({ err, guildId: this.guildId }, 'Failed to build equalizer filter');
       }
     }
+
+    await updateNodeLinkPlayer(
+      this.guildId,
+      sessionId,
+      patch as Parameters<typeof updateNodeLinkPlayer>[2]
+    );
+    const tCold3 = Date.now();
 
     this.consecutiveFailures = 0;
     this.trackStartedAt = Date.now();
     this.pausedAt = null;
-    this.broadcast();
 
-    // Gapless preload for the next track.
+    // Fire gapless preload as soon as the track starts — don't wait for
+    // broadcast so NodeLink has maximum time to fetch + decode.
     if (GuildPlayer.ENABLE_GAPLESS_PRELOAD) {
       this.preloadNextTrack(sessionId);
     }
+
+    this.broadcast();
 
     logger.info(
       {
@@ -891,9 +897,25 @@ export class GuildPlayer {
     const nextTrack = this.peekNextTrack();
     if (!nextTrack) return;
 
-    preloadTrack(this.guildId, sessionId, nextTrack.sourceUrl).catch((err) => {
-      logger.warn({ guildId: this.guildId, track: nextTrack.title, err }, 'Gapless preload failed');
-    });
+    const attempt = async () => {
+      try {
+        await preloadTrack(this.guildId, sessionId, nextTrack.sourceUrl);
+      } catch (err) {
+        logger.warn(
+          { guildId: this.guildId, track: nextTrack.title, err },
+          'Gapless preload failed — retrying once'
+        );
+        try {
+          await preloadTrack(this.guildId, sessionId, nextTrack.sourceUrl);
+        } catch (err2) {
+          logger.warn(
+            { guildId: this.guildId, track: nextTrack.title, err: err2 },
+            'Gapless preload retry also failed'
+          );
+        }
+      }
+    };
+    attempt(); // fire-and-forget — don't block the caller
   }
 
   private async fetchStreamWithRetry(

--- a/packages/server/src/utils/nodelink.ts
+++ b/packages/server/src/utils/nodelink.ts
@@ -406,30 +406,18 @@ export async function getPlaylistMetadataWithVideos(
 }
 
 export async function preloadTrack(guildId: string, sessionId: string, url: string): Promise<void> {
-  // Resolve the track via NodeLink's loadtracks endpoint.
-  const loadUrl = new URL('/v4/loadtracks', NODELINK_URL);
-  loadUrl.searchParams.set('identifier', url);
-
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-  if (NODELINK_AUTH) headers.Authorization = NODELINK_AUTH;
-
-  const resp = await fetch(loadUrl, { method: 'GET', headers });
-  if (!resp.ok) {
-    throw new Error(`NodeLink loadtracks returned ${resp.status}`);
-  }
-
-  const data = (await resp.json()) as LoadTrackResponse;
-  const encoded = data.data?.encoded;
+  // Resolve the track via NodeLink's loadtracks endpoint.  Use the same
+  // fallback as getStreamFormat: if data.encoded is missing (e.g.
+  // playlist/search response), grab the first track from data.tracks.
+  const data = await loadTrack(url);
+  const encoded = data.data?.encoded ?? data.data?.tracks?.[0]?.encoded;
   if (!encoded) {
     throw new Error('NodeLink returned no encoded track for preload');
   }
 
-  // Set nextTrack on the player. Only send nextTrack — do NOT include
-  // the current track in the PATCH body. The Lavalink v4 spec expects
-  // noReplace as a query parameter, not a body field. Including track
-  // in the body without a proper noReplace query param causes NodeLink
-  // to restart the currently-playing track (audible restart glitch
-  // ~500ms into playback).
+  // Set nextTrack on the player.  Only send nextTrack — do NOT include
+  // track in the PATCH body, otherwise NodeLink will restart the
+  // currently-playing track.
   const patchUrl = new URL(
     `/v4/sessions/${encodeURIComponent(sessionId)}/players/${encodeURIComponent(guildId)}`,
     NODELINK_URL
@@ -443,7 +431,7 @@ export async function preloadTrack(guildId: string, sessionId: string, url: stri
     throw new Error(`NodeLink preload PATCH returned ${patchResp.status}`);
   }
 
-  logger.debug({ guildId, url }, 'Gapless preload succeeded');
+  logger.info({ guildId, url }, 'Gapless preload succeeded');
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the ~3 second silence gap between tracks during natural playback transitions. Root cause was a known encoder bug in NodeLink v3.7.0, now resolved by updating to the dev branch. Also fixes several issues in Alfira's gapless implementation discovered during investigation.

## Changes

- **Pin NodeLink to dev commit `e524ed7`** — fixes the ~3s encoder silence present in v3.7.0
- **Combine cold-start PATCH into single request** — was 3 serial PATCH calls (track, compressor, equalizer) that also caused filters to overwrite each other
- **Fire gapless preload before broadcast** — gives NodeLink maximum time to fetch and decode the next track
- **Add preload retry** — retries once on first failure instead of silently falling through to cold-start
- **Add `data.tracks[0]` fallback in preloadTrack** — matches `getStreamFormat` behavior for playlist/search responses