### PR TITLE
ui(web): tighten virtual list spacing and add scroll fade

### DIFF
--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -247,7 +247,7 @@ function QueueLayout() {
   return (
     <>
       <div className='flex-1 flex flex-col min-w-0 pt-14 md:pt-0 overflow-hidden'>
-        <main className='flex-1 overflow-y-auto pb-22 md:pb-20'>
+        <main className='flex-1 overflow-y-auto pb-8 md:pb-8'>
           <AnimatedOutlet />
         </main>
         <NowPlayingBar />

--- a/packages/web/src/components/ListToolbar.tsx
+++ b/packages/web/src/components/ListToolbar.tsx
@@ -151,7 +151,7 @@ export default function ListToolbar({
   return (
     <>
       {/* ── Toolbar ── */}
-      <div className='flex items-center gap-2 mb-3'>
+      <div className='flex items-center gap-2 mb-1'>
         {/* Search */}
         <div className='relative flex-1'>
           <MagnifyingGlassIcon
@@ -269,7 +269,7 @@ export default function ListToolbar({
 
       {/* ── Filter chips ── */}
       {hasActiveFilters && (
-        <div className='mb-2'>
+        <div className='mb-1'>
           <FilterChips
             tags={filterTags}
             sources={filterSources}

--- a/packages/web/src/components/VirtualList.tsx
+++ b/packages/web/src/components/VirtualList.tsx
@@ -138,13 +138,13 @@ function VirtualListInner<T>({
       {showContent && (
         <div
           ref={scrollRef}
-          className='overflow-y-auto px-4 pt-4 pb-4 min-h-0'
+          className='overflow-y-auto px-2 pt-3 pb-4 min-h-0'
           style={{
-            maxHeight: 'calc(100vh - 340px)',
+            maxHeight: 'calc(100vh - 245px)',
             WebkitMaskImage:
-              'linear-gradient(to bottom, black 0%, black calc(100% - 40px), transparent 100%)',
+              'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 40px), transparent 100%)',
             maskImage:
-              'linear-gradient(to bottom, black 0%, black calc(100% - 40px), transparent 100%)',
+              'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 40px), transparent 100%)',
           }}
         >
           <div

--- a/packages/web/src/components/VirtualSongGrid.tsx
+++ b/packages/web/src/components/VirtualSongGrid.tsx
@@ -200,7 +200,7 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
     }) => {
       const p = cardPropsRef.current;
       return (
-        <div style={{ width, padding: '0 8px 16px' }}>
+        <div style={{ width, padding: '0 6px 16px' }}>
           <SongCard
             song={song}
             variant='grid'
@@ -245,15 +245,15 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
   return (
     <div
       ref={scrollRefCallback}
-      className='min-h-0'
+      className='pt-3 min-h-0'
       style={{
-        maxHeight: 'calc(100vh - 340px)',
+        maxHeight: 'calc(100vh - 260px)',
         overflowY: isContentReady ? 'auto' : 'hidden',
         WebkitMaskImage: isContentReady
-          ? 'linear-gradient(to bottom, black 0%, black calc(100% - 40px), transparent 100%)'
+          ? 'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 40px), transparent 100%)'
           : undefined,
         maskImage: isContentReady
-          ? 'linear-gradient(to bottom, black 0%, black calc(100% - 40px), transparent 100%)'
+          ? 'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 40px), transparent 100%)'
           : undefined,
       }}
     >


### PR DESCRIPTION
## Summary

Tightens spacing around the virtual song list and masonry grid, and adds fade gradients at both top and bottom of the scroll containers.

## Changes

- Reduce `<main>` bottom padding to bring content closer to the NowPlayingBar
- Tighten horizontal padding inside virtual list and grid card gutters
- Reduce toolbar bottom margin to shift the list up
- Add top fade gradient to match the existing bottom fade
- Adjust `maxHeight` to balance the spacing changes