### PR TITLE
fix(web): fix portal menu flash at top-left on chromium

### DIFF
--- a/packages/web/src/components/ContextMenu.tsx
+++ b/packages/web/src/components/ContextMenu.tsx
@@ -1,5 +1,13 @@
 import { DotsThreeOutlineVerticalIcon } from '@phosphor-icons/react';
-import { type ReactNode, type RefObject, useCallback, useEffect, useRef, useState } from 'react';
+import {
+  type ReactNode,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import { createPortal } from 'react-dom';
 import { EditSubmenuPanel } from './ContextMenu/EditSubmenuPanel';
 import { MenuItemButton } from './ContextMenu/MenuItemButton';
@@ -133,8 +141,8 @@ export function ContextMenu({
   const currentItemsRef = useRef(currentItems);
   currentItemsRef.current = currentItems;
 
-  // Position calculation
-  useEffect(() => {
+  // Position calculation — useLayoutEffect runs before paint, preventing a (0,0) flash.
+  useLayoutEffect(() => {
     if (!isOpen || !triggerRef.current) return;
 
     const lastUpdateRef = { current: 0 };
@@ -175,7 +183,7 @@ export function ContextMenu({
     };
   }, [isOpen, triggerRef, align]);
 
-  // Reset submenu and focus when opening
+  // Reset submenu and focus when opening (useEffect is fine — not position-critical)
   useEffect(() => {
     if (isOpen) {
       setActiveSubmenu(null);

--- a/packages/web/src/components/UserMenu.tsx
+++ b/packages/web/src/components/UserMenu.tsx
@@ -1,6 +1,6 @@
 import type { User } from '@alfira/server/shared';
 import { SignOutIcon, UserIcon } from '@phosphor-icons/react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 interface UserMenuProps {
@@ -42,14 +42,12 @@ export default function UserMenu({ user, collapsed, onLogout }: UserMenuProps) {
     setPosition({ top, left });
   }, []);
 
-  useEffect(() => {
+  // Position before paint (useLayoutEffect) to avoid a (0,0) flash.
+  useLayoutEffect(() => {
     if (!open) return;
-    // Wait for the portal content to be in the DOM before measuring
-    requestAnimationFrame(() => {
-      updatePosition();
-      window.addEventListener('resize', updatePosition);
-      window.addEventListener('scroll', updatePosition, true);
-    });
+    updatePosition();
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
     return () => {
       window.removeEventListener('resize', updatePosition);
       window.removeEventListener('scroll', updatePosition, true);


### PR DESCRIPTION
## Summary

Portaled popup menus (ContextMenu and UserMenu) briefly flash at position (0,0) in Chromium-based browsers before snapping to their correct location. This doesn't occur in Firefox due to different frame scheduling.

## Root cause

Both components used `useEffect` (and `requestAnimationFrame` in UserMenu) for position calculation, which runs after the browser has already painted the initial render at (0,0).

## Fix

Replaced `useEffect` → `useLayoutEffect` for position calculation in both components. `useLayoutEffect` runs synchronously after DOM commit but before paint, so the position update happens within the same frame as the initial render — the browser never paints the incorrect (0,0) position.

## Changes

- `ContextMenu.tsx`: Change position calculation from `useEffect` to `useLayoutEffect`
- `UserMenu.tsx`: Same change, also removes the unnecessary `requestAnimationFrame` wrapper