### PR TITLE
fix(web): eliminate queue panel close jank and grid view layout flash

### DIFF
--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -267,7 +267,7 @@ function QueueLayout() {
         className='shrink-0 flex-col bg-elevated overflow-hidden clay-floating md:flex hidden h-full'
         animate={{ width: queueOpen ? 384 : 0 }}
         initial={false}
-        transition={{ type: 'spring', stiffness: 500, damping: 25 }}
+        transition={{ type: 'spring', stiffness: 500, damping: 45 }}
       >
         {queueOpen && <QueuePanel />}
       </m.aside>

--- a/packages/web/src/components/VirtualSongGrid.tsx
+++ b/packages/web/src/components/VirtualSongGrid.tsx
@@ -1,7 +1,6 @@
 import type { Playlist, Song } from '@alfira/server/shared';
 import { useMasonry, usePositioner, useResizeObserver } from 'masonic';
-import { memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { flushSync } from 'react-dom';
+import { memo, useCallback, useMemo, useRef } from 'react';
 import { useScrollObserver } from '../hooks/useScrollObserver';
 import SongCard from './SongCard';
 
@@ -96,42 +95,29 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const masonryContainerRef = useRef<HTMLDivElement>(null);
 
-  // rAF-batched scroll tracking + isScrolling flag (enables masonic's
-  // will-change / pointer-events optimizations during scroll) + height
-  // measurement via ResizeObserver.
-  const { scrollTop, isScrolling, height: containerHeight } = useScrollObserver(scrollContainerRef);
+  // rAF-batched scroll + isScrolling + size tracking via a single
+  // ResizeObserver. Width is throttled (see useScrollObserver) to avoid
+  // recalculating masonry columns on every frame during animated resizes.
+  const {
+    scrollTop,
+    isScrolling,
+    height: containerHeight,
+    width: gridWidth,
+  } = useScrollObserver(scrollContainerRef);
 
-  // Width: state initializer provides a reasonable fallback for SSR / first
-  // page load. On subsequent mounts (view switches), a callback ref with
-  // flushSync reads the real element width during commit and forces React
-  // to process the state update synchronously before the browser paints.
-  // A ResizeObserver handles subsequent layout changes.
-  const [gridWidth, setGridWidth] = useState(() => {
-    if (typeof window === 'undefined') return 960;
-    return document.querySelector('main')?.clientWidth ?? 960;
-  });
-
+  // Callback ref wires the DOM node into scrollContainerRef so
+  // useScrollObserver can observe it. React attaches refs before
+  // useLayoutEffect, so the hook sees the element on first pass.
   const scrollRefCallback = useCallback((el: HTMLDivElement | null) => {
     scrollContainerRef.current = el;
-    if (el) {
-      flushSync(() => {
-        setGridWidth(el.clientWidth);
-      });
-    }
-  }, []);
-
-  useLayoutEffect(() => {
-    const el = scrollContainerRef.current;
-    if (!el) return;
-    const ro = new ResizeObserver(([entry]) => {
-      if (entry) setGridWidth(entry.contentRect.width);
-    });
-    ro.observe(el);
-    return () => ro.disconnect();
   }, []);
 
   const positioner = usePositioner({
-    width: gridWidth,
+    // Fall back to 960 while the ResizeObserver hasn't fired yet.
+    // useLayoutEffect updates this synchronously before paint, so the
+    // fallback is never visible — it just prevents usePositioner from
+    // seeing 0 during the initial internal render pass.
+    width: gridWidth || 960,
     columnWidth: 260,
     columnGutter: 0, // We handle padding in the render wrapper
   });

--- a/packages/web/src/components/VirtualSongGrid.tsx
+++ b/packages/web/src/components/VirtualSongGrid.tsx
@@ -113,11 +113,7 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
   }, []);
 
   const positioner = usePositioner({
-    // Fall back to 960 while the ResizeObserver hasn't fired yet.
-    // useLayoutEffect updates this synchronously before paint, so the
-    // fallback is never visible — it just prevents usePositioner from
-    // seeing 0 during the initial internal render pass.
-    width: gridWidth || 960,
+    width: gridWidth,
     columnWidth: 260,
     columnGutter: 0, // We handle padding in the render wrapper
   });
@@ -212,6 +208,19 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
   const showSkeleton = isLoading;
   const showEmpty = hasLoaded && items.length === 0;
   const isContentReady = !isLoading && hasLoaded && items.length > 0;
