### PR TITLE
chore(web): enable react-perf lint rules and fix 33 components

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
 
   ignorePatterns: ['.pi/**', '.zed/**'],
 
-  plugins: ['react', 'jsx-a11y', 'typescript', 'promise', 'import'],
+  plugins: ['react', 'react-perf', 'jsx-a11y', 'typescript', 'promise', 'import'],
 
   rules: {
     // -----------------------------------------------------------------------
@@ -216,6 +216,19 @@ export default defineConfig({
     'react/no-unstable-nested-components': 'warn',
 
     // -----------------------------------------------------------------------
+    // react-perf — rendering performance anti-patterns
+    // -----------------------------------------------------------------------
+    // Inline functions/objects/JSX as props break React.memo and cause
+    // unnecessary re-renders. Fix with useCallback / useMemo / extract outside.
+    'react-perf/jsx-no-new-function-as-prop': 'warn',
+    'react-perf/jsx-no-new-object-as-prop': 'warn',
+    'react-perf/jsx-no-jsx-as-prop': 'warn',
+    // Context value objects constructed inline cause full subtree re-renders
+    'react/jsx-no-constructed-context-values': 'warn',
+    // Default prop arrays/objects break referential equality
+    'react/no-object-type-as-default-prop': 'warn',
+
+    // -----------------------------------------------------------------------
     // typescript strictness — close the `any` escape hatch
     // -----------------------------------------------------------------------
     '@typescript-eslint/no-unsafe-assignment': 'warn',
@@ -346,6 +359,35 @@ export default defineConfig({
       },
     },
 
+    // EQ slider bands: fixed-length array with stable order, index is the correct key
+    {
+      files: ['packages/web/src/components/settings/EqualizerSection.tsx'],
+      rules: {
+        'react/no-array-index-key': 'off',
+      },
+    },
+
+    // VirtualList: dynamic virtualizer styles are generated per-item from scroll position —
+    // height/transform values are inherently unique and cannot be statically extracted.
+    {
+      files: ['packages/web/src/components/VirtualList.tsx'],
+      rules: {
+        'react-perf/jsx-no-new-object-as-prop': 'off',
+      },
+    },
+
+    // VirtualSongGrid: GridCard created inside useMemo([]) for masonry stable identity.
+    // Inline functions/objects in the render body are intentional — cardPropsRef.current
+    // provides latest values while keeping component type identity stable.
+    {
+      files: ['packages/web/src/components/VirtualSongGrid.tsx'],
+      rules: {
+        'react/no-unstable-nested-components': 'off',
+        'react-perf/jsx-no-new-function-as-prop': 'off',
+        'react-perf/jsx-no-new-object-as-prop': 'off',
+      },
+    },
+
     // Song/Playlist rows and panels: relaxed a11y
     {
       files: [
@@ -391,6 +433,43 @@ export default defineConfig({
       files: ['packages/server/src/shared/logger.ts'],
       rules: {
         'no-console': 'off',
+      },
+    },
+
+    // =======================================================================
+    // react-perf: temporary overrides while fixing file-by-file.
+    // Remove files from this list as they are cleaned up.
+    // When the list is empty, delete this entire override block.
+    // =======================================================================
+    {
+      files: [
+        'packages/web/src/App.tsx',
+        'packages/web/src/components/AddSongModal.tsx',
+        'packages/web/src/components/AddSongsModal.tsx',
+        'packages/web/src/components/BulkEditModal.tsx',
+        'packages/web/src/components/ContextMenu.tsx',
+        'packages/web/src/components/Layout.tsx',
+        'packages/web/src/components/ListToolbar.tsx',
+        'packages/web/src/components/MobileNav.tsx',
+        'packages/web/src/components/NowPlayingBar.tsx',
+        'packages/web/src/components/QueuePanel.tsx',
+        'packages/web/src/components/SongCard.tsx',
+        'packages/web/src/components/SongEditPanel.tsx',
+        'packages/web/src/components/settings/AdminSection.tsx',
+        'packages/web/src/pages/PermissionsPage.tsx',
+        'packages/web/src/pages/PlaylistDetailPage.tsx',
+        'packages/web/src/pages/PlaylistsPage.tsx',
+        'packages/web/src/pages/RequestsPage.tsx',
+        'packages/web/src/pages/SongsPage.tsx',
+        'packages/web/src/pages/SetupWizard.tsx',
+        'packages/web/src/pages/TagsPage.tsx',
+      ],
+      rules: {
+        'react-perf/jsx-no-new-function-as-prop': 'off',
+        'react-perf/jsx-no-new-object-as-prop': 'off',
+        'react-perf/jsx-no-jsx-as-prop': 'off',
+        'react/jsx-no-constructed-context-values': 'off',
+        'react/no-object-type-as-default-prop': 'off',
       },
     },
 

--- a/packages/web/src/components/AddFilterPopover.tsx
+++ b/packages/web/src/components/AddFilterPopover.tsx
@@ -1,5 +1,7 @@
+import type React from 'react';
+
 import { MagnifyingGlassIcon, XIcon } from '@phosphor-icons/react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 
 import { type TagItem, useTagColors } from '../context/TagsContext';
 import { getTagColorClasses } from '../utils/tagColors';
@@ -19,6 +21,74 @@ const SOURCES: { key: string; label: string }[] = [
   { key: 'tidal', label: 'Tidal' },
   { key: 'googledrive', label: 'Google Drive' },
 ];
+
+// ---------------------------------------------------------------------------
+// Child components — extracted so useCallback closures are stable per item
+// ---------------------------------------------------------------------------
+
+interface FilterTagButtonProps {
+  tag: TagItem;
+  isActive: boolean;
+  onClick: (tag: TagItem) => void;
+}
+
+const FilterTagButton = memo(function FilterTagButton({
+  tag,
+  isActive,
+  onClick,
+}: FilterTagButtonProps) {
+  const explicitColor = tag.color ?? null;
+  const colors = getTagColorClasses(tag.canonicalName, explicitColor);
+  const handleClick = useCallback(() => onClick(tag), [onClick, tag]);
+
+  return (
+    <button
+      type='button'
+      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium whitespace-nowrap cursor-pointer transition-opacity hover:opacity-80 active:opacity-70 ${
+        isActive
+          ? `${colors.bg} ${colors.text} ring-1 ring-inset ring-current/30`
+          : `${colors.bg} ${colors.text} opacity-60 hover:opacity-90`
+      }`}
+      onClick={handleClick}
+    >
+      {isActive && <XIcon size={10} weight='bold' />}
+      {tag.canonicalName}
+    </button>
+  );
+});
+
+interface FilterSourceRowProps {
+  source: { key: string; label: string };
+  isActive: boolean;
+  onToggle: (sourceKey: string) => void;
+}
+
+const FilterSourceRow = memo(function FilterSourceRow({
+  source,
+  isActive,
+  onToggle,
+}: FilterSourceRowProps) {
+  const handleChange = useCallback(() => onToggle(source.key), [onToggle, source.key]);
+
+  return (
+    <label
+      className={`flex items-center gap-3 px-3 py-2 rounded-lg cursor-pointer transition-colors select-none ${
+        isActive ? 'bg-accent/5 text-accent' : 'hover:bg-elevated active:bg-elevated/80 text-muted'
+      }`}
+    >
+      <input type='checkbox' checked={isActive} onChange={handleChange} className='sr-only' />
+      <span className='flex items-center gap-2 flex-1'>
+        <SourceIcon sourceKey={source.key} />
+        <span className='font-body text-sm'>{source.label}</span>
+      </span>
+      {isActive && <span className='text-[11px] font-mono text-accent'>active</span>}
+    </label>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
 
 interface AddFilterPopoverProps {
   activeTags: string[];
@@ -76,6 +146,10 @@ export default function AddFilterPopover({
     [activeTags, onAddTag, onRemoveTag]
   );
 
+  const handleSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setTagSearch(e.target.value);
+  }, []);
+
   const handleSourceToggle = useCallback(
     (sourceKey: string) => {
       if (activeSources.includes(sourceKey)) {
@@ -117,7 +191,7 @@ export default function AddFilterPopover({
                 className='input pl-8 py-1.5 text-xs'
                 placeholder='Search tags...'
                 value={tagSearch}
-                onChange={(e) => setTagSearch(e.target.value)}
+                onChange={handleSearchChange}
               />
             </div>
 
@@ -129,22 +203,13 @@ export default function AddFilterPopover({
               <div className='flex flex-wrap gap-1.5 max-h-40 overflow-y-auto'>
                 {filteredTags.map((tag) => {
                   const isActive = activeTags.includes(tag.nameLower);
-                  const explicitColor = tag.color ?? null;
-                  const colors = getTagColorClasses(tag.canonicalName, explicitColor);
                   return (
-                    <button
+                    <FilterTagButton
                       key={tag.nameLower}
-                      type='button'
-                      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium whitespace-nowrap cursor-pointer transition-opacity hover:opacity-80 active:opacity-70 ${
-                        isActive
-                          ? `${colors.bg} ${colors.text} ring-1 ring-inset ring-current/30`
-                          : `${colors.bg} ${colors.text} opacity-60 hover:opacity-90`
-                      }`}
-                      onClick={() => handleTagClick(tag)}
-                    >
-                      {isActive && <XIcon size={10} weight='bold' />}
-                      {tag.canonicalName}
-                    </button>
+                      tag={tag}
+                      isActive={isActive}
+                      onClick={handleTagClick}
+                    />
                   );
                 })}
               </div>
@@ -158,31 +223,14 @@ export default function AddFilterPopover({
             </p>
 
             <div className='space-y-1'>
-              {SOURCES.map((source) => {
-                const isActive = activeSources.includes(source.key);
-                return (
-                  <label
-                    key={source.key}
-                    className={`flex items-center gap-3 px-3 py-2 rounded-lg cursor-pointer transition-colors select-none ${
-                      isActive
-                        ? 'bg-accent/5 text-accent'
-                        : 'hover:bg-elevated active:bg-elevated/80 text-muted'
-                    }`}
-                  >
-                    <input
-                      type='checkbox'
-                      checked={isActive}
-                      onChange={() => handleSourceToggle(source.key)}
-                      className='sr-only'
-                    />
-                    <span className='flex items-center gap-2 flex-1'>
-                      <SourceIcon sourceKey={source.key} />
-                      <span className='font-body text-sm'>{source.label}</span>
-                    </span>
-                    {isActive && <span className='text-[11px] font-mono text-accent'>active</span>}
-                  </label>
-                );
-              })}
+              {SOURCES.map((source) => (
+                <FilterSourceRow
+                  key={source.key}
+                  source={source}
+                  isActive={activeSources.includes(source.key)}
+                  onToggle={handleSourceToggle}
+                />
+              ))}
             </div>
           </div>
         </div>

--- a/packages/web/src/components/Backdrop.tsx
+++ b/packages/web/src/components/Backdrop.tsx
@@ -1,5 +1,7 @@
 import type React from 'react';
 
+import { useCallback } from 'react';
+
 export function Backdrop({
   children,
   onClose,
@@ -7,19 +9,29 @@ export function Backdrop({
   children: React.ReactNode;
   onClose: () => void;
 }) {
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) {
+        onClose();
+      }
+    },
+    [onClose]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    },
+    [onClose]
+  );
+
   return (
     <div
       className='fixed inset-0 z-50 bg-black/70 flex items-center justify-center p-4 cursor-default'
-      onMouseDown={(e) => {
-        if (e.target === e.currentTarget) {
-          onClose();
-        }
-      }}
-      onKeyDown={(e) => {
-        if (e.key === 'Escape') {
-          onClose();
-        }
-      }}
+      onMouseDown={handleMouseDown}
+      onKeyDown={handleKeyDown}
       role='presentation'
     >
       {children}

--- a/packages/web/src/components/ContextMenu/EditSubmenuPanel.tsx
+++ b/packages/web/src/components/ContextMenu/EditSubmenuPanel.tsx
@@ -1,5 +1,7 @@
+import type React from 'react';
+
 import { CaretLeftIcon } from '@phosphor-icons/react';
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import { type MenuItem } from '../ContextMenu';
 import { SpringUp } from '../ui/SpringUp';
@@ -19,6 +21,24 @@ export function EditSubmenuPanel({ config, onBack, onSave }: EditSubmenuPanelPro
     return () => clearTimeout(timer);
   }, []);
 
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => config.onChange(e.target.value),
+    [config]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      e.stopPropagation();
+      if (e.key === 'Enter') {
+        onSave();
+      }
+      if (e.key === 'Escape') {
+        onBack();
+      }
+    },
+    [onSave, onBack]
+  );
+
   return (
     <SpringUp>
       <div className='flex items-center gap-2 px-3 py-2 border-b border-border'>
@@ -37,16 +57,8 @@ export function EditSubmenuPanel({ config, onBack, onSave }: EditSubmenuPanelPro
           ref={inputRef}
           className='input text-xs py-1.5 px-2 w-full mb-2'
           value={config.value}
-          onChange={(e) => config.onChange(e.target.value)}
-          onKeyDown={(e) => {
-            e.stopPropagation();
-            if (e.key === 'Enter') {
-              onSave();
-            }
-            if (e.key === 'Escape') {
-              onBack();
-            }
-          }}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
           disabled={config.saving}
           placeholder={config.placeholder ?? 'Enter value...'}
         />

--- a/packages/web/src/components/ContextMenu/SubmenuPanel.tsx
+++ b/packages/web/src/components/ContextMenu/SubmenuPanel.tsx
@@ -1,4 +1,5 @@
 import { CaretLeftIcon } from '@phosphor-icons/react';
+import { memo, useCallback } from 'react';
 
 import { type SubmenuConfig } from '../ContextMenu';
 import { SpringUp } from '../ui/SpringUp';
@@ -8,6 +9,29 @@ interface SubmenuPanelProps {
   onBack: () => void;
   onSelect: (id: string) => void;
 }
+
+interface SubmenuItemProps {
+  item: SubmenuConfig['items'][number];
+  onSelect: (id: string) => void;
+}
+
+const SubmenuItem = memo(function SubmenuItem({ item, onSelect }: SubmenuItemProps) {
+  const handleClick = useCallback(() => onSelect(item.id), [onSelect, item.id]);
+
+  return (
+    <button
+      type='button'
+      role='menuitem'
+      tabIndex={-1}
+      disabled={item.disabled}
+      onClick={handleClick}
+      className='w-full text-left px-3 py-1.5 text-xs font-mono text-fg hover:bg-border/50 transition-colors duration-100 disabled:opacity-50 flex items-center gap-2'
+    >
+      {item.icon && <span className='shrink-0'>{item.icon}</span>}
+      <span className='truncate'>{item.label}</span>
+    </button>
+  );
+});
 
 export function SubmenuPanel({ config, onBack, onSelect }: SubmenuPanelProps) {
   return (
@@ -32,17 +56,7 @@ export function SubmenuPanel({ config, onBack, onSelect }: SubmenuPanelProps) {
           config.items.map((item, idx) => (
             <div key={item.id}>
               {idx > 0 && <div className='border-b border-border' />}
-              <button
-                type='button'
-                role='menuitem'
-                tabIndex={-1}
-                disabled={item.disabled}
-                onClick={() => onSelect(item.id)}
-                className='w-full text-left px-3 py-1.5 text-xs font-mono text-fg hover:bg-border/50 transition-colors duration-100 disabled:opacity-50 flex items-center gap-2'
-              >
-                {item.icon && <span className='shrink-0'>{item.icon}</span>}
-                <span className='truncate'>{item.label}</span>
-              </button>
+              <SubmenuItem item={item} onSelect={onSelect} />
             </div>
           ))
         )}

--- a/packages/web/src/components/FilterChips.tsx
+++ b/packages/web/src/components/FilterChips.tsx
@@ -1,4 +1,5 @@
 import { TagIcon, XIcon } from '@phosphor-icons/react';
+import { memo, useCallback } from 'react';
 
 import { getTagColorClasses } from '../utils/tagColors';
 import { SourceIcon } from './SourceIcons';
@@ -15,6 +16,80 @@ const SOURCE_LABELS: Record<string, string> = {
   googledrive: 'Google Drive',
 };
 
+// ---------------------------------------------------------------------------
+// Child components — extracted so useCallback closures are stable per item
+// ---------------------------------------------------------------------------
+
+interface FilterTagChipProps {
+  tag: string;
+  onRemove: (tag: string) => void;
+}
+
+const FilterTagChip = memo(function FilterTagChip({ tag, onRemove }: FilterTagChipProps) {
+  const colors = getTagColorClasses(tag, null);
+  const handleRemove = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onRemove(tag);
+    },
+    [onRemove, tag]
+  );
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium whitespace-nowrap select-none ${colors.bg} ${colors.text}`}
+    >
+      <TagIcon size={11} weight='fill' />
+      <span>{tag}</span>
+      <button
+        type='button'
+        className='ml-0.5 cursor-pointer rounded-full p-px hover:bg-black/10 dark:hover:bg-white/10 transition-colors'
+        onClick={handleRemove}
+        aria-label={`Remove tag filter: ${tag}`}
+      >
+        <XIcon size={10} weight='bold' />
+      </button>
+    </span>
+  );
+});
+
+interface FilterSourceChipProps {
+  source: string;
+  onRemove: (source: string) => void;
+}
+
+const FilterSourceChip = memo(function FilterSourceChip({
+  source,
+  onRemove,
+}: FilterSourceChipProps) {
+  const handleRemove = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onRemove(source);
+    },
+    [onRemove, source]
+  );
+
+  return (
+    <span className='inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium whitespace-nowrap select-none bg-elevated text-muted border border-border/50'>
+      <SourceIcon sourceKey={source} />
+      <span>{SOURCE_LABELS[source] ?? source}</span>
+      <button
+        type='button'
+        className='ml-0.5 cursor-pointer rounded-full p-px hover:bg-black/10 dark:hover:bg-white/10 transition-colors'
+        onClick={handleRemove}
+        aria-label={`Remove source filter: ${SOURCE_LABELS[source] ?? source}`}
+      >
+        <XIcon size={10} weight='bold' />
+      </button>
+    </span>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
 interface FilterChipsProps {
   tags: string[];
   sources: string[];
@@ -30,51 +105,11 @@ export default function FilterChips({
 }: FilterChipsProps) {
   return (
     <div className='flex items-center gap-2 flex-wrap'>
-      {/* Tag chips */}
-      {tags.map((tag) => {
-        const colors = getTagColorClasses(tag, null);
-        return (
-          <span
-            key={`tag-${tag}`}
-            className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium whitespace-nowrap select-none ${colors.bg} ${colors.text}`}
-          >
-            <TagIcon size={11} weight='fill' />
-            <span>{tag}</span>
-            <button
-              type='button'
-              className='ml-0.5 cursor-pointer rounded-full p-px hover:bg-black/10 dark:hover:bg-white/10 transition-colors'
-              onClick={(e) => {
-                e.stopPropagation();
-                onRemoveTag(tag);
-              }}
-              aria-label={`Remove tag filter: ${tag}`}
-            >
-              <XIcon size={10} weight='bold' />
-            </button>
-          </span>
-        );
-      })}
-
-      {/* Source chips */}
+      {tags.map((tag) => (
+        <FilterTagChip key={`tag-${tag}`} tag={tag} onRemove={onRemoveTag} />
+      ))}
       {sources.map((source) => (
-        <span
-          key={`source-${source}`}
-          className='inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium whitespace-nowrap select-none bg-elevated text-muted border border-border/50'
-        >
-          <SourceIcon sourceKey={source} />
-          <span>{SOURCE_LABELS[source] ?? source}</span>
-          <button
-            type='button'
-            className='ml-0.5 cursor-pointer rounded-full p-px hover:bg-black/10 dark:hover:bg-white/10 transition-colors'
-            onClick={(e) => {
-              e.stopPropagation();
-              onRemoveSource(source);
-            }}
-            aria-label={`Remove source filter: ${SOURCE_LABELS[source] ?? source}`}
-          >
-            <XIcon size={10} weight='bold' />
-          </button>
-        </span>
+        <FilterSourceChip key={`source-${source}`} source={source} onRemove={onRemoveSource} />
       ))}
     </div>
   );

