### PR TITLE
chore: update zed editor settings and oxlint ignore pattern

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,4 +1,6 @@
 {
+  "tab_size": 2,
+  "file_scan_exclusions": ["**/node_modules/**", "**/dist/**", ".pi/**", "**/*.sqlite"],
   "lsp": {
     "oxlint": {
       "initialization_options": {
@@ -29,7 +31,7 @@
       ]
     },
     "JavaScript": {
-      "language_servers": ["oxlint", "..."],
+      "language_servers": ["oxlint", "!eslint", "..."],
       "format_on_save": "on",
       "formatter": [
         {
@@ -45,6 +47,7 @@
     "TypeScript": {
       "language_servers": [
         "oxlint",
+        "!eslint",
         "!typescript-ls",
         "!typescript-language-server",
         "!vtsls",
@@ -70,9 +73,11 @@
     "TSX": {
       "language_servers": [
         "oxlint",
+        "!eslint",
         "!typescript-ls",
         "!typescript-language-server",
         "!vtsls",
+        "tailwindcss-language-server",
         "..."
       ],
       "format_on_save": "on",
@@ -90,10 +95,11 @@
         "enabled": true,
         "show_parameter_hints": true,
         "show_type_hints": true
-      }
+      },
+      "use_autoclose": true
     },
     "JSON": {
-      "language_servers": ["oxlint", "..."],
+      "language_servers": ["oxlint", "!eslint", "..."],
       "format_on_save": "on",
       "formatter": [
         {
@@ -104,6 +110,11 @@
       ]
     },
     "Markdown": {
+      "language_servers": ["marksman", "..."],
+      "format_on_save": "on"
+    },
+    "Dockerfile": {
+      "language_servers": ["dockerfile-language-server", "..."],
       "format_on_save": "on"
     }
   },

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     typeCheck: true,
   },
 
-  ignorePatterns: ['.pi/**'],
+  ignorePatterns: ['.pi/**', '.zed/**'],
 
   plugins: ['react', 'jsx-a11y', 'typescript'],
 


### PR DESCRIPTION
## Summary

Improve Zed editor config and exclude `.zed/` from oxlint.

## Changes

- Disable ESLint LSP, add Tailwind TSX / Markdown / Dockerfile support, file scan exclusions, tab size
- Add `.zed/**` to oxlint ignore patterns