### PR TITLE
fix(web): restore full page padding, remove scroll container bottom padding

### DIFF
--- a/packages/web/src/components/AnimatedOutlet.tsx
+++ b/packages/web/src/components/AnimatedOutlet.tsx
@@ -19,6 +19,7 @@ export function AnimatedOutlet() {
   return (
     <AnimatePresence mode='wait'>
       <m.div
+        className='flex-1 min-h-0'
         key={location.pathname}
         variants={pageVariants}
         initial='initial'

--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -45,7 +45,7 @@ function LayoutContent() {
   };
 
   return (
-    <div className='flex h-full bg-surface'>
+    <div className='flex h-full bg-surface overflow-hidden'>
       {/* ------------------------------------------------------------------ */}
       {/* Mobile Navigation - visible on small screens */}
       {/* ------------------------------------------------------------------ */}
@@ -247,7 +247,7 @@ function QueueLayout() {
   return (
     <>
       <div className='flex-1 flex flex-col min-w-0 pt-14 md:pt-0 overflow-hidden'>
-        <main className='flex-1 overflow-y-auto pb-8 md:pb-8'>
+        <main className='flex-1 overflow-y-auto pb-24 md:pb-20'>
           <AnimatedOutlet />
         </main>
         <NowPlayingBar />

--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -45,40 +45,66 @@ function LayoutContent() {
   };
 
   return (
-    <div className='flex h-full bg-surface overflow-hidden'>
+    <div className='flex flex-col h-full bg-surface overflow-hidden'>
       {/* ------------------------------------------------------------------ */}
       {/* Mobile Navigation - visible on small screens */}
       {/* ------------------------------------------------------------------ */}
       <MobileNav />
 
       {/* ------------------------------------------------------------------ */}
-      {/* Sidebar - visible on medium screens and up */}
+      {/* Middle row: sidebar + content */}
       {/* ------------------------------------------------------------------ */}
-      <m.aside
-        className='hidden md:flex shrink-0 flex-col bg-elevated overflow-hidden h-[calc(100vh-5rem)]'
-        animate={{ width: collapsed ? 64 : 224 }}
-        initial={false}
-        transition={{ type: 'spring', stiffness: 500, damping: 25 }}
-      >
-        {/* Wordmark */}
-        <div
-          className={`flex pt-6 pb-4 ${
-            collapsed ? 'flex-col items-center justify-start px-3 gap-2' : 'items-center px-5'
-          }`}
+      <div className='flex-1 flex overflow-hidden'>
+        {/* ------------------------------------------------------------------ */}
+        {/* Sidebar - visible on medium screens and up */}
+        {/* ------------------------------------------------------------------ */}
+        <m.aside
+          className='hidden md:flex shrink-0 flex-col bg-elevated overflow-hidden h-full'
+          animate={{ width: collapsed ? 64 : 224 }}
+          initial={false}
+          transition={{ type: 'spring', stiffness: 500, damping: 25 }}
         >
-          {!collapsed && (
-            <div className='flex items-center gap-2 min-w-0'>
+          {/* Wordmark */}
+          <div
+            className={`flex pt-6 pb-4 ${
+              collapsed ? 'flex-col items-center justify-start px-3 gap-2' : 'items-center px-5'
+            }`}
+          >
+            {!collapsed && (
+              <div className='flex items-center gap-2 min-w-0'>
+                <button
+                  type='button'
+                  onClick={toggleAdminView}
+                  title={
+                    user?.isAdmin
+                      ? isAdminView
+                        ? 'Switch to Member view'
+                        : 'Switch to Admin view'
+                      : undefined
+                  }
+                  className={`flex items-center justify-center w-10 h-10 shrink-0 rounded border border-accent/30 bg-accent/10 self-end transition-opacity ${user?.isAdmin ? 'cursor-pointer hover:opacity-80' : 'cursor-default'}`}
+                >
+                  {isAdminView ? (
+                    <CraneTowerIcon size={24} weight='duotone' className='text-accent' />
+                  ) : (
+                    <GuitarIcon size={24} weight='duotone' className='text-accent' />
+                  )}
+                </button>
+                <span className='font-display text-5xl text-accent tracking-wider'>Alfira</span>
+              </div>
+            )}
+            {collapsed && (
               <button
                 type='button'
                 onClick={toggleAdminView}
+                className={`w-10 h-10 flex items-center justify-center shrink-0 rounded border border-accent/30 bg-accent/10 transition-opacity ${user?.isAdmin ? 'cursor-pointer hover:opacity-80' : 'cursor-default'}`}
                 title={
                   user?.isAdmin
                     ? isAdminView
-                      ? 'Switch to Member view'
-                      : 'Switch to Admin view'
+                      ? 'Admin mode — click to switch'
+                      : 'Member mode — click to switch'
                     : undefined
                 }
-                className={`flex items-center justify-center w-10 h-10 shrink-0 rounded border border-accent/30 bg-accent/10 self-end transition-opacity ${user?.isAdmin ? 'cursor-pointer hover:opacity-80' : 'cursor-default'}`}
               >
                 {isAdminView ? (
                   <CraneTowerIcon size={24} weight='duotone' className='text-accent' />
@@ -86,157 +112,141 @@ function LayoutContent() {
                   <GuitarIcon size={24} weight='duotone' className='text-accent' />
                 )}
               </button>
-              <span className='font-display text-5xl text-accent tracking-wider'>Alfira</span>
+            )}
+          </div>
+
+          {/* Spacer between wordmark and nav */}
+          {collapsed ? (
+            <div className='flex justify-center px-2'>
+              <div className='w-full h-px bg-fg/20' />
+            </div>
+          ) : (
+            <div className='px-5'>
+              <div className='h-px bg-fg/20' />
             </div>
           )}
-          {collapsed && (
+
+          {/* Nav */}
+          <nav className={`flex-1 ${collapsed ? 'px-2 pt-3' : 'px-3 pt-3'} space-y-2`}>
+            {NAV_ITEMS.map(({ to, label, icon: Icon }) => (
+              <NavLink
+                key={to}
+                to={to}
+                title={collapsed ? label : undefined}
+                className={({ isActive }) =>
+                  `flex items-center rounded-xl font-body text-md transition-all duration-150 cursor-pointer ${
+                    collapsed ? 'justify-center px-0 py-3' : 'px-3 py-3'
+                  } ${isActive ? 'btn-inherit pressed' : 'btn-inherit'}`
+                }
+                style={{ '--btn-surface': 'var(--color-elevated)' } as React.CSSProperties}
+              >
+                {!collapsed && <span className='mr-auto'>{label}</span>}
+                <Icon size={22} weight='duotone' />
+              </NavLink>
+            ))}
+            {isAdminView && ADMIN_NAV_ITEMS.length > 0 && (
+              <>
+                {/* Separator between user and admin nav items */}
+                {collapsed ? (
+                  <div className='flex justify-center px-2 py-1'>
+                    <div className='w-6 h-px bg-fg/15' />
+                  </div>
+                ) : (
+                  <div className='px-2 py-1'>
+                    <div className='h-px bg-fg/15' />
+                  </div>
+                )}
+                {ADMIN_NAV_ITEMS.map(({ to, label, icon: Icon }) => (
+                  <NavLink
+                    key={to}
+                    to={to}
+                    title={collapsed ? label : undefined}
+                    className={({ isActive }) =>
+                      `flex items-center rounded-xl font-body text-md transition-all duration-150 cursor-pointer ${
+                        collapsed ? 'justify-center px-0 py-3' : 'px-3 py-3'
+                      } ${isActive ? 'btn-inherit pressed' : 'btn-inherit'}`
+                    }
+                    style={{ '--btn-surface': 'var(--color-elevated)' } as React.CSSProperties}
+                  >
+                    {!collapsed && <span className='mr-auto'>{label}</span>}
+                    <Icon size={22} weight='duotone' />
+                  </NavLink>
+                ))}
+              </>
+            )}
+          </nav>
+
+          {/* Connection status */}
+          {connectionStatus !== 'connected' && (
+            <div className={collapsed ? 'flex justify-center px-2 pb-2' : 'px-3 pb-2'}>
+              <div
+                title={connectionStatus === 'reconnecting' ? 'Reconnecting...' : 'Disconnected'}
+                className={`flex items-center rounded-xl font-body w-full select-none ${
+                  collapsed ? 'justify-center px-0 py-3' : 'px-3 py-3 gap-3'
+                } ${connectionStatus === 'reconnecting' ? 'text-warning' : 'text-danger'}`}
+              >
+                {!collapsed && (
+                  <span className='mr-auto text-sm text-fg/80'>
+                    {connectionStatus === 'reconnecting' ? 'Reconnecting...' : 'Disconnected'}
+                  </span>
+                )}
+                <LinkBreakIcon
+                  size={22}
+                  weight='duotone'
+                  className={connectionStatus === 'reconnecting' ? 'animate-pulse' : ''}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Settings Menu */}
+          <SettingsMenu collapsed={collapsed} />
+
+          {/* Collapse toggle */}
+          <div className={collapsed ? 'flex justify-center px-2 pb-4' : 'px-3 pb-4'}>
             <button
               type='button'
-              onClick={toggleAdminView}
-              className={`w-10 h-10 flex items-center justify-center shrink-0 rounded border border-accent/30 bg-accent/10 transition-opacity ${user?.isAdmin ? 'cursor-pointer hover:opacity-80' : 'cursor-default'}`}
-              title={
-                user?.isAdmin
-                  ? isAdminView
-                    ? 'Admin mode — click to switch'
-                    : 'Member mode — click to switch'
-                  : undefined
-              }
-            >
-              {isAdminView ? (
-                <CraneTowerIcon size={24} weight='duotone' className='text-accent' />
-              ) : (
-                <GuitarIcon size={24} weight='duotone' className='text-accent' />
-              )}
-            </button>
-          )}
-        </div>
-
-        {/* Spacer between wordmark and nav */}
-        {collapsed ? (
-          <div className='flex justify-center px-2'>
-            <div className='w-full h-px bg-fg/20' />
-          </div>
-        ) : (
-          <div className='px-5'>
-            <div className='h-px bg-fg/20' />
-          </div>
-        )}
-
-        {/* Nav */}
-        <nav className={`flex-1 ${collapsed ? 'px-2 pt-3' : 'px-3 pt-3'} space-y-2`}>
-          {NAV_ITEMS.map(({ to, label, icon: Icon }) => (
-            <NavLink
-              key={to}
-              to={to}
-              title={collapsed ? label : undefined}
-              className={({ isActive }) =>
-                `flex items-center rounded-xl font-body text-md transition-all duration-150 cursor-pointer ${
-                  collapsed ? 'justify-center px-0 py-3' : 'px-3 py-3'
-                } ${isActive ? 'btn-inherit pressed' : 'btn-inherit'}`
-              }
+              onClick={() => setCollapsed((c) => !c)}
+              title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+              className={`flex items-center rounded-xl font-body transition-all duration-150 cursor-pointer w-full ${
+                collapsed ? 'justify-center px-0 py-2' : 'px-3 py-2'
+              } btn-inherit`}
               style={{ '--btn-surface': 'var(--color-elevated)' } as React.CSSProperties}
             >
-              {!collapsed && <span className='mr-auto'>{label}</span>}
-              <Icon size={22} weight='duotone' />
-            </NavLink>
-          ))}
-          {isAdminView && ADMIN_NAV_ITEMS.length > 0 && (
-            <>
-              {/* Separator between user and admin nav items */}
-              {collapsed ? (
-                <div className='flex justify-center px-2 py-1'>
-                  <div className='w-6 h-px bg-fg/15' />
-                </div>
-              ) : (
-                <div className='px-2 py-1'>
-                  <div className='h-px bg-fg/15' />
-                </div>
-              )}
-              {ADMIN_NAV_ITEMS.map(({ to, label, icon: Icon }) => (
-                <NavLink
-                  key={to}
-                  to={to}
-                  title={collapsed ? label : undefined}
-                  className={({ isActive }) =>
-                    `flex items-center rounded-xl font-body text-md transition-all duration-150 cursor-pointer ${
-                      collapsed ? 'justify-center px-0 py-3' : 'px-3 py-3'
-                    } ${isActive ? 'btn-inherit pressed' : 'btn-inherit'}`
-                  }
-                  style={{ '--btn-surface': 'var(--color-elevated)' } as React.CSSProperties}
-                >
-                  {!collapsed && <span className='mr-auto'>{label}</span>}
-                  <Icon size={22} weight='duotone' />
-                </NavLink>
-              ))}
-            </>
-          )}
-        </nav>
+              {!collapsed && <span className='mr-auto'>Collapse</span>}
+              <CaretLeftIcon size={18} weight='duotone' className={collapsed ? 'rotate-180' : ''} />
+            </button>
+          </div>
 
-        {/* Connection status */}
-        {connectionStatus !== 'connected' && (
-          <div className={collapsed ? 'flex justify-center px-2 pb-2' : 'px-3 pb-2'}>
-            <div
-              title={connectionStatus === 'reconnecting' ? 'Reconnecting...' : 'Disconnected'}
-              className={`flex items-center rounded-xl font-body w-full select-none ${
-                collapsed ? 'justify-center px-0 py-3' : 'px-3 py-3 gap-3'
-              } ${connectionStatus === 'reconnecting' ? 'text-warning' : 'text-danger'}`}
-            >
-              {!collapsed && (
-                <span className='mr-auto text-sm text-fg/80'>
-                  {connectionStatus === 'reconnecting' ? 'Reconnecting...' : 'Disconnected'}
-                </span>
-              )}
-              <LinkBreakIcon
-                size={22}
-                weight='duotone'
-                className={connectionStatus === 'reconnecting' ? 'animate-pulse' : ''}
-              />
+          {/* Separator above user section */}
+          {collapsed ? (
+            <div className='flex justify-center px-2'>
+              <div className='w-full h-px bg-fg/20' />
             </div>
-          </div>
-        )}
+          ) : (
+            <div className='px-5'>
+              <div className='h-px bg-fg/20' />
+            </div>
+          )}
 
-        {/* Settings Menu */}
-        <SettingsMenu collapsed={collapsed} />
+          {/* User section */}
+          {user && (
+            <div className={collapsed ? 'px-2 py-3' : 'p-3'}>
+              <UserMenu user={user} collapsed={collapsed} onLogout={handleLogout} />
+            </div>
+          )}
+        </m.aside>
 
-        {/* Collapse toggle */}
-        <div className={collapsed ? 'flex justify-center px-2 pb-4' : 'px-3 pb-4'}>
-          <button
-            type='button'
-            onClick={() => setCollapsed((c) => !c)}
-            title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-            className={`flex items-center rounded-xl font-body transition-all duration-150 cursor-pointer w-full ${
-              collapsed ? 'justify-center px-0 py-2' : 'px-3 py-2'
-            } btn-inherit`}
-            style={{ '--btn-surface': 'var(--color-elevated)' } as React.CSSProperties}
-          >
-            {!collapsed && <span className='mr-auto'>Collapse</span>}
-            <CaretLeftIcon size={18} weight='duotone' className={collapsed ? 'rotate-180' : ''} />
-          </button>
-        </div>
-
-        {/* Separator above user section */}
-        {collapsed ? (
-          <div className='flex justify-center px-2'>
-            <div className='w-full h-px bg-fg/20' />
-          </div>
-        ) : (
-          <div className='px-5'>
-            <div className='h-px bg-fg/20' />
-          </div>
-        )}
-
-        {/* User section */}
-        {user && (
-          <div className={collapsed ? 'px-2 py-3' : 'p-3'}>
-            <UserMenu user={user} collapsed={collapsed} onLogout={handleLogout} />
-          </div>
-        )}
-      </m.aside>
+        {/* ------------------------------------------------------------------ */}
+        {/* Main content + queue panel */}
+        {/* ------------------------------------------------------------------ */}
+        <QueueLayout />
+      </div>
 
       {/* ------------------------------------------------------------------ */}
-      {/* Main content + now playing bar + queue panel */}
+      {/* Now Playing Bar — full width, in flow, at root level */}
       {/* ------------------------------------------------------------------ */}
-      <QueueLayout />
+      <NowPlayingBar />
     </div>
   );
 }
@@ -250,12 +260,11 @@ function QueueLayout() {
         <main className='flex-1 flex flex-col overflow-hidden'>
           <AnimatedOutlet />
         </main>
-        <NowPlayingBar />
       </div>
 
       {/* Desktop: right-side panel that pushes content */}
       <m.aside
-        className='shrink-0 flex-col bg-elevated overflow-hidden clay-floating md:flex hidden h-[calc(100vh-5rem)]'
+        className='shrink-0 flex-col bg-elevated overflow-hidden clay-floating md:flex hidden h-full'
         animate={{ width: queueOpen ? 384 : 0 }}
         initial={false}
         transition={{ type: 'spring', stiffness: 500, damping: 25 }}

--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -247,7 +247,7 @@ function QueueLayout() {
   return (
     <>
       <div className='flex-1 flex flex-col min-w-0 pt-14 md:pt-0 overflow-hidden'>
-        <main className='flex-1 overflow-y-auto pb-24 md:pb-20'>
+        <main className='flex-1 flex flex-col overflow-hidden'>
           <AnimatedOutlet />
         </main>
         <NowPlayingBar />

--- a/packages/web/src/components/NowPlayingBar.tsx
+++ b/packages/web/src/components/NowPlayingBar.tsx
@@ -523,7 +523,7 @@ export function NowPlayingBar() {
   }, [setOverrideElapsed]);
 
   return (
-    <div className='shrink-0 w-full bg-base fixed bottom-0 left-0 right-0 z-10'>
+    <div className='shrink-0 w-full bg-base'>
       {/* Mobile: progress bar on top */}
       <ProgressBar
         currentSong={currentSong}

--- a/packages/web/src/components/VirtualList.tsx
+++ b/packages/web/src/components/VirtualList.tsx
@@ -128,7 +128,7 @@ function VirtualListInner<T>({
   return (
     <div
       ref={containerRef}
-      className='relative'
+      className='relative flex-1 min-h-0 flex flex-col'
       style={{ opacity: 0, transition: 'opacity 120ms ease' }}
     >
       {showSkeleton && skeleton}
@@ -138,9 +138,8 @@ function VirtualListInner<T>({
       {showContent && (
         <div
           ref={scrollRef}
-          className='overflow-y-auto px-2 pt-3 pb-4 min-h-0'
+          className='overflow-y-auto px-2 pt-3 pb-24 md:pb-20 min-h-0 flex-1'
           style={{
-            maxHeight: 'calc(100vh - 245px)',
             WebkitMaskImage:
               'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 40px), transparent 100%)',
             maskImage:

--- a/packages/web/src/components/VirtualList.tsx
+++ b/packages/web/src/components/VirtualList.tsx
@@ -140,9 +140,9 @@ function VirtualListInner<T>({
           className='overflow-y-auto px-2 pt-3 pb-4 min-h-0 flex-1'
           style={{
             WebkitMaskImage:
-              'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 40px), transparent 100%)',
+              'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 20px), transparent 100%)',
             maskImage:
-              'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 40px), transparent 100%)',
+              'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 20px), transparent 100%)',
           }}
         >
           <div

--- a/packages/web/src/components/VirtualList.tsx
+++ b/packages/web/src/components/VirtualList.tsx
@@ -127,7 +127,7 @@ function VirtualListInner<T>({
   return (
     <div
       ref={containerRef}
-      className='relative flex-1 min-h-0 flex flex-col'
+      className='relative flex-1 min-h-0 flex flex-col overflow-x-hidden'
       style={{ opacity: 0, transition: 'opacity 120ms ease' }}
     >
       {showSkeleton && skeleton}
@@ -137,7 +137,7 @@ function VirtualListInner<T>({
       {showContent && (
         <div
           ref={scrollRef}
-          className='overflow-y-auto px-2 pt-3 pb-4 min-h-0 flex-1'
+          className='overflow-y-auto overflow-x-hidden px-2 pt-3 pb-4 min-h-0 flex-1'
           style={{
             WebkitMaskImage:
               'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 20px), transparent 100%)',
@@ -216,6 +216,7 @@ function VirtualListInner<T>({
                     width: '100%',
                     height: `${virtualRow.size}px`,
                     transform: `translateY(${virtualRow.start}px)`,
+                    overflow: 'hidden',
                   }}
                 >
                   <m.div layout initial='initial' animate='animate' variants={listItemVariants}>

--- a/packages/web/src/components/VirtualList.tsx
+++ b/packages/web/src/components/VirtualList.tsx
@@ -1,5 +1,4 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { type Transition } from 'motion/react';
 import * as m from 'motion/react-m';
 import { memo, useEffect, useLayoutEffect, useRef } from 'react';
 import { listItemVariants } from '../lib/motion';
@@ -219,12 +218,7 @@ function VirtualListInner<T>({
                     transform: `translateY(${virtualRow.start}px)`,
                   }}
                 >
-                  <m.div
-                    initial='initial'
-                    animate='animate'
-                    variants={listItemVariants}
-                    transition={{ duration: 0.2, ease: 'easeOut' } as Transition}
-                  >
+                  <m.div layout initial='initial' animate='animate' variants={listItemVariants}>
                     {renderItem(item, virtualRow.index)}
                   </m.div>
                   {spacer}

--- a/packages/web/src/components/VirtualList.tsx
+++ b/packages/web/src/components/VirtualList.tsx
@@ -137,7 +137,7 @@ function VirtualListInner<T>({
       {showContent && (
         <div
           ref={scrollRef}
-          className='overflow-y-auto px-2 pt-3 pb-24 md:pb-20 min-h-0 flex-1'
+          className='overflow-y-auto px-2 pt-3 pb-4 min-h-0 flex-1'
           style={{
             WebkitMaskImage:
               'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 40px), transparent 100%)',

--- a/packages/web/src/components/VirtualList.tsx
+++ b/packages/web/src/components/VirtualList.tsx
@@ -137,7 +137,7 @@ function VirtualListInner<T>({
       {showContent && (
         <div
           ref={scrollRef}
-          className='overflow-y-auto overflow-x-hidden px-2 pt-3 pb-4 min-h-0 flex-1'
+          className='overflow-y-auto overflow-x-hidden px-2 pt-3 min-h-0 flex-1'
           style={{
             WebkitMaskImage:
               'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 20px), transparent 100%)',

--- a/packages/web/src/components/VirtualList.tsx
+++ b/packages/web/src/components/VirtualList.tsx
@@ -137,7 +137,7 @@ function VirtualListInner<T>({
       {showContent && (
         <div
           ref={scrollRef}
-          className='overflow-y-auto overflow-x-hidden px-2 pt-3 min-h-0 flex-1'
+          className='overflow-y-auto overflow-x-hidden px-2 pt-3 min-h-0 flex-1 bg-surface'
           style={{
             WebkitMaskImage:
               'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 20px), transparent 100%)',
@@ -227,9 +227,6 @@ function VirtualListInner<T>({
               );
             })}
           </div>
-
-          {/* End spacer when everything is loaded */}
-          {!isFetching && !isError && !hasMore && <div className='h-4' />}
         </div>
       )}
     </div>

--- a/packages/web/src/components/VirtualSongGrid.tsx
+++ b/packages/web/src/components/VirtualSongGrid.tsx
@@ -249,10 +249,10 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
       style={{
         overflowY: isContentReady ? 'auto' : 'hidden',
         WebkitMaskImage: isContentReady
-          ? 'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 40px), transparent 100%)'
+          ? 'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 20px), transparent 100%)'
           : undefined,
         maskImage: isContentReady
-          ? 'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 40px), transparent 100%)'
+          ? 'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 20px), transparent 100%)'
           : undefined,
       }}
     >

--- a/packages/web/src/components/VirtualSongGrid.tsx
+++ b/packages/web/src/components/VirtualSongGrid.tsx
@@ -245,7 +245,7 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
   return (
     <div
       ref={scrollRefCallback}
-      className='pt-3 pb-4 min-h-0 flex-1'
+      className='pt-3 min-h-0 flex-1'
       style={{
         overflowX: 'hidden',
         overflowY: isContentReady ? 'auto' : 'hidden',

--- a/packages/web/src/components/VirtualSongGrid.tsx
+++ b/packages/web/src/components/VirtualSongGrid.tsx
@@ -247,6 +247,7 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
       ref={scrollRefCallback}
       className='pt-3 pb-4 min-h-0 flex-1'
       style={{
+        overflowX: 'hidden',
         overflowY: isContentReady ? 'auto' : 'hidden',
         WebkitMaskImage: isContentReady
           ? 'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 20px), transparent 100%)'

--- a/packages/web/src/components/VirtualSongGrid.tsx
+++ b/packages/web/src/components/VirtualSongGrid.tsx
@@ -245,9 +245,8 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
   return (
     <div
       ref={scrollRefCallback}
-      className='pt-3 min-h-0'
+      className='pt-3 min-h-0 flex-1'
       style={{
-        maxHeight: 'calc(100vh - 260px)',
         overflowY: isContentReady ? 'auto' : 'hidden',
         WebkitMaskImage: isContentReady
           ? 'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 40px), transparent 100%)'

--- a/packages/web/src/components/VirtualSongGrid.tsx
+++ b/packages/web/src/components/VirtualSongGrid.tsx
@@ -245,7 +245,7 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
   return (
     <div
       ref={scrollRefCallback}
-      className='pt-3 min-h-0 flex-1'
+      className='pt-3 pb-24 md:pb-20 min-h-0 flex-1'
       style={{
         overflowY: isContentReady ? 'auto' : 'hidden',
         WebkitMaskImage: isContentReady

--- a/packages/web/src/components/VirtualSongGrid.tsx
+++ b/packages/web/src/components/VirtualSongGrid.tsx
@@ -245,7 +245,7 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
   return (
     <div
       ref={scrollRefCallback}
-      className='pt-3 pb-24 md:pb-20 min-h-0 flex-1'
+      className='pt-3 pb-4 min-h-0 flex-1'
       style={{
         overflowY: isContentReady ? 'auto' : 'hidden',
         WebkitMaskImage: isContentReady

--- a/packages/web/src/components/settings/SettingsPage.tsx
+++ b/packages/web/src/components/settings/SettingsPage.tsx
@@ -16,7 +16,7 @@ export default function SettingsPage() {
   }, []);
 
   return (
-    <div className='p-4 md:p-8'>
+    <div className='p-4 md:p-8 h-full overflow-y-auto pb-24 md:pb-20'>
       {/* Page header */}
       <div className='mb-6 md:mb-8 flex items-end justify-between'>
         <h1 className='font-display text-3xl md:text-4xl text-accent tracking-wider flex items-center gap-2'>

--- a/packages/web/src/components/settings/SettingsPage.tsx
+++ b/packages/web/src/components/settings/SettingsPage.tsx
@@ -16,7 +16,7 @@ export default function SettingsPage() {
   }, []);
 
   return (
-    <div className='p-4 md:p-8 h-full overflow-y-auto pb-24 md:pb-20'>
+    <div className='p-4 md:p-8 h-full overflow-y-auto'>
       {/* Page header */}
       <div className='mb-6 md:mb-8 flex items-end justify-between'>
         <h1 className='font-display text-3xl md:text-4xl text-accent tracking-wider flex items-center gap-2'>

--- a/packages/web/src/pages/AudioPage.tsx
+++ b/packages/web/src/pages/AudioPage.tsx
@@ -12,7 +12,7 @@ export default function AudioPage() {
   const canManage = isAdminView || hasPermission('audio.manage');
 
   return (
-    <div className='p-4 md:p-8'>
+    <div className='p-4 md:p-8 h-full overflow-y-auto pb-24 md:pb-20'>
       <PageHeader
         icon={SlidersHorizontal}
         title='Audio'

--- a/packages/web/src/pages/AudioPage.tsx
+++ b/packages/web/src/pages/AudioPage.tsx
@@ -12,7 +12,7 @@ export default function AudioPage() {
   const canManage = isAdminView || hasPermission('audio.manage');
 
   return (
-    <div className='p-4 md:p-8 h-full overflow-y-auto pb-24 md:pb-20'>
+    <div className='p-4 md:p-8 h-full overflow-y-auto'>
       <PageHeader
         icon={SlidersHorizontal}
         title='Audio'

--- a/packages/web/src/pages/PermissionsPage.tsx
+++ b/packages/web/src/pages/PermissionsPage.tsx
@@ -202,7 +202,7 @@ export default function PermissionsPage() {
 
   if (!data) {
     return (
-      <div className='p-4 md:p-8 h-full overflow-y-auto pb-24 md:pb-20'>
+      <div className='p-4 md:p-8 h-full overflow-y-auto'>
         <PageHeader icon={ShieldCheckIcon} title='Permissions' />
         {error ? (
           <ErrorBanner message={error} />
@@ -215,7 +215,7 @@ export default function PermissionsPage() {
 
   // Render ----------------------------------------------------------------
   return (
-    <div className='p-4 md:p-8 h-full overflow-y-auto pb-24 md:pb-20'>
+    <div className='p-4 md:p-8 h-full overflow-y-auto'>
       <PageHeader
         icon={ShieldCheckIcon}
         title='Permissions'

--- a/packages/web/src/pages/PermissionsPage.tsx
+++ b/packages/web/src/pages/PermissionsPage.tsx
@@ -202,7 +202,7 @@ export default function PermissionsPage() {
 
   if (!data) {
     return (
-      <div className='p-4 md:p-8'>
+      <div className='p-4 md:p-8 h-full overflow-y-auto pb-24 md:pb-20'>
         <PageHeader icon={ShieldCheckIcon} title='Permissions' />
         {error ? (
           <ErrorBanner message={error} />
@@ -215,7 +215,7 @@ export default function PermissionsPage() {
 
   // Render ----------------------------------------------------------------
   return (
-    <div className='p-4 md:p-8'>
+    <div className='p-4 md:p-8 h-full overflow-y-auto pb-24 md:pb-20'>
       <PageHeader
         icon={ShieldCheckIcon}
         title='Permissions'

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -581,7 +581,7 @@ export default function PlaylistDetailPage() {
   const songItems: Song[] = songs.map((ps) => ps.song);
 
   return (
-    <div className='pt-4 pr-4 pl-4 pb-0 md:pt-8 md:pr-8 md:pl-8 md:pb-0 flex flex-col min-h-0 h-full'>
+    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full' style={{ paddingBottom: 0 }}>
       {/* Back */}
       <Button
         variant='inherit'

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -581,7 +581,7 @@ export default function PlaylistDetailPage() {
   const songItems: Song[] = songs.map((ps) => ps.song);
 
   return (
-    <div className='pt-4 pr-4 pl-4 md:pt-8 md:pr-8 md:pl-8 flex flex-col min-h-0 h-full'>
+    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full'>
       {/* Back */}
       <Button
         variant='inherit'

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -581,7 +581,7 @@ export default function PlaylistDetailPage() {
   const songItems: Song[] = songs.map((ps) => ps.song);
 
   return (
-    <div className='p-4 md:p-8'>
+    <div className='p-4 md:p-8 flex flex-col min-h-0'>
       {/* Back */}
       <Button
         variant='inherit'
@@ -738,6 +738,7 @@ export default function PlaylistDetailPage() {
           {viewMode === 'list' ? (
             <m.div
               key='list'
+              className='flex-1 min-h-0 flex flex-col'
               variants={pageVariants}
               initial='initial'
               animate='animate'
@@ -776,6 +777,7 @@ export default function PlaylistDetailPage() {
           ) : (
             <m.div
               key='grid'
+              className='flex-1 min-h-0 flex flex-col'
               variants={pageVariants}
               initial='initial'
               animate='animate'

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -581,7 +581,7 @@ export default function PlaylistDetailPage() {
   const songItems: Song[] = songs.map((ps) => ps.song);
 
   return (
-    <div className='p-4 md:p-8 flex flex-col min-h-0'>
+    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full'>
       {/* Back */}
       <Button
         variant='inherit'

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -581,7 +581,7 @@ export default function PlaylistDetailPage() {
   const songItems: Song[] = songs.map((ps) => ps.song);
 
   return (
-    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full'>
+    <div className='pt-4 pr-4 pl-4 md:pt-8 md:pr-8 md:pl-8 flex flex-col min-h-0 h-full'>
       {/* Back */}
       <Button
         variant='inherit'

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -581,7 +581,7 @@ export default function PlaylistDetailPage() {
   const songItems: Song[] = songs.map((ps) => ps.song);
 
   return (
-    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full'>
+    <div className='pt-4 pr-4 pl-4 pb-0 md:pt-8 md:pr-8 md:pl-8 md:pb-0 flex flex-col min-h-0 h-full'>
       {/* Back */}
       <Button
         variant='inherit'

--- a/packages/web/src/pages/PlaylistsPage.tsx
+++ b/packages/web/src/pages/PlaylistsPage.tsx
@@ -79,7 +79,7 @@ export default function PlaylistsPage() {
   );
 
   return (
-    <div className='pt-4 pr-4 pl-4 pb-0 md:pt-8 md:pr-8 md:pl-8 md:pb-0 flex flex-col min-h-0 h-full'>
+    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full' style={{ paddingBottom: 0 }}>
       <PageHeader
         icon={PlaylistIcon}
         title='Playlists'

--- a/packages/web/src/pages/PlaylistsPage.tsx
+++ b/packages/web/src/pages/PlaylistsPage.tsx
@@ -79,7 +79,7 @@ export default function PlaylistsPage() {
   );
 
   return (
-    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full'>
+    <div className='pt-4 pr-4 pl-4 pb-0 md:pt-8 md:pr-8 md:pl-8 md:pb-0 flex flex-col min-h-0 h-full'>
       <PageHeader
         icon={PlaylistIcon}
         title='Playlists'

--- a/packages/web/src/pages/PlaylistsPage.tsx
+++ b/packages/web/src/pages/PlaylistsPage.tsx
@@ -79,7 +79,7 @@ export default function PlaylistsPage() {
   );
 
   return (
-    <div className='p-4 md:p-8 flex flex-col min-h-0'>
+    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full'>
       <PageHeader
         icon={PlaylistIcon}
         title='Playlists'

--- a/packages/web/src/pages/PlaylistsPage.tsx
+++ b/packages/web/src/pages/PlaylistsPage.tsx
@@ -79,7 +79,7 @@ export default function PlaylistsPage() {
   );
 
   return (
-    <div className='pt-4 pr-4 pl-4 md:pt-8 md:pr-8 md:pl-8 flex flex-col min-h-0 h-full'>
+    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full'>
       <PageHeader
         icon={PlaylistIcon}
         title='Playlists'

--- a/packages/web/src/pages/PlaylistsPage.tsx
+++ b/packages/web/src/pages/PlaylistsPage.tsx
@@ -79,7 +79,7 @@ export default function PlaylistsPage() {
   );
 
   return (
-    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full'>
+    <div className='pt-4 pr-4 pl-4 md:pt-8 md:pr-8 md:pl-8 flex flex-col min-h-0 h-full'>
       <PageHeader
         icon={PlaylistIcon}
         title='Playlists'

--- a/packages/web/src/pages/PlaylistsPage.tsx
+++ b/packages/web/src/pages/PlaylistsPage.tsx
@@ -79,7 +79,7 @@ export default function PlaylistsPage() {
   );
 
   return (
-    <div className='p-4 md:p-8'>
+    <div className='p-4 md:p-8 flex flex-col min-h-0'>
       <PageHeader
         icon={PlaylistIcon}
         title='Playlists'

--- a/packages/web/src/pages/RequestsPage.tsx
+++ b/packages/web/src/pages/RequestsPage.tsx
@@ -107,7 +107,7 @@ export default function RequestsPage() {
   const countLabel = hasLoaded ? `${total} request${total !== 1 ? 's' : ''}` : '—';
 
   return (
-    <div className='p-4 md:p-8 flex flex-col min-h-0'>
+    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full'>
       <PageHeader
         icon={TrayIcon}
         title='Requests'

--- a/packages/web/src/pages/RequestsPage.tsx
+++ b/packages/web/src/pages/RequestsPage.tsx
@@ -107,7 +107,7 @@ export default function RequestsPage() {
   const countLabel = hasLoaded ? `${total} request${total !== 1 ? 's' : ''}` : '—';
 
   return (
-    <div className='pt-4 pr-4 pl-4 pb-0 md:pt-8 md:pr-8 md:pl-8 md:pb-0 flex flex-col min-h-0 h-full'>
+    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full' style={{ paddingBottom: 0 }}>
       <PageHeader
         icon={TrayIcon}
         title='Requests'

--- a/packages/web/src/pages/RequestsPage.tsx
+++ b/packages/web/src/pages/RequestsPage.tsx
@@ -107,7 +107,7 @@ export default function RequestsPage() {
   const countLabel = hasLoaded ? `${total} request${total !== 1 ? 's' : ''}` : '—';
 
   return (
-    <div className='pt-4 pr-4 pl-4 md:pt-8 md:pr-8 md:pl-8 flex flex-col min-h-0 h-full'>
+    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full'>
       <PageHeader
         icon={TrayIcon}
         title='Requests'

--- a/packages/web/src/pages/RequestsPage.tsx
+++ b/packages/web/src/pages/RequestsPage.tsx
@@ -107,7 +107,7 @@ export default function RequestsPage() {
   const countLabel = hasLoaded ? `${total} request${total !== 1 ? 's' : ''}` : '—';
 
   return (
-    <div className='p-4 md:p-8'>
+    <div className='p-4 md:p-8 flex flex-col min-h-0'>
       <PageHeader
         icon={TrayIcon}
         title='Requests'

--- a/packages/web/src/pages/RequestsPage.tsx
+++ b/packages/web/src/pages/RequestsPage.tsx
@@ -107,7 +107,7 @@ export default function RequestsPage() {
   const countLabel = hasLoaded ? `${total} request${total !== 1 ? 's' : ''}` : '—';
 
   return (
-    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full'>
+    <div className='pt-4 pr-4 pl-4 md:pt-8 md:pr-8 md:pl-8 flex flex-col min-h-0 h-full'>
       <PageHeader
         icon={TrayIcon}
         title='Requests'

--- a/packages/web/src/pages/RequestsPage.tsx
+++ b/packages/web/src/pages/RequestsPage.tsx
@@ -107,7 +107,7 @@ export default function RequestsPage() {
   const countLabel = hasLoaded ? `${total} request${total !== 1 ? 's' : ''}` : '—';
 
   return (
-    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full'>
+    <div className='pt-4 pr-4 pl-4 pb-0 md:pt-8 md:pr-8 md:pl-8 md:pb-0 flex flex-col min-h-0 h-full'>
       <PageHeader
         icon={TrayIcon}
         title='Requests'

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -310,7 +310,7 @@ export default function SongsPage() {
   );
 
   return (
-    <div className='p-4 md:p-8 flex flex-col min-h-0'>
+    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full'>
       <PageHeader
         icon={MusicNotesIcon}
         title='Songs'

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -310,7 +310,7 @@ export default function SongsPage() {
   );
 
   return (
-    <div className='pt-4 pr-4 pl-4 pb-0 md:pt-8 md:pr-8 md:pl-8 md:pb-0 flex flex-col min-h-0 h-full'>
+    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full' style={{ paddingBottom: 0 }}>
       <PageHeader
         icon={MusicNotesIcon}
         title='Songs'

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -310,7 +310,7 @@ export default function SongsPage() {
   );
 
   return (
-    <div className='pt-4 pr-4 pl-4 md:pt-8 md:pr-8 md:pl-8 flex flex-col min-h-0 h-full'>
+    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full'>
       <PageHeader
         icon={MusicNotesIcon}
         title='Songs'

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -310,7 +310,7 @@ export default function SongsPage() {
   );
 
   return (
-    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full'>
+    <div className='pt-4 pr-4 pl-4 pb-0 md:pt-8 md:pr-8 md:pl-8 md:pb-0 flex flex-col min-h-0 h-full'>
       <PageHeader
         icon={MusicNotesIcon}
         title='Songs'

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -310,7 +310,7 @@ export default function SongsPage() {
   );
 
   return (
-    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full'>
+    <div className='pt-4 pr-4 pl-4 md:pt-8 md:pr-8 md:pl-8 flex flex-col min-h-0 h-full'>
       <PageHeader
         icon={MusicNotesIcon}
         title='Songs'

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -310,7 +310,7 @@ export default function SongsPage() {
   );
 
   return (
-    <div className='p-4 md:p-8'>
+    <div className='p-4 md:p-8 flex flex-col min-h-0'>
       <PageHeader
         icon={MusicNotesIcon}
         title='Songs'
@@ -389,6 +389,7 @@ export default function SongsPage() {
         {viewMode === 'list' ? (
           <m.div
             key='list'
+            className='flex-1 min-h-0 flex flex-col'
             variants={pageVariants}
             initial='initial'
             animate='animate'
@@ -428,6 +429,7 @@ export default function SongsPage() {
         ) : (
           <m.div
             key='grid'
+            className='flex-1 min-h-0 flex flex-col'
             variants={pageVariants}
             initial='initial'
             animate='animate'

--- a/packages/web/src/pages/TagsPage.tsx
+++ b/packages/web/src/pages/TagsPage.tsx
@@ -121,7 +121,7 @@ export default function TagsPage() {
   }, [selected, refreshTags]);
 
   return (
-    <div className='p-4 md:p-8 flex flex-col h-full'>
+    <div className='p-4 md:p-8 h-full overflow-y-auto pb-24 md:pb-20'>
       <PageHeader
         icon={TagIcon}
         title='Tags'

--- a/packages/web/src/pages/TagsPage.tsx
+++ b/packages/web/src/pages/TagsPage.tsx
@@ -121,7 +121,7 @@ export default function TagsPage() {
   }, [selected, refreshTags]);
 
   return (
-    <div className='p-4 md:p-8 h-full overflow-y-auto pb-24 md:pb-20'>
+    <div className='p-4 md:p-8 h-full overflow-y-auto'>
       <PageHeader
         icon={TagIcon}
         title='Tags'


### PR DESCRIPTION
## Summary

Fixes page spacing and a bottom gap on virtualized pages (Songs, Playlists, PlaylistDetail, Requests).

## Changes

- Remove the `h-4` end spacer div from VirtualList scroll container — this was creating a visible gap between the last list item and the NowPlayingBar
- Restore `p-4 md:p-8` on virtualized page wrappers for proper top/left/right spacing (matching non-virtualized pages)
- Zero out bottom padding via inline `paddingBottom: 0` on virtualized page wrappers to eliminate gap below the virtual list
- Remove `pb-4` from VirtualList and VirtualSongGrid scroll containers (redundant with page-level padding)