--- a/packages/web/src/components/PlaylistRow.tsx
+++ b/packages/web/src/components/PlaylistRow.tsx
@@ -1,6 +1,6 @@
 import { type Playlist } from '@alfira/server/shared';
 import { CaretRightIcon, GhostIcon, PlaylistIcon, TagIcon } from '@phosphor-icons/react';
-import { memo } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 
 import { ArtworkImage } from './ui/ArtworkImage';
 import { Card } from './ui/Card';
@@ -31,20 +31,27 @@ export const PlaylistRow = memo(
     const cells = spreadUrls(coverUrls);
     const hasArtwork = coverUrls.length > 0;
 
+    const cardStyle = useMemo(() => ({ animationDelay }), [animationDelay]);
+
+    const handleKeyDown = useCallback(
+      (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick(e as unknown as React.MouseEvent);
+        }
+      },
+      [onClick]
+    );
+
     return (
       <Card
         hoverable
         animate
         className='rounded-xl flex items-center gap-3 md:gap-4 px-4 md:px-5 py-3.5 md:py-4 cursor-pointer group'
-        style={{ animationDelay }}
+        style={cardStyle}
         data-playlist-id={dataPlaylistId}
         onClick={onClick}
-        onKeyDown={(e: React.KeyboardEvent) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            onClick(e as unknown as React.MouseEvent);
-          }
-        }}
+        onKeyDown={handleKeyDown}
         role='button'
         tabIndex={0}
       >

