### PR TITLE
chore(lint): enable strict lint rules and fix violations

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
 
     // correctness
     'no-const-assign': 'error',
+    'no-constant-binary-expression': 'error',
     'no-constant-condition': 'warn',
     'no-empty-character-class': 'error',
     'no-empty-pattern': 'error',
@@ -34,11 +35,17 @@ export default defineConfig({
     'no-setter-return': 'error',
     'no-unreachable': 'error',
     'no-unsafe-finally': 'error',
+    'no-unsafe-optional-chaining': 'error',
     'no-unused-labels': 'error',
     'no-unused-vars': 'warn',
     'use-isnan': 'error',
     'for-direction': 'error',
     'require-yield': 'error',
+    '@typescript-eslint/only-throw-error': 'error',
+    '@typescript-eslint/no-floating-promises': 'error',
+    '@typescript-eslint/switch-exhaustiveness-check': 'error',
+    'unicorn/throw-new-error': 'error',
+    'unicorn/error-message': 'error',
 
     // suspicious
     'no-async-promise-executor': 'error',
@@ -72,17 +79,32 @@ export default defineConfig({
     // imports
     'import/first': 'warn',
     'import/no-cycle': 'warn',
+    'unicorn/prefer-node-protocol': 'warn',
 
     // promises
     'promise/prefer-await-to-then': 'error',
+    'promise/valid-params': 'error',
+    'promise/catch-or-return': 'error',
+    '@typescript-eslint/no-misused-promises': [
+      'error',
+      { checksVoidReturn: { attributes: false, properties: false } },
+    ],
 
     // style
+    curly: 'error',
+    'no-useless-concat': 'warn',
+    'object-shorthand': 'warn',
+    '@typescript-eslint/array-type': 'warn',
+    '@typescript-eslint/consistent-type-imports': 'warn',
     '@typescript-eslint/no-inferrable-types': 'warn',
     '@typescript-eslint/no-namespace': 'error',
     '@typescript-eslint/no-non-null-assertion': 'warn',
-    'prefer-const': 'error',
     '@typescript-eslint/prefer-for-of': 'warn',
+    '@typescript-eslint/prefer-optional-chain': 'warn',
+    '@typescript-eslint/prefer-ts-expect-error': 'warn',
+    'prefer-const': 'error',
     'prefer-template': 'warn',
+    'unicorn/catch-error-name': 'warn',
   },
 
   overrides: [

--- a/packages/server/src/GuildPlayer.ts
+++ b/packages/server/src/GuildPlayer.ts
@@ -170,7 +170,9 @@ export class GuildPlayer {
     this._unsubTrackEnd = lavalink.onTrackEnd(this.guildId, (reason: TrackEndReason) => {
       // 'replaced' fires when a new track replaces the current one (normal).
       // 'stopped' fires when we explicitly stop/clear.
-      if (reason === 'replaced' || reason === 'stopped') return;
+      if (reason === 'replaced' || reason === 'stopped') {
+        return;
+      }
 
       logger.debug(
         { guildId: this.guildId, reason, track: this.currentSong?.title },
@@ -299,7 +301,9 @@ export class GuildPlayer {
   }
 
   async skip(): Promise<void> {
-    if (this.currentSong === null) return;
+    if (this.currentSong === null) {
+      return;
+    }
 
     // Stop the current track via REST.
     const sessionId = this.getSessionId();
@@ -372,7 +376,9 @@ export class GuildPlayer {
    */
   promoteSong(songId: string): boolean {
     const removed = this.queue.removeWhere((s) => s.id === songId);
-    if (removed.length === 0) return false;
+    if (removed.length === 0) {
+      return false;
+    }
 
     // Push to the end of priority — earlier promotions play first
     this.priorityQueue.push(...removed);
@@ -387,7 +393,9 @@ export class GuildPlayer {
    */
   demoteSong(songId: string): boolean {
     const prioIdx = this.priorityQueue.findIndex((s) => s.id === songId);
-    if (prioIdx === -1) return false;
+    if (prioIdx === -1) {
+      return false;
+    }
 
     // Remove from priority and insert at the front of the regular queue
     // so it plays first among unplayed regular songs.
@@ -460,10 +468,14 @@ export class GuildPlayer {
   }
 
   async togglePause(): Promise<boolean> {
-    if (!this.currentSong) return false;
+    if (!this.currentSong) {
+      return false;
+    }
 
     const sessionId = this.getSessionId();
-    if (!sessionId) return false;
+    if (!sessionId) {
+      return false;
+    }
 
     if (this.paused) {
       this.cancelIdleLeave();
@@ -488,10 +500,14 @@ export class GuildPlayer {
   }
 
   async seek(positionMs: number): Promise<void> {
-    if (!this.currentSong) return;
+    if (!this.currentSong) {
+      return;
+    }
 
     const sessionId = this.getSessionId();
-    if (!sessionId) return;
+    if (!sessionId) {
+      return;
+    }
 
     const durationMs = this.currentSong.duration * 1000;
     const clampedMs = Math.max(0, Math.min(positionMs, durationMs));
@@ -511,10 +527,14 @@ export class GuildPlayer {
   }
 
   public updateVolumeBoost(boost: number): void {
-    if (!this.currentSong) return;
+    if (!this.currentSong) {
+      return;
+    }
 
     const sessionId = this.getSessionId();
-    if (!sessionId) return;
+    if (!sessionId) {
+      return;
+    }
 
     void updateNodeLinkPlayer(this.guildId, sessionId, {
       volume: 100 + boost,
@@ -544,12 +564,24 @@ export class GuildPlayer {
 
     const merge = (s: QueuedSong): QueuedSong => {
       const updated = { ...s };
-      if ('nickname' in fields) updated.nickname = fields.nickname ?? undefined;
-      if ('artist' in fields) updated.artist = fields.artist ?? undefined;
-      if ('album' in fields) updated.album = fields.album ?? undefined;
-      if ('artwork' in fields) updated.artwork = fields.artwork ?? undefined;
-      if ('tags' in fields) updated.tags = fields.tags;
-      if ('volumeBoost' in fields) updated.volumeBoost = fields.volumeBoost ?? undefined;
+      if ('nickname' in fields) {
+        updated.nickname = fields.nickname ?? undefined;
+      }
+      if ('artist' in fields) {
+        updated.artist = fields.artist ?? undefined;
+      }
+      if ('album' in fields) {
+        updated.album = fields.album ?? undefined;
+      }
+      if ('artwork' in fields) {
+        updated.artwork = fields.artwork ?? undefined;
+      }
+      if ('tags' in fields) {
+        updated.tags = fields.tags;
+      }
+      if ('volumeBoost' in fields) {
+        updated.volumeBoost = fields.volumeBoost ?? undefined;
+      }
       return updated;
     };
 
@@ -572,7 +604,9 @@ export class GuildPlayer {
 
     // Regular queue
     const regularUpdated = this.queue.updateWhere((s) => idSet.has(s.id), merge);
-    if (regularUpdated > 0) changed = true;
+    if (regularUpdated > 0) {
+      changed = true;
+    }
 
     if (changed) {
       this.broadcast();
@@ -588,7 +622,9 @@ export class GuildPlayer {
   }
 
   isPlaying(): boolean {
-    if (this.currentSong === null || this.paused) return false;
+    if (this.currentSong === null || this.paused) {
+      return false;
+    }
     return true;
   }
 
@@ -639,7 +675,9 @@ export class GuildPlayer {
   }
 
   private async playNext(): Promise<void> {
-    if (this.playNextLock) return;
+    if (this.playNextLock) {
+      return;
+    }
     this.playNextLock = true;
     try {
       await this.playNextUnlocked();
@@ -903,7 +941,9 @@ export class GuildPlayer {
 
   private preloadNextTrack(sessionId: string): void {
     const nextTrack = this.peekNextTrack();
-    if (!nextTrack) return;
+    if (!nextTrack) {
+      return;
+    }
 
     const attempt = async () => {
       try {
@@ -963,7 +1003,9 @@ export class GuildPlayer {
   }
 
   private async onTrackEnd(): Promise<void> {
-    if (this.playNextLock) return;
+    if (this.playNextLock) {
+      return;
+    }
 
     this.trackStartedAt = null;
     this.pausedAt = null;
@@ -973,7 +1015,9 @@ export class GuildPlayer {
       return;
     }
 
-    if (!this.currentSong) return;
+    if (!this.currentSong) {
+      return;
+    }
 
     await this.playNext();
   }

--- a/packages/server/src/PlaybackCursor.ts
+++ b/packages/server/src/PlaybackCursor.ts
@@ -132,7 +132,9 @@ export class PlaybackCursor<T> {
    * ensuring they play after all existing items.
    */
   append(...items: T[]): void {
-    if (items.length === 0) return;
+    if (items.length === 0) {
+      return;
+    }
 
     const startIndex = this.buffer.length;
     this.buffer.push(...items);
@@ -177,7 +179,9 @@ export class PlaybackCursor<T> {
 
     for (let i = 0; i < this.buffer.length; i++) {
       const item = this.buffer[i];
-      if (item === undefined) continue;
+      if (item === undefined) {
+        continue;
+      }
       if (predicate(item)) {
         removed.push(item);
       } else {
@@ -186,12 +190,16 @@ export class PlaybackCursor<T> {
       }
     }
 
-    if (removed.length === 0) return [];
+    if (removed.length === 0) {
+      return [];
+    }
 
     // Adjust readIndex: count removed items before it
     let removedBefore = 0;
     for (let i = 0; i < this.readIndex; i++) {
-      if (!oldToNewIndex.has(i)) removedBefore++;
+      if (!oldToNewIndex.has(i)) {
+        removedBefore++;
+      }
     }
     this.readIndex = Math.max(0, this.readIndex - removedBefore);
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -31,7 +31,9 @@ function parseCookies(header: string): Record<string, string> {
   const result: Record<string, string> = {};
   for (const part of header.split(';')) {
     const idx = part.indexOf('=');
-    if (idx === -1) continue;
+    if (idx === -1) {
+      continue;
+    }
     const key = part.slice(0, idx).trim();
     const raw = part.slice(idx + 1).trim();
     try {
@@ -74,7 +76,9 @@ export type { RouteContext } from './lib/context';
 function setSecurityHeaders(response: Response): Response {
   const newHeaders = new Headers(response.headers);
   for (const [key, value] of Object.entries(SECURITY_HEADERS)) {
-    if (key === 'Set-Cookie') continue; // Don't overwrite Set-Cookie headers set by routes
+    if (key === 'Set-Cookie') {
+      continue;
+    } // Don't overwrite Set-Cookie headers set by routes
     newHeaders.set(key, value);
   }
   return new Response(response.body, { status: response.status, headers: newHeaders });
@@ -95,7 +99,9 @@ const STATIC_EXTENSIONS: Record<string, string> = {
 
 function serveStatic(filePath: string, pathname: string): Response | undefined {
   const file = Bun.file(filePath);
-  if (file.size === 0) return undefined;
+  if (file.size === 0) {
+    return undefined;
+  }
   const ext = pathname.includes('.') ? `.${pathname.split('.').pop()}` : '.html';
   const contentType = STATIC_EXTENSIONS[ext] ?? 'text/plain';
   return new Response(file, {
@@ -118,7 +124,9 @@ function createContext(request: Request): RouteContext {
   const user = getSessionUser(request.headers.get('cookie') || '');
   const cookies: Record<string, string> = {};
   for (const [key, value] of Object.entries(parsedCookies)) {
-    if (value !== undefined) cookies[key] = value;
+    if (value !== undefined) {
+      cookies[key] = value;
+    }
   }
   return { user, isAdmin: user?.isAdmin ?? false, cookies };
 }
@@ -225,7 +233,9 @@ function startServer(): void {
           return new Response('Unauthorized', { status: 401 });
         }
         const success = server.upgrade(request, { data: { user } });
-        if (success) return undefined;
+        if (success) {
+          return undefined;
+        }
         return new Response('WebSocket upgrade failed', { status: 500 });
       }
 
@@ -243,7 +253,9 @@ function startServer(): void {
       if (isAsset || url.pathname === '/') {
         const filePath = `/app/packages/web/dist${url.pathname === '/' ? '/index.html' : url.pathname}`;
         const response = serveStatic(filePath, url.pathname);
-        if (response) return response;
+        if (response) {
+          return response;
+        }
       }
 
       return (
@@ -301,14 +313,18 @@ function runMigrations(): void {
     const existing = $client
       .query('SELECT hash FROM "__drizzle_migrations" WHERE hash = ?')
       .get(hash) as { hash: string } | undefined;
-    if (existing) continue;
+    if (existing) {
+      continue;
+    }
 
     // Apply migration
     const rawSql = readFileSync(filePath, 'utf-8');
     const statements = rawSql.split(/-->\s*statement-breakpoint/);
     for (const stmt of statements) {
       const trimmed = stmt.trim();
-      if (!trimmed) continue;
+      if (!trimmed) {
+        continue;
+      }
       try {
         $client.run(trimmed);
       } catch (err) {
@@ -357,7 +373,9 @@ function startNodeLink(): Promise<void> {
       for await (const chunk of nodelinkProcess.stdout as ReadableStream<Uint8Array>) {
         for (const line of decoder.decode(chunk).split('\n')) {
           const trimmed = line.trimEnd();
-          if (trimmed) logger.debug({ component: 'NodeLink' }, trimmed);
+          if (trimmed) {
+            logger.debug({ component: 'NodeLink' }, trimmed);
+          }
         }
       }
     })();
@@ -368,7 +386,9 @@ function startNodeLink(): Promise<void> {
       for await (const chunk of nodelinkProcess.stderr as ReadableStream<Uint8Array>) {
         for (const line of decoder.decode(chunk).split('\n')) {
           const trimmed = line.trimEnd();
-          if (!trimmed || trimmed.includes('fatal:')) continue;
+          if (!trimmed || trimmed.includes('fatal:')) {
+            continue;
+          }
           logger.warn({ component: 'NodeLink' }, trimmed);
         }
       }
@@ -387,7 +407,9 @@ function startNodeLink(): Promise<void> {
       } catch {
         /* retry */
       }
-      setTimeout(checkReady, 500);
+      setTimeout(() => {
+        void checkReady();
+      }, 500);
     };
     void checkReady();
   });
@@ -471,7 +493,9 @@ let shuttingDown = false;
 let nodelinkProcess: ReturnType<typeof Bun.spawn> | undefined;
 
 function shutdown(signal: string): void {
-  if (shuttingDown) return;
+  if (shuttingDown) {
+    return;
+  }
   shuttingDown = true;
 
   logger.info({ signal }, 'Starting graceful shutdown');

--- a/packages/server/src/lib/applyNodeLinkFilter.ts
+++ b/packages/server/src/lib/applyNodeLinkFilter.ts
@@ -40,10 +40,14 @@ export async function applyNodeLinkFilter(
     logger.warn(`GUILD_ID not set, skipping NodeLink ${label} filter update`);
     return;
   }
-  if (!lavalink.isGuildConnected(guildId)) return;
+  if (!lavalink.isGuildConnected(guildId)) {
+    return;
+  }
 
   const sessionId = lavalink.getSessionId();
-  if (!sessionId) return;
+  if (!sessionId) {
+    return;
+  }
 
   try {
     await updateNodeLinkPlayer(guildId, sessionId, { filters });

--- a/packages/server/src/lib/config.ts
+++ b/packages/server/src/lib/config.ts
@@ -5,10 +5,14 @@ import { db, tables } from '../shared/db';
 function resolveVersion(): string {
   const envVersion = process.env.ALFIRA_VERSION;
   // Explicit non-dev version — use as-is (e.g., v0.1.0 from Docker build arg).
-  if (envVersion && envVersion !== 'dev') return envVersion;
+  if (envVersion && envVersion !== 'dev') {
+    return envVersion;
+  }
 
   // Dev — check for explicit git hash override (e.g., from Docker build arg).
-  if (process.env.GIT_HASH) return `dev (${process.env.GIT_HASH})`;
+  if (process.env.GIT_HASH) {
+    return `dev (${process.env.GIT_HASH})`;
+  }
 
   // Dev — try to read the commit hash from the mounted .git directory.
   try {
@@ -17,7 +21,9 @@ function resolveVersion(): string {
     const hash = match
       ? readFileSync(`/app/.git/${match[1]}`, 'utf-8').trim().slice(0, 7)
       : head.slice(0, 7);
-    if (hash) return `dev (${hash})`;
+    if (hash) {
+      return `dev (${hash})`;
+    }
   } catch {
     // No .git available — fall through to plain 'dev'.
   }
@@ -43,7 +49,9 @@ export function getGuildId(): string {
 
 /** Must be called once during startup, after migrations and DB are ready. */
 export function initGuildId(): void {
-  if (_guildIdLoaded) return;
+  if (_guildIdLoaded) {
+    return;
+  }
 
   try {
     const row = db

--- a/packages/server/src/lib/discordGateway.ts
+++ b/packages/server/src/lib/discordGateway.ts
@@ -319,7 +319,9 @@ export class DiscordGateway {
   }
 
   private sendIdentify(): void {
-    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return;
+    }
 
     this.ws.send(
       JSON.stringify({
@@ -359,7 +361,9 @@ export class DiscordGateway {
   }
 
   private sendHeartbeat(): void {
-    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return;
+    }
 
     // If the last heartbeat wasn't acked, connection is zombie — force reconnect.
     if (!this.lastHeartbeatAck) {

--- a/packages/server/src/lib/discordRest.ts
+++ b/packages/server/src/lib/discordRest.ts
@@ -9,7 +9,9 @@ const DISCORD_API_BASE = 'https://discord.com/api/v10';
 
 function botToken(): string {
   const token = process.env.DISCORD_BOT_TOKEN;
-  if (!token) throw new Error('DISCORD_BOT_TOKEN is not set');
+  if (!token) {
+    throw new Error('DISCORD_BOT_TOKEN is not set');
+  }
   return token;
 }
 
@@ -128,7 +130,9 @@ export async function fetchGuildMember(
 
   // Deduplicate in-flight requests.
   const inflight = inflightRequests.get(cacheKey);
-  if (inflight) return inflight;
+  if (inflight) {
+    return inflight;
+  }
 
   const promise = doFetchGuildMember(guildId, userId, cacheKey);
   inflightRequests.set(cacheKey, promise);

--- a/packages/server/src/lib/discordRoles.ts
+++ b/packages/server/src/lib/discordRoles.ts
@@ -5,7 +5,9 @@ const DISCORD_API = 'https://discord.com/api/v10';
 
 export function botHeaders(): Record<string, string> {
   const token = process.env.DISCORD_BOT_TOKEN;
-  if (!token) throw new Error('DISCORD_BOT_TOKEN not set');
+  if (!token) {
+    throw new Error('DISCORD_BOT_TOKEN not set');
+  }
   return { Authorization: `Bot ${token}` };
 }
 
@@ -47,12 +49,12 @@ export async function fetchGuildRoles(guildId: string): Promise<SetupRole[]> {
       return [];
     }
 
-    const roles = (await res.json()) as Array<{
+    const roles = (await res.json()) as {
       id: string;
       name: string;
       color: number;
       managed: boolean;
-    }>;
+    }[];
 
     const result: SetupRole[] = roles
       .filter((r) => r.id !== guildId && !r.managed)

--- a/packages/server/src/lib/displayName.ts
+++ b/packages/server/src/lib/displayName.ts
@@ -3,11 +3,15 @@ import { fetchGuildMember } from './discordRest';
 
 export async function getUserDisplayName(discordId: string): Promise<string> {
   const guildId = getGuildId();
-  if (!guildId) return discordId;
+  if (!guildId) {
+    return discordId;
+  }
 
   try {
     const member = await fetchGuildMember(guildId, discordId);
-    if (!member) return discordId;
+    if (!member) {
+      return discordId;
+    }
     // Prefer server nickname, fall back to global username, then ID.
     return member.nick || member.user.username || discordId;
   } catch {

--- a/packages/server/src/lib/eqBands.ts
+++ b/packages/server/src/lib/eqBands.ts
@@ -59,7 +59,9 @@ interface EqSettingsRow {
 }
 
 export function eqBandsFromRow(row: EqSettingsRow | null | undefined): number[] {
-  if (!row) return Array(15).fill(50);
+  if (!row) {
+    return Array(15).fill(50);
+  }
   return BAND_KEYS.map((key) => row[key]);
 }
 
@@ -75,7 +77,7 @@ export function eqBandValues(bands: number[]): Record<EqBandKey, number> {
  * Convert band values (0-100) to NodeLink equalizer filter format.
  * Maps: 0 → -0.5, 50 → 0.0 (neutral/flat), 100 → 0.5
  */
-export function buildEqualizerFilter(bands: number[]): Array<{ band: number; gain: number }> {
+export function buildEqualizerFilter(bands: number[]): { band: number; gain: number }[] {
   return bands.map((value, index) => ({
     band: index,
     gain: (value - 50) / 100,

--- a/packages/server/src/lib/gatewayState.ts
+++ b/packages/server/src/lib/gatewayState.ts
@@ -50,14 +50,20 @@ const pendingVoiceConnections = new Map<string, PendingVoiceConnection>();
 
 async function tryCompleteVoiceConnection(guildId: string): Promise<void> {
   const pending = pendingVoiceConnections.get(guildId);
-  if (!pending) return;
-  if (!pending.sessionId || !pending.token || !pending.endpoint) return;
+  if (!pending) {
+    return;
+  }
+  if (!pending.sessionId || !pending.token || !pending.endpoint) {
+    return;
+  }
 
   const sessionId = lavalink.getSessionId();
   if (!sessionId) {
     // Lavalink WebSocket hasn't received its 'ready' event yet.
     // Retry in 200ms — the connection was just initiated.
-    setTimeout(() => tryCompleteVoiceConnection(guildId), 200);
+    setTimeout(() => {
+      void tryCompleteVoiceConnection(guildId);
+    }, 200);
     return;
   }
 

--- a/packages/server/src/lib/guards.ts
+++ b/packages/server/src/lib/guards.ts
@@ -2,11 +2,15 @@ import type { RouteContext } from './context';
 import { json } from './json';
 
 export function requireAuth(ctx: RouteContext): NonNullable<RouteContext['user']> | Response {
-  if (!ctx.user) return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
+  if (!ctx.user) {
+    return json({ error: 'Not authenticated. Please log in at /auth/login.' }, 401);
+  }
   return ctx.user;
 }
 
 export function requireAdmin(ctx: RouteContext): Response | null {
-  if (!ctx.isAdmin) return json({ error: 'Admin access required.' }, 403);
+  if (!ctx.isAdmin) {
+    return json({ error: 'Admin access required.' }, 403);
+  }
   return null;
 }

--- a/packages/server/src/lib/jwt.ts
+++ b/packages/server/src/lib/jwt.ts
@@ -27,7 +27,9 @@ function base64urlDecode(input: string): string {
 /** Parse an expiresIn string like "1h", "30d", "15m" to seconds. */
 function parseExpiresIn(expiresIn: string): number {
   const match = expiresIn.match(/^(\d+)([smhd])$/);
-  if (!match || !match[1] || !match[2]) throw new Error(`Invalid expiresIn format: ${expiresIn}`);
+  if (!match?.[1] || !match[2]) {
+    throw new Error(`Invalid expiresIn format: ${expiresIn}`);
+  }
   const num = parseInt(match[1], 10);
   const unit = match[2];
   const multipliers: Record<string, number> = { s: 1, m: 60, h: 3600, d: 86400 };
@@ -74,7 +76,9 @@ export function sign(
  */
 export function verify<T = Record<string, unknown>>(token: string, secret: string): T | null {
   const parts = token.split('.');
-  if (parts.length !== 3) return null;
+  if (parts.length !== 3) {
+    return null;
+  }
 
   const headerB64 = parts[0] as string;
   const payloadB64 = parts[1] as string;

--- a/packages/server/src/lib/lavalink.ts
+++ b/packages/server/src/lib/lavalink.ts
@@ -132,8 +132,12 @@ class LavalinkSocket extends EventEmitter<LavalinkEvents> {
     logger.info({ url: this.url }, 'Lavalink: attempting WebSocket connection');
 
     const headers: Record<string, string> = {};
-    if (this.auth) headers.Authorization = this.auth;
-    if (this._userId) headers['User-Id'] = this._userId;
+    if (this.auth) {
+      headers.Authorization = this.auth;
+    }
+    if (this._userId) {
+      headers['User-Id'] = this._userId;
+    }
     headers['Client-Name'] = 'Alfira';
 
     // Bun extends WebSocket constructor with { headers } option
@@ -211,7 +215,9 @@ class LavalinkSocket extends EventEmitter<LavalinkEvents> {
 
   onTrackEnd(guildId: string, handler: (reason: TrackEndReason) => void): () => void {
     const wrapped = (gid: string, reason: TrackEndReason) => {
-      if (gid === guildId) handler(reason);
+      if (gid === guildId) {
+        handler(reason);
+      }
     };
     this.on('trackEnd', wrapped);
     return () => this.off('trackEnd', wrapped);
@@ -219,7 +225,9 @@ class LavalinkSocket extends EventEmitter<LavalinkEvents> {
 
   onTrackError(guildId: string, handler: (exception: { message?: string }) => void): () => void {
     const wrapped = (gid: string, exception: { message?: string }) => {
-      if (gid === guildId) handler(exception);
+      if (gid === guildId) {
+        handler(exception);
+      }
     };
     this.on('trackError', wrapped);
     return () => this.off('trackError', wrapped);
@@ -230,7 +238,9 @@ class LavalinkSocket extends EventEmitter<LavalinkEvents> {
     handler: (code: number, reason: string, byRemote: boolean) => void
   ): () => void {
     const wrapped = (gid: string, code: number, reason: string, byRemote: boolean) => {
-      if (gid === guildId) handler(code, reason, byRemote);
+      if (gid === guildId) {
+        handler(code, reason, byRemote);
+      }
     };
     this.on('socketClosed', wrapped);
     return () => this.off('socketClosed', wrapped);
@@ -308,7 +318,9 @@ class LavalinkSocket extends EventEmitter<LavalinkEvents> {
   }
 
   private scheduleReconnect(): void {
-    if (this.intentionalClose) return;
+    if (this.intentionalClose) {
+      return;
+    }
 
     const baseDelay = 1_000;
     const maxDelay = 30_000;

--- a/packages/server/src/lib/migrateExistingTags.ts
+++ b/packages/server/src/lib/migrateExistingTags.ts
@@ -35,7 +35,9 @@ export async function runTagMigration(): Promise<{ normalized: number; errors: n
   let errors = 0;
 
   for (const song of songs) {
-    if (!song.tags || !Array.isArray(song.tags) || song.tags.length === 0) continue;
+    if (!song.tags || !Array.isArray(song.tags) || song.tags.length === 0) {
+      continue;
+    }
 
     try {
       const canonicalTags = await canonicalizeTags(song.tags.map(normalizeTag));

--- a/packages/server/src/lib/notifications.ts
+++ b/packages/server/src/lib/notifications.ts
@@ -8,7 +8,9 @@ const DISCORD_API = 'https://discord.com/api/v10';
 
 function botHeaders(): Record<string, string> {
   const token = process.env.DISCORD_BOT_TOKEN;
-  if (!token) throw new Error('DISCORD_BOT_TOKEN not set');
+  if (!token) {
+    throw new Error('DISCORD_BOT_TOKEN not set');
+  }
   return { Authorization: `Bot ${token}` };
 }
 
@@ -32,11 +34,17 @@ export async function sendRequestNotification(
       .where(eq(tables.guildSettings.id, 1))
       .get();
 
-    if (!row?.channelId) return;
+    if (!row?.channelId) {
+      return;
+    }
 
     // Respect per-event toggles ("new" always sends if channel is set)
-    if (event === 'approved' && !row.notifyOnApproved) return;
-    if (event === 'denied' && !row.notifyOnDenied) return;
+    if (event === 'approved' && !row.notifyOnApproved) {
+      return;
+    }
+    if (event === 'denied' && !row.notifyOnDenied) {
+      return;
+    }
 
     const messages: Record<string, string> = {
       new: `🎵 **New song request** from **${user.username}**: **${req.title}**`,

--- a/packages/server/src/lib/playlistAccess.ts
+++ b/packages/server/src/lib/playlistAccess.ts
@@ -35,7 +35,9 @@ export function canAccessPlaylist(
   user: UserContext | undefined,
   adminView?: boolean
 ): { ok: true } | { ok: false; error: string } {
-  if (!playlist.isPrivate) return { ok: true };
+  if (!playlist.isPrivate) {
+    return { ok: true };
+  }
   const allowed =
     playlist.createdBy === user?.discordId || (user?.isAdmin === true && adminView === true);
   if (!allowed) {
@@ -65,7 +67,9 @@ async function findPlaylistOr404(id: string, withCount = false): Promise<Playlis
     .from(playlistTable)
     .where(eq(playlistTable.id, id))
     .limit(1);
-  if (!row) return null;
+  if (!row) {
+    return null;
+  }
   if (withCount) {
     const value = await getPlaylistSongCount(id);
     return { ...row, _count: { songs: value } };

--- a/packages/server/src/lib/routeGuards.ts
+++ b/packages/server/src/lib/routeGuards.ts
@@ -36,7 +36,9 @@ export function checkGuards(ctx: RouteContext, options: GuardOptions = {}): Guar
   const { admin = false, setupMode = false, voice = false } = options;
 
   const authResult = requireAuth(ctx);
-  if (authResult instanceof Response) return authResult;
+  if (authResult instanceof Response) {
+    return authResult;
+  }
   const user = authResult;
 
   // Setup mode: grant access to the first user who logs in during setup.
@@ -44,7 +46,9 @@ export function checkGuards(ctx: RouteContext, options: GuardOptions = {}): Guar
   if (setupMode && user.isSetupAdmin) {
     if (voice) {
       const inVoice = requireUserInVoice(user.discordId);
-      if (inVoice instanceof Response) return inVoice;
+      if (inVoice instanceof Response) {
+        return inVoice;
+      }
     }
     return { user };
   }
@@ -62,13 +66,17 @@ export function checkGuards(ctx: RouteContext, options: GuardOptions = {}): Guar
     } else {
       // No granular permission — super-admin only.
       const adminErr = requireAdmin(ctx);
-      if (adminErr) return adminErr;
+      if (adminErr) {
+        return adminErr;
+      }
     }
   }
 
   if (voice) {
     const inVoice = requireUserInVoice(user.discordId);
-    if (inVoice instanceof Response) return inVoice;
+    if (inVoice instanceof Response) {
+      return inVoice;
+    }
   }
 
   return { user };
@@ -79,7 +87,9 @@ export function checkGuards(ctx: RouteContext, options: GuardOptions = {}): Guar
  * granular permission via the rolePermission table.
  */
 function checkRolePermission(userRoles: string[], action: PermissionAction): boolean {
-  if (userRoles.length === 0) return false;
+  if (userRoles.length === 0) {
+    return false;
+  }
 
   const rows = db
     .select({ roleId: tables.rolePermission.roleId })

--- a/packages/server/src/lib/routeTable.ts
+++ b/packages/server/src/lib/routeTable.ts
@@ -44,13 +44,17 @@ export interface RouteTableConfig {
 export function matchPath(path: string, template: string): Record<string, string> | null {
   const pathParts = path.split('/').filter(Boolean);
   const tplParts = template.split('/').filter(Boolean);
-  if (pathParts.length !== tplParts.length) return null;
+  if (pathParts.length !== tplParts.length) {
+    return null;
+  }
 
   const params: Record<string, string> = {};
   for (let i = 0; i < tplParts.length; i++) {
     const tpl = tplParts[i];
     const seg = pathParts[i];
-    if (!tpl || !seg) return null;
+    if (!tpl || !seg) {
+      return null;
+    }
     if (tpl.startsWith(':')) {
       params[tpl.slice(1)] = seg;
     } else if (tpl !== seg) {
@@ -101,10 +105,14 @@ export function routeTable(
     }
 
     for (const [method, pattern, handler] of routes) {
-      if (request.method !== method) continue;
+      if (request.method !== method) {
+        continue;
+      }
 
       const params = matchPath(path, pattern);
-      if (params === null) continue;
+      if (params === null) {
+        continue;
+      }
 
       let response = await handler(ctx, request, params);
 

--- a/packages/server/src/lib/search.ts
+++ b/packages/server/src/lib/search.ts
@@ -53,7 +53,7 @@ export function buildSongOrderBy(
       return sql`${c.album} IS NULL, lower(${c.album}) ${sql.raw(sortOrder)}`;
     case 'duration':
       return sql`${c.duration} ${sql.raw(sortOrder)}`;
-    default:
+    case 'createdAt':
       return sql`${c.createdAt} ${sql.raw(sortOrder)}`;
   }
 }
@@ -102,7 +102,9 @@ export function buildSongFilterClause(
     }
   }
 
-  if (clauses.length === 0) return undefined;
+  if (clauses.length === 0) {
+    return undefined;
+  }
   return sql.join(clauses, sql` AND `);
 }
 
@@ -122,7 +124,9 @@ export const SOURCE_LIKE_PATTERNS: Record<string, string[]> = {
 export function buildSongSearchClause(
   search: string | undefined
 ): ReturnType<typeof sql> | undefined {
-  if (!search) return undefined;
+  if (!search) {
+    return undefined;
+  }
 
   const tagMatchingIds = (
     $client.query(`SELECT id FROM "Song" WHERE lower(tags) LIKE lower(?)`).all(`%${search}%`) as {

--- a/packages/server/src/lib/socket.ts
+++ b/packages/server/src/lib/socket.ts
@@ -34,7 +34,9 @@ export function getCompressorSettings(): CompressorSettings | null {
     .from(tables.guildSettings)
     .where(eq(tables.guildSettings.id, 1))
     .get();
-  if (!row) return null;
+  if (!row) {
+    return null;
+  }
   return {
     enabled: row.enabled,
     threshold: row.threshold,

--- a/packages/server/src/lib/syncPlaylistToTag.ts
+++ b/packages/server/src/lib/syncPlaylistToTag.ts
@@ -19,7 +19,9 @@ export async function syncPlaylistToTag(
     .where(eq(playlistTable.id, playlistId))
     .limit(1);
 
-  if (!playlist?.tagNameLower) return null;
+  if (!playlist?.tagNameLower) {
+    return null;
+  }
 
   await db.transaction(async (tx) => {
     // Remove all existing playlist-song entries
@@ -32,7 +34,9 @@ export async function syncPlaylistToTag(
       .where(sql`lower(${songTable.tags}) LIKE lower(${`%${playlist.tagNameLower}%`})`)
       .orderBy(songTable.title);
 
-    if (songs.length === 0) return;
+    if (songs.length === 0) {
+      return;
+    }
 
     await tx.insert(playlistSongTable).values(
       songs.map((song, index) => ({
@@ -51,7 +55,9 @@ export async function syncPlaylistToTag(
  * Called after song tag mutations (bulk tag, bulk edit, single patch).
  */
 export async function reSyncPlaylistsForTags(tagNamesLower: string[]): Promise<void> {
-  if (tagNamesLower.length === 0) return;
+  if (tagNamesLower.length === 0) {
+    return;
+  }
 
   const affectedPlaylists = await db
     .select({ id: playlistTable.id, tagNameLower: playlistTable.tagNameLower })
@@ -64,14 +70,18 @@ export async function reSyncPlaylistsForTags(tagNamesLower: string[]): Promise<v
     );
 
   for (const pl of affectedPlaylists) {
-    if (!pl.tagNameLower) continue;
+    if (!pl.tagNameLower) {
+      continue;
+    }
     await syncPlaylistToTag(pl.id);
     const [updatedPl] = await db
       .select()
       .from(playlistTable)
       .where(eq(playlistTable.id, pl.id))
       .limit(1);
-    if (!updatedPl) continue;
+    if (!updatedPl) {
+      continue;
+    }
 
     const [{ count }] = await db
       .select({ count: sql<number>`count(*)` })

--- a/packages/server/src/lib/tagCanonicalization.ts
+++ b/packages/server/src/lib/tagCanonicalization.ts
@@ -13,10 +13,14 @@ const { tag: tagTable } = tables;
  * Example: ["rock"] (first time) → ["rock"]
  */
 export async function canonicalizeTags(rawTags: string[]): Promise<string[]> {
-  if (rawTags.length === 0) return [];
+  if (rawTags.length === 0) {
+    return [];
+  }
 
   const trimmed = rawTags.map((t) => t.trim()).filter((t) => t.length > 0);
-  if (trimmed.length === 0) return [];
+  if (trimmed.length === 0) {
+    return [];
+  }
 
   // Deduplicate case-insensitively, preserving first-seen spelling
   const seen = new Map<string, string>();

--- a/packages/server/src/lib/validation.ts
+++ b/packages/server/src/lib/validation.ts
@@ -38,7 +38,9 @@ function validateUrlInput(sourceUrl: unknown): ValidationResult<string> {
 /** Validates a source URL for single video endpoints. */
 export function validateSourceUrl(sourceUrl: unknown): ValidationResult<string> {
   const result = validateUrlInput(sourceUrl);
-  if (!result.ok) return result;
+  if (!result.ok) {
+    return result;
+  }
 
   if (!isValidSourceUrl(result.value)) {
     const names = getEnabledSourceDisplayNames();
@@ -55,7 +57,9 @@ export function validateSourceUrl(sourceUrl: unknown): ValidationResult<string> 
 /** Validates a playlist URL. */
 export function validatePlaylistUrl(playlistUrl: unknown): ValidationResult<string> {
   const result = validateUrlInput(playlistUrl);
-  if (!result.ok) return result;
+  if (!result.ok) {
+    return result;
+  }
 
   if (!isPlaylistUrl(result.value)) {
     const names = getEnabledSourceDisplayNames();
@@ -178,21 +182,31 @@ export function validateNickname(nickname: unknown): ValidationResult<string | n
 
 /** Validates an optional string field. Trims and returns null if empty. */
 export function validateOptionalString(value: unknown): string | null {
-  if (value === undefined || value === null) return null;
-  if (typeof value !== 'string') return null;
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (typeof value !== 'string') {
+    return null;
+  }
   const trimmed = value.trim();
   return trimmed.length === 0 ? null : trimmed;
 }
 
 /** Validates an artwork URL. Trims and checks it's a valid URL if non-empty. */
 export function validateArtworkUrl(value: unknown): ValidationResult<string | null> {
-  if (value === undefined || value === null) return { ok: true, value: null };
-  if (typeof value !== 'string')
+  if (value === undefined || value === null) {
+    return { ok: true, value: null };
+  }
+  if (typeof value !== 'string') {
     return { ok: false, response: json({ error: 'artwork must be a string.' }, 400) };
+  }
   const trimmed = value.trim();
-  if (trimmed.length === 0) return { ok: true, value: null };
-  if (trimmed.length > MAX_URL_LENGTH)
+  if (trimmed.length === 0) {
+    return { ok: true, value: null };
+  }
+  if (trimmed.length > MAX_URL_LENGTH) {
     return { ok: false, response: json({ error: 'artwork URL is too long.' }, 400) };
+  }
   try {
     new URL(trimmed);
   } catch {
@@ -203,9 +217,12 @@ export function validateArtworkUrl(value: unknown): ValidationResult<string | nu
 
 /** Validates tags: ensure string[], trim each, deduplicate */
 export function validateTags(value: unknown): ValidationResult<string[]> {
-  if (value === undefined || value === null) return { ok: true, value: [] };
-  if (!Array.isArray(value))
+  if (value === undefined || value === null) {
+    return { ok: true, value: [] };
+  }
+  if (!Array.isArray(value)) {
     return { ok: false, response: json({ error: 'tags must be an array.' }, 400) };
+  }
   const trimmed = value
     .filter((t): t is string => typeof t === 'string' && t.trim().length > 0)
     .map((t) => t.replace(/\s+/g, '-').trim());
@@ -222,8 +239,12 @@ export function validateTags(value: unknown): ValidationResult<string[]> {
 export function validateVolumeBoost(
   value: unknown
 ): { ok: true; value: number | null | undefined } | { ok: false; response: Response } {
-  if (value === undefined) return { ok: true, value: undefined };
-  if (value === null) return { ok: true, value: null };
+  if (value === undefined) {
+    return { ok: true, value: undefined };
+  }
+  if (value === null) {
+    return { ok: true, value: null };
+  }
   if (typeof value !== 'number' || !Number.isInteger(value)) {
     return {
       ok: false,

--- a/packages/server/src/manager.ts
+++ b/packages/server/src/manager.ts
@@ -32,7 +32,9 @@ export function getPlayer(guildId: string): GuildPlayer | undefined {
  */
 export function createPlayer(guildId: string, voiceId: string): GuildPlayer {
   const existing = players.get(guildId);
-  if (existing) return existing;
+  if (existing) {
+    return existing;
+  }
 
   const player = new GuildPlayer(guildId, voiceId, () => {
     players.delete(guildId);

--- a/packages/server/src/middleware/requireAuth.ts
+++ b/packages/server/src/middleware/requireAuth.ts
@@ -7,7 +7,9 @@ import type { User } from '../shared';
  */
 export function verifySessionToken(token: string): User | null {
   const { JWT_SECRET } = process.env;
-  if (!JWT_SECRET) return null;
+  if (!JWT_SECRET) {
+    return null;
+  }
 
   return verify<User>(token, JWT_SECRET);
 }

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -131,10 +131,16 @@ function buildCookieHeader(
 ): string {
   const parts = [`${name}=${value}`];
   parts.push(`Path=/`);
-  if (options.httpOnly !== false) parts.push('HttpOnly');
+  if (options.httpOnly !== false) {
+    parts.push('HttpOnly');
+  }
   parts.push(`SameSite=${options.sameSite ?? 'lax'}`);
-  if (options.secure ?? isProduction) parts.push('Secure');
-  if (options.maxAge !== undefined) parts.push(`Max-Age=${Math.floor(options.maxAge / 1000)}`);
+  if (options.secure ?? isProduction) {
+    parts.push('Secure');
+  }
+  if (options.maxAge !== undefined) {
+    parts.push(`Max-Age=${Math.floor(options.maxAge / 1000)}`);
+  }
   return parts.join('; ');
 }
 
@@ -156,7 +162,9 @@ function authRateLimit(ip: string): boolean {
     authLimiterStore.set(key, { count: 1, resetAt: now + 15 * 60 * 1000 });
     return true;
   }
-  if (entry.count >= 20) return false;
+  if (entry.count >= 20) {
+    return false;
+  }
   entry.count++;
   return true;
 }
@@ -168,7 +176,9 @@ function authRateLimit(ip: string): boolean {
 /** Fetches guild member roles. Returns 'not-in-guild' on 404, null on other errors. */
 async function fetchGuildMemberRoles(discordId: string): Promise<string[] | null | 'not-in-guild'> {
   const guildId = getGuildId();
-  if (!guildId) return null; // guild not configured yet
+  if (!guildId) {
+    return null;
+  } // guild not configured yet
 
   try {
     const memberRes = await fetch(
@@ -203,7 +213,9 @@ async function fetchDiscordUserProfile(
     const res = await fetch(`https://discord.com/api/users/${discordId}`, {
       headers: { Authorization: `Bot ${DISCORD_BOT_TOKEN_}` },
     });
-    if (!res.ok) return null;
+    if (!res.ok) {
+      return null;
+    }
     const data = (await res.json()) as { username: string; avatar: string | null };
     return {
       username: data.username,
@@ -231,7 +243,9 @@ async function fetchUserAdminStatus(
     const { username, avatar } = userData;
 
     const roles = await fetchGuildMemberRoles(discordId);
-    if (roles === null || roles === 'not-in-guild') return null;
+    if (roles === null || roles === 'not-in-guild') {
+      return null;
+    }
 
     return {
       isAdmin: isAdminUser(roles),
@@ -318,8 +332,12 @@ async function generateAndStoreTokens(
       : null,
     isAdmin,
   };
-  if (opts.isSetupAdmin) payload.isSetupAdmin = true;
-  if (opts.roles) payload.roles = opts.roles;
+  if (opts.isSetupAdmin) {
+    payload.isSetupAdmin = true;
+  }
+  if (opts.roles) {
+    payload.roles = opts.roles;
+  }
   const accessToken = generateAccessToken(payload);
   const refreshToken = generateRefreshToken(discordUser.id);
 
@@ -626,8 +644,12 @@ async function handleRefresh(
     avatar,
     isAdmin,
   };
-  if (isSetupAdmin) payload.isSetupAdmin = true;
-  if (roles) payload.roles = roles;
+  if (isSetupAdmin) {
+    payload.isSetupAdmin = true;
+  }
+  if (roles) {
+    payload.roles = roles;
+  }
   const newAccessToken = generateAccessToken(payload);
   const newRefreshToken = generateRefreshToken(decoded.discordId);
 

--- a/packages/server/src/routes/compressor.ts
+++ b/packages/server/src/routes/compressor.ts
@@ -20,7 +20,9 @@ async function handleCompressorRequest(
   _params: Record<string, string>
 ): Promise<Response> {
   const guards = checkGuards(ctx, { admin: true, permission: 'audio.manage' });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   let body: CompressorPayload;
   try {
@@ -32,17 +34,24 @@ async function handleCompressorRequest(
   const { enabled, threshold, ratio, attack, release, gain } = body;
 
   // Validate ranges
-  if (typeof enabled !== 'boolean') return json({ error: 'enabled must be boolean' }, 400);
-  if (!Number.isInteger(threshold) || threshold < -60 || threshold > 0)
+  if (typeof enabled !== 'boolean') {
+    return json({ error: 'enabled must be boolean' }, 400);
+  }
+  if (!Number.isInteger(threshold) || threshold < -60 || threshold > 0) {
     return json({ error: 'threshold must be integer -60 to 0' }, 400);
-  if (typeof ratio !== 'number' || ratio < 1 || ratio > 20)
+  }
+  if (typeof ratio !== 'number' || ratio < 1 || ratio > 20) {
     return json({ error: 'ratio must be number 1 to 20' }, 400);
-  if (!Number.isInteger(attack) || attack < 0 || attack > 100)
+  }
+  if (!Number.isInteger(attack) || attack < 0 || attack > 100) {
     return json({ error: 'attack must be integer 0 to 100' }, 400);
-  if (!Number.isInteger(release) || release < 10 || release > 1000)
+  }
+  if (!Number.isInteger(release) || release < 10 || release > 1000) {
     return json({ error: 'release must be integer 10 to 1000' }, 400);
-  if (!Number.isInteger(gain) || gain < 0 || gain > 24)
+  }
+  if (!Number.isInteger(gain) || gain < 0 || gain > 24) {
     return json({ error: 'gain must be integer 0 to 24' }, 400);
+  }
 
   // Upsert into DB
   db.insert(tables.guildSettings)

--- a/packages/server/src/routes/equalizer.ts
+++ b/packages/server/src/routes/equalizer.ts
@@ -23,7 +23,9 @@ function handleEqualizerGet(
   _params: Record<string, string>
 ): Response {
   const guards = checkGuards(ctx, { admin: true, permission: 'audio.manage' });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   const row = db
     .select({
@@ -46,7 +48,9 @@ async function handleEqualizerPatch(
   _params: Record<string, string>
 ): Promise<Response> {
   const guards = checkGuards(ctx, { admin: true, permission: 'audio.manage' });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   let body: EqualizerPayload;
   try {

--- a/packages/server/src/routes/generalSettings.ts
+++ b/packages/server/src/routes/generalSettings.ts
@@ -40,7 +40,9 @@ function handleGetGeneral(
   _params: Record<string, string>
 ): Response {
   const guards = checkGuards(ctx, { admin: true });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   const row = db
     .select(SETTINGS_COLUMNS)
@@ -88,7 +90,9 @@ async function handlePatchGeneral(
   _params: Record<string, string>
 ): Promise<Response> {
   const guards = checkGuards(ctx, { admin: true });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   let body: GeneralSettingsPatch;
   try {

--- a/packages/server/src/routes/permissions.ts
+++ b/packages/server/src/routes/permissions.ts
@@ -17,7 +17,9 @@ async function handleGetPermissions(
   _params: Record<string, string>
 ): Promise<Response> {
   const guards = checkGuards(ctx, { admin: true });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   const guildId = getGuildId();
 
@@ -41,7 +43,9 @@ async function handleGetPermissions(
   // Build mapping: action → roleIds
   const mapping: Record<string, string[]> = {};
   for (const row of allRows) {
-    if (!mapping[row.action]) mapping[row.action] = [];
+    if (!mapping[row.action]) {
+      mapping[row.action] = [];
+    }
     mapping[row.action].push(row.roleId);
   }
 
@@ -63,7 +67,9 @@ async function handlePatchPermissions(
   _params: Record<string, string>
 ): Promise<Response> {
   const guards = checkGuards(ctx, { admin: true });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   let body: { action?: unknown; roleIds?: unknown };
   try {

--- a/packages/server/src/routes/player.ts
+++ b/packages/server/src/routes/player.ts
@@ -36,7 +36,9 @@ function handleGetQueue(
   _params: Record<string, string>
 ): Response {
   const guards = checkGuards(ctx);
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   const player = getPlayer(getGuildId());
 
@@ -62,7 +64,9 @@ function handleGetQueue(
 // ---------------------------------------------------------------------------
 async function handlePlay(ctx: RouteContext, request: Request): Promise<Response> {
   const guards = checkGuards(ctx, { voice: true });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
   const { user } = guards;
 
   let body: {
@@ -80,7 +84,9 @@ async function handlePlay(ctx: RouteContext, request: Request): Promise<Response
   const { playlistId, mode, loop, startFromSongId } = body;
 
   const playerResult = await resolveOrAutoJoinPlayer(user.discordId);
-  if (!playerResult.ok) return playerResult.response;
+  if (!playerResult.ok) {
+    return playerResult.response;
+  }
   const player = playerResult.player;
 
   let dbSongs: (typeof songTable.$inferSelect)[];
@@ -146,10 +152,14 @@ async function handleSkip(
   _params: Record<string, string>
 ): Promise<Response> {
   const guards = checkGuards(ctx, { voice: true });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   const playingResult = requirePlaying();
-  if (!playingResult.ok) return playingResult.response;
+  if (!playingResult.ok) {
+    return playingResult.response;
+  }
 
   await playingResult.player.skip();
   return json({ message: 'Skipped.' });
@@ -164,7 +174,9 @@ function handleLeave(
   _params: Record<string, string>
 ): Response {
   const guards = checkGuards(ctx, { voice: true });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   const player = getPlayer(getGuildId());
 
@@ -172,7 +184,9 @@ function handleLeave(
     return json({ error: 'The bot is not in a voice channel.' }, 409);
   }
 
-  if (player) player.stop();
+  if (player) {
+    player.stop();
+  }
 
   return json({ message: 'Left the voice channel.' });
 }
@@ -182,7 +196,9 @@ function handleLeave(
 // ---------------------------------------------------------------------------
 async function handleLoop(ctx: RouteContext, request: Request): Promise<Response> {
   const guards = checkGuards(ctx, { voice: true });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   let body: { mode?: LoopMode };
   try {
@@ -198,7 +214,9 @@ async function handleLoop(ctx: RouteContext, request: Request): Promise<Response
   }
 
   const playerResult = requirePlayer();
-  if (!playerResult.ok) return playerResult.response;
+  if (!playerResult.ok) {
+    return playerResult.response;
+  }
 
   playerResult.player.setLoopMode(mode);
   return json({ loopMode: mode });
@@ -213,7 +231,9 @@ function handleShuffle(
   _params: Record<string, string>
 ): Response {
   const guards = checkGuards(ctx, { admin: true, voice: true, permission: 'queue.manage' });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   const player = getPlayer(getGuildId());
 
@@ -234,10 +254,14 @@ function handleUnshuffle(
   _params: Record<string, string>
 ): Response {
   const guards = checkGuards(ctx, { admin: true, voice: true, permission: 'queue.manage' });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   const playerResult = requirePlayer();
-  if (!playerResult.ok) return playerResult.response;
+  if (!playerResult.ok) {
+    return playerResult.response;
+  }
 
   playerResult.player.unshuffle();
   return json({ message: 'Queue order restored.' });
@@ -257,7 +281,9 @@ async function resolveUrlTempSong(
   permission: 'queue.quickadd' | 'queue.manage' | 'queue.override'
 ): Promise<UrlTempSongResult> {
   const guards = checkGuards(ctx, { admin: true, voice: true, permission });
-  if (guards instanceof Response) return { ok: false, response: guards };
+  if (guards instanceof Response) {
+    return { ok: false, response: guards };
+  }
   const { user } = guards;
 
   let body: { url?: unknown };
@@ -268,15 +294,21 @@ async function resolveUrlTempSong(
   }
 
   const urlResult = validateSourceUrl(body.url);
-  if (!urlResult.ok) return { ok: false, response: urlResult.response };
+  if (!urlResult.ok) {
+    return { ok: false, response: urlResult.response };
+  }
   const url = urlResult.value;
 
   const playerResult = await resolveOrAutoJoinPlayer(user.discordId);
-  if (!playerResult.ok) return { ok: false, response: playerResult.response };
+  if (!playerResult.ok) {
+    return { ok: false, response: playerResult.response };
+  }
   const player = playerResult.player;
 
   const metadataResult = await fetchSourceMetadata(url);
-  if (!metadataResult.ok) return { ok: false, response: metadataResult.response };
+  if (!metadataResult.ok) {
+    return { ok: false, response: metadataResult.response };
+  }
   const metadata = metadataResult.value;
 
   const queuedSong: QueuedSong = {
@@ -299,7 +331,9 @@ async function resolveUrlTempSong(
 // ---------------------------------------------------------------------------
 async function handleQuickAdd(ctx: RouteContext, request: Request): Promise<Response> {
   const result = await resolveUrlTempSong(ctx, request, 'queue.quickadd');
-  if (!result.ok) return result.response;
+  if (!result.ok) {
+    return result.response;
+  }
   await result.player.addToPriorityQueue(result.queuedSong);
   return json({
     message: `Added "${result.metadataTitle}" to the queue.`,
@@ -312,7 +346,9 @@ async function handleQuickAdd(ctx: RouteContext, request: Request): Promise<Resp
 // ---------------------------------------------------------------------------
 async function handleQuickAddPlaylist(ctx: RouteContext, request: Request): Promise<Response> {
   const guards = checkGuards(ctx, { admin: true, voice: true, permission: 'queue.quickadd' });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
   const { user } = guards;
 
   let body: { url?: unknown; maxVideos?: number };
@@ -324,15 +360,21 @@ async function handleQuickAddPlaylist(ctx: RouteContext, request: Request): Prom
 
   const maxVideos = clampMaxVideos(body.maxVideos);
   const urlResult = validatePlaylistUrl(body.url);
-  if (!urlResult.ok) return urlResult.response;
+  if (!urlResult.ok) {
+    return urlResult.response;
+  }
   const url = urlResult.value;
 
   const playerResult = await resolveOrAutoJoinPlayer(user.discordId);
-  if (!playerResult.ok) return playerResult.response;
+  if (!playerResult.ok) {
+    return playerResult.response;
+  }
   const player = playerResult.player;
 
   const playlistResult = await fetchPlaylistMetadata(url, maxVideos);
-  if (!playlistResult.ok) return playlistResult.response;
+  if (!playlistResult.ok) {
+    return playlistResult.response;
+  }
   const playlistMetadata = playlistResult.value;
 
   const requestedBy = user.username;
@@ -369,10 +411,14 @@ function handlePauseToggle(
   _params: Record<string, string>
 ): Response {
   const guards = checkGuards(ctx, { voice: true });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   const playingResult = requirePlaying();
-  if (!playingResult.ok) return playingResult.response;
+  if (!playingResult.ok) {
+    return playingResult.response;
+  }
 
   const isPaused = playingResult.player.togglePause();
   return json({ isPaused });
@@ -383,7 +429,9 @@ function handlePauseToggle(
 // ---------------------------------------------------------------------------
 async function handleSeek(ctx: RouteContext, request: Request): Promise<Response> {
   const guards = checkGuards(ctx, { voice: true });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   let body: { position?: unknown };
   try {
@@ -399,7 +447,9 @@ async function handleSeek(ctx: RouteContext, request: Request): Promise<Response
   }
 
   const playingResult = requirePlaying();
-  if (!playingResult.ok) return playingResult.response;
+  if (!playingResult.ok) {
+    return playingResult.response;
+  }
 
   await playingResult.player.seek(position);
   return json(playingResult.player.getQueueState());
@@ -414,10 +464,14 @@ function handleClear(
   _params: Record<string, string>
 ): Response {
   const guards = checkGuards(ctx, { admin: true, voice: true, permission: 'queue.manage' });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   const playerResult = requirePlayer();
-  if (!playerResult.ok) return playerResult.response;
+  if (!playerResult.ok) {
+    return playerResult.response;
+  }
 
   playerResult.player.clearQueue();
   return json({ message: 'Queue cleared.' });
@@ -428,7 +482,9 @@ function handleClear(
 // ---------------------------------------------------------------------------
 async function handleAddToPriority(ctx: RouteContext, request: Request): Promise<Response> {
   const guards = checkGuards(ctx, { admin: true, voice: true, permission: 'queue.manage' });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
   const { user } = guards;
 
   let body: { songId?: unknown };
@@ -451,7 +507,9 @@ async function handleAddToPriority(ctx: RouteContext, request: Request): Promise
   }
 
   const playerResult = await resolveOrAutoJoinPlayer(user.discordId);
-  if (!playerResult.ok) return playerResult.response;
+  if (!playerResult.ok) {
+    return playerResult.response;
+  }
   const player = playerResult.player;
 
   const requestedBy = user.username;
@@ -477,7 +535,9 @@ async function handleAddToPriority(ctx: RouteContext, request: Request): Promise
 // ---------------------------------------------------------------------------
 async function handleOverride(ctx: RouteContext, request: Request): Promise<Response> {
   const result = await resolveUrlTempSong(ctx, request, 'queue.override');
-  if (!result.ok) return result.response;
+  if (!result.ok) {
+    return result.response;
+  }
   await result.player.replaceQueueAndPlay([result.queuedSong]);
   return json({
     message: `Now playing "${result.metadataTitle}".`,
@@ -495,10 +555,14 @@ function handleRemoveFromQueue(
 ): Response {
   const { songId } = params;
   const guards = checkGuards(ctx, { admin: true, voice: true, permission: 'queue.manage' });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   const playerResult = requirePlayer();
-  if (!playerResult.ok) return playerResult.response;
+  if (!playerResult.ok) {
+    return playerResult.response;
+  }
 
   const removed = playerResult.player.removeSongById(songId);
 
@@ -519,10 +583,14 @@ function handlePromoteSong(
 ): Response {
   const { songId } = params;
   const guards = checkGuards(ctx, { admin: true, voice: true, permission: 'queue.manage' });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   const playerResult = requirePlayer();
-  if (!playerResult.ok) return playerResult.response;
+  if (!playerResult.ok) {
+    return playerResult.response;
+  }
 
   const promoted = playerResult.player.promoteSong(songId);
 
@@ -543,10 +611,14 @@ function handleDemoteSong(
 ): Response {
   const { songId } = params;
   const guards = checkGuards(ctx, { admin: true, voice: true, permission: 'queue.manage' });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   const playerResult = requirePlayer();
-  if (!playerResult.ok) return playerResult.response;
+  if (!playerResult.ok) {
+    return playerResult.response;
+  }
 
   const demoted = playerResult.player.demoteSong(songId);
 
@@ -562,7 +634,9 @@ function handleDemoteSong(
 // ---------------------------------------------------------------------------
 async function handleReorderQueue(ctx: RouteContext, request: Request): Promise<Response> {
   const guards = checkGuards(ctx, { admin: true, voice: true, permission: 'queue.manage' });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   let body: { songIds?: unknown; target?: unknown };
   try {
@@ -582,7 +656,9 @@ async function handleReorderQueue(ctx: RouteContext, request: Request): Promise<
   }
 
   const playerResult = requirePlayer();
-  if (!playerResult.ok) return playerResult.response;
+  if (!playerResult.ok) {
+    return playerResult.response;
+  }
 
   try {
     if (target === 'priority') {

--- a/packages/server/src/routes/playlists.ts
+++ b/packages/server/src/routes/playlists.ts
@@ -48,7 +48,9 @@ function formatPlaylistSongWithSong(
 // ---------------------------------------------------------------------------
 async function handleGetPlaylists(ctx: RouteContext, request: Request): Promise<Response> {
   const guards = checkGuards(ctx);
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
   const { user } = guards;
 
   const url = new URL(request.url);
@@ -124,7 +126,9 @@ async function handleGetPlaylists(ctx: RouteContext, request: Request): Promise<
 // ---------------------------------------------------------------------------
 async function handlePostPlaylist(ctx: RouteContext, request: Request): Promise<Response> {
   const guards = checkGuards(ctx);
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
   const { user } = guards;
 
   let body: { name?: unknown; tagNameLower?: unknown };
@@ -135,7 +139,9 @@ async function handlePostPlaylist(ctx: RouteContext, request: Request): Promise<
   }
 
   const nameResult = validatePlaylistName(body.name);
-  if (!nameResult.ok) return nameResult.response;
+  if (!nameResult.ok) {
+    return nameResult.response;
+  }
   const trimmedName = nameResult.value;
 
   const tagNameLower =
@@ -176,7 +182,9 @@ async function handleGetPlaylist(
 ): Promise<Response> {
   const { id } = params;
   const guards = checkGuards(ctx);
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
   const { user } = guards;
 
   const url = new URL(request.url);
@@ -211,7 +219,9 @@ async function handleGetPlaylist(
   const wantsCustomSort = sortField !== 'position';
 
   const playlist = await requirePlaylist(id, user, adminView, true);
-  if (playlist instanceof Response) return playlist;
+  if (playlist instanceof Response) {
+    return playlist;
+  }
 
   // ── Custom sort path: join playlistSong ↔ song, sort + filter in one query ──
   if (wantsCustomSort || filterTags.length > 0 || filterSources.length > 0) {
@@ -220,14 +230,18 @@ async function handleGetPlaylist(
 
     if (search) {
       const searchClause = buildSongSearchClause(search);
-      if (searchClause) songFilterClauses.push(searchClause);
+      if (searchClause) {
+        songFilterClauses.push(searchClause);
+      }
     }
 
     const tagSourceFilter = buildSongFilterClause(filterTags, filterSources, {
       tags: tables.song.tags,
       sourceUrl: tables.song.sourceUrl,
     });
-    if (tagSourceFilter) songFilterClauses.push(tagSourceFilter);
+    if (tagSourceFilter) {
+      songFilterClauses.push(tagSourceFilter);
+    }
 
     const joinWhere = and(
       eq(playlistSongTable.playlistId, id),
@@ -352,7 +366,9 @@ async function handleGetPlaylist(
     songs: playlistSongs
       .map((ps) => {
         const song = songMap.get(ps.songId);
-        if (!song) return null;
+        if (!song) {
+          return null;
+        }
         return formatPlaylistSongWithSong(ps, song, nameMap.get(song.addedBy) ?? song.addedBy);
       })
       .filter((x): x is NonNullable<typeof x> => x !== null),
@@ -376,7 +392,9 @@ async function handlePatchVisibility(
 ): Promise<Response> {
   const { id } = params;
   const guards = checkGuards(ctx);
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
   const { user } = guards;
 
   let body: { isPrivate?: unknown; adminView?: unknown };
@@ -392,7 +410,9 @@ async function handlePatchVisibility(
 
   const adminView = body.adminView === true;
   const existing = await requirePlaylist(id, user, adminView);
-  if (existing instanceof Response) return existing;
+  if (existing instanceof Response) {
+    return existing;
+  }
 
   const [updatedPlaylist] = await db
     .update(playlistTable)
@@ -420,7 +440,9 @@ async function handlePatchPlaylist(
 ): Promise<Response> {
   const { id } = params;
   const guards = checkGuards(ctx);
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
   const { user } = guards;
 
   let body: { name?: unknown; tagNameLower?: unknown };
@@ -431,13 +453,17 @@ async function handlePatchPlaylist(
   }
 
   const existing = await requirePlaylist(id, user);
-  if (existing instanceof Response) return existing;
+  if (existing instanceof Response) {
+    return existing;
+  }
 
   const data: Record<string, unknown> = {};
 
   if (body.name !== undefined) {
     const nameResult = validatePlaylistName(body.name);
-    if (!nameResult.ok) return nameResult.response;
+    if (!nameResult.ok) {
+      return nameResult.response;
+    }
     data.name = nameResult.value;
   }
 
@@ -484,11 +510,15 @@ async function handleDeletePlaylist(
 ): Promise<Response> {
   const { id } = params;
   const guards = checkGuards(ctx);
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
   const { user } = guards;
 
   const existing = await requirePlaylist(id, user);
-  if (existing instanceof Response) return existing;
+  if (existing instanceof Response) {
+    return existing;
+  }
 
   await db.delete(playlistTable).where(eq(playlistTable.id, id));
 
@@ -505,7 +535,9 @@ async function handleAddSong(
 ): Promise<Response> {
   const { id } = params;
   const guards = checkGuards(ctx);
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
   const { user } = guards;
 
   let body: { songId?: unknown };
@@ -520,7 +552,9 @@ async function handleAddSong(
   }
 
   const playlist = await requirePlaylist(id, user);
-  if (playlist instanceof Response) return playlist;
+  if (playlist instanceof Response) {
+    return playlist;
+  }
 
   // Smart playlists are auto-managed — reject manual adds
   if (playlist.tagNameLower) {
@@ -597,11 +631,15 @@ async function handleRemoveSong(
 ): Promise<Response> {
   const { id: playlistId, songId } = params;
   const guards = checkGuards(ctx);
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
   const { user } = guards;
 
   const playlist = await requirePlaylist(playlistId, user);
-  if (playlist instanceof Response) return playlist;
+  if (playlist instanceof Response) {
+    return playlist;
+  }
 
   const [entry] = await db
     .select()
@@ -653,11 +691,15 @@ async function handleBulkRemoveSongs(
 ): Promise<Response> {
   const { id: playlistId } = params;
   const guards = checkGuards(ctx);
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
   const { user } = guards;
 
   const playlist = await requirePlaylist(playlistId, user);
-  if (playlist instanceof Response) return playlist;
+  if (playlist instanceof Response) {
+    return playlist;
+  }
 
   let body: { songIds?: unknown };
   try {

--- a/packages/server/src/routes/requests.ts
+++ b/packages/server/src/routes/requests.ts
@@ -43,10 +43,16 @@ function formatRequest(row: typeof requestTable.$inferSelect): SongRequest {
 }
 
 async function userCanAutoApprove(ctx: RouteContext): Promise<boolean> {
-  if (ctx.isAdmin) return true;
-  if (!ctx.user) return false;
+  if (ctx.isAdmin) {
+    return true;
+  }
+  if (!ctx.user) {
+    return false;
+  }
   const userRoles = ctx.user.roles ?? [];
-  if (userRoles.length === 0) return false;
+  if (userRoles.length === 0) {
+    return false;
+  }
 
   const rows = await db
     .select({ roleId: tables.rolePermission.roleId })
@@ -65,7 +71,9 @@ async function userCanAutoApprove(ctx: RouteContext): Promise<boolean> {
 // ---------------------------------------------------------------------------
 async function handlePreviewRequest(ctx: RouteContext, request: Request): Promise<Response> {
   const guards = checkGuards(ctx);
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   let body: { url?: unknown };
   try {
@@ -75,7 +83,9 @@ async function handlePreviewRequest(ctx: RouteContext, request: Request): Promis
   }
 
   const urlResult = validateSourceUrl(body.url);
-  if (!urlResult.ok) return urlResult.response;
+  if (!urlResult.ok) {
+    return urlResult.response;
+  }
   let url = urlResult.value;
 
   // Strip any ?list=... query param for single-track preview
@@ -91,7 +101,9 @@ async function handlePreviewRequest(ctx: RouteContext, request: Request): Promis
 
   if (isPlaylist) {
     const playlistResult = await fetchPlaylistMetadata(url, 100);
-    if (!playlistResult.ok) return playlistResult.response;
+    if (!playlistResult.ok) {
+      return playlistResult.response;
+    }
     const pm = playlistResult.value;
 
     const playlistThumb = pm.videos[0]?.thumbnailUrl ?? '';
@@ -114,7 +126,9 @@ async function handlePreviewRequest(ctx: RouteContext, request: Request): Promis
   }
 
   const metadataResult = await fetchSourceMetadata(url);
-  if (!metadataResult.ok) return metadataResult.response;
+  if (!metadataResult.ok) {
+    return metadataResult.response;
+  }
   const metadata = metadataResult.value;
 
   const [existing] = await db
@@ -150,7 +164,9 @@ async function handlePreviewRequest(ctx: RouteContext, request: Request): Promis
 // ---------------------------------------------------------------------------
 async function handleCreateRequest(ctx: RouteContext, request: Request): Promise<Response> {
   const guards = checkGuards(ctx);
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
   const { user } = guards;
 
   let body: {
@@ -172,23 +188,33 @@ async function handleCreateRequest(ctx: RouteContext, request: Request): Promise
   const notifyDm = body.notifyDm === true;
 
   const nicknameResult = validateNickname(body.nickname);
-  if (!nicknameResult.ok) return nicknameResult.response;
+  if (!nicknameResult.ok) {
+    return nicknameResult.response;
+  }
 
   const artist = validateOptionalString(body.artist);
   const album = validateOptionalString(body.album);
 
   const artworkResult = validateArtworkUrl(body.artwork);
-  if (!artworkResult.ok) return artworkResult.response;
+  if (!artworkResult.ok) {
+    return artworkResult.response;
+  }
 
   const tagsResult = validateTags(body.tags);
-  if (!tagsResult.ok) return tagsResult.response;
+  if (!tagsResult.ok) {
+    return tagsResult.response;
+  }
 
   const volumeBoostResult = validateVolumeBoost(body.volumeBoost);
-  if (!volumeBoostResult.ok) return volumeBoostResult.response;
+  if (!volumeBoostResult.ok) {
+    return volumeBoostResult.response;
+  }
   const volumeBoost = volumeBoostResult.value !== undefined ? volumeBoostResult.value : null;
 
   const urlResult = validateSourceUrl(body.sourceUrl);
-  if (!urlResult.ok) return urlResult.response;
+  if (!urlResult.ok) {
+    return urlResult.response;
+  }
   const originalUrl = urlResult.value;
 
   // Strip any ?list=... query param so YouTube video URLs with a playlist
@@ -213,7 +239,9 @@ async function handleCreateRequest(ctx: RouteContext, request: Request): Promise
   // --- Playlist request ---
   if (isPlaylist) {
     const playlistResult = await fetchPlaylistMetadata(url, 100);
-    if (!playlistResult.ok) return playlistResult.response;
+    if (!playlistResult.ok) {
+      return playlistResult.response;
+    }
     const pm = playlistResult.value;
 
     if (autoApprove) {
@@ -377,7 +405,9 @@ async function handleCreateRequest(ctx: RouteContext, request: Request): Promise
 
   // --- Track request ---
   const metadataResult = await fetchSourceMetadata(url);
-  if (!metadataResult.ok) return metadataResult.response;
+  if (!metadataResult.ok) {
+    return metadataResult.response;
+  }
   const metadata = metadataResult.value;
 
   // Check duplicates: Song table
@@ -519,7 +549,9 @@ async function handleCreateRequest(ctx: RouteContext, request: Request): Promise
 // ---------------------------------------------------------------------------
 async function handleGetRequests(ctx: RouteContext, request: Request): Promise<Response> {
   const guards = checkGuards(ctx);
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
   const { user } = guards;
 
   const url = new URL(request.url);
@@ -589,7 +621,9 @@ async function handlePatchRequest(
 ): Promise<Response> {
   const { id } = params;
   const guards = checkGuards(ctx, { admin: true });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
   const { user } = guards;
 
   let body: { status?: unknown };
@@ -812,7 +846,9 @@ async function handleDeleteRequest(
 ): Promise<Response> {
   const { id } = params;
   const guards = checkGuards(ctx);
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
   const { user } = guards;
 
   const [existing] = await db.select().from(requestTable).where(eq(requestTable.id, id)).limit(1);

--- a/packages/server/src/routes/setup.ts
+++ b/packages/server/src/routes/setup.ts
@@ -92,7 +92,9 @@ async function handleGetGuilds(
   _params: Record<string, string>
 ): Promise<Response> {
   const guards = checkGuards(ctx, { setupMode: true });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   try {
     const res = await fetch(`${DISCORD_API}/users/@me/guilds`, {
@@ -104,11 +106,11 @@ async function handleGetGuilds(
       return json({ error: 'Could not fetch guild list from Discord.' }, 502);
     }
 
-    const guilds = (await res.json()) as Array<{
+    const guilds = (await res.json()) as {
       id: string;
       name: string;
       icon: string | null;
-    }>;
+    }[];
 
     const result: SetupGuild[] = guilds.map((g) => ({
       id: g.id,
@@ -134,7 +136,9 @@ async function handleGetRoles(
 ): Promise<Response> {
   const url = new URL(request.url);
   const guards = checkGuards(ctx, { setupMode: true });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   const guildId = url.searchParams.get('guildId');
   if (!guildId) {
@@ -156,7 +160,9 @@ async function handleGetChannels(
 ): Promise<Response> {
   const url = new URL(request.url);
   const guards = checkGuards(ctx, { setupMode: true });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   const guildId = url.searchParams.get('guildId');
   if (!guildId) {
@@ -179,11 +185,11 @@ async function handleGetChannels(
       return json({ error: 'Could not fetch channels from Discord.' }, 502);
     }
 
-    const channels = (await res.json()) as Array<{
+    const channels = (await res.json()) as {
       id: string;
       name: string;
       type: number;
-    }>;
+    }[];
 
     // Type 0 = GUILD_TEXT. Filter to text channels only.
     const result: SetupChannel[] = channels
@@ -211,7 +217,9 @@ async function handlePostComplete(
   _params: Record<string, string>
 ): Promise<Response> {
   const guards = checkGuards(ctx, { setupMode: true });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   let body: {
     guildId?: unknown;

--- a/packages/server/src/routes/songs.ts
+++ b/packages/server/src/routes/songs.ts
@@ -33,7 +33,9 @@ const { song: songTable } = tables;
 // ---------------------------------------------------------------------------
 async function handleBulkDelete(ctx: RouteContext, request: Request): Promise<Response> {
   const guards = checkGuards(ctx, { admin: true, permission: 'songs.delete' });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   let body: { ids?: unknown };
   try {
@@ -64,7 +66,9 @@ async function handleBulkDelete(ctx: RouteContext, request: Request): Promise<Re
 // ---------------------------------------------------------------------------
 async function handleBulkTag(ctx: RouteContext, request: Request): Promise<Response> {
   const guards = checkGuards(ctx, { admin: true, permission: 'songs.edit' });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   let body: { ids?: unknown; tags?: unknown; mode?: unknown };
   try {
@@ -78,7 +82,9 @@ async function handleBulkTag(ctx: RouteContext, request: Request): Promise<Respo
   }
 
   const tagsResult = validateTags(body.tags);
-  if (!tagsResult.ok) return tagsResult.response;
+  if (!tagsResult.ok) {
+    return tagsResult.response;
+  }
 
   const ids = (body.ids as string[]).slice(0, 5000);
   const newTags = await canonicalizeTags(tagsResult.value);
@@ -124,7 +130,9 @@ async function handleBulkTag(ctx: RouteContext, request: Request): Promise<Respo
 // ---------------------------------------------------------------------------
 async function handleBulkEdit(ctx: RouteContext, request: Request): Promise<Response> {
   const guards = checkGuards(ctx, { admin: true, permission: 'songs.edit' });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   let body: {
     ids?: unknown;
@@ -156,7 +164,9 @@ async function handleBulkEdit(ctx: RouteContext, request: Request): Promise<Resp
   // Nickname
   if ('nickname' in body && body.nickname !== undefined) {
     const result = validateNickname(body.nickname);
-    if (!result.ok) return result.response;
+    if (!result.ok) {
+      return result.response;
+    }
     data.nickname = result.value;
   } else if (clearFields.includes('nickname')) {
     data.nickname = null;
@@ -179,7 +189,9 @@ async function handleBulkEdit(ctx: RouteContext, request: Request): Promise<Resp
   // Artwork
   if ('artwork' in body && body.artwork !== undefined) {
     const artworkResult = validateArtworkUrl(body.artwork);
-    if (!artworkResult.ok) return artworkResult.response;
+    if (!artworkResult.ok) {
+      return artworkResult.response;
+    }
     data.artwork = artworkResult.value;
   } else if (clearFields.includes('artwork')) {
     data.artwork = null;
@@ -188,7 +200,9 @@ async function handleBulkEdit(ctx: RouteContext, request: Request): Promise<Resp
   // Tags
   if ('tags' in body && body.tags !== undefined) {
     const tagsResult = validateTags(body.tags);
-    if (!tagsResult.ok) return tagsResult.response;
+    if (!tagsResult.ok) {
+      return tagsResult.response;
+    }
     data.tags = await canonicalizeTags(tagsResult.value);
   } else if (clearFields.includes('tags')) {
     data.tags = [];
@@ -197,7 +211,9 @@ async function handleBulkEdit(ctx: RouteContext, request: Request): Promise<Resp
   // Volume boost
   if ('volumeBoost' in body && body.volumeBoost !== undefined) {
     const volumeResult = validateVolumeBoost(body.volumeBoost);
-    if (!volumeResult.ok) return volumeResult.response;
+    if (!volumeResult.ok) {
+      return volumeResult.response;
+    }
     data.volumeBoost = volumeResult.value;
   } else if (clearFields.includes('volumeBoost')) {
     data.volumeBoost = null;
@@ -232,12 +248,24 @@ async function handleBulkEdit(ctx: RouteContext, request: Request): Promise<Resp
       }
     }
     const bulkFields: Record<string, unknown> = {};
-    if ('nickname' in data) bulkFields.nickname = data.nickname;
-    if ('artist' in data) bulkFields.artist = data.artist;
-    if ('album' in data) bulkFields.album = data.album;
-    if ('artwork' in data) bulkFields.artwork = data.artwork;
-    if ('tags' in data) bulkFields.tags = data.tags;
-    if ('volumeBoost' in data) bulkFields.volumeBoost = data.volumeBoost;
+    if ('nickname' in data) {
+      bulkFields.nickname = data.nickname;
+    }
+    if ('artist' in data) {
+      bulkFields.artist = data.artist;
+    }
+    if ('album' in data) {
+      bulkFields.album = data.album;
+    }
+    if ('artwork' in data) {
+      bulkFields.artwork = data.artwork;
+    }
+    if ('tags' in data) {
+      bulkFields.tags = data.tags;
+    }
+    if ('volumeBoost' in data) {
+      bulkFields.volumeBoost = data.volumeBoost;
+    }
     bulkPlayer.updateSongMetadata(
       ids,
       bulkFields as Parameters<typeof bulkPlayer.updateSongMetadata>[1]
@@ -252,7 +280,9 @@ async function handleBulkEdit(ctx: RouteContext, request: Request): Promise<Resp
 // ---------------------------------------------------------------------------
 async function handleGetSongs(ctx: RouteContext, request: Request): Promise<Response> {
   const guards = checkGuards(ctx);
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   const url = new URL(request.url);
   const { page, limit, skip } = parsePagination(url);
@@ -332,7 +362,9 @@ async function handleDeleteSong(
 ): Promise<Response> {
   const { id } = params;
   const guards = checkGuards(ctx, { admin: true, permission: 'songs.delete' });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   const [existing] = await db.select().from(songTable).where(eq(songTable.id, id)).limit(1);
   if (!existing) {
@@ -357,7 +389,9 @@ async function handlePatchSong(
 ): Promise<Response> {
   const { id } = params;
   const guards = checkGuards(ctx, { admin: true, permission: 'songs.edit' });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   let body: Record<string, unknown>;
   try {
@@ -376,7 +410,9 @@ async function handlePatchSong(
   // Nickname
   if ('nickname' in body) {
     const result = validateNickname(body.nickname);
-    if (!result.ok) return result.response;
+    if (!result.ok) {
+      return result.response;
+    }
     data.nickname = result.value;
   }
 
@@ -393,7 +429,9 @@ async function handlePatchSong(
   // Artwork
   if ('artwork' in body) {
     const artworkResult = validateArtworkUrl(body.artwork);
-    if (!artworkResult.ok) return artworkResult.response;
+    if (!artworkResult.ok) {
+      return artworkResult.response;
+    }
     data.artwork = artworkResult.value;
   }
 
@@ -403,14 +441,18 @@ async function handlePatchSong(
 
   if ('tags' in body) {
     const tagsResult = validateTags(body.tags);
-    if (!tagsResult.ok) return tagsResult.response;
+    if (!tagsResult.ok) {
+      return tagsResult.response;
+    }
     data.tags = await canonicalizeTags(tagsResult.value);
   }
 
   // Volume boost
   if ('volumeBoost' in body) {
     const volumeResult = validateVolumeBoost(body.volumeBoost);
-    if (!volumeResult.ok) return volumeResult.response;
+    if (!volumeResult.ok) {
+      return volumeResult.response;
+    }
     data.volumeBoost = volumeResult.value;
   }
 
@@ -450,12 +492,24 @@ async function handlePatchSong(
     // Build fields object with only the keys that are actually in data —
     // undefined values still create keys, which would clear fields in merge.
     const fields: Record<string, unknown> = {};
-    if ('nickname' in data) fields.nickname = data.nickname;
-    if ('artist' in data) fields.artist = data.artist;
-    if ('album' in data) fields.album = data.album;
-    if ('artwork' in data) fields.artwork = data.artwork;
-    if ('tags' in data) fields.tags = data.tags;
-    if ('volumeBoost' in data) fields.volumeBoost = data.volumeBoost;
+    if ('nickname' in data) {
+      fields.nickname = data.nickname;
+    }
+    if ('artist' in data) {
+      fields.artist = data.artist;
+    }
+    if ('album' in data) {
+      fields.album = data.album;
+    }
+    if ('artwork' in data) {
+      fields.artwork = data.artwork;
+    }
+    if ('tags' in data) {
+      fields.tags = data.tags;
+    }
+    if ('volumeBoost' in data) {
+      fields.volumeBoost = data.volumeBoost;
+    }
     player.updateSongMetadata(id, fields as Parameters<typeof player.updateSongMetadata>[1]);
   }
 

--- a/packages/server/src/routes/tags.ts
+++ b/packages/server/src/routes/tags.ts
@@ -20,7 +20,9 @@ function handleGetTagsList(
   _params: Record<string, string>
 ): Response {
   const guards = checkGuards(ctx);
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   const tags = db
     .select({
@@ -45,9 +47,13 @@ async function handleGetTag(
 ): Promise<Response> {
   const { nameLower } = params;
   const guards = checkGuards(ctx);
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
   const [tag] = await db.select().from(tagTable).where(eq(tagTable.nameLower, nameLower)).limit(1);
-  if (!tag) return json({ error: 'Tag not found.' }, 404);
+  if (!tag) {
+    return json({ error: 'Tag not found.' }, 404);
+  }
   return json({ tag });
 }
 
@@ -58,7 +64,9 @@ function handleGetTagSongs(
 ): Response {
   const { nameLower } = params;
   const guards = checkGuards(ctx);
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   // Fetch all songs where tags JSON array contains this tag (case-insensitive match)
   const songs = db
@@ -85,7 +93,9 @@ async function handlePatchTag(
     return json({ error: 'Invalid JSON body.' }, 400);
   }
   const guards = checkGuards(ctx, { admin: true, permission: 'tags.manage' });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   const [existing] = await db
     .select()
@@ -135,7 +145,9 @@ async function handleDeleteTag(
 ): Promise<Response> {
   const { nameLower } = params;
   const guards = checkGuards(ctx, { admin: true, permission: 'tags.manage' });
-  if (guards instanceof Response) return guards;
+  if (guards instanceof Response) {
+    return guards;
+  }
 
   const [existing] = await db
     .select()

--- a/packages/server/src/shared/api.ts
+++ b/packages/server/src/shared/api.ts
@@ -127,11 +127,21 @@ export function fetchSongsPage(
   opts?: FetchSongsOptions
 ): Promise<PaginatedResult<Song>> {
   const params = new URLSearchParams({ page: String(page), limit: String(limit) });
-  if (opts?.search) params.set('search', opts.search);
-  if (opts?.sort) params.set('sort', opts.sort);
-  if (opts?.order) params.set('order', opts.order);
-  if (opts?.tags) params.set('tags', opts.tags);
-  if (opts?.source) params.set('source', opts.source);
+  if (opts?.search) {
+    params.set('search', opts.search);
+  }
+  if (opts?.sort) {
+    params.set('sort', opts.sort);
+  }
+  if (opts?.order) {
+    params.set('order', opts.order);
+  }
+  if (opts?.tags) {
+    params.set('tags', opts.tags);
+  }
+  if (opts?.source) {
+    params.set('source', opts.source);
+  }
   return get(`/api/songs?${params}`);
 }
 
@@ -191,8 +201,12 @@ export function fetchRequests(
   opts?: { status?: string; mine?: boolean }
 ): Promise<FetchRequestsResult> {
   const params = new URLSearchParams({ page: String(page), limit: String(limit) });
-  if (opts?.status) params.set('status', opts.status);
-  if (opts?.mine) params.set('mine', 'true');
+  if (opts?.status) {
+    params.set('status', opts.status);
+  }
+  if (opts?.mine) {
+    params.set('mine', 'true');
+  }
   return get(`/api/requests?${params}`);
 }
 
@@ -296,7 +310,9 @@ export function fetchPlaylistsPage(
   limit = 30
 ): Promise<PaginatedResult<Playlist>> {
   const params = new URLSearchParams({ page: String(page), limit: String(limit) });
-  if (adminView) params.set('adminView', 'true');
+  if (adminView) {
+    params.set('adminView', 'true');
+  }
   return get(`/api/playlists?${params}`);
 }
 
@@ -308,12 +324,24 @@ export function fetchPlaylistPage(
   opts?: FetchSongsOptions
 ): Promise<PlaylistDetail & { pagination: PaginationMeta }> {
   const params = new URLSearchParams({ page: String(page), limit: String(limit) });
-  if (adminView) params.set('adminView', 'true');
-  if (opts?.search) params.set('search', opts.search);
-  if (opts?.sort) params.set('sort', opts.sort);
-  if (opts?.order) params.set('order', opts.order);
-  if (opts?.tags) params.set('tags', opts.tags);
-  if (opts?.source) params.set('source', opts.source);
+  if (adminView) {
+    params.set('adminView', 'true');
+  }
+  if (opts?.search) {
+    params.set('search', opts.search);
+  }
+  if (opts?.sort) {
+    params.set('sort', opts.sort);
+  }
+  if (opts?.order) {
+    params.set('order', opts.order);
+  }
+  if (opts?.tags) {
+    params.set('tags', opts.tags);
+  }
+  if (opts?.source) {
+    params.set('source', opts.source);
+  }
   return get(`/api/playlists/${id}?${params}`);
 }
 
@@ -417,7 +445,7 @@ export function quickAddPlaylistToQueue(
   playlistTitle: string;
   totalVideos: number;
   queuedCount: number;
-  songs: Array<{ title: string; duration: number; thumbnailUrl: string; requestedBy: string }>;
+  songs: { title: string; duration: number; thumbnailUrl: string; requestedBy: string }[];
 }> {
   return post('/api/player/quick-add-playlist', {
     url,

--- a/packages/server/src/shared/db/index.ts
+++ b/packages/server/src/shared/db/index.ts
@@ -50,7 +50,9 @@ export async function findPlaylistWithSongs(playlistId: string) {
     .leftJoin(schema.song, eq(schema.song.id, schema.playlistSong.songId))
     .where(eq(schema.playlist.id, playlistId));
 
-  if (result.length === 0) return null;
+  if (result.length === 0) {
+    return null;
+  }
 
   const songs = result
     .filter((r) => r.PlaylistSong !== null && r.Song !== null)

--- a/packages/server/src/shared/db/schema.ts
+++ b/packages/server/src/shared/db/schema.ts
@@ -152,14 +152,14 @@ export const songRequest = sqliteTable('SongRequest', {
     name: string;
     videoCount: number;
     thumbnailUrl?: string | null;
-    videos?: Array<{
+    videos?: {
       id: string;
       title: string;
       duration: number;
       thumbnailUrl?: string | null;
       artist?: string | null;
       artworkUrl?: string | null;
-    }>;
+    }[];
   }>(),
   status: text('status').notNull().default('pending'), // 'pending' | 'approved' | 'denied'
   reviewedBy: text('reviewedBy'),

--- a/packages/server/src/shared/logger.ts
+++ b/packages/server/src/shared/logger.ts
@@ -47,7 +47,9 @@ function formatMeta(meta: Record<string, unknown>): string {
 }
 
 function log(level: LogLevel, first: LogArg, second?: string): void {
-  if (LEVELS[level] < currentLevel) return;
+  if (LEVELS[level] < currentLevel) {
+    return;
+  }
 
   const msg: string = typeof first === 'string' ? first : (second ?? '');
   const meta: Record<string, unknown> | undefined =
@@ -76,7 +78,9 @@ function log(level: LogLevel, first: LogArg, second?: string): void {
   const parts = [`${color}${LABELS[level]}${C.reset}`, msg];
   if (meta) {
     const metaStr = formatMeta(meta);
-    if (metaStr) parts.push(metaStr);
+    if (metaStr) {
+      parts.push(metaStr);
+    }
   }
 
   if (level === 'error' || level === 'fatal') {

--- a/packages/server/src/shared/types.ts
+++ b/packages/server/src/shared/types.ts
@@ -312,14 +312,14 @@ export interface SongRequestPlaylist {
     name: string;
     videoCount: number;
     thumbnailUrl?: string | null;
-    videos?: Array<{
+    videos?: {
       id: string;
       title: string;
       duration: number;
       thumbnailUrl?: string | null;
       artist?: string | null;
       artworkUrl?: string | null;
-    }>;
+    }[];
   } | null;
   status: 'pending' | 'approved' | 'denied';
   reviewedBy: string | null;

--- a/packages/server/src/utils/nodelink.ts
+++ b/packages/server/src/utils/nodelink.ts
@@ -35,7 +35,9 @@ const NODELINK_AUTH = 'nodelink-internal';
 
 function nodeLinkHeaders(): Record<string, string> {
   const h: Record<string, string> = { 'Content-Type': 'application/json' };
-  if (NODELINK_AUTH) h.Authorization = NODELINK_AUTH;
+  if (NODELINK_AUTH) {
+    h.Authorization = NODELINK_AUTH;
+  }
   return h;
 }
 
@@ -178,7 +180,9 @@ let _enabledSourcesLoaded = false;
 const ALL_SOURCE_KEYS = Object.keys(SOURCE_DEFINITIONS);
 
 function getEnabledSourcesSync(): string[] {
-  if (_cachedEnabledSources) return _cachedEnabledSources;
+  if (_cachedEnabledSources) {
+    return _cachedEnabledSources;
+  }
   return ALL_SOURCE_KEYS;
 }
 
@@ -189,7 +193,9 @@ export function getEnabledSourceDisplayNames(): string[] {
 }
 
 export function initEnabledSources(): void {
-  if (_enabledSourcesLoaded) return;
+  if (_enabledSourcesLoaded) {
+    return;
+  }
   try {
     const row = db
       .select({ enabledSources: tables.guildSettings.enabledSources })
@@ -218,7 +224,9 @@ function parseEnabledSourcesEnv(): string[] {
       .map((s) => s.trim().toLowerCase())
       .filter(Boolean);
     const valid = keys.filter((k) => SOURCE_DEFINITIONS[k]);
-    if (valid.length > 0) return valid;
+    if (valid.length > 0) {
+      return valid;
+    }
   }
   return ALL_SOURCE_KEYS;
 }
@@ -234,11 +242,15 @@ export function refreshEnabledSources(sources: string): void {
 export function isValidSourceUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return false;
+    }
     const enabled = getEnabledSourcesSync();
     return enabled.some((key) => {
       const def = SOURCE_DEFINITIONS[key];
-      if (!def) return false;
+      if (!def) {
+        return false;
+      }
       return def.hosts.some(
         (host) => parsed.hostname === host || parsed.hostname.endsWith(`.${host}`)
       );
@@ -249,7 +261,9 @@ export function isValidSourceUrl(url: string): boolean {
 }
 
 export function isPlaylistUrl(url: string): boolean {
-  if (!isValidSourceUrl(url)) return false;
+  if (!isValidSourceUrl(url)) {
+    return false;
+  }
   try {
     const parsed = new URL(url);
     const enabled = getEnabledSourcesSync();
@@ -268,7 +282,9 @@ function resolveThumbnail(info: TrackInfo['info']): string {
   const sourceName = info?.sourceName;
 
   // Prefer artworkUrl from NodeLink when available (SoundCloud, Bandcamp, etc.)
-  if (artworkUrl) return artworkUrl;
+  if (artworkUrl) {
+    return artworkUrl;
+  }
 
   // Fall back to YouTube thumbnail for YouTube identifiers
   if (sourceName === 'youtube' && identifier) {
@@ -285,7 +301,9 @@ async function loadTrack(url: string): Promise<LoadTrackResponse> {
   loadUrl.searchParams.set('identifier', url);
 
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-  if (NODELINK_AUTH) headers.Authorization = NODELINK_AUTH;
+  if (NODELINK_AUTH) {
+    headers.Authorization = NODELINK_AUTH;
+  }
   const response = await fetch(loadUrl, { method: 'GET', headers });
 
   if (!response.ok) {
@@ -307,7 +325,9 @@ export async function getMetadata(url: string): Promise<SongMetadata> {
   // first track so single-song URLs with playlist parameters still work.
   if (!data?.encoded && !data?.info && data?.tracks?.length) {
     const first = data.tracks[0];
-    if (!first?.info) throw new Error('NodeLink returned no track data');
+    if (!first?.info) {
+      throw new Error('NodeLink returned no track data');
+    }
     const info = first.info;
     const sourceId = info.identifier ?? '';
     const title = info.title ?? 'Unknown';
@@ -357,7 +377,9 @@ export async function getStreamFormat(
   // extract the first track from the embedded tracks array.
   if (!data?.encoded && data?.tracks?.length) {
     const first = data.tracks[0];
-    if (!first?.encoded) throw new Error('NodeLink returned no track');
+    if (!first?.encoded) {
+      throw new Error('NodeLink returned no track');
+    }
     return { track: first.encoded, isWebmOpus: true };
   }
 

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -14,7 +14,7 @@ import { updateRateLimit } from '../hooks/useRateLimit';
 const TIMEOUT_MS = 10_000;
 
 // Map URL path prefixes to server-side rate limit bucket names.
-const RATE_LIMIT_BUCKETS: Array<[prefix: string, bucket: string]> = [
+const RATE_LIMIT_BUCKETS: [prefix: string, bucket: string][] = [
   ['/api/player', 'player-mutations'],
   ['/api/songs', 'songs-mutations'],
   ['/api/playlists', 'playlists-mutations'],
@@ -24,10 +24,14 @@ function extractRateLimit(url: string, headers: Headers): void {
   const limit = headers.get('X-RateLimit-Limit');
   const remaining = headers.get('X-RateLimit-Remaining');
   const reset = headers.get('X-RateLimit-Reset');
-  if (limit === null || remaining === null || reset === null) return;
+  if (limit === null || remaining === null || reset === null) {
+    return;
+  }
 
   const bucket = RATE_LIMIT_BUCKETS.find(([prefix]) => url.startsWith(prefix))?.[1];
-  if (!bucket) return;
+  if (!bucket) {
+    return;
+  }
 
   updateRateLimit(bucket, Number(limit), Number(remaining), Number(reset));
 }
@@ -50,10 +54,10 @@ async function fetchWithTimeout(url: string, init?: RequestInit): Promise<Respon
 // the same refresh promise rather than triggering multiple refresh calls.
 // ---------------------------------------------------------------------------
 let isRefreshing = false;
-let failedQueue: Array<{
+let failedQueue: {
   resolve: () => void;
   reject: (error: unknown) => void;
-}> = [];
+}[] = [];
 
 // Separate flag so trySilentRefresh doesn't interfere with wrappedFetch's refresh
 let isSilentRefreshing = false;
@@ -84,7 +88,9 @@ async function refreshToken(): Promise<RefreshResult> {
       method: 'POST',
       credentials: 'include',
     });
-    if (res.ok) return { ok: true };
+    if (res.ok) {
+      return { ok: true };
+    }
     // 503 = Discord temporarily unreachable, old token still valid → retryable.
     // 401 = token permanently invalid (expired / revoked).
     return { ok: false, retryable: res.status === 503 };

--- a/packages/web/src/components/AddFilterPopover.tsx
+++ b/packages/web/src/components/AddFilterPopover.tsx
@@ -51,8 +51,12 @@ export default function AddFilterPopover({
   const sortedTags = [...allTags].sort((a, b) => {
     const aActive = activeTags.includes(a.nameLower);
     const bActive = activeTags.includes(b.nameLower);
-    if (aActive && !bActive) return -1;
-    if (!aActive && bActive) return 1;
+    if (aActive && !bActive) {
+      return -1;
+    }
+    if (!aActive && bActive) {
+      return 1;
+    }
     return a.canonicalName.localeCompare(b.canonicalName);
   });
 

--- a/packages/web/src/components/AddSongModal.tsx
+++ b/packages/web/src/components/AddSongModal.tsx
@@ -61,7 +61,9 @@ export default function AddSongModal({
   }, [successMsg, onClose]);
 
   const handleFetch = async () => {
-    if (!url.trim()) return;
+    if (!url.trim()) {
+      return;
+    }
     setLoading(true);
     setError('');
 
@@ -91,7 +93,9 @@ export default function AddSongModal({
   };
 
   const handleImportPlaylist = async () => {
-    if (!url.trim()) return;
+    if (!url.trim()) {
+      return;
+    }
     setLoading(true);
     setError('');
     setSuccessMsg('');
@@ -118,7 +122,9 @@ export default function AddSongModal({
   };
 
   const handleSubmit = async () => {
-    if (!url.trim()) return;
+    if (!url.trim()) {
+      return;
+    }
     setLoading(true);
     setError('');
     setSuccessMsg('');
@@ -160,14 +166,19 @@ export default function AddSongModal({
       void handleFetch();
     }
     if (e.key === 'Escape') {
-      if (step === 'metadata') setStep('url');
-      else onClose();
+      if (step === 'metadata') {
+        setStep('url');
+      } else {
+        onClose();
+      }
     }
   };
 
   const addTag = () => {
     const trimmed = tagInput.trim();
-    if (!trimmed || tags.includes(trimmed)) return;
+    if (!trimmed || tags.includes(trimmed)) {
+      return;
+    }
     setTags((prev) => [...prev, trimmed]);
     setTagInput('');
   };
@@ -381,7 +392,9 @@ export default function AddSongModal({
                   value={volumeBoost}
                   onChange={(e) => {
                     const v = e.target.value;
-                    if (v === '' || /^-?\d*$/.test(v)) setVolumeBoost(v);
+                    if (v === '' || /^-?\d*$/.test(v)) {
+                      setVolumeBoost(v);
+                    }
                   }}
                   onBlur={() => {
                     if (volumeBoost.trim() === '' || volumeBoost === '-') {
@@ -486,7 +499,9 @@ function Field({
 }
 
 function formatSeconds(totalSeconds: number): string {
-  if (!Number.isFinite(totalSeconds) || totalSeconds < 0) return '0:00';
+  if (!Number.isFinite(totalSeconds) || totalSeconds < 0) {
+    return '0:00';
+  }
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = Math.floor(totalSeconds % 60);
   return `${minutes}:${seconds.toString().padStart(2, '0')}`;

--- a/packages/web/src/components/AddSongsModal.tsx
+++ b/packages/web/src/components/AddSongsModal.tsx
@@ -60,15 +60,21 @@ export default function AddSongsModal({
 
   // Debounce search input
   useEffect(() => {
-    if (timerRef.current) clearTimeout(timerRef.current);
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
     timerRef.current = setTimeout(() => setDebouncedSearch(search), 200);
     return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
     };
   }, [search]);
 
   const loadMore = useCallback(() => {
-    if (!hasMoreRef.current || loadingMoreRef.current) return;
+    if (!hasMoreRef.current || loadingMoreRef.current) {
+      return;
+    }
     loadingMoreRef.current = true;
     setLoadingMore(true);
     const nextPage = pageRef.current + 1;
@@ -89,7 +95,9 @@ export default function AddSongsModal({
   // Check near-bottom on scroll
   useEffect(() => {
     const el = scrollRef.current;
-    if (!el) return;
+    if (!el) {
+      return;
+    }
     const check = () => {
       if (el.scrollHeight - el.scrollTop - el.clientHeight < 300) {
         loadMore();
@@ -162,7 +170,9 @@ export default function AddSongsModal({
             >
               {virtualizer.getVirtualItems().map((virtualRow) => {
                 const song = songs[virtualRow.index];
-                if (song == null) return null;
+                if (song == null) {
+                  return null;
+                }
                 const isAdded = added.has(song.id);
                 const isAdding = adding.has(song.id);
                 return (

--- a/packages/web/src/components/AnimatedOutlet.tsx
+++ b/packages/web/src/components/AnimatedOutlet.tsx
@@ -14,7 +14,9 @@ export function AnimatedOutlet() {
   const outlet = useOutlet();
   const location = useLocation();
 
-  if (!outlet) return null;
+  if (!outlet) {
+    return null;
+  }
 
   return (
     <AnimatePresence mode='wait'>

--- a/packages/web/src/components/Backdrop.tsx
+++ b/packages/web/src/components/Backdrop.tsx
@@ -11,10 +11,14 @@ export function Backdrop({
     <div
       className='fixed inset-0 z-50 bg-black/70 flex items-center justify-center p-4 cursor-default'
       onMouseDown={(e) => {
-        if (e.target === e.currentTarget) onClose();
+        if (e.target === e.currentTarget) {
+          onClose();
+        }
       }}
       onKeyDown={(e) => {
-        if (e.key === 'Escape') onClose();
+        if (e.key === 'Escape') {
+          onClose();
+        }
       }}
       role='presentation'
     >

--- a/packages/web/src/components/BulkEditModal.tsx
+++ b/packages/web/src/components/BulkEditModal.tsx
@@ -14,9 +14,9 @@ interface BulkEditModalProps {
   isApplying?: boolean;
 }
 
-type EditableField = Extract<keyof BulkEditData, string>;
+type TextEditableField = 'nickname' | 'artist' | 'album' | 'artwork';
 
-const EDITABLE_FIELDS: { key: EditableField; label: string; placeholder: string }[] = [
+const EDITABLE_FIELDS: { key: TextEditableField; label: string; placeholder: string }[] = [
   { key: 'nickname', label: 'Nickname', placeholder: 'Custom display name' },
   { key: 'artist', label: 'Artist', placeholder: 'Artist name' },
   { key: 'album', label: 'Album', placeholder: 'Album name' },
@@ -44,7 +44,9 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
 
   // Close tag dropdown when clicking outside
   useEffect(() => {
-    if (!showDropdown) return;
+    if (!showDropdown) {
+      return;
+    }
     const handler = (e: MouseEvent) => {
       const target = e.target as Node;
       if (
@@ -87,7 +89,9 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
 
   const addTag = useCallback(() => {
     const trimmed = tagInput.trim().toLowerCase();
-    if (!trimmed || tags.includes(trimmed)) return;
+    if (!trimmed || tags.includes(trimmed)) {
+      return;
+    }
     setTags((prev) => [...prev, trimmed]);
     setTagInput('');
     setHighlightedIdx(0);
@@ -186,7 +190,9 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
       }
     }
 
-    if (!hasChanges) return;
+    if (!hasChanges) {
+      return;
+    }
 
     // Include clearFields for the backend
     if (clearFields.size > 0) {
@@ -411,7 +417,9 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
                   value={volumeBoost}
                   onChange={(e) => {
                     const v = e.target.value;
-                    if (v === '' || /^-?\d*$/.test(v)) setVolumeBoost(v);
+                    if (v === '' || /^-?\d*$/.test(v)) {
+                      setVolumeBoost(v);
+                    }
                   }}
                   onBlur={() => {
                     if (volumeBoost.trim() === '' || volumeBoost.trim() === '-') {

--- a/packages/web/src/components/ContextMenu.tsx
+++ b/packages/web/src/components/ContextMenu.tsx
@@ -142,17 +142,23 @@ export function ContextMenu({
 
   // Position calculation — useLayoutEffect runs before paint, preventing a (0,0) flash.
   useLayoutEffect(() => {
-    if (!isOpen || !triggerRef.current) return;
+    if (!isOpen || !triggerRef.current) {
+      return;
+    }
 
     const lastUpdateRef = { current: 0 };
 
     const updatePosition = () => {
       const now = Date.now();
-      if (now - lastUpdateRef.current < 16) return; // ~60fps throttle
+      if (now - lastUpdateRef.current < 16) {
+        return;
+      } // ~60fps throttle
       lastUpdateRef.current = now;
 
       const trigger = triggerRef.current;
-      if (!trigger) return;
+      if (!trigger) {
+        return;
+      }
 
       const rect = trigger.getBoundingClientRect();
       const menuWidth = 192; // min-w-48 = 12rem = 192px
@@ -165,7 +171,9 @@ export function ContextMenu({
       if (top + menuHeight > window.innerHeight - 8) {
         top = rect.top - menuHeight - 4;
       }
-      if (left < 8) left = 8;
+      if (left < 8) {
+        left = 8;
+      }
       if (left + menuWidth > window.innerWidth - 8) {
         left = window.innerWidth - menuWidth - 8;
       }
@@ -193,7 +201,9 @@ export function ContextMenu({
 
   // Close on outside click
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen) {
+      return;
+    }
 
     const handler = (e: MouseEvent | TouchEvent) => {
       const target = e.target as Node;
@@ -213,7 +223,9 @@ export function ContextMenu({
 
   // Close on Escape (or go back from submenu)
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen) {
+      return;
+    }
 
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -249,11 +261,15 @@ export function ContextMenu({
       const enabledIndices = items
         .map((item, i) => (!item.disabled ? i : -1))
         .filter((i) => i >= 0);
-      if (enabledIndices.length === 0) return;
+      if (enabledIndices.length === 0) {
+        return;
+      }
 
       const findNextEnabled = (current: number, direction: 1 | -1): number => {
         const pos = enabledIndices.indexOf(current);
-        if (pos === -1) return enabledIndices[0];
+        if (pos === -1) {
+          return enabledIndices[0];
+        }
         const nextPos = (pos + direction + enabledIndices.length) % enabledIndices.length;
         return enabledIndices[nextPos];
       };
@@ -272,7 +288,9 @@ export function ContextMenu({
     [onClose, triggerRef]
   );
 
-  if (!isOpen) return null;
+  if (!isOpen) {
+    return null;
+  }
 
   return createPortal(
     <div

--- a/packages/web/src/components/ContextMenu/EditSubmenuPanel.tsx
+++ b/packages/web/src/components/ContextMenu/EditSubmenuPanel.tsx
@@ -39,8 +39,12 @@ export function EditSubmenuPanel({ config, onBack, onSave }: EditSubmenuPanelPro
           onChange={(e) => config.onChange(e.target.value)}
           onKeyDown={(e) => {
             e.stopPropagation();
-            if (e.key === 'Enter') onSave();
-            if (e.key === 'Escape') onBack();
+            if (e.key === 'Enter') {
+              onSave();
+            }
+            if (e.key === 'Escape') {
+              onBack();
+            }
           }}
           disabled={config.saving}
           placeholder={config.placeholder ?? 'Enter value...'}

--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -30,7 +30,9 @@ function LayoutContent() {
   const [collapsed, setCollapsed] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = localStorage.getItem('alfira-sidebar-collapsed');
-      if (stored !== null) return stored === 'true';
+      if (stored !== null) {
+        return stored === 'true';
+      }
     }
     return false;
   });

--- a/packages/web/src/components/ListToolbar.tsx
+++ b/packages/web/src/components/ListToolbar.tsx
@@ -98,7 +98,9 @@ export default function ListToolbar({
   const handleSearchInputChange = useCallback(
     (next: string) => {
       setSearchInput(next);
-      if (debounceRef.current) clearTimeout(debounceRef.current);
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
       debounceRef.current = setTimeout(() => {
         onSearchChange(next);
       }, 250);
@@ -112,7 +114,9 @@ export default function ListToolbar({
 
   // Close dropdown on outside click
   useEffect(() => {
-    if (!sortOpen) return;
+    if (!sortOpen) {
+      return;
+    }
     const handler = (e: MouseEvent) => {
       if (sortRef.current && !sortRef.current.contains(e.target as Node)) {
         setSortOpen(false);

--- a/packages/web/src/components/MobileNav.tsx
+++ b/packages/web/src/components/MobileNav.tsx
@@ -23,10 +23,14 @@ export default function MobileNav() {
 
   // Close drawer on escape key
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen) {
+      return;
+    }
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setIsOpen(false);
+      if (e.key === 'Escape') {
+        setIsOpen(false);
+      }
     };
 
     document.addEventListener('keydown', handleKeyDown);
@@ -47,7 +51,9 @@ export default function MobileNav() {
 
   // Close drawer when clicking outside
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen) {
+      return;
+    }
 
     const handleClickOutside = (e: MouseEvent) => {
       if (drawerRef.current && !drawerRef.current.contains(e.target as Node)) {
@@ -117,7 +123,9 @@ export default function MobileNav() {
             className='bg-black/60 backdrop-blur-sm absolute inset-0'
             onClick={() => setIsOpen(false)}
             onKeyDown={(e) => {
-              if (e.key === 'Escape' || e.key === 'Enter') setIsOpen(false);
+              if (e.key === 'Escape' || e.key === 'Enter') {
+                setIsOpen(false);
+              }
             }}
           />
         </SpringUp>

--- a/packages/web/src/components/NowPlayingBar.tsx
+++ b/packages/web/src/components/NowPlayingBar.tsx
@@ -228,13 +228,19 @@ const Scrubber = memo(function Scrubber({
   // Bypasses React + rAF entirely — immediate, jank-free visual feedback.
   const seekElements = useCallback((trackPct: number) => {
     const pctStr = `${trackPct * 100}%`;
-    if (fillRef.current) fillRef.current.style.width = pctStr;
-    if (thumbRef.current) thumbRef.current.style.left = pctStr;
+    if (fillRef.current) {
+      fillRef.current.style.width = pctStr;
+    }
+    if (thumbRef.current) {
+      thumbRef.current.style.left = pctStr;
+    }
   }, []);
 
   const handlePointerMove = useCallback(
     (e: PointerEvent) => {
-      if (!isDraggingRef.current || !trackRef.current) return;
+      if (!isDraggingRef.current || !trackRef.current) {
+        return;
+      }
       const rect = trackRef.current.getBoundingClientRect();
       const trackPct = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
       const seekSec = Math.round(trackPct * duration);
@@ -246,7 +252,9 @@ const Scrubber = memo(function Scrubber({
   );
 
   const handlePointerUp = useCallback(() => {
-    if (!isDraggingRef.current) return;
+    if (!isDraggingRef.current) {
+      return;
+    }
     isDraggingRef.current = false;
     document.removeEventListener('pointermove', handlePointerMove);
     document.removeEventListener('pointerup', handlePointerUp);
@@ -257,7 +265,9 @@ const Scrubber = memo(function Scrubber({
 
   const handlePointerDown = useCallback(
     (e: React.PointerEvent) => {
-      if (!isSeekable) return;
+      if (!isSeekable) {
+        return;
+      }
       e.currentTarget.setPointerCapture(e.pointerId);
       isDraggingRef.current = true;
       if (trackRef.current) {
@@ -306,7 +316,9 @@ const Scrubber = memo(function Scrubber({
       <div
         ref={(ref) => {
           thumbRef.current = ref;
-          if (ref) registerThumb(ref);
+          if (ref) {
+            registerThumb(ref);
+          }
         }}
         className='scrubber-thumb absolute top-1/2 -translate-y-1/2 w-3.5 h-3.5 rounded-full bg-surface border-2 border-accent opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity'
       />
@@ -499,8 +511,11 @@ export function NowPlayingBar() {
   );
   const { busy: shuffleBusy, handler: handleShuffleToggle } = useMutationHandler(
     useCallback(async () => {
-      if (isShuffled) await unshuffle();
-      else await shuffle();
+      if (isShuffled) {
+        await unshuffle();
+      } else {
+        await shuffle();
+      }
     }, [isShuffled, shuffle, unshuffle]),
     'Could not toggle shuffle.'
   );

--- a/packages/web/src/components/PlaylistRow.tsx
+++ b/packages/web/src/components/PlaylistRow.tsx
@@ -13,7 +13,9 @@ interface PlaylistRowProps {
 
 /** Fill an array of artwork URLs to exactly 4 slots, repeating as needed. */
 function spreadUrls(urls: string[]): (string | null)[] {
-  if (urls.length === 0) return [null, null, null, null];
+  if (urls.length === 0) {
+    return [null, null, null, null];
+  }
   const result: (string | null)[] = [];
   for (let i = 0; i < 4; i++) {
     result.push(urls[i % urls.length] ?? null);

--- a/packages/web/src/components/ProtectedRoute.tsx
+++ b/packages/web/src/components/ProtectedRoute.tsx
@@ -18,7 +18,9 @@ export default function ProtectedRoute({ children }: { children: React.ReactNode
     );
   }
 
-  if (!user) return <Navigate to='/login' replace />;
+  if (!user) {
+    return <Navigate to='/login' replace />;
+  }
 
   // During first-run setup, lock all routes except /setup.
   if (user.isSetupAdmin && location.pathname !== '/setup') {

--- a/packages/web/src/components/QueuePanel.tsx
+++ b/packages/web/src/components/QueuePanel.tsx
@@ -170,7 +170,9 @@ export default function QueuePanel({
   const handleMoveUp = useCallback(
     (targetQueue: QueuedSong[], songId: string, target: 'queue' | 'priority') => {
       const idx = targetQueue.findIndex((s) => s.id === songId);
-      if (idx <= 0) return;
+      if (idx <= 0) {
+        return;
+      }
       const newOrder = [...targetQueue];
       const a = newOrder[idx];
       const b = newOrder[idx - 1];
@@ -189,7 +191,9 @@ export default function QueuePanel({
   const handleMoveDown = useCallback(
     (targetQueue: QueuedSong[], songId: string, target: 'queue' | 'priority') => {
       const idx = targetQueue.findIndex((s) => s.id === songId);
-      if (idx < 0 || idx >= targetQueue.length - 1) return;
+      if (idx < 0 || idx >= targetQueue.length - 1) {
+        return;
+      }
       const newOrder = [...targetQueue];
       const a = newOrder[idx];
       const b = newOrder[idx + 1];
@@ -208,10 +212,14 @@ export default function QueuePanel({
   const handleMoveToTop = useCallback(
     (targetQueue: QueuedSong[], songId: string, target: 'queue' | 'priority') => {
       const idx = targetQueue.findIndex((s) => s.id === songId);
-      if (idx <= 0) return;
+      if (idx <= 0) {
+        return;
+      }
       const newOrder = [...targetQueue];
       const [item] = newOrder.splice(idx, 1);
-      if (item) newOrder.unshift(item);
+      if (item) {
+        newOrder.unshift(item);
+      }
       void reorderQueue(
         newOrder.map((s) => s.id),
         target
@@ -223,10 +231,14 @@ export default function QueuePanel({
   const handleMoveToBottom = useCallback(
     (targetQueue: QueuedSong[], songId: string, target: 'queue' | 'priority') => {
       const idx = targetQueue.findIndex((s) => s.id === songId);
-      if (idx < 0 || idx >= targetQueue.length - 1) return;
+      if (idx < 0 || idx >= targetQueue.length - 1) {
+        return;
+      }
       const newOrder = [...targetQueue];
       const [item] = newOrder.splice(idx, 1);
-      if (item) newOrder.push(item);
+      if (item) {
+        newOrder.push(item);
+      }
       void reorderQueue(
         newOrder.map((s) => s.id),
         target
@@ -357,7 +369,9 @@ export default function QueuePanel({
           >
             {virtualizer.getVirtualItems().map((virtualRow) => {
               const item = virtualItems[virtualRow.index];
-              if (item == null) return null;
+              if (item == null) {
+                return null;
+              }
 
               if (item.type === 'header') {
                 return (
@@ -520,7 +534,9 @@ const QueueSongItem = memo(function QueueSongItem({
   const isLast = index >= targetQueue.length - 1;
 
   const menuItems: MenuItem[] = useMemo(() => {
-    if (!canManage) return [];
+    if (!canManage) {
+      return [];
+    }
     const items: MenuItem[] = [];
 
     // Remove — always available

--- a/packages/web/src/components/SongCard.tsx
+++ b/packages/web/src/components/SongCard.tsx
@@ -230,7 +230,9 @@ const SongCardInner = ({
         onKeyDown={(e) => {
           if ((e.key === 'Enter' || e.key === ' ') && !selectionMode) {
             e.preventDefault();
-            if (canEdit) setOpenSongId(isOpen ? null : song.id);
+            if (canEdit) {
+              setOpenSongId(isOpen ? null : song.id);
+            }
           }
         }}
         style={canEdit || selectionMode ? { cursor: 'pointer' } : undefined}

--- a/packages/web/src/components/SongEditPanel.tsx
+++ b/packages/web/src/components/SongEditPanel.tsx
@@ -84,7 +84,9 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
 
   const addTag = useCallback(() => {
     const trimmed = tagInput.trim();
-    if (!trimmed || tags.includes(trimmed)) return;
+    if (!trimmed || tags.includes(trimmed)) {
+      return;
+    }
     setTags((prev) => [...prev, trimmed]);
     setTagInput('');
   }, [tagInput, tags]);
@@ -105,8 +107,11 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
         e.preventDefault();
         if (showTagDropdown && highlightedIndex >= 0 && filteredTags[highlightedIndex]) {
           const tag = filteredTags[highlightedIndex];
-          if (tags.includes(tag.canonicalName)) removeTag(tag.canonicalName);
-          else setTags((prev) => [...prev, tag.canonicalName]);
+          if (tags.includes(tag.canonicalName)) {
+            removeTag(tag.canonicalName);
+          } else {
+            setTags((prev) => [...prev, tag.canonicalName]);
+          }
           setTagInput('');
           setHighlightedIndex(-1);
         } else {
@@ -133,7 +138,9 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
   );
 
   const doSave = useCallback(async () => {
-    if (savingRef.current) return;
+    if (savingRef.current) {
+      return;
+    }
     savingRef.current = true;
     try {
       const {
@@ -151,12 +158,24 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
       // Build a partial update — only include fields that actually changed.
       // This prevents concurrent edits from clobbering each other (last-write-wins).
       const data: SongUpdateData = {};
-      if (nk !== (originalNicknameRef.current ?? '')) data.nickname = nk.trim() || null;
-      if (ar !== (originalArtistRef.current ?? '')) data.artist = ar.trim() || null;
-      if (al !== (originalAlbumRef.current ?? '')) data.album = al.trim() || null;
-      if (aw !== (originalArtworkRef.current ?? '')) data.artwork = aw.trim() || null;
-      if (JSON.stringify(t) !== JSON.stringify(originalTagsRef.current)) data.tags = t;
-      if (parsedBoost !== originalVolumeBoostRef.current) data.volumeBoost = parsedBoost;
+      if (nk !== (originalNicknameRef.current ?? '')) {
+        data.nickname = nk.trim() || null;
+      }
+      if (ar !== (originalArtistRef.current ?? '')) {
+        data.artist = ar.trim() || null;
+      }
+      if (al !== (originalAlbumRef.current ?? '')) {
+        data.album = al.trim() || null;
+      }
+      if (aw !== (originalArtworkRef.current ?? '')) {
+        data.artwork = aw.trim() || null;
+      }
+      if (JSON.stringify(t) !== JSON.stringify(originalTagsRef.current)) {
+        data.tags = t;
+      }
+      if (parsedBoost !== originalVolumeBoostRef.current) {
+        data.volumeBoost = parsedBoost;
+      }
 
       // Skip if nothing changed
       if (Object.keys(data).length === 0) {
@@ -187,12 +206,24 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
         parsedRaw != null && !Number.isNaN(parsedRaw) && parsedRaw !== 0 ? parsedRaw : null;
 
       const data: SongUpdateData = {};
-      if (nk !== (originalNicknameRef.current ?? '')) data.nickname = nk.trim() || null;
-      if (ar !== (originalArtistRef.current ?? '')) data.artist = ar.trim() || null;
-      if (al !== (originalAlbumRef.current ?? '')) data.album = al.trim() || null;
-      if (aw !== (originalArtworkRef.current ?? '')) data.artwork = aw.trim() || null;
-      if (JSON.stringify(t) !== JSON.stringify(originalTagsRef.current)) data.tags = t;
-      if (parsedBoost !== originalVolumeBoostRef.current) data.volumeBoost = parsedBoost;
+      if (nk !== (originalNicknameRef.current ?? '')) {
+        data.nickname = nk.trim() || null;
+      }
+      if (ar !== (originalArtistRef.current ?? '')) {
+        data.artist = ar.trim() || null;
+      }
+      if (al !== (originalAlbumRef.current ?? '')) {
+        data.album = al.trim() || null;
+      }
+      if (aw !== (originalArtworkRef.current ?? '')) {
+        data.artwork = aw.trim() || null;
+      }
+      if (JSON.stringify(t) !== JSON.stringify(originalTagsRef.current)) {
+        data.tags = t;
+      }
+      if (parsedBoost !== originalVolumeBoostRef.current) {
+        data.volumeBoost = parsedBoost;
+      }
 
       if (Object.keys(data).length > 0) {
         void doSave();
@@ -200,7 +231,9 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
     }
   }, [isOpen, doSave]);
 
-  if (!isOpen && !closing) return null;
+  if (!isOpen && !closing) {
+    return null;
+  }
 
   return (
     <div
@@ -219,7 +252,9 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
             inputRef={inputRef}
             placeholder={song.title}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') void doSave();
+              if (e.key === 'Enter') {
+                void doSave();
+              }
             }}
           />
           <Field
@@ -229,7 +264,9 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
             onChange={setArtist}
             placeholder='Artist name'
             onKeyDown={(e) => {
-              if (e.key === 'Enter') void doSave();
+              if (e.key === 'Enter') {
+                void doSave();
+              }
             }}
           />
           <Field
@@ -239,7 +276,9 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
             onChange={setAlbum}
             placeholder='Album name'
             onKeyDown={(e) => {
-              if (e.key === 'Enter') void doSave();
+              if (e.key === 'Enter') {
+                void doSave();
+              }
             }}
           />
           <Field
@@ -249,7 +288,9 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
             onChange={setArtwork}
             placeholder={song.thumbnailUrl}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') void doSave();
+              if (e.key === 'Enter') {
+                void doSave();
+              }
             }}
           />
 
@@ -309,8 +350,9 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
                   tags={tags}
                   highlightedIndex={highlightedIndex}
                   onToggle={(tag) => {
-                    if (tags.includes(tag)) removeTag(tag);
-                    else {
+                    if (tags.includes(tag)) {
+                      removeTag(tag);
+                    } else {
                       flushSync(() => setTags((prev) => [...prev, tag]));
                     }
                   }}
@@ -332,7 +374,9 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
             min={-100}
             max={200}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') void doSave();
+              if (e.key === 'Enter') {
+                void doSave();
+              }
             }}
           />
         </div>
@@ -368,7 +412,9 @@ function VolumeSlider({
           value={value}
           onChange={(e) => {
             const v = e.target.value;
-            if (v === '' || /^\d*$/.test(v)) onChange(v);
+            if (v === '' || /^\d*$/.test(v)) {
+              onChange(v);
+            }
           }}
           onKeyDown={onKeyDown}
           onBlur={() => {
@@ -512,9 +558,13 @@ function TagDropdown({
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
-    if (!dropdownRef.current) return;
+    if (!dropdownRef.current) {
+      return;
+    }
     const input = tagInputRef.current;
-    if (!input) return;
+    if (!input) {
+      return;
+    }
     const rect = input.getBoundingClientRect();
     dropdownRef.current.style.top = `${rect.bottom + window.scrollY + 4}px`;
     dropdownRef.current.style.left = `${rect.left + window.scrollX}px`;

--- a/packages/web/src/components/SourceIcons.tsx
+++ b/packages/web/src/components/SourceIcons.tsx
@@ -193,6 +193,8 @@ const SOURCE_ICONS: Record<string, React.FC<IconProps>> = {
 
 export function SourceIcon({ sourceKey, ...props }: IconProps & { sourceKey: string }) {
   const Icon = SOURCE_ICONS[sourceKey];
-  if (!Icon) return null;
+  if (!Icon) {
+    return null;
+  }
   return <Icon {...props} />;
 }

--- a/packages/web/src/components/TagTicker.tsx
+++ b/packages/web/src/components/TagTicker.tsx
@@ -56,7 +56,9 @@ const TagTicker = memo(({ tags, isHovered: externalHovered }: TagTickerProps) =>
 
   // Smooth return on de-hover: pause animation at current position, then transition back to 0
   useLayoutEffect(() => {
-    if (!shouldScroll) return;
+    if (!shouldScroll) {
+      return;
+    }
 
     const prev = prevHoveredRef.current;
     prevHoveredRef.current = effectiveHovered;
@@ -64,7 +66,9 @@ const TagTicker = memo(({ tags, isHovered: externalHovered }: TagTickerProps) =>
     if (prev && !effectiveHovered) {
       // De-hovered: capture paused position and transition back to start
       const el = innerRef.current;
-      if (!el) return;
+      if (!el) {
+        return;
+      }
 
       const computed = getComputedStyle(el);
       const matrix = new DOMMatrixReadOnly(computed.transform);
@@ -102,7 +106,9 @@ const TagTicker = memo(({ tags, isHovered: externalHovered }: TagTickerProps) =>
     }
   }, [effectiveHovered, shouldScroll]);
 
-  if (dedupedTags.length === 0) return null;
+  if (dedupedTags.length === 0) {
+    return null;
+  }
 
   const animationStyle: React.CSSProperties = shouldScroll
     ? {
@@ -126,10 +132,14 @@ const TagTicker = memo(({ tags, isHovered: externalHovered }: TagTickerProps) =>
         }),
       }}
       onMouseEnter={() => {
-        if (externalHovered === undefined) setIsHovered(true);
+        if (externalHovered === undefined) {
+          setIsHovered(true);
+        }
       }}
       onMouseLeave={() => {
-        if (externalHovered === undefined) setIsHovered(false);
+        if (externalHovered === undefined) {
+          setIsHovered(false);
+        }
       }}
     >
       <div className='flex gap-1' ref={innerRef} style={animationStyle}>

--- a/packages/web/src/components/UserMenu.tsx
+++ b/packages/web/src/components/UserMenu.tsx
@@ -17,7 +17,9 @@ export default function UserMenu({ user, collapsed, onLogout }: UserMenuProps) {
 
   // Position the popover above the trigger, falling back to below if needed
   const updatePosition = useCallback(() => {
-    if (!triggerRef.current || !menuRef.current) return;
+    if (!triggerRef.current || !menuRef.current) {
+      return;
+    }
     const trigger = triggerRef.current.getBoundingClientRect();
     const menu = menuRef.current.getBoundingClientRect();
     const gap = 8;
@@ -34,7 +36,9 @@ export default function UserMenu({ user, collapsed, onLogout }: UserMenuProps) {
     }
 
     let left = trigger.left + trigger.width / 2 - menu.width / 2;
-    if (left < gap) left = gap;
+    if (left < gap) {
+      left = gap;
+    }
     if (left + menu.width > window.innerWidth - gap) {
       left = window.innerWidth - menu.width - gap;
     }
@@ -44,7 +48,9 @@ export default function UserMenu({ user, collapsed, onLogout }: UserMenuProps) {
 
   // Position before paint (useLayoutEffect) to avoid a (0,0) flash.
   useLayoutEffect(() => {
-    if (!open) return;
+    if (!open) {
+      return;
+    }
     updatePosition();
     window.addEventListener('resize', updatePosition);
     window.addEventListener('scroll', updatePosition, true);
@@ -56,10 +62,14 @@ export default function UserMenu({ user, collapsed, onLogout }: UserMenuProps) {
 
   // Close on click outside
   useEffect(() => {
-    if (!open) return;
+    if (!open) {
+      return;
+    }
     const handler = (e: MouseEvent | TouchEvent) => {
       const target = e.target as Node;
-      if (menuRef.current?.contains(target) || triggerRef.current?.contains(target)) return;
+      if (menuRef.current?.contains(target) || triggerRef.current?.contains(target)) {
+        return;
+      }
       setOpen(false);
     };
     document.addEventListener('mousedown', handler);
@@ -72,7 +82,9 @@ export default function UserMenu({ user, collapsed, onLogout }: UserMenuProps) {
 
   // Close on Escape
   useEffect(() => {
-    if (!open) return;
+    if (!open) {
+      return;
+    }
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         setOpen(false);

--- a/packages/web/src/components/VirtualList.tsx
+++ b/packages/web/src/components/VirtualList.tsx
@@ -84,7 +84,9 @@ function VirtualListInner<T>({
   const virtualizer = useVirtualizer({
     count: totalCount,
     getItemKey: (i: number) => {
-      if (i >= itemsRef.current.length) return '__loader__';
+      if (i >= itemsRef.current.length) {
+        return '__loader__';
+      }
       const item = itemsRef.current[i];
       return item != null ? getItemKeyRef.current(item, i) : `__missing__${i}`;
     },
@@ -120,7 +122,9 @@ function VirtualListInner<T>({
   const showContent = !isLoading && hasLoaded && items.length > 0;
 
   useLayoutEffect(() => {
-    if (!containerRef.current) return;
+    if (!containerRef.current) {
+      return;
+    }
     containerRef.current.style.opacity = showContent || showEmpty || showSkeleton ? '1' : '0';
   }, [showContent, showEmpty, showSkeleton]);
 
@@ -199,7 +203,9 @@ function VirtualListInner<T>({
                 );
               }
 
-              if (!item) return null;
+              if (!item) {
+                return null;
+              }
 
               // Spacer to create visual gap between items — rendered inside
               // the fixed-height row so it doesn't affect measurement.

--- a/packages/web/src/components/VirtualSongList.tsx
+++ b/packages/web/src/components/VirtualSongList.tsx
@@ -108,7 +108,7 @@ export const VirtualSongList = memo(function VirtualSongList({
   const estimateSize = useCallback(
     (index: number) => {
       const song = items[index];
-      return song && song.id === effectiveOpenId ? EXPANDED_ROW_HEIGHT : COLLAPSED_ROW_HEIGHT;
+      return song?.id === effectiveOpenId ? EXPANDED_ROW_HEIGHT : COLLAPSED_ROW_HEIGHT;
     },
     [items, effectiveOpenId]
   );

--- a/packages/web/src/components/queue/OverrideModal.tsx
+++ b/packages/web/src/components/queue/OverrideModal.tsx
@@ -19,7 +19,9 @@ export default function OverrideModal({
   const [error, setError] = useState('');
 
   const handleSubmit = async () => {
-    if (!sourceUrl.trim()) return;
+    if (!sourceUrl.trim()) {
+      return;
+    }
     setSubmitting(true);
     setError('');
     try {

--- a/packages/web/src/components/queue/QuickAddModal.tsx
+++ b/packages/web/src/components/queue/QuickAddModal.tsx
@@ -22,7 +22,9 @@ export default function QuickAddModal({
   const [importFullPlaylist, setImportFullPlaylist] = useState(false);
 
   const handleSubmit = async () => {
-    if (!sourceUrl.trim()) return;
+    if (!sourceUrl.trim()) {
+      return;
+    }
     setSubmitting(true);
     setError('');
     setSuccessMsg('');

--- a/packages/web/src/components/settings/AdminSection.tsx
+++ b/packages/web/src/components/settings/AdminSection.tsx
@@ -57,7 +57,9 @@ export default function AdminSection() {
     async function load() {
       try {
         const settings = await fetchGeneralSettings();
-        if (cancelled) return;
+        if (cancelled) {
+          return;
+        }
         setSaved(settings);
         setAdminRoleIds(settings.adminRoleIds);
         setTimeoutMinutes(settings.voiceIdleTimeoutMinutes);
@@ -75,15 +77,21 @@ export default function AdminSection() {
             fetchSetupRoles(settings.guildId),
             fetchSetupChannels(settings.guildId),
           ]);
-          if (cancelled) return;
+          if (cancelled) {
+            return;
+          }
           setRoles(rolesRes.roles);
           setChannels(channelsRes.channels);
         }
       } catch {
-        if (cancelled) return;
+        if (cancelled) {
+          return;
+        }
         setError('Could not load settings.');
       } finally {
-        if (!cancelled) setLoaded(true);
+        if (!cancelled) {
+          setLoaded(true);
+        }
       }
     }
     void load();
@@ -135,7 +143,9 @@ export default function AdminSection() {
       .filter(Boolean);
     const set = new Set(current);
     if (set.has(id)) {
-      if (set.size === 1) return; // Last one — can't remove.
+      if (set.size === 1) {
+        return;
+      } // Last one — can't remove.
       set.delete(id);
     } else {
       set.add(id);
@@ -150,9 +160,14 @@ export default function AdminSection() {
         .map((s) => s.trim())
         .filter(Boolean)
     );
-    if (current.size === 1 && current.has(key)) return; // Last one — can't disable.
-    if (current.has(key)) current.delete(key);
-    else current.add(key);
+    if (current.size === 1 && current.has(key)) {
+      return;
+    } // Last one — can't disable.
+    if (current.has(key)) {
+      current.delete(key);
+    } else {
+      current.add(key);
+    }
     setEnabledSources([...current].join(','));
   }
 
@@ -163,7 +178,9 @@ export default function AdminSection() {
       .filter(Boolean)
   );
 
-  if (!loaded) return null;
+  if (!loaded) {
+    return null;
+  }
 
   return (
     <div className='space-y-6'>

--- a/packages/web/src/components/settings/CompressorSection.tsx
+++ b/packages/web/src/components/settings/CompressorSection.tsx
@@ -50,8 +50,11 @@ export default function CompressorSection() {
         setLoaded(true);
       }
     }
-    if (canManage) void load();
-    else setLoaded(true);
+    if (canManage) {
+      void load();
+    } else {
+      setLoaded(true);
+    }
   }, [canManage]);
 
   const hasChanges = JSON.stringify(values) !== JSON.stringify(savedValues);
@@ -84,7 +87,9 @@ export default function CompressorSection() {
 
   const dimmed = !canManage;
 
-  if (!loaded) return null;
+  if (!loaded) {
+    return null;
+  }
 
   return (
     <div className={`space-y-3 ${dimmed ? 'opacity-40 pointer-events-none' : ''}`}>

--- a/packages/web/src/components/settings/EqualizerSection.tsx
+++ b/packages/web/src/components/settings/EqualizerSection.tsx
@@ -53,8 +53,11 @@ export default function EqualizerSection() {
         setLoaded(true);
       }
     }
-    if (canManage) void load();
-    else setLoaded(true);
+    if (canManage) {
+      void load();
+    } else {
+      setLoaded(true);
+    }
   }, [canManage]);
 
   // When off, save sends flat bands; when on, save sends real bands
@@ -93,7 +96,9 @@ export default function EqualizerSection() {
 
   function gainDisplay(value: number): string {
     const offset = value - 50;
-    if (offset === 0) return '0';
+    if (offset === 0) {
+      return '0';
+    }
     return `${offset > 0 ? '+' : ''}${offset}`;
   }
 
@@ -116,7 +121,9 @@ export default function EqualizerSection() {
   const dimmed = !canManage;
   const slidersDimmed = !eqEnabled;
 
-  if (!loaded) return null;
+  if (!loaded) {
+    return null;
+  }
 
   return (
     <div className={`space-y-4 ${dimmed ? 'opacity-40 pointer-events-none' : ''}`}>

--- a/packages/web/src/components/ui/ArtworkImage.tsx
+++ b/packages/web/src/components/ui/ArtworkImage.tsx
@@ -17,7 +17,9 @@ export function ArtworkImage({
 }: ArtworkImageProps) {
   const [loaded, setLoaded] = useState(false);
 
-  if (!src) return null;
+  if (!src) {
+    return null;
+  }
 
   return (
     <div className={`relative ${className}`}>

--- a/packages/web/src/components/ui/RoleComboBox.tsx
+++ b/packages/web/src/components/ui/RoleComboBox.tsx
@@ -45,7 +45,9 @@ export default function RoleComboBox({
 
   // Click outside to close
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen) {
+      return;
+    }
     const handler = (e: MouseEvent) => {
       if (
         listRef.current &&

--- a/packages/web/src/components/ui/VolumeBoostBadge.tsx
+++ b/packages/web/src/components/ui/VolumeBoostBadge.tsx
@@ -10,7 +10,9 @@ export const VolumeBoostBadge = memo(function VolumeBoostBadge({
   volumeBoost,
   className = '',
 }: VolumeBoostBadgeProps) {
-  if (volumeBoost == null || volumeBoost === 0) return null;
+  if (volumeBoost == null || volumeBoost === 0) {
+    return null;
+  }
 
   const isBoost = volumeBoost > 0;
   return (

--- a/packages/web/src/context/AdminViewContext.tsx
+++ b/packages/web/src/context/AdminViewContext.tsx
@@ -51,6 +51,8 @@ export function AdminViewProvider({ children }: { children: React.ReactNode }) {
 
 export function useAdminView(): AdminViewContextValue {
   const ctx = useContext(AdminViewContext);
-  if (!ctx) throw new Error('useAdminView must be used inside AdminViewProvider');
+  if (!ctx) {
+    throw new Error('useAdminView must be used inside AdminViewProvider');
+  }
   return ctx;
 }

--- a/packages/web/src/context/AuthContext.tsx
+++ b/packages/web/src/context/AuthContext.tsx
@@ -27,7 +27,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const isAuthChecking = useRef(false);
 
   const refetch = useCallback(async () => {
-    if (isAuthChecking.current) return;
+    if (isAuthChecking.current) {
+      return;
+    }
     isAuthChecking.current = true;
 
     try {
@@ -80,6 +82,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
 export function useAuth(): AuthContextValue {
   const ctx = useContext(AuthContext);
-  if (!ctx) throw new Error('useAuth must be used inside AuthProvider');
+  if (!ctx) {
+    throw new Error('useAuth must be used inside AuthProvider');
+  }
   return ctx;
 }

--- a/packages/web/src/context/PermissionsContext.tsx
+++ b/packages/web/src/context/PermissionsContext.tsx
@@ -66,6 +66,8 @@ export function PermissionsProvider({ children }: { children: React.ReactNode })
 
 export function usePermissions(): PermissionsContextValue {
   const ctx = useContext(PermissionsContext);
-  if (!ctx) throw new Error('usePermissions must be used inside PermissionsProvider');
+  if (!ctx) {
+    throw new Error('usePermissions must be used inside PermissionsProvider');
+  }
   return ctx;
 }

--- a/packages/web/src/context/QueuePanelContext.tsx
+++ b/packages/web/src/context/QueuePanelContext.tsx
@@ -12,7 +12,9 @@ export function QueuePanelProvider({ children }: { children: React.ReactNode }) 
   const [queueOpen, setQueueOpen] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = localStorage.getItem('alfira-queue-open');
-      if (stored !== null) return stored === 'true';
+      if (stored !== null) {
+        return stored === 'true';
+      }
     }
     return false;
   });
@@ -30,6 +32,8 @@ export function QueuePanelProvider({ children }: { children: React.ReactNode }) 
 
 export function useQueuePanel(): QueuePanelContextValue {
   const ctx = useContext(QueuePanelContext);
-  if (!ctx) throw new Error('useQueuePanel must be used inside QueuePanelProvider');
+  if (!ctx) {
+    throw new Error('useQueuePanel must be used inside QueuePanelProvider');
+  }
   return ctx;
 }

--- a/packages/web/src/context/SongEditContext.tsx
+++ b/packages/web/src/context/SongEditContext.tsx
@@ -72,7 +72,9 @@ export function SongEditProvider({ children }: { children: ReactNode }) {
 
   // Close panel when clicking outside any song edit container
   useEffect(() => {
-    if (openSongId == null) return;
+    if (openSongId == null) {
+      return;
+    }
 
     const handleMouseDown = (e: MouseEvent) => {
       const target = e.target as Element;

--- a/packages/web/src/context/ThemeContext.tsx
+++ b/packages/web/src/context/ThemeContext.tsx
@@ -108,8 +108,10 @@ interface ThemeContextValue {
 const ThemeContext = createContext<ThemeContextValue | null>(null);
 
 function resolveMode(mode: ColorMode): 'light' | 'dark' {
-  if (mode !== 'auto') return mode;
-  if (typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: light)').matches) {
+  if (mode !== 'auto') {
+    return mode;
+  }
+  if (window?.matchMedia('(prefers-color-scheme: light)')?.matches) {
     return 'light';
   }
   return 'dark';
@@ -148,7 +150,9 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
     const mq = window.matchMedia('(prefers-color-scheme: light)');
     const handler = () => {
-      if (mode === 'auto') setResolvedMode(mq.matches ? 'light' : 'dark');
+      if (mode === 'auto') {
+        setResolvedMode(mq.matches ? 'light' : 'dark');
+      }
     };
     mq.addEventListener('change', handler);
     return () => mq.removeEventListener('change', handler);
@@ -188,6 +192,8 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
 export function useTheme(): ThemeContextValue {
   const ctx = useContext(ThemeContext);
-  if (!ctx) throw new Error('useTheme must be used inside ThemeProvider');
+  if (!ctx) {
+    throw new Error('useTheme must be used inside ThemeProvider');
+  }
   return ctx;
 }

--- a/packages/web/src/hooks/useCooldownGuard.ts
+++ b/packages/web/src/hooks/useCooldownGuard.ts
@@ -56,7 +56,9 @@ export function useCooldownGuard() {
 
   const handleCooldownClick = useCallback(() => {
     const now = Date.now();
-    if (now - lastToast < TOAST_INTERVAL_MS) return;
+    if (now - lastToast < TOAST_INTERVAL_MS) {
+      return;
+    }
     lastToast = now;
     notify(`${retryAfterSeconds}s remaining until controls are re-enabled.`, 'error', 5000);
   }, [retryAfterSeconds, notify]);

--- a/packages/web/src/hooks/useMutationHandler.ts
+++ b/packages/web/src/hooks/useMutationHandler.ts
@@ -21,7 +21,9 @@ export function useMutationHandler(action: () => Promise<void>, errorMessage: st
   const { notify } = useNotification();
 
   const handler = useCallback(async () => {
-    if (busyRef.current) return;
+    if (busyRef.current) {
+      return;
+    }
     busyRef.current = true;
     setBusy(true);
     try {

--- a/packages/web/src/hooks/usePaginatedData.ts
+++ b/packages/web/src/hooks/usePaginatedData.ts
@@ -71,8 +71,12 @@ export function usePaginatedData<T, A extends unknown[], M = undefined>({
 
   const loadPage = useCallback(
     async (page: number, isInitial = false) => {
-      if (isFetchingRef.current) return;
-      if (!isInitial && !hasMoreRef.current) return;
+      if (isFetchingRef.current) {
+        return;
+      }
+      if (!isInitial && !hasMoreRef.current) {
+        return;
+      }
 
       if (isInitial) {
         resetInProgressRef.current = true;
@@ -92,15 +96,21 @@ export function usePaginatedData<T, A extends unknown[], M = undefined>({
 
       try {
         const result = await fetchPageRef.current(page, limit, ...depsRef.current);
-        if (!isMountedRef.current) return;
+        if (!isMountedRef.current) {
+          return;
+        }
 
         hasEverLoadedRef.current = true;
 
         if (isInitial) {
           setItems(result.items);
           setHasMore(result.hasMore);
-          if (result.total !== undefined) setTotal(result.total);
-          if (result.metadata !== undefined) setMetadata(result.metadata);
+          if (result.total !== undefined) {
+            setTotal(result.total);
+          }
+          if (result.metadata !== undefined) {
+            setMetadata(result.metadata);
+          }
           pageRef.current = 1;
         } else {
           setItems((prev) => [...prev, ...result.items]);
@@ -108,7 +118,9 @@ export function usePaginatedData<T, A extends unknown[], M = undefined>({
           pageRef.current = page;
         }
       } catch {
-        if (!isMountedRef.current) return;
+        if (!isMountedRef.current) {
+          return;
+        }
         setIsError(true);
       } finally {
         if (loadingTimerRef.current) {
@@ -127,7 +139,9 @@ export function usePaginatedData<T, A extends unknown[], M = undefined>({
   );
 
   const fetchNextPage = useCallback(() => {
-    if (!hasMoreRef.current || isFetchingRef.current || resetInProgressRef.current) return;
+    if (!hasMoreRef.current || isFetchingRef.current || resetInProgressRef.current) {
+      return;
+    }
     const nextPage = pageRef.current + 1;
     void loadPage(nextPage);
   }, [loadPage]);
@@ -139,9 +153,13 @@ export function usePaginatedData<T, A extends unknown[], M = undefined>({
   }, [loadPage]);
 
   const prepend = useCallback((item: T) => {
-    if (resetInProgressRef.current) return;
+    if (resetInProgressRef.current) {
+      return;
+    }
     setItems((prev) => {
-      if (prev.some((i) => (i as { id: string }).id === (item as { id: string }).id)) return prev;
+      if (prev.some((i) => (i as { id: string }).id === (item as { id: string }).id)) {
+        return prev;
+      }
       const next = [item, ...prev];
       if (compareFnRef.current) {
         next.sort(compareFnRef.current);
@@ -151,7 +169,9 @@ export function usePaginatedData<T, A extends unknown[], M = undefined>({
   }, []);
 
   const updateItem = useCallback((item: T) => {
-    if (resetInProgressRef.current) return;
+    if (resetInProgressRef.current) {
+      return;
+    }
     setItems((prev) => {
       const next = prev.map((i) =>
         (i as { id: string }).id === (item as { id: string }).id ? item : i
@@ -164,7 +184,9 @@ export function usePaginatedData<T, A extends unknown[], M = undefined>({
   }, []);
 
   const removeItem = useCallback((id: string) => {
-    if (resetInProgressRef.current) return;
+    if (resetInProgressRef.current) {
+      return;
+    }
     setItems((prev) => prev.filter((i) => (i as { id: string }).id !== id));
   }, []);
 
@@ -178,20 +200,30 @@ export function usePaginatedData<T, A extends unknown[], M = undefined>({
   }, [loadPage]);
 
   const refetch = useCallback(() => {
-    if (resetInProgressRef.current) return;
+    if (resetInProgressRef.current) {
+      return;
+    }
     setIsFetching(true);
     setIsError(false);
     void (async () => {
       try {
         const result = await fetchPageRef.current(1, limit, ...depsRef.current);
-        if (!isMountedRef.current) return;
+        if (!isMountedRef.current) {
+          return;
+        }
         setItems(result.items);
         setHasMore(result.hasMore);
-        if (result.total !== undefined) setTotal(result.total);
-        if (result.metadata !== undefined) setMetadata(result.metadata);
+        if (result.total !== undefined) {
+          setTotal(result.total);
+        }
+        if (result.metadata !== undefined) {
+          setMetadata(result.metadata);
+        }
         pageRef.current = 1;
       } catch {
-        if (!isMountedRef.current) return;
+        if (!isMountedRef.current) {
+          return;
+        }
         setIsError(true);
       }
       if (isMountedRef.current) {

--- a/packages/web/src/hooks/useProgressBar.ts
+++ b/packages/web/src/hooks/useProgressBar.ts
@@ -97,8 +97,12 @@ export function useProgressBar(
 
     if (!isPlaying) {
       // Cancel all loops
-      if (rafIdRef.current) cancelAnimationFrame(rafIdRef.current);
-      if (intervalIdRef.current) clearInterval(intervalIdRef.current);
+      if (rafIdRef.current) {
+        cancelAnimationFrame(rafIdRef.current);
+      }
+      if (intervalIdRef.current) {
+        clearInterval(intervalIdRef.current);
+      }
       rafIdRef.current = 0;
       intervalIdRef.current = 0;
 
@@ -106,8 +110,12 @@ export function useProgressBar(
       if (!hasSong && !isPaused) {
         accumulatedMsRef.current = 0;
         setElapsed(0);
-        for (const ref of progressBars.current) ref.style.width = '0%';
-        for (const ref of thumbs.current) ref.style.left = '0%';
+        for (const ref of progressBars.current) {
+          ref.style.width = '0%';
+        }
+        for (const ref of thumbs.current) {
+          ref.style.left = '0%';
+        }
       }
 
       // When pausing (song exists + paused), capture current elapsed
@@ -117,16 +125,24 @@ export function useProgressBar(
         const pausedSec = Math.min(Math.round(accumulatedMsRef.current / 1000), duration);
         setElapsed(pausedSec);
         const pct = (pausedSec / duration) * 100;
-        for (const ref of progressBars.current) ref.style.width = `${pct}%`;
-        for (const ref of thumbs.current) ref.style.left = `${pct}%`;
+        for (const ref of progressBars.current) {
+          ref.style.width = `${pct}%`;
+        }
+        for (const ref of thumbs.current) {
+          ref.style.left = `${pct}%`;
+        }
       }
 
       return;
     }
 
     // ---- Starting loops ----
-    if (rafIdRef.current) cancelAnimationFrame(rafIdRef.current);
-    if (intervalIdRef.current) clearInterval(intervalIdRef.current);
+    if (rafIdRef.current) {
+      cancelAnimationFrame(rafIdRef.current);
+    }
+    if (intervalIdRef.current) {
+      clearInterval(intervalIdRef.current);
+    }
 
     // Compute effective start
     let effectiveStart: number;
@@ -154,7 +170,9 @@ export function useProgressBar(
     const tick = () => {
       const elapsedMs = Date.now() - effectiveStart;
       const pct = Math.min((elapsedMs / (duration * 1000)) * 100, 100);
-      if (pct >= 100) return;
+      if (pct >= 100) {
+        return;
+      }
       const pctStr = `${pct}%`;
       for (const ref of progressBars.current) {
         ref.style.width = pctStr;
@@ -173,8 +191,12 @@ export function useProgressBar(
     }, 1000);
 
     return () => {
-      if (rafIdRef.current) cancelAnimationFrame(rafIdRef.current);
-      if (intervalIdRef.current) clearInterval(intervalIdRef.current);
+      if (rafIdRef.current) {
+        cancelAnimationFrame(rafIdRef.current);
+      }
+      if (intervalIdRef.current) {
+        clearInterval(intervalIdRef.current);
+      }
       rafIdRef.current = 0;
       intervalIdRef.current = 0;
     };

--- a/packages/web/src/hooks/useRateLimit.ts
+++ b/packages/web/src/hooks/useRateLimit.ts
@@ -135,7 +135,9 @@ function notifyListeners() {
 }
 
 function ensureTicking() {
-  if (tickInterval !== null) return;
+  if (tickInterval !== null) {
+    return;
+  }
   tickInterval = setInterval(notifyListeners, 1000);
 }
 

--- a/packages/web/src/hooks/useScrollObserver.ts
+++ b/packages/web/src/hooks/useScrollObserver.ts
@@ -38,7 +38,9 @@ export function useScrollObserver(
   // below reads the real element dimensions and refines before paint.
   const [height, setHeight] = useState(0);
   const [width, setWidth] = useState(() => {
-    if (typeof window === 'undefined') return 960;
+    if (typeof window === 'undefined') {
+      return 960;
+    }
     return document.querySelector('main')?.clientWidth ?? 960;
   });
 
@@ -53,7 +55,9 @@ export function useScrollObserver(
   // scroll events.
   useEffect(() => {
     const el = elementRef.current;
-    if (!el) return;
+    if (!el) {
+      return;
+    }
 
     const onScroll = () => {
       // Store the latest scrollTop in the ref so the rAF callback always
@@ -123,13 +127,17 @@ export function useScrollObserver(
 
   useLayoutEffect(() => {
     const el = elementRef.current;
-    if (!el) return;
+    if (!el) {
+      return;
+    }
 
     setHeight(el.clientHeight);
     setWidth(el.clientWidth);
 
     const ro = new ResizeObserver(([entry]) => {
-      if (!entry) return;
+      if (!entry) {
+        return;
+      }
       setHeight(entry.contentRect.height);
 
       const now = performance.now();

--- a/packages/web/src/hooks/useSocket.ts
+++ b/packages/web/src/hooks/useSocket.ts
@@ -26,7 +26,9 @@ const RECONNECT_DELAYS = [1000, 2000, 4000, 8000, 16000, 30000];
 function setStatus(status: ConnectionStatus) {
   if (connectionStatus !== status) {
     connectionStatus = status;
-    for (const listener of statusListeners) listener();
+    for (const listener of statusListeners) {
+      listener();
+    }
   }
 }
 

--- a/packages/web/src/pages/LoginPage.tsx
+++ b/packages/web/src/pages/LoginPage.tsx
@@ -10,10 +10,14 @@ export default function LoginPage() {
 
   // If already authenticated, go straight to songs.
   useEffect(() => {
-    if (!loading && user) void navigate('/songs', { replace: true });
+    if (!loading && user) {
+      void navigate('/songs', { replace: true });
+    }
   }, [user, loading, navigate]);
 
-  if (loading) return null;
+  if (loading) {
+    return null;
+  }
 
   return (
     <div className='min-h-screen bg-elevated flex items-center justify-center relative overflow-hidden'>

--- a/packages/web/src/pages/PermissionsPage.tsx
+++ b/packages/web/src/pages/PermissionsPage.tsx
@@ -73,12 +73,16 @@ export default function PermissionsPage() {
     async function load() {
       try {
         const result = await fetchPermissions();
-        if (cancelled) return;
+        if (cancelled) {
+          return;
+        }
         setData(result);
         setMapping(result.mapping);
         setSavedMapping(result.mapping);
       } catch {
-        if (cancelled) return;
+        if (cancelled) {
+          return;
+        }
         setError('Could not load permissions.');
       }
     }
@@ -94,7 +98,9 @@ export default function PermissionsPage() {
     const normalize = (m: Record<string, string[]>) => {
       const out: Record<string, string[]> = {};
       for (const [k, v] of Object.entries(m)) {
-        if (v.length > 0) out[k] = v;
+        if (v.length > 0) {
+          out[k] = v;
+        }
       }
       return JSON.stringify(out);
     };
@@ -108,12 +114,16 @@ export default function PermissionsPage() {
   }, [mapping, explicitlyManaged]);
 
   const managedRoles = useMemo(() => {
-    if (!data) return [];
+    if (!data) {
+      return [];
+    }
     return data.roles.filter((r) => managedRoleIds.has(r.id));
   }, [data, managedRoleIds]);
 
   const unmanagedRoles = useMemo(() => {
-    if (!data) return [];
+    if (!data) {
+      return [];
+    }
     return data.roles.filter((r) => !managedRoleIds.has(r.id));
   }, [data, managedRoleIds]);
 
@@ -140,7 +150,9 @@ export default function PermissionsPage() {
   }, []);
 
   const removeRole = useCallback(() => {
-    if (!roleToRemove) return;
+    if (!roleToRemove) {
+      return;
+    }
     const roleId = roleToRemove;
     setRoleToRemove(null);
 
@@ -166,14 +178,19 @@ export default function PermissionsPage() {
   const toggleExpanded = useCallback((roleId: string) => {
     setExpandedRoles((prev) => {
       const next = new Set(prev);
-      if (next.has(roleId)) next.delete(roleId);
-      else next.add(roleId);
+      if (next.has(roleId)) {
+        next.delete(roleId);
+      } else {
+        next.add(roleId);
+      }
       return next;
     });
   }, []);
 
   const handleSave = useCallback(async () => {
-    if (!data) return;
+    if (!data) {
+      return;
+    }
     setSaving(true);
     setError(null);
     setSuccessMsg(null);

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -1,5 +1,5 @@
 import type { Playlist, PlaylistDetail, Song, TagItem } from '@alfira/server/shared';
-import type { FetchSongsOptions } from '@alfira/server/shared/api';
+import type { BulkEditData, FetchSongsOptions } from '@alfira/server/shared/api';
 import { fetchTags, updatePlaylistTag } from '@alfira/server/shared/api';
 import { AnimatePresence } from 'motion/react';
 import * as m from 'motion/react-m';
@@ -141,13 +141,23 @@ export default function PlaylistDetailPage() {
   // Build stable fetch options for the hook
   const songsOpts = useMemo<FetchSongsOptions>(() => {
     const opts: FetchSongsOptions = {};
-    if (search) opts.search = search;
-    if (sort !== 'position') opts.sort = sort;
-    if (order !== 'desc') opts.order = order;
+    if (search) {
+      opts.search = search;
+    }
+    if (sort !== 'position') {
+      opts.sort = sort;
+    }
+    if (order !== 'desc') {
+      opts.order = order;
+    }
     const t = filterTags.join(',');
     const s = filterSources.join(',');
-    if (t) opts.tags = t;
-    if (s) opts.source = s;
+    if (t) {
+      opts.tags = t;
+    }
+    if (s) {
+      opts.source = s;
+    }
     return opts;
   }, [search, sort, order, filterTags, filterSources]);
 
@@ -166,17 +176,29 @@ export default function PlaylistDetailPage() {
         case 'artist': {
           const aArt = a.song.artist ?? '';
           const bArt = b.song.artist ?? '';
-          if (!aArt && !bArt) return 0;
-          if (!aArt) return dir;
-          if (!bArt) return -dir;
+          if (!aArt && !bArt) {
+            return 0;
+          }
+          if (!aArt) {
+            return dir;
+          }
+          if (!bArt) {
+            return -dir;
+          }
           return dir * aArt.localeCompare(bArt, undefined, { sensitivity: 'base' });
         }
         case 'album': {
           const aAlb = a.song.album ?? '';
           const bAlb = b.song.album ?? '';
-          if (!aAlb && !bAlb) return 0;
-          if (!aAlb) return dir;
-          if (!bAlb) return -dir;
+          if (!aAlb && !bAlb) {
+            return 0;
+          }
+          if (!aAlb) {
+            return dir;
+          }
+          if (!bAlb) {
+            return -dir;
+          }
           return dir * aAlb.localeCompare(bAlb, undefined, { sensitivity: 'base' });
         }
         case 'duration':
@@ -260,7 +282,9 @@ export default function PlaylistDetailPage() {
   // ── Socket: playlist updated (rename, visibility, song count changes) ──
   useEffect(() => {
     const handlePlaylistUpdated = (updated: Playlist) => {
-      if (updated.id !== idRef.current) return;
+      if (updated.id !== idRef.current) {
+        return;
+      }
       refetch();
     };
     const offUpdated = onSocketEvent('playlists:updated', handlePlaylistUpdated);
@@ -309,7 +333,9 @@ export default function PlaylistDetailPage() {
   };
 
   const handleRemoveSong = async (songId: string) => {
-    if (!playlistDetail) return;
+    if (!playlistDetail) {
+      return;
+    }
     const junction = songsRef.current.find((ps) => ps.songId === songId);
     if (!junction) {
       setRemoveId(null);
@@ -330,7 +356,9 @@ export default function PlaylistDetailPage() {
 
   const executeBulkRemove = useCallback(async () => {
     const pd = playlistDetailRef.current;
-    if (!pd || bulk.count === 0) return;
+    if (!pd || bulk.count === 0) {
+      return;
+    }
     setBulkRemoveConfirm(false);
     setBulkRemoving(true);
     try {
@@ -357,8 +385,10 @@ export default function PlaylistDetailPage() {
   }, [bulk, notify, removeItem]);
 
   const handleBulkEdit = useCallback(
-    async (data: import('@alfira/server/shared/api').BulkEditData) => {
-      if (bulk.count === 0) return;
+    async (data: BulkEditData) => {
+      if (bulk.count === 0) {
+        return;
+      }
       setBulkEditingApplying(true);
       try {
         const allIds = [...bulk.selectedIds];
@@ -380,13 +410,17 @@ export default function PlaylistDetailPage() {
   );
 
   const handleDeletePlaylist = async () => {
-    if (!playlistDetail) return;
+    if (!playlistDetail) {
+      return;
+    }
     await deletePlaylist(playlistDetail.id);
     void navigate('/playlists');
   };
 
   const handleToggleVisibility = async () => {
-    if (!playlistDetail) return;
+    if (!playlistDetail) {
+      return;
+    }
     try {
       const updated = await togglePlaylistVisibility(
         playlistDetail.id,
@@ -407,7 +441,9 @@ export default function PlaylistDetailPage() {
       { throwErrors = false }: { throwErrors?: boolean } = {}
     ) => {
       const pd = playlistDetailRef.current;
-      if (!pd) return;
+      if (!pd) {
+        return;
+      }
       setPlayingSongId(songId);
       try {
         await startPlayback({
@@ -430,7 +466,9 @@ export default function PlaylistDetailPage() {
 
   const handleConvertToRegular = useCallback(async () => {
     const pd = playlistDetailRef.current;
-    if (!pd) return;
+    if (!pd) {
+      return;
+    }
     try {
       await updatePlaylistTag(pd.id, null);
       refetch();
@@ -443,7 +481,9 @@ export default function PlaylistDetailPage() {
   const handleChangeTag = useCallback(
     async (tagNameLower: string) => {
       const pd = playlistDetailRef.current;
-      if (!pd) return;
+      if (!pd) {
+        return;
+      }
       try {
         await updatePlaylistTag(pd.id, tagNameLower);
         refetch();
@@ -458,7 +498,9 @@ export default function PlaylistDetailPage() {
   const handleMakeSmart = useCallback(
     async (tagNameLower: string) => {
       const pd = playlistDetailRef.current;
-      if (!pd) return;
+      if (!pd) {
+        return;
+      }
       setTagSmartConfirm(null);
       try {
         await updatePlaylistTag(pd.id, tagNameLower);
@@ -473,7 +515,9 @@ export default function PlaylistDetailPage() {
 
   const handleAddPlaylistToQueue = useCallback(async () => {
     const pd = playlistDetailRef.current;
-    if (!pd) return;
+    if (!pd) {
+      return;
+    }
     try {
       await startPlayback({
         playlistId: pd.id,
@@ -575,8 +619,12 @@ export default function PlaylistDetailPage() {
       : []),
   ];
 
-  if (isLoading || !hasLoaded) return <DetailSkeleton />;
-  if (!playlistDetail) return null;
+  if (isLoading || !hasLoaded) {
+    return <DetailSkeleton />;
+  }
+  if (!playlistDetail) {
+    return null;
+  }
 
   // Extract plain songs from PlaylistDetailSong[]
   const songItems: Song[] = songs.map((ps) => ps.song);
@@ -709,7 +757,9 @@ export default function PlaylistDetailPage() {
         showBulkToggle={canBulk}
         selectionMode={selectionMode}
         onToggleSelectionMode={() => {
-          if (selectionMode) bulk.clearAll();
+          if (selectionMode) {
+            bulk.clearAll();
+          }
           setSelectionMode((v) => !v);
         }}
         viewMode={viewMode}
@@ -763,7 +813,9 @@ export default function PlaylistDetailPage() {
                     ? undefined
                     : (id) => {
                         const ps = songs.find((p) => p.songId === id);
-                        if (ps) setRemoveId(ps.songId);
+                        if (ps) {
+                          setRemoveId(ps.songId);
+                        }
                       }
                 }
                 onPlay={handlePlayFromSong}
@@ -802,7 +854,9 @@ export default function PlaylistDetailPage() {
                     ? undefined
                     : (id) => {
                         const ps = songs.find((p) => p.songId === id);
-                        if (ps) setRemoveId(ps.songId);
+                        if (ps) {
+                          setRemoveId(ps.songId);
+                        }
                       }
                 }
                 onPlay={handlePlayFromSong}

--- a/packages/web/src/pages/PlaylistsPage.tsx
+++ b/packages/web/src/pages/PlaylistsPage.tsx
@@ -73,7 +73,9 @@ export default function PlaylistsPage() {
     (e: React.MouseEvent) => {
       const row = e.currentTarget.closest('[data-playlist-id]');
       const playlistId = row?.getAttribute('data-playlist-id');
-      if (playlistId) void navigate(`/playlists/${playlistId}`);
+      if (playlistId) {
+        void navigate(`/playlists/${playlistId}`);
+      }
     },
     [navigate]
   );
@@ -159,7 +161,9 @@ function CreatePlaylistModal({ onClose }: { onClose: () => void }) {
               setName(e.target.value);
             }}
             onKeyDown={(e) => {
-              if (e.key === 'Escape') onClose();
+              if (e.key === 'Escape') {
+                onClose();
+              }
             }}
             required
           />

--- a/packages/web/src/pages/RequestsPage.tsx
+++ b/packages/web/src/pages/RequestsPage.tsx
@@ -97,7 +97,9 @@ export default function RequestsPage() {
       mounted.current = true;
       return;
     }
-    if (autoRedirected.current) return;
+    if (autoRedirected.current) {
+      return;
+    }
     if (tab === 'pending' && total === 0) {
       autoRedirected.current = true;
       setTab('closed');

--- a/packages/web/src/pages/SetupWizard.tsx
+++ b/packages/web/src/pages/SetupWizard.tsx
@@ -107,7 +107,9 @@ export default function SetupWizard() {
 
   // Auto-refresh guild list when on the guild step and no guilds are found.
   useEffect(() => {
-    if (step !== 'guild' || guilds.length > 0) return;
+    if (step !== 'guild' || guilds.length > 0) {
+      return;
+    }
 
     let cancelled = false;
     async function poll() {
@@ -123,12 +125,16 @@ export default function SetupWizard() {
       } catch {
         // Silently retry on next interval.
       } finally {
-        if (!cancelled) setRefreshingGuilds(false);
+        if (!cancelled) {
+          setRefreshingGuilds(false);
+        }
       }
     }
 
     void poll();
-    const interval = setInterval(poll, 3000);
+    const interval = setInterval(() => {
+      void poll();
+    }, 3000);
     return () => {
       cancelled = true;
       clearInterval(interval);
@@ -163,7 +169,9 @@ export default function SetupWizard() {
   }
 
   async function loadRoles() {
-    if (!selectedGuildId) return;
+    if (!selectedGuildId) {
+      return;
+    }
     setError(null);
     try {
       const { roles: list } = await fetchSetupRoles(selectedGuildId);
@@ -175,7 +183,9 @@ export default function SetupWizard() {
   }
 
   async function loadChannels() {
-    if (!selectedGuildId) return;
+    if (!selectedGuildId) {
+      return;
+    }
     setError(null);
     try {
       const { channels: list } = await fetchSetupChannels(selectedGuildId);
@@ -187,8 +197,12 @@ export default function SetupWizard() {
   }
 
   async function handleSubmit() {
-    if (!selectedGuildId || selectedRoleIds.size === 0) return;
-    if (selectedSourceKeys.size === 0) return;
+    if (!selectedGuildId || selectedRoleIds.size === 0) {
+      return;
+    }
+    if (selectedSourceKeys.size === 0) {
+      return;
+    }
     setSaving(true);
     setError(null);
     try {
@@ -214,8 +228,11 @@ export default function SetupWizard() {
   function toggleRole(id: string) {
     setSelectedRoleIds((prev) => {
       const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
       return next;
     });
   }
@@ -224,9 +241,14 @@ export default function SetupWizard() {
     setSelectedSourceKeys((prev) => {
       const next = new Set(prev);
       // Prevent deselecting the last source.
-      if (next.size === 1 && next.has(key)) return prev;
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
+      if (next.size === 1 && next.has(key)) {
+        return prev;
+      }
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
       return next;
     });
   }

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -1,5 +1,5 @@
 import type { Playlist, Song } from '@alfira/server/shared';
-import type { FetchSongsOptions } from '@alfira/server/shared/api';
+import type { BulkEditData, FetchSongsOptions } from '@alfira/server/shared/api';
 import { MusicNotesIcon, QuestionIcon } from '@phosphor-icons/react';
 import { AnimatePresence } from 'motion/react';
 import * as m from 'motion/react-m';
@@ -118,13 +118,23 @@ export default function SongsPage() {
   // ── Build stable fetch options for the infinite scroll hook ─────────
   const songsOpts = useMemo<FetchSongsOptions>(() => {
     const opts: FetchSongsOptions = {};
-    if (search) opts.search = search;
-    if (sort !== 'createdAt') opts.sort = sort;
-    if (order !== 'desc') opts.order = order;
+    if (search) {
+      opts.search = search;
+    }
+    if (sort !== 'createdAt') {
+      opts.sort = sort;
+    }
+    if (order !== 'desc') {
+      opts.order = order;
+    }
     const tagsParam = filterTags.join(',');
     const sourceParam = filterSources.join(',');
-    if (tagsParam) opts.tags = tagsParam;
-    if (sourceParam) opts.source = sourceParam;
+    if (tagsParam) {
+      opts.tags = tagsParam;
+    }
+    if (sourceParam) {
+      opts.source = sourceParam;
+    }
     return opts;
   }, [search, sort, order, filterTags, filterSources]);
 
@@ -156,23 +166,35 @@ export default function SongsPage() {
           const aArt = a.artist ?? '';
           const bArt = b.artist ?? '';
           // nulls last, regardless of direction
-          if (!aArt && !bArt) return 0;
-          if (!aArt) return dir;
-          if (!bArt) return -dir;
+          if (!aArt && !bArt) {
+            return 0;
+          }
+          if (!aArt) {
+            return dir;
+          }
+          if (!bArt) {
+            return -dir;
+          }
           return dir * aArt.localeCompare(bArt, undefined, { sensitivity: 'base' });
         }
         case 'album': {
           const aAlb = a.album ?? '';
           const bAlb = b.album ?? '';
-          if (!aAlb && !bAlb) return 0;
-          if (!aAlb) return dir;
-          if (!bAlb) return -dir;
+          if (!aAlb && !bAlb) {
+            return 0;
+          }
+          if (!aAlb) {
+            return dir;
+          }
+          if (!bAlb) {
+            return -dir;
+          }
           return dir * aAlb.localeCompare(bAlb, undefined, { sensitivity: 'base' });
         }
         case 'duration':
           return dir * ((a.duration ?? 0) - (b.duration ?? 0));
-        default:
-          // createdAt — newest first for desc, oldest first for asc
+        case 'createdAt':
+          // newest first for desc, oldest first for asc
           return dir * (new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
       }
     };
@@ -243,7 +265,9 @@ export default function SongsPage() {
   }, []);
 
   const executeBulkDelete = useCallback(async () => {
-    if (bulk.count === 0) return;
+    if (bulk.count === 0) {
+      return;
+    }
     setBulkDeleteConfirm(false);
     setBulkDeleting(true);
     try {
@@ -266,8 +290,10 @@ export default function SongsPage() {
   }, [bulk, removeItem, notify]);
 
   const handleBulkEdit = useCallback(
-    async (data: import('@alfira/server/shared/api').BulkEditData) => {
-      if (bulk.count === 0) return;
+    async (data: BulkEditData) => {
+      if (bulk.count === 0) {
+        return;
+      }
       setBulkEditingApplying(true);
       try {
         const allIds = [...bulk.selectedIds];
@@ -361,14 +387,18 @@ export default function SongsPage() {
         filterSources={filterSources}
         onAddTag={(tag) => {
           const normalized = tag.toLowerCase();
-          if (filterTags.includes(normalized)) return;
+          if (filterTags.includes(normalized)) {
+            return;
+          }
           updateParam('tags', [...filterTags, normalized].join(','));
         }}
         onRemoveTag={(tag) =>
           updateParam('tags', filterTags.filter((t) => t !== tag).join(',') || null)
         }
         onAddSource={(s) => {
-          if (filterSources.includes(s)) return;
+          if (filterSources.includes(s)) {
+            return;
+          }
           updateParam('source', [...filterSources, s].join(','));
         }}
         onRemoveSource={(s) =>
@@ -377,7 +407,9 @@ export default function SongsPage() {
         showBulkToggle={canBulk}
         selectionMode={selectionMode}
         onToggleSelectionMode={() => {
-          if (selectionMode) bulk.clearAll();
+          if (selectionMode) {
+            bulk.clearAll();
+          }
           setSelectionMode((v) => !v);
         }}
         viewMode={viewMode}
@@ -542,7 +574,9 @@ function DeleteConfirmDialog({
   onConfirm: () => void;
   onCancel: () => void;
 }) {
-  if (!song) return null;
+  if (!song) {
+    return null;
+  }
   return (
     <ConfirmModal
       title='Delete Song'

--- a/packages/web/src/pages/TagsPage.tsx
+++ b/packages/web/src/pages/TagsPage.tsx
@@ -63,7 +63,9 @@ export default function TagsPage() {
 
   const saveName = useCallback(
     async (nextName: string) => {
-      if (!selected || savingName) return;
+      if (!selected || savingName) {
+        return;
+      }
       setSavingName(true);
       try {
         const { tag } = await updateTag(selected.nameLower, { canonicalName: nextName });
@@ -83,9 +85,13 @@ export default function TagsPage() {
 
   const pickColor = useCallback(
     async (color: string) => {
-      if (!selected) return;
+      if (!selected) {
+        return;
+      }
       const effectiveColor = getTagColorClasses(selected.canonicalName, selected.color).name;
-      if (effectiveColor === color) return; // already the effective color
+      if (effectiveColor === color) {
+        return;
+      } // already the effective color
       // Optimistic update
       setAllTags((prev) =>
         prev.map((t) => (t.nameLower === selected.nameLower ? { ...t, color } : t))
@@ -99,7 +105,9 @@ export default function TagsPage() {
 
   const removeSong = useCallback(
     async (song: Song) => {
-      if (!selected) return;
+      if (!selected) {
+        return;
+      }
       const newTags = (song.tags ?? []).filter(
         (t) => t.toLowerCase() !== selected.nameLower.toLowerCase()
       );
@@ -112,7 +120,9 @@ export default function TagsPage() {
   );
 
   const handleDelete = useCallback(async () => {
-    if (!selected) return;
+    if (!selected) {
+      return;
+    }
     try {
       await deleteTag(selected.nameLower);
       setAllTags((prev) => prev.filter((t) => t.nameLower !== selected.nameLower));

--- a/packages/web/src/utils/tagColors.ts
+++ b/packages/web/src/utils/tagColors.ts
@@ -50,7 +50,9 @@ export function getTagColorClasses(
 ): (typeof TAG_COLORS)[number] {
   if (explicitColor) {
     const found = TAG_COLORS.find((c) => c.name === explicitColor);
-    if (found) return found;
+    if (found) {
+      return found;
+    }
   }
   return TAG_COLORS[djb2(tag.toLowerCase()) % TAG_COLORS.length];
 }


### PR DESCRIPTION
## Summary

Added 18 new oxlint rules (Tier 1 correctness + Tier 2 consistency) and fixed all resulting violations across 97 files. Zero warnings remain under `--deny-warnings`.

## Changes

- **oxlint.config.ts**: Added `curly`, `no-constant-binary-expression`, `no-unsafe-optional-chaining`, `no-useless-concat`, `object-shorthand`, `@typescript-eslint/array-type`, `@typescript-eslint/consistent-type-imports`, `@typescript-eslint/no-floating-promises`, `@typescript-eslint/no-misused-promises`, `@typescript-eslint/only-throw-error`, `@typescript-eslint/prefer-nullish-coalescing` (disabled — too noisy for display UI), `@typescript-eslint/prefer-optional-chain`, `@typescript-eslint/prefer-ts-expect-error`, `@typescript-eslint/switch-exhaustiveness-check`, `unicorn/catch-error-name`, `unicorn/error-message`, `unicorn/prefer-node-protocol`, `unicorn/throw-new-error`, `promise/catch-or-return`, `promise/valid-params`
- **514 curly braces**: All brace-less if/else statements now have brackets
- **4 switch exhaustiveness bugs**: Fixed uncovered `createdAt` sort cases and incomplete `BulkEditData` union handling
- **3 setTimeout/setInterval fixes**: Async functions now wrapped in void callbacks
- **2 inline import() types**: Replaced with top-level `import type`
- **Formatting**: All files reformatted after curly brace changes