+
+  // Pre-populate the positioner with estimated heights for items that
+  // haven't been measured yet. This prevents the visible flash of items
+  // jumping from estimated positions to measured positions — they start
+  // at near-correct positions and the ResizeObserver refines async.
+  // 420px ≈ typical grid card height at common column widths (thumbnail
+  // ~260-280px + info ~100px + wrapper padding 16px).
+  const posSize = positioner.size();
+  if (posSize < items.length) {
+    for (let i = posSize; i < items.length; i++) {
+      positioner.set(i, 420);
+    }
+  }
 
   const masonry = useMasonry({
     positioner,

--- a/packages/web/src/hooks/useScrollObserver.ts
+++ b/packages/web/src/hooks/useScrollObserver.ts
@@ -33,8 +33,14 @@ export function useScrollObserver(
 ): ScrollObserverResult {
   const [scrollTop, setScrollTop] = useState(0);
   const [isScrolling, setIsScrolling] = useState(false);
+  // Seed with a reasonable DOM-based fallback so the first render pass
+  // has a close-to-correct width for usePositioner. The useLayoutEffect
+  // below reads the real element dimensions and refines before paint.
   const [height, setHeight] = useState(0);
-  const [width, setWidth] = useState(0);
+  const [width, setWidth] = useState(() => {
+    if (typeof window === 'undefined') return 960;
+    return document.querySelector('main')?.clientWidth ?? 960;
+  });
 
   const didMountRef = useRef(0);
   const tickingRef = useRef(false);

--- a/packages/web/src/hooks/useScrollObserver.ts
+++ b/packages/web/src/hooks/useScrollObserver.ts
@@ -8,6 +8,8 @@ export interface ScrollObserverResult {
   scrollTop: number;
   isScrolling: boolean;
   height: number;
+  /** Width of the observed element, throttled to avoid excessive masonry recalculations during animated resizes. */
+  width: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -32,6 +34,7 @@ export function useScrollObserver(
   const [scrollTop, setScrollTop] = useState(0);
   const [isScrolling, setIsScrolling] = useState(false);
   const [height, setHeight] = useState(0);
+  const [width, setWidth] = useState(0);
 
   const didMountRef = useRef(0);
   const tickingRef = useRef(false);
@@ -100,18 +103,33 @@ export function useScrollObserver(
     };
   }, [fps, scrollTop]);
 
-  // ── Height tracking via ResizeObserver ─────────────────────────────
-  // useLayoutEffect reads the initial clientHeight before the first
-  // paint, avoiding a flash where the grid renders at the wrong height.
+  // ── Height + Width tracking via ResizeObserver ─────────────────────
+  // useLayoutEffect reads the initial dimensions before the first paint,
+  // avoiding a flash where the grid renders at the wrong size.
+  //
+  // Height updates immediately (masonic viewport sizing needs it).
+  // Width is throttled to at most one update per MIN_WIDTH_INTERVAL_MS —
+  // this prevents usePositioner from recalculating masonry columns on
+  // every animation frame during smooth resizes (e.g. queue panel
+  // open/close), while still feeling responsive on manual browser resizes.
+  const MIN_WIDTH_INTERVAL_MS = 64; // ~4 frames at 60fps
+  const lastWidthUpdateRef = useRef(0);
+
   useLayoutEffect(() => {
     const el = elementRef.current;
     if (!el) return;
 
     setHeight(el.clientHeight);
+    setWidth(el.clientWidth);
 
     const ro = new ResizeObserver(([entry]) => {
-      if (entry) {
-        setHeight(entry.contentRect.height);
+      if (!entry) return;
+      setHeight(entry.contentRect.height);
+
+      const now = performance.now();
+      if (now - lastWidthUpdateRef.current >= MIN_WIDTH_INTERVAL_MS) {
+        lastWidthUpdateRef.current = now;
+        setWidth(entry.contentRect.width);
       }
     });
     ro.observe(el);
@@ -120,5 +138,5 @@ export function useScrollObserver(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return { scrollTop, isScrolling, height };
+  return { scrollTop, isScrolling, height, width };
 }


### PR DESCRIPTION
## Summary

Two animation/layout fixes for the web UI:

1. **Queue panel close jank** — Spring was underdamped (damping 25, critical ~45), causing the spring to overshoot past width:0. CSS clamped it but framer-motion physics kept ticking at the boundary, creating a visible freeze. Raised damping to 45.

2. **Grid view layout flash** — Masonic's two-pass render cycle (invisible measurement items → measure → visible items) caused all cards to visibly jump on mount. Pre-populate the positioner with estimated heights so items start near-correct positions from the first paint.

3. **Merged duplicate ResizeObservers** — VirtualSongGrid had two separate ResizeObservers on the same element. Merged into useScrollObserver, with width updates throttled to 64ms to avoid masonry recalculations during animated resizes.

## Changes

- `Layout.tsx`: Queue panel spring damping 25 → 45 (critically damped)
- `VirtualSongGrid.tsx`: Pre-populate positioner, remove duplicate ResizeObserver, remove flushSync width init
- `useScrollObserver.ts`: Add width tracking (throttled), seed from DOM query