--- a/packages/web/src/components/RequestCard.tsx
+++ b/packages/web/src/components/RequestCard.tsx
@@ -1,7 +1,7 @@
 import { type SongRequest } from '@alfira/server/shared';
 import { formatDuration } from '@alfira/server/shared';
 import { CheckCircleIcon, TrashIcon, XCircleIcon } from '@phosphor-icons/react';
-import { memo } from 'react';
+import { memo, useCallback } from 'react';
 
 import { SourceIcon } from './SourceIcons';
 import { ArtworkImage } from './ui/ArtworkImage';
@@ -37,6 +37,10 @@ export const RequestCard = memo(function RequestCard({
     ? req.playlistData?.thumbnailUrl || req.thumbnailUrl
     : req.artworkUrl || req.thumbnailUrl;
   const dateLabel = new Date(req.createdAt).toLocaleDateString();
+
+  const handleCancel = useCallback(() => onCancel(req.id), [onCancel, req.id]);
+  const handleApprove = useCallback(() => onApprove(req.id), [onApprove, req.id]);
+  const handleDeny = useCallback(() => onDeny(req.id), [onDeny, req.id]);
 
   return (
     <Card className='rounded-xl flex items-center gap-4 p-4'>
@@ -93,7 +97,7 @@ export const RequestCard = memo(function RequestCard({
           {isOwn && (
             <Button
               variant='inherit'
-              onClick={() => onCancel(req.id)}
+              onClick={handleCancel}
               surface='elevated'
               title='Cancel request'
             >
@@ -102,20 +106,10 @@ export const RequestCard = memo(function RequestCard({
           )}
           {isAdmin && (
             <>
-              <Button
-                variant='inherit'
-                onClick={() => onApprove(req.id)}
-                surface='elevated'
-                title='Approve'
-              >
+              <Button variant='inherit' onClick={handleApprove} surface='elevated' title='Approve'>
                 <CheckCircleIcon size={16} weight='duotone' className='text-emerald-400' />
               </Button>
-              <Button
-                variant='inherit'
-                onClick={() => onDeny(req.id)}
-                surface='elevated'
-                title='Deny'
-              >
+              <Button variant='inherit' onClick={handleDeny} surface='elevated' title='Deny'>
                 <XCircleIcon size={16} weight='duotone' className='text-danger' />
               </Button>
             </>

--- a/packages/web/src/components/SettingsMenu.tsx
+++ b/packages/web/src/components/SettingsMenu.tsx
@@ -1,4 +1,5 @@
 import { WrenchIcon } from '@phosphor-icons/react';
+import { useCallback, useMemo } from 'react';
 import { NavLink } from 'react-router-dom';
 
 interface SettingsMenuProps {
@@ -7,18 +8,27 @@ interface SettingsMenuProps {
 }
 
 export default function SettingsMenu({ collapsed = false, onClick }: SettingsMenuProps) {
+  const classNameFn = useCallback(
+    ({ isActive }: { isActive: boolean }) =>
+      `flex items-center rounded-xl font-body transition-all duration-150 cursor-pointer w-full ${
+        collapsed ? 'justify-center px-0 py-3' : 'px-3 py-3'
+      } ${isActive ? 'btn-inherit pressed' : 'btn-inherit'}`,
+    [collapsed]
+  );
+
+  const linkStyle = useMemo(
+    () => ({ '--btn-surface': 'var(--color-elevated)' }) as React.CSSProperties,
+    []
+  );
+
   return (
     <div className={collapsed ? 'flex justify-center px-2 pb-2' : 'px-3 pb-2'}>
       <NavLink
         to='/settings'
         title={collapsed ? 'Settings' : undefined}
         onClick={onClick}
-        className={({ isActive }) =>
-          `flex items-center rounded-xl font-body transition-all duration-150 cursor-pointer w-full ${
-            collapsed ? 'justify-center px-0 py-3' : 'px-3 py-3'
-          } ${isActive ? 'btn-inherit pressed' : 'btn-inherit'}`
-        }
-        style={{ '--btn-surface': 'var(--color-elevated)' } as React.CSSProperties}
+        className={classNameFn}
+        style={linkStyle}
       >
         {!collapsed && <span className='mr-auto'>Settings</span>}
         <WrenchIcon size={22} weight='duotone' />

--- a/packages/web/src/components/TagTicker.tsx
+++ b/packages/web/src/components/TagTicker.tsx
@@ -107,17 +107,45 @@ const TagTicker = memo(({ tags, isHovered: externalHovered }: TagTickerProps) =>
     }
   }, [effectiveHovered, shouldScroll]);
 
+  const animationStyle: React.CSSProperties = useMemo(
+    () =>
+      shouldScroll
+        ? {
+            width: 'max-content',
+            animation: `ticker-scroll ${duration}s linear infinite`,
+            animationPlayState: effectiveHovered ? 'running' : 'paused',
+          }
+        : {},
+    [shouldScroll, duration, effectiveHovered]
+  );
+
+  const maskStyle: React.CSSProperties = useMemo(
+    () =>
+      shouldScroll
+        ? {
+            maskImage: 'linear-gradient(to right, transparent, black 8%, black 80%, transparent)',
+            WebkitMaskImage:
+              'linear-gradient(to right, transparent, black 8%, black 80%, transparent)',
+          }
+        : {},
+    [shouldScroll]
+  );
+
+  const handleMouseEnter = useCallback(() => {
+    if (externalHovered === undefined) {
+      setIsHovered(true);
+    }
+  }, [externalHovered]);
+
+  const handleMouseLeave = useCallback(() => {
+    if (externalHovered === undefined) {
+      setIsHovered(false);
+    }
+  }, [externalHovered]);
+
   if (dedupedTags.length === 0) {
     return null;
   }
-
-  const animationStyle: React.CSSProperties = shouldScroll
-    ? {
-        width: 'max-content',
-        animation: `ticker-scroll ${duration}s linear infinite`,
-        animationPlayState: effectiveHovered ? 'running' : 'paused',
-      }
-    : {};
 
   return (
     // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- hover state pauses ticker; marquee has dedicated role
@@ -125,23 +153,9 @@ const TagTicker = memo(({ tags, isHovered: externalHovered }: TagTickerProps) =>
       role='marquee'
       className='overflow-hidden py-0 max-w-[60%]'
       ref={outerRef}
-      style={{
-        ...(shouldScroll && {
-          maskImage: 'linear-gradient(to right, transparent, black 8%, black 80%, transparent)',
-          WebkitMaskImage:
-            'linear-gradient(to right, transparent, black 8%, black 80%, transparent)',
-        }),
-      }}
-      onMouseEnter={() => {
-        if (externalHovered === undefined) {
-          setIsHovered(true);
-        }
-      }}
-      onMouseLeave={() => {
-        if (externalHovered === undefined) {
-          setIsHovered(false);
-        }
-      }}
+      style={maskStyle}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
     >
       <div className='flex gap-1' ref={innerRef} style={animationStyle}>
         {renderTags('a')}

--- a/packages/web/src/components/UserMenu.tsx
+++ b/packages/web/src/components/UserMenu.tsx
@@ -1,6 +1,8 @@
+import type React from 'react';
+
 import { type User } from '@alfira/server/shared';
 import { SignOutIcon, UserIcon } from '@phosphor-icons/react';
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 interface UserMenuProps {
@@ -95,10 +97,19 @@ export default function UserMenu({ user, collapsed, onLogout }: UserMenuProps) {
     return () => document.removeEventListener('keydown', handler);
   }, [open]);
 
-  const handleLogout = () => {
+  const handleLogout = useCallback(() => {
     setOpen(false);
     onLogout();
-  };
+  }, [onLogout]);
+
+  const handleToggle = useCallback(() => setOpen((o) => !o), []);
+
+  const handleStopPropagation = useCallback((e: React.SyntheticEvent) => e.stopPropagation(), []);
+
+  const portalStyle = useMemo(
+    () => ({ position: 'fixed' as const, top: position.top, left: position.left }),
+    [position.top, position.left]
+  );
 
   const avatarSize = collapsed ? 'size-[22px]' : 'w-7 h-7';
   const avatarFallbackSize = collapsed ? 'text-[11px]' : 'text-sm';
@@ -120,7 +131,10 @@ export default function UserMenu({ user, collapsed, onLogout }: UserMenuProps) {
     </div>
   );
 
-  const triggerSurfaceVar = { '--btn-surface': 'var(--color-elevated)' } as React.CSSProperties;
+  const triggerSurfaceVar = useMemo(
+    () => ({ '--btn-surface': 'var(--color-elevated)' }) as React.CSSProperties,
+    []
+  );
 
   return (
     <>
@@ -128,7 +142,7 @@ export default function UserMenu({ user, collapsed, onLogout }: UserMenuProps) {
       <button
         ref={triggerRef}
         type='button'
-        onClick={() => setOpen((o) => !o)}
+        onClick={handleToggle}
         title={user.username}
         className={`flex items-center rounded-xl font-body transition-all duration-150 cursor-pointer w-full btn-inherit ${
           collapsed ? 'justify-center px-0 py-3' : 'gap-3 px-3 py-2.5'
@@ -150,10 +164,10 @@ export default function UserMenu({ user, collapsed, onLogout }: UserMenuProps) {
             ref={menuRef}
             role='menu'
             tabIndex={-1}
-            style={{ position: 'fixed', top: position.top, left: position.left }}
+            style={portalStyle}
             className='z-9999 min-w-40'
-            onKeyDown={(e) => e.stopPropagation()}
-            onClick={(e) => e.stopPropagation()}
+            onKeyDown={handleStopPropagation}
+            onClick={handleStopPropagation}
           >
             <div className='glass-popover outline-2 outline-accent/20'>
               {/* Username header — mirrors ContextMenu InfoRow */}

--- a/packages/web/src/components/VirtualList.tsx
+++ b/packages/web/src/components/VirtualList.tsx
@@ -1,6 +1,6 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
 import * as m from 'motion/react-m';
-import { memo, useEffect, useLayoutEffect, useRef } from 'react';
+import { memo, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 
 import { listItemVariants } from '../lib/motion';
 import EmptyState from './EmptyState';
@@ -122,6 +122,19 @@ function VirtualListInner<T>({
   const showEmpty = hasLoaded && items.length === 0;
   const showContent = !isLoading && hasLoaded && items.length > 0;
 
+  // Stable styles for the outer containers.
+  const containerStyle = useMemo(() => ({ opacity: 0, transition: 'opacity 120ms ease' }), []);
+
+  const scrollMaskStyle = useMemo(
+    () => ({
+      WebkitMaskImage:
+        'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 20px), transparent 100%)',
+      maskImage:
+        'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 20px), transparent 100%)',
+    }),
+    []
+  );
+
   useLayoutEffect(() => {
     if (!containerRef.current) {
       return;
@@ -133,7 +146,7 @@ function VirtualListInner<T>({
     <div
       ref={containerRef}
       className='relative flex-1 min-h-0 flex flex-col overflow-x-hidden'
-      style={{ opacity: 0, transition: 'opacity 120ms ease' }}
+      style={containerStyle}
     >
       {showSkeleton && skeleton}
 
@@ -143,12 +156,7 @@ function VirtualListInner<T>({
         <div
           ref={scrollRef}
           className='overflow-y-auto overflow-x-hidden px-2 pt-3 min-h-0 flex-1 bg-surface'
-          style={{
-            WebkitMaskImage:
-              'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 20px), transparent 100%)',
-            maskImage:
-              'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 20px), transparent 100%)',
-          }}
+          style={scrollMaskStyle}
         >
           <div
             style={{

--- a/packages/web/src/components/VirtualPlaylistList.tsx
+++ b/packages/web/src/components/VirtualPlaylistList.tsx
@@ -1,5 +1,5 @@
 import { type Playlist } from '@alfira/server/shared';
-import { memo } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 
 import PlaylistRow from './PlaylistRow';
 import { VirtualList } from './VirtualList';
@@ -60,18 +60,27 @@ export const VirtualPlaylistList = memo(function VirtualPlaylistList({
   emptyTitle,
   emptyMessage,
 }: VirtualPlaylistListProps) {
+  const getItemKey = useCallback((playlist: Playlist) => playlist.id, []);
+
+  const renderItem = useCallback(
+    (playlist: Playlist) => (
+      <PlaylistRow
+        playlist={playlist}
+        animationDelay='0ms'
+        onClick={onRowClick}
+        data-playlist-id={playlist.id}
+      />
+    ),
+    [onRowClick]
+  );
+
+  const skeleton = useMemo(() => <SkeletonList />, []);
+
   return (
     <VirtualList
       items={items}
-      getItemKey={(playlist) => playlist.id}
-      renderItem={(playlist) => (
-        <PlaylistRow
-          playlist={playlist}
-          animationDelay='0ms'
-          onClick={onRowClick}
-          data-playlist-id={playlist.id}
-        />
-      )}
+      getItemKey={getItemKey}
+      renderItem={renderItem}
       estimateSize={120}
       itemClassName='pb-4'
       isLoading={isLoading}
@@ -81,7 +90,7 @@ export const VirtualPlaylistList = memo(function VirtualPlaylistList({
       hasMore={hasMore}
       onRetry={onRetry}
       onFetchMore={onFetchMore}
-      skeleton={<SkeletonList />}
+      skeleton={skeleton}
       emptyTitle={emptyTitle}
       emptyMessage={emptyMessage}
     />

--- a/packages/web/src/components/VirtualRequestList.tsx
+++ b/packages/web/src/components/VirtualRequestList.tsx
@@ -1,5 +1,5 @@
 import { type SongRequest } from '@alfira/server/shared';
-import { memo } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 
 import RequestCard from './RequestCard';
 import { VirtualList } from './VirtualList';
@@ -71,20 +71,29 @@ export const VirtualRequestList = memo(function VirtualRequestList({
   emptyTitle,
   emptyMessage,
 }: VirtualRequestListProps) {
+  const getItemKey = useCallback((req: SongRequest) => req.id, []);
+
+  const renderItem = useCallback(
+    (req: SongRequest) => (
+      <RequestCard
+        req={req}
+        isOwn={isOwnFn(req.requestedBy)}
+        isAdmin={isAdmin}
+        onApprove={onApprove}
+        onDeny={onDeny}
+        onCancel={onCancel}
+      />
+    ),
+    [isOwnFn, isAdmin, onApprove, onDeny, onCancel]
+  );
+
+  const skeleton = useMemo(() => <SkeletonList />, []);
+
   return (
     <VirtualList
       items={items}
-      getItemKey={(req) => req.id}
-      renderItem={(req) => (
-        <RequestCard
-          req={req}
-          isOwn={isOwnFn(req.requestedBy)}
-          isAdmin={isAdmin}
-          onApprove={onApprove}
-          onDeny={onDeny}
-          onCancel={onCancel}
-        />
-      )}
+      getItemKey={getItemKey}
+      renderItem={renderItem}
       estimateSize={95}
       itemClassName='pb-4'
       isLoading={isLoading}
@@ -94,7 +103,7 @@ export const VirtualRequestList = memo(function VirtualRequestList({
       hasMore={hasMore}
       onRetry={onRetry}
       onFetchMore={onFetchMore}
-      skeleton={<SkeletonList />}
+      skeleton={skeleton}
       emptyTitle={emptyTitle}
       emptyMessage={emptyMessage}
     />

--- a/packages/web/src/components/VirtualSongGrid.tsx
+++ b/packages/web/src/components/VirtualSongGrid.tsx
@@ -42,13 +42,14 @@ interface GridSongItem {
 // Skeleton
 // ---------------------------------------------------------------------------
 
+const SKELETON_GRID_STYLE = {
+  gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))',
+} as const;
+
 function SkeletonGrid() {
   return (
     <div className='px-4 pt-4'>
-      <div
-        className='grid gap-4'
-        style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))' }}
-      >
+      <div className='grid gap-4' style={SKELETON_GRID_STYLE}>
         {Array.from({ length: 8 }).map((_, i) => (
           <div
             key={`skeleton-${i}`}
@@ -171,7 +172,6 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
   };
 
   const GridCard = useMemo(() => {
-    // eslint-disable-next-line react/no-unstable-nested-components -- must be created inside useMemo([]) for stable type identity; masonic's render prop requires a component, not an element
     const Component = ({
       index: _index,
       width,
@@ -238,21 +238,27 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
     onRender: isContentReady ? handleRender : undefined,
   });
 
+  const scrollStyle = useMemo(
+    () => ({
+      overflowX: 'hidden' as const,
+      overflowY: isContentReady ? ('auto' as const) : ('hidden' as const),
+      WebkitMaskImage: isContentReady
+        ? 'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 20px), transparent 100%)'
+        : undefined,
+      maskImage: isContentReady
+        ? 'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 20px), transparent 100%)'
+        : undefined,
+    }),
+    [isContentReady]
+  );
+
+  const masonryWrapperStyle = useMemo(
+    () => ({ display: isContentReady ? undefined : ('none' as const) }),
+    [isContentReady]
+  );
+
   return (
-    <div
-      ref={scrollRefCallback}
-      className='pt-3 min-h-0 flex-1'
-      style={{
-        overflowX: 'hidden',
-        overflowY: isContentReady ? 'auto' : 'hidden',
-        WebkitMaskImage: isContentReady
-          ? 'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 20px), transparent 100%)'
-          : undefined,
-        maskImage: isContentReady
-          ? 'linear-gradient(to bottom, transparent 0%, black 20px, black calc(100% - 20px), transparent 100%)'
-          : undefined,
-      }}
-    >
+    <div ref={scrollRefCallback} className='pt-3 min-h-0 flex-1' style={scrollStyle}>
       {showSkeleton && <SkeletonGrid />}
 
       {showEmpty && (
@@ -265,7 +271,7 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
       )}
 
       {/* Masonry is always in the DOM (ref attachment) but hidden until content is ready */}
-      <div style={{ display: isContentReady ? undefined : 'none' }}>{masonry}</div>
+      <div style={masonryWrapperStyle}>{masonry}</div>
 
       {isContentReady && isFetching && (
         <div className='flex justify-center py-4 gap-2'>

--- a/packages/web/src/components/VirtualSongList.tsx
+++ b/packages/web/src/components/VirtualSongList.tsx
@@ -1,5 +1,5 @@
 import { type Playlist, type Song } from '@alfira/server/shared';
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useSongEdit } from '../context/SongEditContext';
 import SongCard from './SongCard';
@@ -63,6 +63,59 @@ function SkeletonList() {
 }
 
 // ---------------------------------------------------------------------------
+// Item wrapper — creates stable event callbacks per song
+// ---------------------------------------------------------------------------
+
+interface SongListItemProps {
+  song: Song;
+  isAdminView: boolean;
+  playlists: Playlist[];
+  playingId: string | null;
+  selectionMode: boolean;
+  isSelected: boolean;
+  onDelete?: (id: string) => void;
+  onPlay: (id: string) => void;
+  onAddToQueue: (id: string) => void;
+  onToggleSelect?: (id: string) => void;
+}
+
+const SongListItem = memo(function SongListItem({
+  song,
+  isAdminView,
+  playlists,
+  playingId,
+  selectionMode,
+  isSelected,
+  onDelete,
+  onPlay,
+  onAddToQueue,
+  onToggleSelect,
+}: SongListItemProps) {
+  const handlePlay = useCallback(() => onPlay(song.id), [onPlay, song.id]);
+  const handleAddToQueue = useCallback(() => onAddToQueue(song.id), [onAddToQueue, song.id]);
+  const handleToggleSelect = useCallback(
+    () => onToggleSelect?.(song.id),
+    [onToggleSelect, song.id]
+  );
+
+  return (
+    <SongCard
+      song={song}
+      variant='list'
+      isAdminView={isAdminView}
+      playlists={playlists}
+      onDelete={onDelete}
+      onPlay={handlePlay}
+      isPlaying={playingId === song.id}
+      onAddToQueue={handleAddToQueue}
+      selectionMode={selectionMode}
+      isSelected={isSelected}
+      onToggleSelect={onToggleSelect ? handleToggleSelect : undefined}
+    />
+  );
+});
+
+// ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
@@ -114,25 +167,43 @@ export const VirtualSongList = memo(function VirtualSongList({
     [items, effectiveOpenId]
   );
 
+  const getItemKey = useCallback((song: Song) => song.id, []);
+
+  const renderItem = useCallback(
+    (song: Song) => (
+      <SongListItem
+        song={song}
+        isAdminView={isAdminView}
+        playlists={playlists}
+        playingId={playingId}
+        selectionMode={selectionMode}
+        isSelected={isSelected?.(song.id) ?? false}
+        onDelete={onDelete}
+        onPlay={onPlay}
+        onAddToQueue={onAddToQueue}
+        onToggleSelect={onToggleSelect}
+      />
+    ),
+    [
+      isAdminView,
+      playlists,
+      playingId,
+      selectionMode,
+      isSelected,
+      onDelete,
+      onPlay,
+      onAddToQueue,
+      onToggleSelect,
+    ]
+  );
+
+  const skeleton = useMemo(() => <SkeletonList />, []);
+
   return (
     <VirtualList
       items={items}
-      getItemKey={(song) => song.id}
-      renderItem={(song) => (
-        <SongCard
-          song={song}
-          variant='list'
-          isAdminView={isAdminView}
-          playlists={playlists}
-          onDelete={onDelete}
-          onPlay={() => onPlay(song.id)}
-          isPlaying={playingId === song.id}
-          onAddToQueue={() => onAddToQueue(song.id)}
-          selectionMode={selectionMode}
-          isSelected={isSelected?.(song.id) ?? false}
-          onToggleSelect={onToggleSelect ? () => onToggleSelect(song.id) : undefined}
-        />
-      )}
+      getItemKey={getItemKey}
+      renderItem={renderItem}
       estimateSize={estimateSize}
       itemClassName='pb-3'
       isLoading={isLoading}
@@ -142,7 +213,7 @@ export const VirtualSongList = memo(function VirtualSongList({
       hasMore={hasMore}
       onRetry={onRetry}
       onFetchMore={onFetchMore}
-      skeleton={<SkeletonList />}
+      skeleton={skeleton}
       emptyTitle={emptyTitle}
       emptyMessage={emptyMessage}
     />

--- a/packages/web/src/components/queue/OverrideModal.tsx
+++ b/packages/web/src/components/queue/OverrideModal.tsx
@@ -1,5 +1,7 @@
+import type React from 'react';
+
 import { WarningIcon } from '@phosphor-icons/react';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { overridePlay } from '../../api/api';
 import { apiErrorMessage, isRateLimitError } from '../../utils/api';
@@ -19,7 +21,7 @@ export default function OverrideModal({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
 
-  const handleSubmit = async () => {
+  const handleSubmit = useCallback(async () => {
     if (!sourceUrl.trim()) {
       return;
     }
@@ -36,7 +38,21 @@ export default function OverrideModal({
       }
       setSubmitting(false);
     }
-  };
+  }, [sourceUrl, onOverride]);
+
+  const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setSourceUrl(e.target.value);
+    setError('');
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && sourceUrl.trim()) {
+        void handleSubmit();
+      }
+    },
+    [sourceUrl, handleSubmit]
+  );
 
   return (
     <Backdrop onClose={onClose}>
@@ -55,18 +71,11 @@ export default function OverrideModal({
             <input
               type='text'
               value={sourceUrl}
-              onChange={(e) => {
-                setSourceUrl(e.target.value);
-                setError('');
-              }}
+              onChange={handleChange}
               placeholder='https://...'
               className='input w-full'
               disabled={submitting}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && sourceUrl.trim()) {
-                  void handleSubmit();
-                }
-              }}
+              onKeyDown={handleKeyDown}
             />
           </div>
         </div>

--- a/packages/web/src/components/queue/QuickAddModal.tsx
+++ b/packages/web/src/components/queue/QuickAddModal.tsx
@@ -1,4 +1,6 @@
-import { useState } from 'react';
+import type React from 'react';
+
+import { useCallback, useState } from 'react';
 
 import { quickAddPlaylistToQueue, quickAddToQueue } from '../../api/api';
 import { apiErrorMessage, isRateLimitError } from '../../utils/api';
@@ -22,7 +24,7 @@ export default function QuickAddModal({
   const isPlaylist = sourceUrl.includes('list=');
   const [importFullPlaylist, setImportFullPlaylist] = useState(false);
 
-  const handleSubmit = async () => {
+  const handleSubmit = useCallback(async () => {
     if (!sourceUrl.trim()) {
       return;
     }
@@ -48,7 +50,22 @@ export default function QuickAddModal({
       }
       setSubmitting(false);
     }
-  };
+  }, [sourceUrl, importFullPlaylist, onAdded]);
+
+  const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setSourceUrl(e.target.value);
+    setError('');
+    setSuccessMsg('');
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && sourceUrl.trim()) {
+        void handleSubmit();
+      }
+    },
+    [sourceUrl, handleSubmit]
+  );
 
   return (
     <Backdrop onClose={onClose}>
@@ -66,19 +83,11 @@ export default function QuickAddModal({
             <input
               type='text'
               value={sourceUrl}
-              onChange={(e) => {
-                setSourceUrl(e.target.value);
-                setError('');
-                setSuccessMsg('');
-              }}
+              onChange={handleChange}
               placeholder='https://...'
               className='input w-full'
               disabled={submitting}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && sourceUrl.trim()) {
-                  void handleSubmit();
-                }
-              }}
+              onKeyDown={handleKeyDown}
             />
             {isPlaylist && (
               <label className='flex items-center gap-2 cursor-pointer mt-2'>

--- a/packages/web/src/components/settings/CompressorSection.tsx
+++ b/packages/web/src/components/settings/CompressorSection.tsx
@@ -1,5 +1,7 @@
+import type React from 'react';
+
 import { ArrowCounterClockwise, FloppyDisk } from '@phosphor-icons/react';
-import { useEffect, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useAdminView } from '../../context/AdminViewContext';
 import { usePermissions } from '../../context/PermissionsContext';
@@ -16,6 +18,56 @@ const SLIDERS = [
 ] as const;
 
 type SliderKey = (typeof SLIDERS)[number]['key'];
+
+// ---------------------------------------------------------------------------
+// Child component — extracted for stable onChange + style in the map loop
+// ---------------------------------------------------------------------------
+
+interface CompressorSliderProps {
+  config: (typeof SLIDERS)[number];
+  value: number;
+  onChange: (key: SliderKey, value: number) => void;
+}
+
+const CompressorSlider = memo(function CompressorSlider({
+  config: { key, label, min, max, step, unit },
+  value,
+  onChange,
+}: CompressorSliderProps) {
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => onChange(key, parseFloat(e.target.value)),
+    [onChange, key]
+  );
+
+  const rangePct = ((value - min) / (max - min)) * 100;
+  const sliderStyle = useMemo(
+    () => ({ '--range-pct': `${rangePct}%` }) as React.CSSProperties,
+    [rangePct]
+  );
+
+  return (
+    <div className='flex items-center gap-3'>
+      <span className='font-mono text-[11px] text-muted w-20 shrink-0'>{label}</span>
+      <span className='font-mono text-[11px] text-fg w-16 shrink-0'>
+        {key === 'ratio'
+          ? `${value.toFixed(1)}:1`
+          : key === 'gain'
+            ? `+${value} ${unit}`
+            : `${value} ${unit}`}
+      </span>
+      <input
+        type='range'
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={handleChange}
+        className='flex-1 range-input range-input-h'
+        style={sliderStyle}
+      />
+    </div>
+  );
+});
 
 interface CompressorValues {
   enabled: boolean;
@@ -60,7 +112,7 @@ export default function CompressorSection() {
 
   const hasChanges = JSON.stringify(values) !== JSON.stringify(savedValues);
 
-  async function handleSave() {
+  const handleSave = useCallback(async () => {
     setSaving(true);
     try {
       const res = await fetch('/api/settings/compressor', {
@@ -76,15 +128,17 @@ export default function CompressorSection() {
     } finally {
       setSaving(false);
     }
-  }
+  }, [values]);
 
-  function handleReset() {
+  const handleReset = useCallback(() => {
     setValues({ ...DEFAULTS, enabled: values.enabled });
-  }
+  }, [values.enabled]);
 
-  function updateValue(key: SliderKey, value: number) {
+  const updateValue = useCallback((key: SliderKey, value: number) => {
     setValues((v) => ({ ...v, [key]: value }));
-  }
+  }, []);
+
+  const handleToggle = useCallback(() => setValues((v) => ({ ...v, enabled: !v.enabled })), []);
 
   const dimmed = !canManage;
 
@@ -101,7 +155,7 @@ export default function CompressorSection() {
           role='switch'
           aria-checked={values.enabled}
           aria-label='Enable compressor'
-          onClick={() => setValues((v) => ({ ...v, enabled: !v.enabled }))}
+          onClick={handleToggle}
           className={`relative shrink-0 w-9 h-5 rounded-full transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface ${
             values.enabled ? 'bg-accent' : 'bg-border'
           }`}
@@ -115,31 +169,13 @@ export default function CompressorSection() {
       </div>
 
       <div className={`space-y-2 ${!values.enabled ? 'opacity-40' : ''}`}>
-        {SLIDERS.map(({ key, label, min, max, step, unit }) => (
-          <div key={key} className='flex items-center gap-3'>
-            <span className='font-mono text-[11px] text-muted w-20 shrink-0'>{label}</span>
-            <span className='font-mono text-[11px] text-fg w-16 shrink-0'>
-              {key === 'ratio'
-                ? `${values[key].toFixed(1)}:1`
-                : key === 'gain'
-                  ? `+${values[key]} ${unit}`
-                  : `${values[key]} ${unit}`}
-            </span>
-            <input
-              type='range'
-              min={min}
-              max={max}
-              step={step}
-              value={values[key]}
-              onChange={(e) => updateValue(key, parseFloat(e.target.value))}
-              className='flex-1 range-input range-input-h'
-              style={
-                {
-                  '--range-pct': `${((values[key] - min) / (max - min)) * 100}%`,
-                } as React.CSSProperties
-              }
-            />
-          </div>
+        {SLIDERS.map((config) => (
+          <CompressorSlider
+            key={config.key}
+            config={config}
+            value={values[config.key]}
+            onChange={updateValue}
+          />
         ))}
       </div>
 

--- a/packages/web/src/components/settings/EqualizerSection.tsx
+++ b/packages/web/src/components/settings/EqualizerSection.tsx
@@ -1,5 +1,7 @@
+import type React from 'react';
+
 import { ArrowCounterClockwise, FloppyDisk } from '@phosphor-icons/react';
-import { useEffect, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useAdminView } from '../../context/AdminViewContext';
 import { usePermissions } from '../../context/PermissionsContext';
@@ -23,6 +25,64 @@ const FREQ_LABELS = [
   '16k',
 ];
 const DEFAULT_BANDS = Array(15).fill(50);
+
+// ---------------------------------------------------------------------------
+// Child component — extracted for stable onChange + style in the map loop
+// ---------------------------------------------------------------------------
+
+interface EqBandSliderProps {
+  index: number;
+  value: number;
+  label: string;
+  onChange: (index: number, value: number) => void;
+}
+
+const EqBandSlider = memo(function EqBandSlider({
+  index,
+  value,
+  label,
+  onChange,
+}: EqBandSliderProps) {
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => onChange(index, parseInt(e.target.value, 10)),
+    [onChange, index]
+  );
+
+  const gainOffset = value - 50;
+  const gainLabel = gainOffset === 0 ? '0' : `${gainOffset > 0 ? '+' : ''}${gainOffset}`;
+
+  const sliderStyle = useMemo(
+    () => ({
+      writingMode: 'vertical-lr' as const,
+      direction: 'rtl' as const,
+      width: '8px',
+      height: '120px',
+      borderRadius: '4px',
+      background: `linear-gradient(to top, var(--color-accent) 0%, var(--color-accent) ${(value / 100) * 100}%, var(--color-border) ${(value / 100) * 100}%, var(--color-border) 100%)`,
+    }),
+    [value]
+  );
+
+  return (
+    <div className='flex flex-col items-center gap-1 shrink-0'>
+      <span className='font-mono text-[10px] text-muted'>{label}</span>
+      <div className='relative h-[120px] w-2'>
+        <input
+          type='range'
+          min={0}
+          max={100}
+          step={1}
+          value={value}
+          onChange={handleChange}
+          className='range-input'
+          style={sliderStyle}
+        />
+        <div className='absolute inset-x-0 top-1/2 h-px bg-border/50 pointer-events-none' />
+      </div>
+      <span className='font-mono text-[10px] text-fg min-w-[2em] text-right'>{gainLabel}</span>
+    </div>
+  );
+});
 
 export default function EqualizerSection() {
   const { isAdminView } = useAdminView();
@@ -66,7 +126,7 @@ export default function EqualizerSection() {
   const hasChanges =
     JSON.stringify(effectiveBands) !== JSON.stringify(savedBands) || eqEnabled !== savedEnabled;
 
-  async function handleSave() {
+  const handleSave = useCallback(async () => {
     setSaving(true);
     try {
       const res = await fetch('/api/settings/equalizer', {
@@ -83,25 +143,21 @@ export default function EqualizerSection() {
     } finally {
       setSaving(false);
     }
-  }
+  }, [effectiveBands, eqEnabled]);
 
-  function handleReset() {
+  const handleReset = useCallback(() => {
     setBands(DEFAULT_BANDS);
-  }
+  }, []);
 
-  function updateBand(index: number, value: number) {
-    const next = [...bands];
-    next[index] = value;
-    setBands(next);
-  }
+  const updateBand = useCallback((index: number, value: number) => {
+    setBands((prev) => {
+      const next = [...prev];
+      next[index] = value;
+      return next;
+    });
+  }, []);
 
-  function gainDisplay(value: number): string {
-    const offset = value - 50;
-    if (offset === 0) {
-      return '0';
-    }
-    return `${offset > 0 ? '+' : ''}${offset}`;
-  }
+  const handleToggle = useCallback(() => setEqEnabled((v) => !v), []);
 
   // EQ curve SVG visualization
   const curvePath = (() => {
@@ -136,7 +192,7 @@ export default function EqualizerSection() {
           role='switch'
           aria-checked={eqEnabled}
           aria-label='Enable equalizer'
-          onClick={() => setEqEnabled(!eqEnabled)}
+          onClick={handleToggle}
           className={`relative shrink-0 w-9 h-5 rounded-full transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface ${
             eqEnabled ? 'bg-accent' : 'bg-border'
           }`}
@@ -177,33 +233,13 @@ export default function EqualizerSection() {
         className={`flex flex-wrap justify-center gap-2 md:flex-nowrap ${slidersDimmed ? 'opacity-40' : ''}`}
       >
         {bands.map((value, i) => (
-          // eslint-disable-next-line react/no-array-index-key -- static UI elements with stable order
-          <div key={i} className='flex flex-col items-center gap-1 shrink-0'>
-            <span className='font-mono text-[10px] text-muted'>{FREQ_LABELS[i]}</span>
-            <div className='relative h-[120px] w-2'>
-              <input
-                type='range'
-                min={0}
-                max={100}
-                step={1}
-                value={value}
-                onChange={(e) => updateBand(i, parseInt(e.target.value, 10))}
-                className='range-input'
-                style={{
-                  writingMode: 'vertical-lr',
-                  direction: 'rtl',
-                  width: '8px',
-                  height: '120px',
-                  borderRadius: '4px',
-                  background: `linear-gradient(to top, var(--color-accent) 0%, var(--color-accent) ${(value / 100) * 100}%, var(--color-border) ${(value / 100) * 100}%, var(--color-border) 100%)`,
-                }}
-              />
-              <div className='absolute inset-x-0 top-1/2 h-px bg-border/50 pointer-events-none' />
-            </div>
-            <span className='font-mono text-[10px] text-fg min-w-[2em] text-right'>
-              {gainDisplay(value)}
-            </span>
-          </div>
+          <EqBandSlider
+            key={i}
+            index={i}
+            value={value}
+            label={FREQ_LABELS[i]}
+            onChange={updateBand}
+          />
         ))}
       </div>
 

--- a/packages/web/src/components/settings/SettingsToggle.tsx
+++ b/packages/web/src/components/settings/SettingsToggle.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 interface SettingsToggleProps {
   label: string;
   description?: string;
@@ -13,6 +15,11 @@ export default function SettingsToggle({
   onChange,
   disabled = false,
 }: SettingsToggleProps) {
+  const handleClick = useCallback(
+    () => !disabled && onChange(!checked),
+    [disabled, onChange, checked]
+  );
+
   return (
     <div className={`flex items-start gap-4 ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}>
       <div className='flex-1 min-w-0'>
@@ -25,7 +32,7 @@ export default function SettingsToggle({
         aria-checked={checked}
         aria-label={label}
         disabled={disabled}
-        onClick={() => !disabled && onChange(!checked)}
+        onClick={handleClick}
         className={`relative shrink-0 w-11 h-6 rounded-full transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface mt-1.5 ${
           checked ? 'bg-accent' : 'bg-elevated'
         } ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'}`}

--- a/packages/web/src/components/settings/UserSection.tsx
+++ b/packages/web/src/components/settings/UserSection.tsx
@@ -1,6 +1,105 @@
 import { DesktopIcon, MoonIcon, SunIcon } from '@phosphor-icons/react';
+import { memo, useCallback, useMemo } from 'react';
 
 import { useTheme } from '../../context/ThemeContext';
+
+// ---------------------------------------------------------------------------
+// Child components — extracted so useCallback closures are stable per item
+// ---------------------------------------------------------------------------
+
+interface ThemeModeButtonProps {
+  mode: 'auto' | 'light' | 'dark';
+  icon: typeof DesktopIcon;
+  label: string;
+  isSelected: boolean;
+  onSelect: (mode: 'auto' | 'light' | 'dark') => void;
+}
+
+const ThemeModeButton = memo(function ThemeModeButton({
+  mode,
+  icon: Icon,
+  label,
+  isSelected,
+  onSelect,
+}: ThemeModeButtonProps) {
+  const handleClick = useCallback(() => onSelect(mode), [onSelect, mode]);
+
+  return (
+    <button
+      type='button'
+      onClick={handleClick}
+      className={`flex flex-col items-center p-1 rounded-lg transition-all cursor-pointer group ${
+        isSelected ? 'opacity-100' : 'opacity-50'
+      }`}
+    >
+      <span
+        className={`w-10 h-10 sm:w-12 sm:h-12 rounded-full flex items-center justify-center text-muted transition-all ${
+          isSelected
+            ? 'bg-accent/15 text-accent ring-2 ring-offset-2 ring-offset-background ring-foreground'
+            : 'bg-muted/10 group-hover:ring-1 group-hover:ring-muted/30'
+        }`}
+      >
+        <Icon size={20} weight='duotone' />
+      </span>
+      <span className='text-[11px] text-muted leading-none mt-1'>{label}</span>
+    </button>
+  );
+});
+
+interface ThemeColorButtonProps {
+  name: string;
+  displayName: string;
+  accentColor: string;
+  isSelected: boolean;
+  onSelect: (name: string) => void;
+}
+
+const ThemeColorButton = memo(function ThemeColorButton({
+  name,
+  displayName,
+  accentColor,
+  isSelected,
+  onSelect,
+}: ThemeColorButtonProps) {
+  const handleClick = useCallback(() => onSelect(name), [onSelect, name]);
+
+  const dotStyle = useMemo(() => ({ backgroundColor: accentColor }), [accentColor]);
+
+  return (
+    <button
+      type='button'
+      onClick={handleClick}
+      className={`flex flex-col items-center p-1 rounded-lg transition-all cursor-pointer group ${
+        isSelected ? 'opacity-100' : 'opacity-80'
+      }`}
+    >
+      <span
+        className={`w-10 h-10 sm:w-12 sm:h-12 rounded-full flex items-center justify-center transition-all border border-border/40 ${
+          isSelected
+            ? 'ring-2 ring-offset-2 ring-offset-background ring-foreground'
+            : 'group-hover:ring-2 group-hover:ring-muted/30'
+        }`}
+        style={dotStyle}
+      >
+        {isSelected ? (
+          <svg
+            className='w-5 h-5 text-white'
+            fill='currentColor'
+            viewBox='0 0 12 12'
+            aria-hidden='true'
+          >
+            <path d='M10.28 2.28L4.5 8.06l-2.78-2.79a.5.5 0 0 0-.71.71l3.15 3.15a.5.5 0 0 0 .71 0l6.36-6.36a.5.5 0 0 0 0-.71.5.5 0 0 0-.71 0z' />
+          </svg>
+        ) : null}
+      </span>
+      <span className='text-[11px] text-muted leading-none mt-1'>{displayName}</span>
+    </button>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
 
 export default function UserSection() {
   const { colorTheme, mode, setColorTheme, setMode, colorThemes } = useTheme();
@@ -17,30 +116,16 @@ export default function UserSection() {
               { key: 'auto' as const, icon: DesktopIcon, label: 'Auto' },
               { key: 'light' as const, icon: SunIcon, label: 'Light' },
               { key: 'dark' as const, icon: MoonIcon, label: 'Dark' },
-            ].map(({ key, icon: Icon, label }) => {
-              const isSelected = mode === key;
-              return (
-                <button
-                  key={key}
-                  type='button'
-                  onClick={() => setMode(key)}
-                  className={`flex flex-col items-center p-1 rounded-lg transition-all cursor-pointer group ${
-                    isSelected ? 'opacity-100' : 'opacity-50'
-                  }`}
-                >
-                  <span
-                    className={`w-10 h-10 sm:w-12 sm:h-12 rounded-full flex items-center justify-center text-muted transition-all ${
-                      isSelected
-                        ? 'bg-accent/15 text-accent ring-2 ring-offset-2 ring-offset-background ring-foreground'
-                        : 'bg-muted/10 group-hover:ring-1 group-hover:ring-muted/30'
-                    }`}
-                  >
-                    <Icon size={20} weight='duotone' />
-                  </span>
-                  <span className='text-[11px] text-muted leading-none mt-1'>{label}</span>
-                </button>
-              );
-            })}
+            ].map(({ key, icon, label }) => (
+              <ThemeModeButton
+                key={key}
+                mode={key}
+                icon={icon}
+                label={label}
+                isSelected={mode === key}
+                onSelect={setMode}
+              />
+            ))}
           </div>
         </div>
 
@@ -51,40 +136,16 @@ export default function UserSection() {
         <div className='space-y-3 flex-1 min-w-0'>
           <h3 className='font-mono text-[11px] text-muted uppercase tracking-wider pl-1'>Color</h3>
           <div className='grid grid-cols-4 sm:grid-cols-5 md:grid-cols-4 lg:grid-cols-5 gap-3 justify-items-start'>
-            {colorThemes.map((t) => {
-              const isSelected = colorTheme === t.name;
-              return (
-                <button
-                  key={t.name}
-                  type='button'
-                  onClick={() => setColorTheme(t.name)}
-                  className={`flex flex-col items-center p-1 rounded-lg transition-all cursor-pointer group ${
-                    isSelected ? 'opacity-100' : 'opacity-80'
-                  }`}
-                >
-                  <span
-                    className={`w-10 h-10 sm:w-12 sm:h-12 rounded-full flex items-center justify-center transition-all border border-border/40 ${
-                      isSelected
-                        ? 'ring-2 ring-offset-2 ring-offset-background ring-foreground'
-                        : 'group-hover:ring-2 group-hover:ring-muted/30'
-                    }`}
-                    style={{ backgroundColor: t.accentColor }}
-                  >
-                    {isSelected ? (
-                      <svg
-                        className='w-5 h-5 text-white'
-                        fill='currentColor'
-                        viewBox='0 0 12 12'
-                        aria-hidden='true'
-                      >
-                        <path d='M10.28 2.28L4.5 8.06l-2.78-2.79a.5.5 0 0 0-.71.71l3.15 3.15a.5.5 0 0 0 .71 0l6.36-6.36a.5.5 0 0 0 0-.71.5.5 0 0 0-.71 0z' />
-                      </svg>
-                    ) : null}
-                  </span>
-                  <span className='text-[11px] text-muted leading-none mt-1'>{t.displayName}</span>
-                </button>
-              );
-            })}
+            {colorThemes.map((t) => (
+              <ThemeColorButton
+                key={t.name}
+                name={t.name}
+                displayName={t.displayName}
+                accentColor={t.accentColor}
+                isSelected={colorTheme === t.name}
+                onSelect={setColorTheme as (name: string) => void}
+              />
+            ))}
           </div>
         </div>
       </div>

--- a/packages/web/src/components/ui/ArtworkImage.tsx
+++ b/packages/web/src/components/ui/ArtworkImage.tsx
@@ -1,5 +1,5 @@
 import { DiscIcon } from '@phosphor-icons/react';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 interface ArtworkImageProps {
   src?: string | null;
@@ -16,6 +16,8 @@ export function ArtworkImage({
   imageClassName = '',
 }: ArtworkImageProps) {
   const [loaded, setLoaded] = useState(false);
+
+  const handleLoad = useCallback(() => setLoaded(true), []);
 
   if (!src) {
     return null;
@@ -37,7 +39,7 @@ export function ArtworkImage({
         alt={alt}
         loading='lazy'
         decoding='async'
-        onLoad={() => setLoaded(true)}
+        onLoad={handleLoad}
         className={`absolute inset-0 w-full h-full object-cover transition-opacity duration-200 ${loaded ? 'opacity-100' : 'opacity-0'} ${imageClassName}`}
       />
     </div>

--- a/packages/web/src/components/ui/Button.tsx
+++ b/packages/web/src/components/ui/Button.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 
-import { forwardRef } from 'react';
+import { forwardRef, useMemo } from 'react';
 
 type ButtonVariant = 'primary' | 'secondary' | 'surface' | 'inherit' | 'danger';
 type ButtonSize = 'default' | 'icon';
@@ -49,10 +49,13 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
   ref
 ) {
   const base = size === 'icon' ? iconClasses[variant] : defaultClasses[variant];
-  const inheritStyle: React.CSSProperties =
-    variant === 'inherit'
-      ? ({ ...style, '--btn-surface': surfaceVars[surface] } as React.CSSProperties)
-      : style || {};
+  const inheritStyle: React.CSSProperties = useMemo(
+    () =>
+      variant === 'inherit'
+        ? ({ ...style, '--btn-surface': surfaceVars[surface] } as React.CSSProperties)
+        : style || {},
+    [variant, style, surface]
+  );
 
   // dimmed = visually disabled but still clickable (for cooldown toasts).
   // Don't pass disabled to the native element when dimmed.

--- a/packages/web/src/components/ui/Checkbox.tsx
+++ b/packages/web/src/components/ui/Checkbox.tsx
@@ -1,4 +1,7 @@
+import type React from 'react';
+
 import { Check } from '@phosphor-icons/react';
+import { useCallback } from 'react';
 
 interface CheckboxProps {
   checked: boolean;
@@ -34,6 +37,11 @@ export default function Checkbox({
 }: CheckboxProps) {
   const s = sizeConfig[size];
 
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.checked),
+    [onChange]
+  );
+
   return (
     <span
       className={`group relative inline-flex shrink-0 ${disabled ? 'opacity-50 pointer-events-none' : ''}`}
@@ -43,7 +51,7 @@ export default function Checkbox({
         type='checkbox'
         checked={checked}
         disabled={disabled}
-        onChange={(e) => onChange(e.target.checked)}
+        onChange={handleChange}
         className={`opacity-0 absolute inset-0 z-10 ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'}`}
       />
       <span

--- a/packages/web/src/components/ui/PlayButton.tsx
+++ b/packages/web/src/components/ui/PlayButton.tsx
@@ -1,5 +1,7 @@
+import type React from 'react';
+
 import { CircleNotchIcon, PlayIcon } from '@phosphor-icons/react';
-import { memo, useMemo } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 
 import { useCooldownGuard } from '../../hooks/useCooldownGuard';
 import { Button } from './Button';
@@ -25,23 +27,30 @@ export const PlayButton = memo(function PlayButton({
     [coolingDown, statusTitle, handleCooldownClick]
   );
 
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+  }, []);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (coolingDown) {
+        handleCooldownClick();
+      } else {
+        onClick();
+      }
+    },
+    [coolingDown, handleCooldownClick, onClick]
+  );
+
   return (
     <Button
       variant='primary'
       size='icon'
       {...cooldownButtonProps(cooldown, { onClick, disabled: isPlaying, title })}
-      onMouseDown={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-      }}
-      onClick={(e) => {
-        e.stopPropagation();
-        if (coolingDown) {
-          handleCooldownClick();
-        } else {
-          onClick();
-        }
-      }}
+      onMouseDown={handleMouseDown}
+      onClick={handleClick}
       className={`shrink-0 disabled:cursor-default ${className}`}
     >
       {isPlaying ? (

--- a/packages/web/src/components/ui/RoleComboBox.tsx
+++ b/packages/web/src/components/ui/RoleComboBox.tsx
@@ -1,11 +1,70 @@
+import type React from 'react';
+
 import { CaretDown } from '@phosphor-icons/react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 interface RoleOption {
   id: string;
   name: string;
   color: number;
 }
+
+// ---------------------------------------------------------------------------
+// Child component — stable callbacks per role option
+// ---------------------------------------------------------------------------
+
+interface RoleOptionItemProps {
+  role: RoleOption;
+  index: number;
+  isHighlighted: boolean;
+  onSelect: (role: RoleOption) => void;
+  onHighlight: (index: number) => void;
+}
+
+const RoleOptionItem = memo(function RoleOptionItem({
+  role,
+  index,
+  isHighlighted,
+  onSelect,
+  onHighlight,
+}: RoleOptionItemProps) {
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault(); // prevent input blur before click
+      onSelect(role);
+    },
+    [onSelect, role]
+  );
+
+  const handleMouseEnter = useCallback(() => onHighlight(index), [onHighlight, index]);
+
+  const dotStyle = useMemo(
+    () => ({
+      backgroundColor: role.color
+        ? `#${role.color.toString(16).padStart(6, '0')}`
+        : 'var(--color-muted)',
+    }),
+    [role.color]
+  );
+
+  return (
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- combobox option, keyboard handled at list level
+    <li
+      onMouseDown={handleMouseDown}
+      onMouseEnter={handleMouseEnter}
+      className={`flex items-center gap-2 px-3 py-2 cursor-pointer transition-colors
+        ${isHighlighted ? 'bg-accent/10 text-fg' : 'text-fg hover:bg-surface'}
+      `}
+    >
+      <span className='w-2.5 h-2.5 rounded-full shrink-0' style={dotStyle} />
+      <span className='truncate'>{role.name}</span>
+    </li>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
 
 interface RoleComboBoxProps {
   roles: RoleOption[];
@@ -72,38 +131,55 @@ export default function RoleComboBox({
     [onSelect]
   );
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (!isOpen) {
-      if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
-        setIsOpen(true);
-        e.preventDefault();
+  const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setQuery(e.target.value);
+    setIsOpen(true);
+  }, []);
+
+  const handleFocus = useCallback(() => setIsOpen(true), []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!isOpen) {
+        if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+          setIsOpen(true);
+          e.preventDefault();
+          return;
+        }
         return;
       }
-      return;
-    }
 
-    switch (e.key) {
-      case 'ArrowDown':
-        e.preventDefault();
-        setHighlightedIndex((prev) => (prev + 1) % Math.max(filtered.length, 1));
-        break;
-      case 'ArrowUp':
-        e.preventDefault();
-        setHighlightedIndex((prev) => (prev - 1 + filtered.length) % Math.max(filtered.length, 1));
-        break;
-      case 'Enter':
-        e.preventDefault();
-        if (filtered[highlightedIndex]) {
-          selectRole(filtered[highlightedIndex]);
-        }
-        break;
-      case 'Escape':
-        e.preventDefault();
-        setIsOpen(false);
-        inputRef.current?.blur();
-        break;
-    }
-  };
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          setHighlightedIndex((prev) => (prev + 1) % Math.max(filtered.length, 1));
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          setHighlightedIndex(
+            (prev) => (prev - 1 + filtered.length) % Math.max(filtered.length, 1)
+          );
+          break;
+        case 'Enter':
+          e.preventDefault();
+          if (filtered[highlightedIndex]) {
+            selectRole(filtered[highlightedIndex]);
+          }
+          break;
+        case 'Escape':
+          e.preventDefault();
+          setIsOpen(false);
+          inputRef.current?.blur();
+          break;
+      }
+    },
+    [isOpen, filtered, highlightedIndex, selectRole]
+  );
+
+  const caretStyle = useMemo(
+    () => (isOpen ? { transform: 'translateY(-50%) rotate(180deg)' } : undefined),
+    [isOpen]
+  );
 
   return (
     <div className='relative w-full max-w-sm'>
@@ -112,11 +188,8 @@ export default function RoleComboBox({
           ref={inputRef}
           type='text'
           value={query}
-          onChange={(e) => {
-            setQuery(e.target.value);
-            setIsOpen(true);
-          }}
-          onFocus={() => setIsOpen(true)}
+          onChange={handleChange}
+          onFocus={handleFocus}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
           className='w-full bg-surface border border-border rounded-lg px-3 py-2 pr-9 text-sm text-fg placeholder:text-muted
@@ -127,7 +200,7 @@ export default function RoleComboBox({
           size={16}
           weight='bold'
           className='absolute right-3 top-1/2 -translate-y-1/2 text-muted pointer-events-none transition-transform'
-          style={isOpen ? { transform: 'translateY(-50%) rotate(180deg)' } : undefined}
+          style={caretStyle}
         />
       </div>
 
@@ -141,28 +214,14 @@ export default function RoleComboBox({
             <li className='px-3 py-2 text-muted italic'>No roles found</li>
           ) : (
             filtered.map((role, i) => (
-              // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- combobox option, keyboard handled at list level
-              <li
+              <RoleOptionItem
                 key={role.id}
-                onMouseDown={(e) => {
-                  e.preventDefault(); // prevent input blur before click
-                  selectRole(role);
-                }}
-                onMouseEnter={() => setHighlightedIndex(i)}
-                className={`flex items-center gap-2 px-3 py-2 cursor-pointer transition-colors
-                  ${i === highlightedIndex ? 'bg-accent/10 text-fg' : 'text-fg hover:bg-surface'}
-                `}
-              >
-                <span
-                  className='w-2.5 h-2.5 rounded-full shrink-0'
-                  style={{
-                    backgroundColor: role.color
-                      ? `#${role.color.toString(16).padStart(6, '0')}`
-                      : 'var(--color-muted)',
-                  }}
-                />
-                <span className='truncate'>{role.name}</span>
-              </li>
+                role={role}
+                index={i}
+                isHighlighted={i === highlightedIndex}
+                onSelect={selectRole}
+                onHighlight={setHighlightedIndex}
+              />
             ))
           )}
         </ul>

--- a/packages/web/src/components/ui/VolumeBoostBadge.tsx
+++ b/packages/web/src/components/ui/VolumeBoostBadge.tsx
@@ -1,5 +1,5 @@
 import { HeadphonesIcon } from '@phosphor-icons/react';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 
 interface VolumeBoostBadgeProps {
   volumeBoost: number | null | undefined;
@@ -10,16 +10,15 @@ export const VolumeBoostBadge = memo(function VolumeBoostBadge({
   volumeBoost,
   className = '',
 }: VolumeBoostBadgeProps) {
+  const isBoost = (volumeBoost ?? 0) > 0;
+  const colorStyle = useMemo(() => ({ color: isBoost ? '#22c55e' : '#eab308' }), [isBoost]);
+
   if (volumeBoost == null || volumeBoost === 0) {
     return null;
   }
 
-  const isBoost = volumeBoost > 0;
   return (
-    <span
-      className={`flex items-center gap-0.5 text-xs ${className}`}
-      style={{ color: isBoost ? '#22c55e' : '#eab308' }}
-    >
+    <span className={`flex items-center gap-0.5 text-xs ${className}`} style={colorStyle}>
       <HeadphonesIcon size={11} weight='fill' className='shrink-0' />
       {isBoost ? '+' : ''}
       {volumeBoost}%

--- a/packages/web/src/context/SongEditContext.tsx
+++ b/packages/web/src/context/SongEditContext.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -87,11 +88,12 @@ export function SongEditProvider({ children }: { children: ReactNode }) {
     return () => document.removeEventListener('mousedown', handleMouseDown);
   }, [openSongId, setOpenSongIdSequenced]);
 
-  return (
-    <SongEditContext value={{ openSongId, closingSongId, setOpenSongId: setOpenSongIdSequenced }}>
-      {children}
-    </SongEditContext>
+  const value = useMemo(
+    () => ({ openSongId, closingSongId, setOpenSongId: setOpenSongIdSequenced }),
+    [openSongId, closingSongId, setOpenSongIdSequenced]
   );
+
+  return <SongEditContext value={value}>{children}</SongEditContext>;
 }
 
 export function useSongEdit() {

--- a/packages/web/src/context/SongMenuContext.tsx
+++ b/packages/web/src/context/SongMenuContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, type ReactNode, useCallback, useContext, useState } from 'react';
+import { createContext, type ReactNode, useCallback, useContext, useMemo, useState } from 'react';
 
 const SongMenuContext = createContext<{
   activeMenuSongId: string | null;
@@ -17,9 +17,12 @@ export function SongMenuProvider({ children }: { children: ReactNode }) {
     setActiveMenuSongIdState(id);
   }, []);
 
-  return (
-    <SongMenuContext value={{ activeMenuSongId, setActiveMenuSongId }}>{children}</SongMenuContext>
+  const value = useMemo(
+    () => ({ activeMenuSongId, setActiveMenuSongId }),
+    [activeMenuSongId, setActiveMenuSongId]
   );
+
+  return <SongMenuContext value={value}>{children}</SongMenuContext>;
 }
 
 export function useSongMenu() {

--- a/packages/web/src/context/TagsContext.tsx
+++ b/packages/web/src/context/TagsContext.tsx
@@ -1,5 +1,13 @@
 import { fetchTags } from '@alfira/server/shared/api';
-import { createContext, type ReactNode, useCallback, useContext, useEffect, useState } from 'react';
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 
 export interface TagItem {
   canonicalName: string;
@@ -37,11 +45,12 @@ export function TagsProvider({ children }: { children: ReactNode }) {
     refreshTags();
   }, [refreshTags]);
 
-  return (
-    <TagsContext.Provider value={{ tags, tagColorMap, refreshTags }}>
-      {children}
-    </TagsContext.Provider>
+  const value = useMemo(
+    () => ({ tags, tagColorMap, refreshTags }),
+    [tags, tagColorMap, refreshTags]
   );
+
+  return <TagsContext.Provider value={value}>{children}</TagsContext.Provider>;
 }
 
 export function useTagColors() {

--- a/packages/web/src/pages/LoginPage.tsx
+++ b/packages/web/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { DiscordLogoIcon } from '@phosphor-icons/react';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { SpringUp } from '../components/ui/SpringUp';
@@ -16,17 +16,9 @@ export default function LoginPage() {
     }
   }, [user, loading, navigate]);
 
-  if (loading) {
-    return null;
-  }
-
-  return (
-    <div className='min-h-screen bg-elevated flex items-center justify-center relative overflow-hidden'>
-      {/* Background texture */}
-      <div
-        className='absolute inset-0 opacity-[0.03]'
-        style={{
-          backgroundImage: `repeating-linear-gradient(
+  const bgStyle = useMemo(
+    () => ({
+      backgroundImage: `repeating-linear-gradient(
           0deg,
           transparent,
           transparent 40px,
@@ -40,8 +32,18 @@ export default function LoginPage() {
           #c8f135 40px,
           #c8f135 41px
         )`,
-        }}
-      />
+    }),
+    []
+  );
+
+  if (loading) {
+    return null;
+  }
+
+  return (
+    <div className='min-h-screen bg-elevated flex items-center justify-center relative overflow-hidden'>
+      {/* Background texture */}
+      <div className='absolute inset-0 opacity-[0.03]' style={bgStyle} />
 
       {/* Card */}
       <SpringUp className='relative z-10 w-full max-w-sm mx-4'>


### PR DESCRIPTION
## Summary

Enable oxlint's `react-perf` plugin with 5 new performance rules and fix
33 of 53 components with violations. The remaining 20 large files are
temporarily suppressed and will be fixed in follow-up PRs.

## Rules added

| Rule | Description |
|---|---|
| `react-perf/jsx-no-new-function-as-prop` | Inline functions in JSX props break memo |
| `react-perf/jsx-no-new-object-as-prop` | Inline objects in JSX props break memo |
| `react-perf/jsx-no-jsx-as-prop` | JSX as prop values breaks memo |
| `react/jsx-no-constructed-context-values` | Context value objects cause full subtree re-renders |
| `react/no-object-type-as-default-prop` | Default prop objects/arrays break referential equality |

## Fixes applied

- **33 files** fixed with `useCallback` / `useMemo` / component extraction
- **3 files** given permanent overrides for intentional patterns (VirtualList virtualizer styles, VirtualSongGrid masonry pattern, EqualizerSection array index keys)
- **20 files** remain in a temporary override, to be fixed in follow-up

## Verification

- [x] `bun run check` — zero warnings
- [x] Server build — passes
- [x] Web build — passes