### PR TITLE
fix: correct oxfmt config key and disable conflicting typescript-ls

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -11,7 +11,7 @@
     "oxfmt": {
       "initialization_options": {
         "settings": {
-          "configPath": "./oxfmt.config.ts"
+          "fmt.configPath": "./oxfmt.config.ts"
         }
       }
     }
@@ -44,8 +44,8 @@
     },
     "TypeScript": {
       "language_servers": [
-        "typescript-ls",
         "oxlint",
+        "!typescript-ls",
         "!typescript-language-server",
         "!vtsls",
         "..."
@@ -69,8 +69,8 @@
     },
     "TSX": {
       "language_servers": [
-        "typescript-ls",
         "oxlint",
+        "!typescript-ls",
         "!typescript-language-server",
         "!vtsls",
         "..."


### PR DESCRIPTION
## Summary

Fixes two issues in `.zed/settings.json` that were causing problems with the Zed editor's Oxc extension integration.

## Changes

- Fix oxfmt LSP config key from `configPath` to `fmt.configPath` (the oxfmt language server expects the `fmt.configPath` key, not `configPath`)
- Disable the built-in `typescript-ls` in TypeScript and TSX language server lists (it conflicts with oxlint, matching the existing pattern of disabling `typescript-language-server` and `vtsls`)