### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alfira",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
Missed the package.json version bump in the v0.2.1 release.