### PR TITLE
refactor(web): extract inline handlers to useCallback/useMemo in 6 files

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -443,14 +443,8 @@ export default defineConfig({
     // =======================================================================
     {
       files: [
-        'packages/web/src/components/AddSongModal.tsx',
-        'packages/web/src/components/BulkEditModal.tsx',
         'packages/web/src/components/NowPlayingBar.tsx',
         'packages/web/src/components/QueuePanel.tsx',
-        'packages/web/src/components/SongEditPanel.tsx',
-        'packages/web/src/pages/PlaylistDetailPage.tsx',
-        'packages/web/src/pages/SongsPage.tsx',
-        'packages/web/src/pages/SetupWizard.tsx',
       ],
       rules: {
         'react-perf/jsx-no-new-function-as-prop': 'off',

--- a/packages/web/src/components/AddSongModal.tsx
+++ b/packages/web/src/components/AddSongModal.tsx
@@ -1,5 +1,5 @@
 import { type RequestPreview, type Song } from '@alfira/server/shared';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { createRequest, previewRequest } from '../api/api';
 import { useTagColors } from '../context/TagsContext';
@@ -61,7 +61,7 @@ export default function AddSongModal({
     }
   }, [successMsg, onClose]);
 
-  const handleFetch = async () => {
+  const handleFetch = useCallback(async () => {
     if (!url.trim()) {
       return;
     }
@@ -91,9 +91,9 @@ export default function AddSongModal({
     } finally {
       setLoading(false);
     }
-  };
+  }, [url]);
 
-  const handleImportPlaylist = async () => {
+  const handleImportPlaylist = useCallback(async () => {
     if (!url.trim()) {
       return;
     }
@@ -120,9 +120,9 @@ export default function AddSongModal({
     } finally {
       setLoading(false);
     }
-  };
+  }, [url, onRequestCreated]);
 
-  const handleSubmit = async () => {
+  const handleSubmit = useCallback(async () => {
     if (!url.trim()) {
       return;
     }
@@ -160,48 +160,130 @@ export default function AddSongModal({
     } finally {
       setLoading(false);
     }
-  };
+  }, [
+    url,
+    notifyDm,
+    nickname,
+    artist,
+    album,
+    artwork,
+    tags,
+    volumeBoost,
+    onRequestCreated,
+    onAdded,
+  ]);
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && step === 'url') {
-      void handleFetch();
-    }
-    if (e.key === 'Escape') {
-      if (step === 'metadata') {
-        setStep('url');
-      } else {
-        onClose();
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && step === 'url') {
+        void handleFetch();
       }
-    }
-  };
+      if (e.key === 'Escape') {
+        if (step === 'metadata') {
+          setStep('url');
+        } else {
+          onClose();
+        }
+      }
+    },
+    [step, handleFetch, onClose]
+  );
 
-  const addTag = () => {
+  const addTag = useCallback(() => {
     const trimmed = tagInput.trim();
     if (!trimmed || tags.includes(trimmed)) {
       return;
     }
     setTags((prev) => [...prev, trimmed]);
     setTagInput('');
-  };
+  }, [tagInput, tags]);
 
-  const removeTag = (tag: string) => {
+  const removeTag = useCallback((tag: string) => {
     setTags((prev) => prev.filter((t) => t !== tag));
-  };
+  }, []);
 
-  const handleTagKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      addTag();
-    }
-    if (e.key === 'Backspace' && tagInput === '' && tags.length > 0) {
-      removeTag(tags[tags.length - 1]);
-    }
-  };
+  const handleTagKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        addTag();
+      }
+      if (e.key === 'Backspace' && tagInput === '' && tags.length > 0) {
+        removeTag(tags[tags.length - 1]);
+      }
+    },
+    [addTag, removeTag, tagInput, tags]
+  );
 
-  const handleBackToUrl = () => {
+  const handleBackToUrl = useCallback(() => {
     setStep('url');
     setError('');
-  };
+  }, []);
+
+  const handleUrlChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setUrl(e.target.value);
+    setError('');
+    setSuccessMsg('');
+  }, []);
+
+  const handleFocusTagInput = useCallback(() => {
+    document.getElementById('add-tag-input')?.focus();
+  }, []);
+
+  const handleTagPillRemove = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.stopPropagation();
+      const tag = e.currentTarget.closest('[data-tag]')?.getAttribute('data-tag');
+      if (tag) {
+        removeTag(tag);
+      }
+    },
+    [removeTag]
+  );
+
+  const handleTagInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => setTagInput(e.target.value),
+    []
+  );
+
+  const handleVolumeTextChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = e.target.value;
+    if (v === '' || /^-?\d*$/.test(v)) {
+      setVolumeBoost(v);
+    }
+  }, []);
+
+  const handleVolumeBlur = useCallback(() => {
+    if (volumeBoost.trim() === '' || volumeBoost === '-') {
+      setVolumeBoost('0');
+    } else {
+      const n = parseInt(volumeBoost, 10);
+      if (!Number.isNaN(n)) {
+        setVolumeBoost(String(Math.min(200, Math.max(-100, n))));
+      }
+    }
+  }, [volumeBoost]);
+
+  const handleVolumeRangeChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => setVolumeBoost(e.target.value),
+    []
+  );
+
+  const volumeSliderValue = useMemo(
+    () =>
+      volumeBoost.trim() === '' || volumeBoost === '-'
+        ? 0
+        : Math.min(200, Math.max(-100, parseInt(volumeBoost, 10) || 0)),
+    [volumeBoost]
+  );
+
+  const volumeRangeStyle = useMemo(
+    () =>
+      ({
+        '--volume-pct': `${((Math.min(200, Math.max(-100, parseInt(volumeBoost, 10) || 0)) + 100) / 300) * 100}%`,
+      }) as React.CSSProperties,
+    [volumeBoost]
+  );
 
   const canSubmit = step === 'metadata' && !loading && !preview?.alreadyExists;
 
@@ -223,11 +305,7 @@ export default function AddSongModal({
               className='input mb-3'
               placeholder='https://...'
               value={url}
-              onChange={(e) => {
-                setUrl(e.target.value);
-                setError('');
-                setSuccessMsg('');
-              }}
+              onChange={handleUrlChange}
               onKeyDown={handleKeyDown}
               disabled={loading}
             />
@@ -346,7 +424,7 @@ export default function AddSongModal({
               {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- container click focuses inner input; keyboard handled by input */}
               <div
                 className='input text-sm flex flex-wrap gap-1.5 items-center min-h-9.5 cursor-text'
-                onClick={() => document.getElementById('add-tag-input')?.focus()}
+                onClick={handleFocusTagInput}
               >
                 {tags.map((tag) => {
                   const c = getTagColorClasses(tag, tagColorMap[tag.toLowerCase()]);
@@ -359,10 +437,8 @@ export default function AddSongModal({
                       <button
                         type='button'
                         className='ml-0.5 opacity-70 hover:opacity-100'
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          removeTag(tag);
-                        }}
+                        data-tag={tag}
+                        onClick={handleTagPillRemove}
                       >
                         &times;
                       </button>
@@ -374,7 +450,7 @@ export default function AddSongModal({
                   className='flex-1 min-w-20 bg-transparent outline-none text-sm text-fg placeholder:text-faint'
                   placeholder={tags.length === 0 ? 'Custom grouping (enter to confirm)' : ''}
                   value={tagInput}
-                  onChange={(e) => setTagInput(e.target.value)}
+                  onChange={handleTagInputChange}
                   onKeyDown={handleTagKeyDown}
                 />
               </div>
@@ -391,44 +467,18 @@ export default function AddSongModal({
                   className='input text-sm w-16 text-center'
                   type='text'
                   value={volumeBoost}
-                  onChange={(e) => {
-                    const v = e.target.value;
-                    if (v === '' || /^-?\d*$/.test(v)) {
-                      setVolumeBoost(v);
-                    }
-                  }}
-                  onBlur={() => {
-                    if (volumeBoost.trim() === '' || volumeBoost === '-') {
-                      setVolumeBoost('0');
-                    } else {
-                      const n = parseInt(volumeBoost, 10);
-                      if (!Number.isNaN(n)) {
-                        setVolumeBoost(String(Math.min(200, Math.max(-100, n))));
-                      }
-                    }
-                  }}
+                  onChange={handleVolumeTextChange}
+                  onBlur={handleVolumeBlur}
                 />
                 <span className='text-xs text-muted font-mono w-8 text-left'>%</span>
                 <input
                   type='range'
                   min={-100}
                   max={200}
-                  value={
-                    volumeBoost.trim() === '' || volumeBoost === '-'
-                      ? 0
-                      : Math.min(200, Math.max(-100, parseInt(volumeBoost, 10) || 0))
-                  }
-                  onChange={(e) => setVolumeBoost(e.target.value)}
+                  value={volumeSliderValue}
+                  onChange={handleVolumeRangeChange}
                   className='volume-range-input'
-                  style={
-                    {
-                      '--volume-pct': `${
-                        ((Math.min(200, Math.max(-100, parseInt(volumeBoost, 10) || 0)) + 100) /
-                          300) *
-                        100
-                      }%`,
-                    } as React.CSSProperties
-                  }
+                  style={volumeRangeStyle}
                 />
               </div>
             </div>
@@ -483,6 +533,10 @@ function Field({
   onChange: (v: string) => void;
   placeholder?: string;
 }) {
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.value),
+    [onChange]
+  );
   return (
     <div>
       <label htmlFor={id} className='block font-mono text-[10px] text-muted uppercase mb-1'>
@@ -492,7 +546,7 @@ function Field({
         id={id}
         className='input text-sm'
         value={value}
-        onChange={(e) => onChange(e.target.value)}
+        onChange={handleChange}
         placeholder={placeholder}
       />
     </div>

--- a/packages/web/src/components/BulkEditModal.tsx
+++ b/packages/web/src/components/BulkEditModal.tsx
@@ -1,6 +1,6 @@
 import { type BulkEditData, fetchTags, type TagItem } from '@alfira/server/shared/api';
 import { EraserIcon, XIcon } from '@phosphor-icons/react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useTagColors } from '../context/TagsContext';
 import { getTagColorClasses } from '../utils/tagColors';
@@ -102,34 +102,37 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
     setTags((prev) => prev.filter((t) => t !== tag));
   }, []);
 
-  const handleTagKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      if (showDropdown && highlightedIdx >= 0 && filtered[highlightedIdx]) {
-        const tag = filtered[highlightedIdx].nameLower;
-        if (!tags.includes(tag)) {
-          setTags((prev) => [...prev, tag]);
+  const handleTagKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        if (showDropdown && highlightedIdx >= 0 && filtered[highlightedIdx]) {
+          const tag = filtered[highlightedIdx].nameLower;
+          if (!tags.includes(tag)) {
+            setTags((prev) => [...prev, tag]);
+          }
+          setTagInput('');
+          setHighlightedIdx(0);
+        } else {
+          addTag();
         }
-        setTagInput('');
-        setHighlightedIdx(0);
-      } else {
-        addTag();
+        return;
       }
-      return;
-    }
 
-    if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      setHighlightedIdx((prev) => Math.min(prev + 1, filtered.length - 1));
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      setHighlightedIdx((prev) => Math.max(prev - 1, 0));
-    } else if (e.key === 'Escape') {
-      setShowDropdown(false);
-    }
-  };
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setHighlightedIdx((prev) => Math.min(prev + 1, filtered.length - 1));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setHighlightedIdx((prev) => Math.max(prev - 1, 0));
+      } else if (e.key === 'Escape') {
+        setShowDropdown(false);
+      }
+    },
+    [showDropdown, highlightedIdx, filtered, tags, addTag]
+  );
 
-  const toggleClear = (field: string) => {
+  const toggleClear = useCallback((field: string) => {
     setClearFields((prev) => {
       const next = new Set(prev);
       if (next.has(field)) {
@@ -139,7 +142,7 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
       }
       return next;
     });
-  };
+  }, []);
 
   // Volume boost slider derived values
   const volumeNumeric =
@@ -148,7 +151,111 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
       : Math.min(200, Math.max(-100, Number.parseInt(volumeBoost, 10) || 0));
   const volumePct = `${((volumeNumeric - -100) / (200 - -100)) * 100}%`;
 
-  const handleApply = () => {
+  const fieldValues: Record<TextEditableField, string> = { nickname, artist, album, artwork };
+
+  const handleFieldChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const field = e.currentTarget.dataset.field as TextEditableField;
+    const value = e.target.value;
+    switch (field) {
+      case 'nickname':
+        setNickname(value);
+        break;
+      case 'artist':
+        setArtist(value);
+        break;
+      case 'album':
+        setAlbum(value);
+        break;
+      case 'artwork':
+        setArtwork(value);
+        break;
+    }
+  }, []);
+
+  const handleClearField = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const field = e.currentTarget.dataset.field;
+      if (field) {
+        toggleClear(field);
+      }
+    },
+    [toggleClear]
+  );
+
+  const handleBackdropClick = useCallback((e: React.MouseEvent) => e.stopPropagation(), []);
+
+  const handleFocusTagInput = useCallback(() => {
+    tagInputRef.current?.focus();
+    setShowDropdown(true);
+  }, []);
+
+  const handleTagPillRemove = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.stopPropagation();
+      const tag = e.currentTarget.closest('[data-tag]')?.getAttribute('data-tag');
+      if (tag) {
+        removeTag(tag);
+      }
+    },
+    [removeTag]
+  );
+
+  const handleTagInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setTagInput(e.target.value);
+    setShowDropdown(true);
+    setHighlightedIdx(0);
+  }, []);
+
+  const handleTagInputFocus = useCallback(() => setShowDropdown(true), []);
+
+  const handleClearTags = useCallback(() => toggleClear('tags'), [toggleClear]);
+
+  const handleDropdownSelect = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.preventDefault();
+      const tagNameLower = e.currentTarget.dataset.tag;
+      if (tagNameLower && !tags.includes(tagNameLower)) {
+        setTags((prev) => [...prev, tagNameLower]);
+      }
+      setTagInput('');
+      setHighlightedIdx(0);
+      setShowDropdown(false);
+      tagInputRef.current?.focus();
+    },
+    [tags]
+  );
+
+  const handleVolumeTextChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = e.target.value;
+    if (v === '' || /^-?\d*$/.test(v)) {
+      setVolumeBoost(v);
+    }
+  }, []);
+
+  const handleVolumeBlur = useCallback(() => {
+    if (volumeBoost.trim() === '' || volumeBoost.trim() === '-') {
+      setVolumeBoost('0');
+    } else {
+      const n = Number.parseInt(volumeBoost, 10);
+      if (!Number.isNaN(n)) {
+        setVolumeBoost(String(Math.min(200, Math.max(-100, n))));
+      }
+    }
+  }, [volumeBoost]);
+
+  const handleVolumeRangeChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => setVolumeBoost(e.target.value),
+    []
+  );
+
+  const handleClearVolumeBoost = useCallback(() => toggleClear('volumeBoost'), [toggleClear]);
+
+  const volumeRangeStyle = useMemo(
+    () => ({ '--volume-pct': volumePct }) as React.CSSProperties,
+    [volumePct]
+  );
+
+  const handleApply = useCallback(() => {
     const data: BulkEditData = {};
     let hasChanges = false;
 
@@ -201,13 +308,13 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
     }
 
     onApply(data);
-  };
+  }, [nickname, artist, album, artwork, tags, volumeBoost, clearFields, onApply]);
 
   return (
     <Backdrop onClose={onClose}>
       <SpringUp
         className='w-full max-w-md mx-4 p-6 glass-modal max-h-[85vh] overflow-y-auto'
-        onClick={(e) => e.stopPropagation()}
+        onClick={handleBackdropClick}
       >
         <h2 className='font-display text-lg text-fg mb-1'>Edit {count} songs</h2>
         <p className='text-xs text-muted font-mono mb-4'>
@@ -229,36 +336,9 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
                   id={`bulk-edit-${key}`}
                   className={`input text-sm w-full${clearFields.has(key) ? ' opacity-30 pointer-events-none' : ''}`}
                   placeholder={placeholder}
-                  value={(() => {
-                    switch (key) {
-                      case 'nickname':
-                        return nickname;
-                      case 'artist':
-                        return artist;
-                      case 'album':
-                        return album;
-                      case 'artwork':
-                        return artwork;
-                      default:
-                        return '';
-                    }
-                  })()}
-                  onChange={(e) => {
-                    switch (key) {
-                      case 'nickname':
-                        setNickname(e.target.value);
-                        break;
-                      case 'artist':
-                        setArtist(e.target.value);
-                        break;
-                      case 'album':
-                        setAlbum(e.target.value);
-                        break;
-                      case 'artwork':
-                        setArtwork(e.target.value);
-                        break;
-                    }
-                  }}
+                  value={fieldValues[key]}
+                  onChange={handleFieldChange}
+                  data-field={key}
                   disabled={clearFields.has(key)}
                 />
               </div>
@@ -267,7 +347,8 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
                   type='checkbox'
                   className='sr-only peer'
                   checked={clearFields.has(key)}
-                  onChange={() => toggleClear(key)}
+                  onChange={handleClearField}
+                  data-field={key}
                 />
                 <span className='text-[9px] font-mono uppercase text-muted peer-checked:text-danger transition-colors'>
                   Clear
@@ -295,10 +376,7 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
                 <div
                   ref={tagAreaRef}
                   className={`input text-sm flex flex-wrap gap-1.5 items-center min-h-9.5 cursor-text relative${clearFields.has('tags') ? ' opacity-30 pointer-events-none' : ''}`}
-                  onClick={() => {
-                    tagInputRef.current?.focus();
-                    setShowDropdown(true);
-                  }}
+                  onClick={handleFocusTagInput}
                 >
                   {tags.map((tag) => {
                     const c = getTagColorClasses(tag, tagColorMap[tag.toLowerCase()]);
@@ -311,10 +389,8 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
                         <button
                           type='button'
                           className='cursor-pointer opacity-60 hover:opacity-100'
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            removeTag(tag);
-                          }}
+                          onClick={handleTagPillRemove}
+                          data-tag={tag}
                         >
                           <XIcon size={10} weight='bold' />
                         </button>
@@ -329,12 +405,8 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
                       tags.length === 0 ? 'Type a tag and press Enter...' : 'Add another...'
                     }
                     value={tagInput}
-                    onChange={(e) => {
-                      setTagInput(e.target.value);
-                      setShowDropdown(true);
-                      setHighlightedIdx(0);
-                    }}
-                    onFocus={() => setShowDropdown(true)}
+                    onChange={handleTagInputChange}
+                    onFocus={handleTagInputFocus}
                     onKeyDown={handleTagKeyDown}
                     disabled={clearFields.has('tags')}
                   />
@@ -345,7 +417,7 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
                   type='checkbox'
                   className='sr-only peer'
                   checked={clearFields.has('tags')}
-                  onChange={() => toggleClear('tags')}
+                  onChange={handleClearTags}
                 />
                 <span className='text-[9px] font-mono uppercase text-muted peer-checked:text-danger transition-colors'>
                   Clear
@@ -376,16 +448,8 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
                             ? 'bg-accent/10 text-accent'
                             : 'text-fg hover:bg-surface'
                         }`}
-                        onMouseDown={(e) => {
-                          e.preventDefault();
-                          if (!tags.includes(t.nameLower)) {
-                            setTags((prev) => [...prev, t.nameLower]);
-                          }
-                          setTagInput('');
-                          setHighlightedIdx(0);
-                          setShowDropdown(false);
-                          tagInputRef.current?.focus();
-                        }}
+                        onMouseDown={handleDropdownSelect}
+                        data-tag={t.nameLower}
                       >
                         <span
                           className={`inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium ${c.bg} ${c.text}`}
@@ -416,22 +480,8 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
                   placeholder='0'
                   type='text'
                   value={volumeBoost}
-                  onChange={(e) => {
-                    const v = e.target.value;
-                    if (v === '' || /^-?\d*$/.test(v)) {
-                      setVolumeBoost(v);
-                    }
-                  }}
-                  onBlur={() => {
-                    if (volumeBoost.trim() === '' || volumeBoost.trim() === '-') {
-                      setVolumeBoost('0');
-                    } else {
-                      const n = Number.parseInt(volumeBoost, 10);
-                      if (!Number.isNaN(n)) {
-                        setVolumeBoost(String(Math.min(200, Math.max(-100, n))));
-                      }
-                    }
-                  }}
+                  onChange={handleVolumeTextChange}
+                  onBlur={handleVolumeBlur}
                   disabled={clearFields.has('volumeBoost')}
                 />
                 <span className='text-xs text-muted font-mono w-8 text-left'>dB</span>
@@ -440,10 +490,10 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
                   min={-100}
                   max={200}
                   value={volumeNumeric}
-                  onChange={(e) => setVolumeBoost(e.target.value)}
+                  onChange={handleVolumeRangeChange}
                   className={`volume-range-input${clearFields.has('volumeBoost') ? ' opacity-30 pointer-events-none' : ''}`}
                   disabled={clearFields.has('volumeBoost')}
-                  style={{ '--volume-pct': volumePct } as React.CSSProperties}
+                  style={volumeRangeStyle}
                 />
               </div>
             </div>
@@ -452,7 +502,7 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
                 type='checkbox'
                 className='sr-only peer'
                 checked={clearFields.has('volumeBoost')}
-                onChange={() => toggleClear('volumeBoost')}
+                onChange={handleClearVolumeBoost}
               />
               <span className='text-[9px] font-mono uppercase text-muted peer-checked:text-danger transition-colors'>
                 Clear

--- a/packages/web/src/components/SongEditPanel.tsx
+++ b/packages/web/src/components/SongEditPanel.tsx
@@ -1,7 +1,7 @@
 import { type Song } from '@alfira/server/shared';
 import { type SongUpdateData, type TagItem } from '@alfira/server/shared/api';
 import { fetchTags, updateSong } from '@alfira/server/shared/api';
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { createPortal, flushSync } from 'react-dom';
 
 import { useTagColors } from '../context/TagsContext';
@@ -232,6 +232,65 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
     }
   }, [isOpen, doSave]);
 
+  const handleEnterSave = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        void doSave();
+      }
+    },
+    [doSave]
+  );
+
+  const handlePanelClick = useCallback((e: React.MouseEvent) => e.stopPropagation(), []);
+
+  const panelStyle = useMemo(
+    () => (closing ? ({ pointerEvents: 'none' } as const) : undefined),
+    [closing]
+  );
+
+  const handleFocusTagInput = useCallback(() => {
+    tagInputRef.current?.focus();
+    if (!fetchedTags) {
+      void (async () => {
+        const t = await fetchTags();
+        setAvailableTags(t);
+        setFetchedTags(true);
+      })();
+    }
+    setShowTagDropdown(true);
+  }, [fetchedTags]);
+
+  const handleTagPillRemove = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      const tag = e.currentTarget.closest('[data-tag]')?.getAttribute('data-tag');
+      if (tag) {
+        removeTag(tag);
+      }
+    },
+    [removeTag]
+  );
+
+  const handleTagInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => setTagInput(e.target.value),
+    []
+  );
+
+  const handleTagToggle = useCallback(
+    (tag: string) => {
+      if (tags.includes(tag)) {
+        removeTag(tag);
+      } else {
+        flushSync(() => setTags((prev) => [...prev, tag]));
+      }
+    },
+    [tags, removeTag]
+  );
+
+  const handleTagDropdownClose = useCallback(() => {
+    setShowTagDropdown(false);
+    setHighlightedIndex(-1);
+  }, []);
+
   if (!isOpen && !closing) {
     return null;
   }
@@ -240,8 +299,8 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
     <div
       className='expand-panel-content'
       data-closing={closing ? 'true' : undefined}
-      style={closing ? { pointerEvents: 'none' } : undefined}
-      onClick={(e) => e.stopPropagation()}
+      style={panelStyle}
+      onClick={handlePanelClick}
     >
       <div className='px-3 md:px-4 pt-4 pb-4 border-t border-border'>
         <div className='flex flex-col gap-3'>
@@ -252,11 +311,7 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
             onChange={setNickname}
             inputRef={inputRef}
             placeholder={song.title}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                void doSave();
-              }
-            }}
+            onKeyDown={handleEnterSave}
           />
           <Field
             id='panel-artist'
@@ -264,11 +319,7 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
             value={artist}
             onChange={setArtist}
             placeholder='Artist name'
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                void doSave();
-              }
-            }}
+            onKeyDown={handleEnterSave}
           />
           <Field
             id='panel-album'
@@ -276,11 +327,7 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
             value={album}
             onChange={setAlbum}
             placeholder='Album name'
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                void doSave();
-              }
-            }}
+            onKeyDown={handleEnterSave}
           />
           <Field
             id='panel-artwork'
@@ -288,11 +335,7 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
             value={artwork}
             onChange={setArtwork}
             placeholder={song.thumbnailUrl}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                void doSave();
-              }
-            }}
+            onKeyDown={handleEnterSave}
           />
 
           {/* Tags */}
@@ -305,17 +348,7 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
             </label>
             <div
               className='input text-sm flex flex-wrap gap-1.5 items-center min-h-9.5 cursor-text relative'
-              onClick={() => {
-                tagInputRef.current?.focus();
-                if (!fetchedTags) {
-                  void (async () => {
-                    const t = await fetchTags();
-                    setAvailableTags(t);
-                    setFetchedTags(true);
-                  })();
-                }
-                setShowTagDropdown(true);
-              }}
+              onClick={handleFocusTagInput}
             >
               {tags.map((tag) => {
                 const c = getTagColorClasses(tag, tagColorMap[tag.toLowerCase()]);
@@ -328,7 +361,8 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
                     <button
                       type='button'
                       className='ml-0.5 opacity-70 hover:opacity-100'
-                      onClick={() => removeTag(tag)}
+                      onClick={handleTagPillRemove}
+                      data-tag={tag}
                     >
                       &times;
                     </button>
@@ -341,7 +375,7 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
                 className='flex-1 min-w-20 bg-transparent outline-none text-sm text-fg placeholder:text-faint'
                 placeholder={tags.length === 0 ? 'Custom grouping (enter to confirm)' : ''}
                 value={tagInput}
-                onChange={(e) => setTagInput(e.target.value)}
+                onChange={handleTagInputChange}
                 onKeyDown={handleTagKeyDown}
               />
               {showTagDropdown && (
@@ -350,18 +384,9 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
                   tagInput={tagInput}
                   tags={tags}
                   highlightedIndex={highlightedIndex}
-                  onToggle={(tag) => {
-                    if (tags.includes(tag)) {
-                      removeTag(tag);
-                    } else {
-                      flushSync(() => setTags((prev) => [...prev, tag]));
-                    }
-                  }}
+                  onToggle={handleTagToggle}
                   onHighlight={setHighlightedIndex}
-                  onClose={() => {
-                    setShowTagDropdown(false);
-                    setHighlightedIndex(-1);
-                  }}
+                  onClose={handleTagDropdownClose}
                   tagInputRef={tagInputRef}
                   onTagInputChange={setTagInput}
                 />
@@ -374,11 +399,7 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
             onChange={setVolumeBoost}
             min={-100}
             max={200}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                void doSave();
-              }
-            }}
+            onKeyDown={handleEnterSave}
           />
         </div>
       </div>
@@ -402,6 +423,40 @@ function VolumeSlider({
   const numeric = value.trim() === '' ? 0 : Math.min(max, Math.max(min, parseInt(value, 10) || 0));
   const pct = `${((numeric - min) / (max - min)) * 100}%`;
 
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const v = e.target.value;
+      if (v === '' || /^\d*$/.test(v)) {
+        onChange(v);
+      }
+    },
+    [onChange]
+  );
+
+  const handleBlur = useCallback(() => {
+    if (value.trim() === '') {
+      onChange('0');
+    } else {
+      const n = parseInt(value, 10);
+      if (!Number.isNaN(n)) {
+        onChange(String(Math.min(max, Math.max(min, n))));
+      }
+    }
+  }, [value, onChange, min, max]);
+
+  const handleRangeChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.value),
+    [onChange]
+  );
+
+  const rangeStyle = useMemo(
+    () =>
+      ({
+        '--volume-pct': pct,
+      }) as React.CSSProperties,
+    [pct]
+  );
+
   return (
     <div>
       <span className='block font-mono text-[10px] text-muted uppercase mb-1'>Volume Boost</span>
@@ -411,23 +466,9 @@ function VolumeSlider({
           className='input text-sm w-16 text-center'
           type='text'
           value={value}
-          onChange={(e) => {
-            const v = e.target.value;
-            if (v === '' || /^\d*$/.test(v)) {
-              onChange(v);
-            }
-          }}
+          onChange={handleChange}
           onKeyDown={onKeyDown}
-          onBlur={() => {
-            if (value.trim() === '') {
-              onChange('0');
-            } else {
-              const n = parseInt(value, 10);
-              if (!Number.isNaN(n)) {
-                onChange(String(Math.min(max, Math.max(min, n))));
-              }
-            }
-          }}
+          onBlur={handleBlur}
         />
         <span className='text-xs text-muted font-mono w-8 text-left'>%</span>
         <input
@@ -435,13 +476,9 @@ function VolumeSlider({
           min={min}
           max={max}
           value={numeric}
-          onChange={(e) => onChange(e.target.value)}
+          onChange={handleRangeChange}
           className='volume-range-input min-w-0'
-          style={
-            {
-              '--volume-pct': pct,
-            } as React.CSSProperties
-          }
+          style={rangeStyle}
         />
       </div>
     </div>
@@ -471,6 +508,10 @@ function Field({
   min?: number;
   max?: number;
 }) {
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.value),
+    [onChange]
+  );
   return (
     <div>
       <label htmlFor={id} className='block font-mono text-[10px] text-muted uppercase mb-1'>
@@ -484,7 +525,7 @@ function Field({
         min={type === 'number' ? min : undefined}
         max={type === 'number' ? max : undefined}
         value={value}
-        onChange={(e) => onChange(e.target.value)}
+        onChange={handleChange}
         onKeyDown={onKeyDown}
         placeholder={placeholder}
       />
@@ -532,6 +573,8 @@ function CrossIcon() {
     </svg>
   );
 }
+
+const TAG_DROPDOWN_PLACEHOLDER_STYLE: React.CSSProperties = { top: 0, left: 0 };
 
 interface TagDropdownProps {
   availableTags: TagItem[];
@@ -595,11 +638,33 @@ function TagDropdown({
       t.nameLower.includes(tagInput.toLowerCase())
   );
 
+  const handleItemMouseDown = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const tag = e.currentTarget.dataset.tag;
+      if (tag) {
+        onToggle(tag);
+      }
+      onTagInputChange('');
+      tagInputRef.current?.focus();
+    },
+    [onToggle, onTagInputChange, tagInputRef]
+  );
+
+  const handleItemMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      const idx = parseInt(e.currentTarget.dataset.index ?? '0', 10);
+      onHighlight(idx);
+    },
+    [onHighlight]
+  );
+
   const dropdown = (
     <div
       ref={dropdownRef}
       className='fixed z-50 min-w-45 glass-popover max-h-48'
-      style={{ top: 0, left: 0 }}
+      style={TAG_DROPDOWN_PLACEHOLDER_STYLE}
     >
       {filtered.length === 0 ? (
         <div className='px-3 py-2 text-xs text-muted cursor-default'>
@@ -615,14 +680,10 @@ function TagDropdown({
               className={`flex items-center gap-2 px-3 py-2 text-sm cursor-pointer ${
                 i === highlightedIndex ? 'bg-elevated' : 'hover:bg-elevated/70'
               }`}
-              onMouseDown={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                onToggle(tag.canonicalName);
-                onTagInputChange('');
-                tagInputRef.current?.focus();
-              }}
-              onMouseEnter={() => onHighlight(i)}
+              onMouseDown={handleItemMouseDown}
+              data-tag={tag.canonicalName}
+              onMouseEnter={handleItemMouseEnter}
+              data-index={i}
             >
               <span className={`font-mono text-xs ${c.text}`}>{tag.canonicalName}</span>
               <span className='ml-auto text-muted text-xs'>

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -262,12 +262,10 @@ export default function PlaylistDetailPage() {
   });
 
   // Derive PlaylistDetail for JSX — metadata from the hook, songs from items
-  const playlistDetail = playlistMeta
-    ? {
-        ...playlistMeta,
-        songs,
-      }
-    : null;
+  const playlistDetail = useMemo(
+    () => (playlistMeta ? { ...playlistMeta, songs } : null),
+    [playlistMeta, songs]
+  );
 
   // Stable ref for callbacks — avoids playlistDetail changing every render
   const playlistDetailRef = useRef(playlistDetail);
@@ -277,6 +275,69 @@ export default function PlaylistDetailPage() {
   const canEdit = isAdminView || isOwner || hasPermission('songs.edit');
   const canBulk = canEdit;
   const isSmart = !!playlistDetail?.tagNameLower;
+
+  const songItems: Song[] = useMemo(() => songs.map((ps) => ps.song), [songs]);
+
+  const pageStyle = useMemo(() => ({ paddingBottom: 0 }), []);
+  const handleGoBack = useCallback(() => navigate('/playlists'), [navigate]);
+  const handleToggleMenu = useCallback(() => setMenuOpen((v) => !v), []);
+  const handleCloseMenu = useCallback(() => setMenuOpen(false), []);
+  const handleSortChange = useCallback((field: string, newOrder: string) => {
+    setSort(field);
+    setOrder(newOrder);
+  }, []);
+  const handleAddTag = useCallback((tag: string) => {
+    const t = tag.toLowerCase();
+    setFilterTags((prev) => (prev.includes(t) ? prev : [...prev, t]));
+  }, []);
+  const handleRemoveTag = useCallback(
+    (tag: string) => setFilterTags((prev) => prev.filter((t) => t !== tag)),
+    []
+  );
+  const handleAddSource = useCallback(
+    (s: string) => setFilterSources((prev) => (prev.includes(s) ? prev : [...prev, s])),
+    []
+  );
+  const handleRemoveSource = useCallback(
+    (s: string) => setFilterSources((prev) => prev.filter((x) => x !== s)),
+    []
+  );
+  const handleToggleSelectionMode = useCallback(() => {
+    if (selectionMode) {
+      bulk.clearAll();
+    }
+    setSelectionMode((v) => !v);
+  }, [selectionMode, bulk]);
+  const handleViewModeChange = useCallback((mode: 'list' | 'grid') => {
+    localStorage.setItem('alfira-playlist-view', mode);
+    setViewMode(mode);
+  }, []);
+  const handleSongDelete = useCallback(
+    (id: string) => {
+      const ps = songs.find((p) => p.songId === id);
+      if (ps) {
+        setRemoveId(ps.songId);
+      }
+    },
+    [songs]
+  );
+  const handleCloseAddSongs = useCallback(() => setShowAddSongs(false), []);
+  const handleAddSongsAdded = useCallback(() => {
+    refetch();
+    setShowAddSongs(false);
+  }, [refetch]);
+  const handleCancelBulkRemove = useCallback(() => setBulkRemoveConfirm(false), []);
+  const handleCancelRemove = useCallback(() => setRemoveId(null), []);
+  const handleCancelDeletePlaylist = useCallback(() => setDeleteConfirm(false), []);
+  const handleCancelMakeSmart = useCallback(() => setTagSmartConfirm(null), []);
+  const handleBulkTag = useCallback(() => setBulkEditingOpen(true), []);
+  const handleSelectAll = useCallback(
+    () => bulk.selectAll(songs.map((ps) => ps.songId)),
+    [bulk, songs]
+  );
+  const handleEmptyAdd = useCallback(() => setShowAddSongs(true), []);
+
+  const handleCloseBulkEdit = useCallback(() => setBulkEditingOpen(false), []);
 
   // ── Socket: playlist updated (rename, visibility, song count changes) ──
   useEffect(() => {
@@ -331,22 +392,31 @@ export default function PlaylistDetailPage() {
     }
   };
 
-  const handleRemoveSong = async (songId: string) => {
-    if (!playlistDetail) {
-      return;
+  const handleRemoveSong = useCallback(
+    async (songId: string) => {
+      if (!playlistDetail) {
+        return;
+      }
+      const junction = songsRef.current.find((ps) => ps.songId === songId);
+      if (!junction) {
+        setRemoveId(null);
+        return;
+      }
+      try {
+        await removeSongFromPlaylist(playlistDetail.id, songId);
+        removeItem(junction.id);
+      } finally {
+        setRemoveId(null);
+      }
+    },
+    [playlistDetail, removeItem]
+  );
+
+  const handleConfirmRemove = useCallback(() => {
+    if (removeId) {
+      void handleRemoveSong(removeId);
     }
-    const junction = songsRef.current.find((ps) => ps.songId === songId);
-    if (!junction) {
-      setRemoveId(null);
-      return;
-    }
-    try {
-      await removeSongFromPlaylist(playlistDetail.id, songId);
-      removeItem(junction.id);
-    } finally {
-      setRemoveId(null);
-    }
-  };
+  }, [removeId, handleRemoveSong]);
 
   // ── Bulk actions ─────────────────────────────────────────────────────
   const handleBulkRemove = useCallback(() => {
@@ -408,13 +478,18 @@ export default function PlaylistDetailPage() {
     [bulk, notify]
   );
 
-  const handleDeletePlaylist = async () => {
+  const handleDeletePlaylist = useCallback(async () => {
     if (!playlistDetail) {
       return;
     }
     await deletePlaylist(playlistDetail.id);
     void navigate('/playlists');
-  };
+  }, [playlistDetail, navigate]);
+
+  const handleConfirmDeletePlaylist = useCallback(() => {
+    setDeleteConfirm(false);
+    void handleDeletePlaylist();
+  }, [handleDeletePlaylist]);
 
   const handleToggleVisibility = async () => {
     if (!playlistDetail) {
@@ -511,6 +586,12 @@ export default function PlaylistDetailPage() {
     },
     [refetch, notify]
   );
+
+  const handleConfirmMakeSmart = useCallback(() => {
+    if (tagSmartConfirm) {
+      void handleMakeSmart(tagSmartConfirm);
+    }
+  }, [tagSmartConfirm, handleMakeSmart]);
 
   const handleAddPlaylistToQueue = useCallback(async () => {
     const pd = playlistDetailRef.current;
@@ -625,16 +706,13 @@ export default function PlaylistDetailPage() {
     return null;
   }
 
-  // Extract plain songs from PlaylistDetailSong[]
-  const songItems: Song[] = songs.map((ps) => ps.song);
-
   return (
-    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full' style={{ paddingBottom: 0 }}>
+    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full' style={pageStyle}>
       {/* Back */}
       <Button
         variant='inherit'
         surface='surface'
-        onClick={() => navigate('/playlists')}
+        onClick={handleGoBack}
         className='flex items-center gap-1.5 font-mono text-xs mb-4 md:mb-6 min-h-11 md:min-h-0'
       >
         <CaretLeftIcon size={16} weight='duotone' className='md:w-3.5 md:h-3.5' />
@@ -714,7 +792,7 @@ export default function PlaylistDetailPage() {
           </Button>
           <ContextMenuTrigger
             ref={menuTriggerRef}
-            onToggle={() => setMenuOpen((v) => !v)}
+            onToggle={handleToggleMenu}
             isOpen={menuOpen}
             surface='surface'
             size='default'
@@ -724,7 +802,7 @@ export default function PlaylistDetailPage() {
             <ContextMenu
               items={menuItems}
               isOpen={menuOpen}
-              onClose={() => setMenuOpen(false)}
+              onClose={handleCloseMenu}
               triggerRef={menuTriggerRef}
             />
           )}
@@ -738,34 +816,20 @@ export default function PlaylistDetailPage() {
         sortOptions={[...SORT_OPTIONS]}
         sort={sort}
         order={order as 'asc' | 'desc'}
-        onSortChange={(field, newOrder) => {
-          setSort(field);
-          setOrder(newOrder);
-        }}
+        onSortChange={handleSortChange}
         defaultSort='position'
         textSortFields={['title', 'artist', 'album']}
         filterTags={filterTags}
         filterSources={filterSources}
-        onAddTag={(tag) => {
-          const normalized = tag.toLowerCase();
-          setFilterTags((prev) => (prev.includes(normalized) ? prev : [...prev, normalized]));
-        }}
-        onRemoveTag={(tag) => setFilterTags((prev) => prev.filter((t) => t !== tag))}
-        onAddSource={(s) => setFilterSources((prev) => (prev.includes(s) ? prev : [...prev, s]))}
-        onRemoveSource={(s) => setFilterSources((prev) => prev.filter((x) => x !== s))}
+        onAddTag={handleAddTag}
+        onRemoveTag={handleRemoveTag}
+        onAddSource={handleAddSource}
+        onRemoveSource={handleRemoveSource}
         showBulkToggle={canBulk}
         selectionMode={selectionMode}
-        onToggleSelectionMode={() => {
-          if (selectionMode) {
-            bulk.clearAll();
-          }
-          setSelectionMode((v) => !v);
-        }}
+        onToggleSelectionMode={handleToggleSelectionMode}
         viewMode={viewMode}
-        onViewModeChange={(mode) => {
-          localStorage.setItem('alfira-playlist-view', mode);
-          setViewMode(mode);
-        }}
+        onViewModeChange={handleViewModeChange}
       />
 
       {/* Song list */}
@@ -779,7 +843,7 @@ export default function PlaylistDetailPage() {
           <EmptyState
             title='Empty Playlist'
             isAdmin={canEdit}
-            onAdd={() => setShowAddSongs(true)}
+            onAdd={handleEmptyAdd}
             addLabel='add some songs'
           />
         )
@@ -807,16 +871,7 @@ export default function PlaylistDetailPage() {
                 playingId={playingSongId}
                 onRetry={retry}
                 onFetchMore={fetchNextPage}
-                onDelete={
-                  selectionMode
-                    ? undefined
-                    : (id) => {
-                        const ps = songs.find((p) => p.songId === id);
-                        if (ps) {
-                          setRemoveId(ps.songId);
-                        }
-                      }
-                }
+                onDelete={selectionMode ? undefined : handleSongDelete}
                 onPlay={handlePlayFromSong}
                 onAddToQueue={handleAddToQueue}
                 selectionMode={selectionMode}
@@ -848,16 +903,7 @@ export default function PlaylistDetailPage() {
                 playingId={playingSongId}
                 onRetry={retry}
                 onFetchMore={fetchNextPage}
-                onDelete={
-                  selectionMode
-                    ? undefined
-                    : (id) => {
-                        const ps = songs.find((p) => p.songId === id);
-                        if (ps) {
-                          setRemoveId(ps.songId);
-                        }
-                      }
-                }
+                onDelete={selectionMode ? undefined : handleSongDelete}
                 onPlay={handlePlayFromSong}
                 onAddToQueue={handleAddToQueue}
                 selectionMode={selectionMode}
@@ -875,11 +921,8 @@ export default function PlaylistDetailPage() {
       {showAddSongs && (
         <AddSongsModal
           playlist={playlistDetail}
-          onClose={() => setShowAddSongs(false)}
-          onAdded={() => {
-            refetch();
-            setShowAddSongs(false);
-          }}
+          onClose={handleCloseAddSongs}
+          onAdded={handleAddSongsAdded}
         />
       )}
       {/* Notification Toast */}
@@ -900,7 +943,7 @@ export default function PlaylistDetailPage() {
           }
           confirmLabel='Remove'
           onConfirm={executeBulkRemove}
-          onCancel={() => setBulkRemoveConfirm(false)}
+          onCancel={handleCancelBulkRemove}
         />
       )}
       {removeId && (
@@ -916,8 +959,8 @@ export default function PlaylistDetailPage() {
             </>
           }
           confirmLabel='Remove'
-          onConfirm={() => handleRemoveSong(removeId)}
-          onCancel={() => setRemoveId(null)}
+          onConfirm={handleConfirmRemove}
+          onCancel={handleCancelRemove}
         />
       )}
       {deleteConfirm && (
@@ -925,11 +968,8 @@ export default function PlaylistDetailPage() {
           title='Delete Playlist'
           message='This playlist will be permanently deleted. This cannot be undone.'
           confirmLabel='Delete'
-          onConfirm={() => {
-            setDeleteConfirm(false);
-            void handleDeletePlaylist();
-          }}
-          onCancel={() => setDeleteConfirm(false)}
+          onConfirm={handleConfirmDeletePlaylist}
+          onCancel={handleCancelDeletePlaylist}
         />
       )}
       {tagSmartConfirm && (
@@ -946,8 +986,8 @@ export default function PlaylistDetailPage() {
             </>
           }
           confirmLabel='Convert'
-          onConfirm={() => handleMakeSmart(tagSmartConfirm)}
-          onCancel={() => setTagSmartConfirm(null)}
+          onConfirm={handleConfirmMakeSmart}
+          onCancel={handleCancelMakeSmart}
         />
       )}
 
@@ -961,8 +1001,8 @@ export default function PlaylistDetailPage() {
           canTag={canEdit}
           deleteLabel='Remove selected'
           onDelete={handleBulkRemove}
-          onTag={() => setBulkEditingOpen(true)}
-          onSelectAll={() => bulk.selectAll(songItems.map((s) => s.id))}
+          onTag={handleBulkTag}
+          onSelectAll={handleSelectAll}
           onDeselectAll={bulk.clearAll}
           isDeleting={bulkRemoving}
         />
@@ -973,7 +1013,7 @@ export default function PlaylistDetailPage() {
         <BulkEditModal
           count={bulk.count}
           onApply={handleBulkEdit}
-          onClose={() => setBulkEditingOpen(false)}
+          onClose={handleCloseBulkEdit}
           isApplying={bulkEditingApplying}
         />
       )}

--- a/packages/web/src/pages/SetupWizard.tsx
+++ b/packages/web/src/pages/SetupWizard.tsx
@@ -8,7 +8,7 @@ import {
   ShieldCheckIcon,
   TimerIcon,
 } from '@phosphor-icons/react';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 
 import {
@@ -49,6 +49,44 @@ const STEP_ORDER: Step[] = [
   'publicUrl',
   'confirm',
 ];
+
+function getRoleBgColor(color: number | null): string {
+  return color ? `#${color.toString(16).padStart(6, '0')}` : 'var(--color-muted)';
+}
+
+function RoleColorDot({ color }: { color: number | null }) {
+  const style = useMemo<React.CSSProperties>(
+    () => ({ backgroundColor: getRoleBgColor(color) }),
+    [color]
+  );
+  return <span className='w-3 h-3 rounded-full shrink-0' style={style} />;
+}
+
+function SourceCheckbox({
+  sourceKey,
+  checked,
+  onToggle,
+}: {
+  sourceKey: string;
+  checked: boolean;
+  onToggle: (key: string) => void;
+}) {
+  const handleChange = useCallback(() => onToggle(sourceKey), [sourceKey, onToggle]);
+  return <Checkbox checked={checked} onChange={handleChange} />;
+}
+
+function RoleCheckbox({
+  roleId,
+  checked,
+  onToggle,
+}: {
+  roleId: string;
+  checked: boolean;
+  onToggle: (id: string) => void;
+}) {
+  const handleChange = useCallback(() => onToggle(roleId), [roleId, onToggle]);
+  return <Checkbox checked={checked} onChange={handleChange} />;
+}
 
 const AVAILABLE_SOURCES = [
   { key: 'youtube', displayName: 'YouTube', requiresCredentials: false, helpText: undefined },
@@ -142,20 +180,7 @@ export default function SetupWizard() {
     };
   }, [step, guilds.length]);
 
-  // Only the first user (setup admin) can access the wizard.
-  if (!user?.isSetupAdmin && !loading) {
-    return <Navigate to='/' replace />;
-  }
-
-  if (loading) {
-    return (
-      <div className='h-full flex items-center justify-center bg-elevated'>
-        <Spinner size='lg' />
-      </div>
-    );
-  }
-
-  async function loadGuilds() {
+  const loadGuilds = useCallback(async () => {
     setError(null);
     try {
       const { guilds: list } = await fetchSetupGuilds();
@@ -167,9 +192,9 @@ export default function SetupWizard() {
     } catch {
       setError('Could not fetch server list. Is the bot connected to Discord?');
     }
-  }
+  }, []);
 
-  async function loadRoles() {
+  const loadRoles = useCallback(async () => {
     if (!selectedGuildId) {
       return;
     }
@@ -181,9 +206,9 @@ export default function SetupWizard() {
     } catch {
       setError('Could not fetch roles.');
     }
-  }
+  }, [selectedGuildId]);
 
-  async function loadChannels() {
+  const loadChannels = useCallback(async () => {
     if (!selectedGuildId) {
       return;
     }
@@ -195,9 +220,9 @@ export default function SetupWizard() {
     } catch {
       setError('Could not fetch channels.');
     }
-  }
+  }, [selectedGuildId]);
 
-  async function handleSubmit() {
+  const handleSubmit = useCallback(async () => {
     if (!selectedGuildId || selectedRoleIds.size === 0) {
       return;
     }
@@ -224,9 +249,16 @@ export default function SetupWizard() {
       setSaving(false);
       setStep('confirm');
     }
-  }
+  }, [
+    selectedGuildId,
+    selectedRoleIds,
+    selectedSourceKeys,
+    timeoutMinutes,
+    selectedChannelId,
+    publicUrl,
+  ]);
 
-  function toggleRole(id: string) {
+  const toggleRole = useCallback((id: string) => {
     setSelectedRoleIds((prev) => {
       const next = new Set(prev);
       if (next.has(id)) {
@@ -236,9 +268,9 @@ export default function SetupWizard() {
       }
       return next;
     });
-  }
+  }, []);
 
-  function toggleSource(key: string) {
+  const toggleSource = useCallback((key: string) => {
     setSelectedSourceKeys((prev) => {
       const next = new Set(prev);
       // Prevent deselecting the last source.
@@ -252,9 +284,60 @@ export default function SetupWizard() {
       }
       return next;
     });
-  }
+  }, []);
+
+  const handleGoToStep = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
+    const target = e.currentTarget.dataset.step as Step | undefined;
+    if (target) {
+      setStep(target);
+    }
+  }, []);
+
+  const handleGuildSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setSelectedGuildId(e.currentTarget.dataset.guild ?? '');
+  }, []);
+
+  const handleChannelSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setSelectedChannelId(e.currentTarget.dataset.channel ?? '');
+  }, []);
+
+  const handleSkipChannel = useCallback(() => {
+    setSelectedChannelId('');
+    setStep('timeout');
+  }, []);
+
+  const handleTimeoutChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => setTimeoutMinutes(Number(e.target.value)),
+    []
+  );
+
+  const handlePublicUrlChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => setPublicUrl(e.target.value),
+    []
+  );
+
+  const timeoutRangeStyle = useMemo(
+    () =>
+      ({
+        '--range-pct': `${((timeoutMinutes - 1) / (120 - 1)) * 100}%`,
+      }) as React.CSSProperties,
+    [timeoutMinutes]
+  );
 
   const stepIndex = STEP_ORDER.indexOf(step);
+
+  // Only the first user (setup admin) can access the wizard.
+  if (!user?.isSetupAdmin && !loading) {
+    return <Navigate to='/' replace />;
+  }
+
+  if (loading) {
+    return (
+      <div className='h-full flex items-center justify-center bg-elevated'>
+        <Spinner size='lg' />
+      </div>
+    );
+  }
 
   return (
     <div className='min-h-full bg-surface flex items-center justify-center p-4'>
@@ -339,7 +422,8 @@ export default function SetupWizard() {
                         name='guild'
                         value={g.id}
                         checked={selectedGuildId === g.id}
-                        onChange={() => setSelectedGuildId(g.id)}
+                        onChange={handleGuildSelect}
+                        data-guild={g.id}
                         className='accent-accent'
                       />
                       <span className='text-sm text-fg'>{g.name}</span>
@@ -350,7 +434,8 @@ export default function SetupWizard() {
               <div className='flex justify-between pt-2'>
                 <button
                   type='button'
-                  onClick={() => setStep('welcome')}
+                  onClick={handleGoToStep}
+                  data-step='welcome'
                   className='flex items-center gap-1 text-sm text-muted hover:text-fg transition-colors cursor-pointer'
                 >
                   <CaretLeftIcon size={14} />
@@ -358,7 +443,8 @@ export default function SetupWizard() {
                 </button>
                 <Button
                   variant='primary'
-                  onClick={() => setStep('sources')}
+                  onClick={handleGoToStep}
+                  data-step='sources'
                   disabled={!selectedGuildId}
                 >
                   Next
@@ -388,9 +474,10 @@ export default function SetupWizard() {
                           : 'border-border hover:border-muted'
                       }`}
                     >
-                      <Checkbox
+                      <SourceCheckbox
+                        sourceKey={source.key}
                         checked={selectedSourceKeys.has(source.key)}
-                        onChange={() => toggleSource(source.key)}
+                        onToggle={toggleSource}
                       />
                       <SourceIcon sourceKey={source.key} className='shrink-0' />
                       <span className='text-sm text-fg'>{source.displayName}</span>
@@ -425,7 +512,8 @@ export default function SetupWizard() {
               <div className='flex justify-between pt-2'>
                 <button
                   type='button'
-                  onClick={() => setStep('guild')}
+                  onClick={handleGoToStep}
+                  data-step='guild'
                   className='flex items-center gap-1 text-sm text-muted hover:text-fg transition-colors cursor-pointer'
                 >
                   <CaretLeftIcon size={14} />
@@ -463,18 +551,12 @@ export default function SetupWizard() {
                           : 'border-border hover:border-muted'
                       }`}
                     >
-                      <Checkbox
+                      <RoleCheckbox
+                        roleId={r.id}
                         checked={selectedRoleIds.has(r.id)}
-                        onChange={() => toggleRole(r.id)}
+                        onToggle={toggleRole}
                       />
-                      <span
-                        className='w-3 h-3 rounded-full shrink-0'
-                        style={{
-                          backgroundColor: r.color
-                            ? `#${r.color.toString(16).padStart(6, '0')}`
-                            : 'var(--color-muted)',
-                        }}
-                      />
+                      <RoleColorDot color={r.color} />
                       <span className='text-sm text-fg'>{r.name}</span>
                     </label>
                   ))}
@@ -483,7 +565,8 @@ export default function SetupWizard() {
               <div className='flex justify-between pt-2'>
                 <button
                   type='button'
-                  onClick={() => setStep('sources')}
+                  onClick={handleGoToStep}
+                  data-step='sources'
                   className='flex items-center gap-1 text-sm text-muted hover:text-fg transition-colors cursor-pointer'
                 >
                   <CaretLeftIcon size={14} />
@@ -528,7 +611,8 @@ export default function SetupWizard() {
                         name='channel'
                         value={c.id}
                         checked={selectedChannelId === c.id}
-                        onChange={() => setSelectedChannelId(c.id)}
+                        onChange={handleChannelSelect}
+                        data-channel={c.id}
                         className='accent-accent'
                       />
                       <span className='text-sm text-fg'># {c.name}</span>
@@ -539,24 +623,18 @@ export default function SetupWizard() {
               <div className='flex justify-between pt-2'>
                 <button
                   type='button'
-                  onClick={() => setStep('roles')}
+                  onClick={handleGoToStep}
+                  data-step='roles'
                   className='flex items-center gap-1 text-sm text-muted hover:text-fg transition-colors cursor-pointer'
                 >
                   <CaretLeftIcon size={14} />
                   Back
                 </button>
                 <div className='flex gap-2'>
-                  <Button
-                    variant='inherit'
-                    onClick={() => {
-                      setSelectedChannelId('');
-                      setStep('timeout');
-                    }}
-                    surface='surface'
-                  >
+                  <Button variant='inherit' onClick={handleSkipChannel} surface='surface'>
                     Skip
                   </Button>
-                  <Button variant='primary' onClick={() => setStep('timeout')}>
+                  <Button variant='primary' onClick={handleGoToStep} data-step='timeout'>
                     Next
                   </Button>
                 </div>
@@ -579,13 +657,9 @@ export default function SetupWizard() {
                   min={1}
                   max={120}
                   value={timeoutMinutes}
-                  onChange={(e) => setTimeoutMinutes(Number(e.target.value))}
+                  onChange={handleTimeoutChange}
                   className='flex-1 range-input range-input-h'
-                  style={
-                    {
-                      '--range-pct': `${((timeoutMinutes - 1) / (120 - 1)) * 100}%`,
-                    } as React.CSSProperties
-                  }
+                  style={timeoutRangeStyle}
                 />
                 <span className='font-mono text-lg text-fg w-20 text-right whitespace-nowrap'>
                   {timeoutMinutes} min
@@ -594,13 +668,14 @@ export default function SetupWizard() {
               <div className='flex justify-between pt-2'>
                 <button
                   type='button'
-                  onClick={() => setStep('channel')}
+                  onClick={handleGoToStep}
+                  data-step='channel'
                   className='flex items-center gap-1 text-sm text-muted hover:text-fg transition-colors cursor-pointer'
                 >
                   <CaretLeftIcon size={14} />
                   Back
                 </button>
-                <Button variant='primary' onClick={() => setStep('publicUrl')}>
+                <Button variant='primary' onClick={handleGoToStep} data-step='publicUrl'>
                   Next
                 </Button>
               </div>
@@ -620,20 +695,21 @@ export default function SetupWizard() {
               <input
                 type='text'
                 value={publicUrl}
-                onChange={(e) => setPublicUrl(e.target.value)}
+                onChange={handlePublicUrlChange}
                 placeholder='https://music.yourserver.com'
                 className='input font-mono'
               />
               <div className='flex justify-between pt-2'>
                 <button
                   type='button'
-                  onClick={() => setStep('timeout')}
+                  onClick={handleGoToStep}
+                  data-step='timeout'
                   className='flex items-center gap-1 text-sm text-muted hover:text-fg transition-colors cursor-pointer'
                 >
                   <CaretLeftIcon size={14} />
                   Back
                 </button>
-                <Button variant='primary' onClick={() => setStep('confirm')}>
+                <Button variant='primary' onClick={handleGoToStep} data-step='confirm'>
                   Review
                 </Button>
               </div>
@@ -693,7 +769,8 @@ export default function SetupWizard() {
               <div className='flex justify-between pt-2'>
                 <button
                   type='button'
-                  onClick={() => setStep('publicUrl')}
+                  onClick={handleGoToStep}
+                  data-step='publicUrl'
                   className='flex items-center gap-1 text-sm text-muted hover:text-fg transition-colors cursor-pointer'
                 >
                   <CaretLeftIcon size={14} />

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -252,11 +252,11 @@ export default function SongsPage() {
     };
   }, [prepend, updateItem, removeItem]);
 
-  const handleDelete = async (id: string) => {
+  const handleDelete = useCallback(async (id: string) => {
     await deleteSong(id);
     setDeleteId(null);
     // Socket event will update the songs list
-  };
+  }, []);
 
   // ── Bulk actions ─────────────────────────────────────────────────────
   const handleBulkDelete = useCallback(() => {
@@ -337,8 +337,97 @@ export default function SongsPage() {
     [queueState.loopMode, notify]
   );
 
+  const pageStyle = useMemo(() => ({ paddingBottom: 0 }), []);
+
+  const handleSearchChange = useCallback(
+    (v: string) => updateParam('search', v || null),
+    [updateParam]
+  );
+
+  const handleSortChange = useCallback(
+    (field: string, newOrder: string) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (field === 'createdAt') {
+            next.delete('sort');
+          } else {
+            next.set('sort', field);
+          }
+          if (newOrder === 'asc') {
+            next.set('order', 'asc');
+          } else {
+            next.delete('order');
+          }
+          return next;
+        },
+        { replace: true }
+      );
+    },
+    [setSearchParams]
+  );
+
+  const handleAddTag = useCallback(
+    (tag: string) => {
+      const normalized = tag.toLowerCase();
+      if (filterTags.includes(normalized)) {
+        return;
+      }
+      updateParam('tags', [...filterTags, normalized].join(','));
+    },
+    [filterTags, updateParam]
+  );
+
+  const handleRemoveTag = useCallback(
+    (tag: string) => updateParam('tags', filterTags.filter((t) => t !== tag).join(',') || null),
+    [filterTags, updateParam]
+  );
+
+  const handleAddSource = useCallback(
+    (s: string) => {
+      if (filterSources.includes(s)) {
+        return;
+      }
+      updateParam('source', [...filterSources, s].join(','));
+    },
+    [filterSources, updateParam]
+  );
+
+  const handleRemoveSource = useCallback(
+    (s: string) => updateParam('source', filterSources.filter((x) => x !== s).join(',') || null),
+    [filterSources, updateParam]
+  );
+
+  const handleToggleSelectionMode = useCallback(() => {
+    if (selectionMode) {
+      bulk.clearAll();
+    }
+    setSelectionMode((v) => !v);
+  }, [selectionMode, bulk]);
+
+  const handleViewModeChange = useCallback((mode: 'list' | 'grid') => {
+    localStorage.setItem('alfira-song-view', mode);
+    setViewMode(mode);
+  }, []);
+
+  const handleConfirmDelete = useCallback(() => {
+    if (deleteId) {
+      void handleDelete(deleteId);
+    }
+  }, [deleteId, handleDelete]);
+
+  const handleCancelDelete = useCallback(() => setDeleteId(null), []);
+
+  const handleCancelBulkDelete = useCallback(() => setBulkDeleteConfirm(false), []);
+
+  const handleBulkTag = useCallback(() => setBulkEditingOpen(true), []);
+
+  const handleSelectAll = useCallback(() => bulk.selectAll(items.map((s) => s.id)), [bulk, items]);
+
+  const handleCloseBulkEdit = useCallback(() => setBulkEditingOpen(false), []);
+
   return (
-    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full' style={{ paddingBottom: 0 }}>
+    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full' style={pageStyle}>
       <PageHeader
         icon={MusicNotesIcon}
         title='Songs'
@@ -356,66 +445,25 @@ export default function SongsPage() {
 
       <ListToolbar
         searchValue={search}
-        onSearchChange={(v) => updateParam('search', v || null)}
+        onSearchChange={handleSearchChange}
         searchPlaceholder='Search by title, nickname, artist, album, or tag...'
         sortOptions={SORT_OPTIONS}
         sort={sort}
         order={order as 'asc' | 'desc'}
-        onSortChange={(field, newOrder) => {
-          setSearchParams(
-            (prev) => {
-              const next = new URLSearchParams(prev);
-              if (field === 'createdAt') {
-                next.delete('sort');
-              } else {
-                next.set('sort', field);
-              }
-              if (newOrder === 'asc') {
-                next.set('order', 'asc');
-              } else {
-                next.delete('order');
-              }
-              return next;
-            },
-            { replace: true }
-          );
-        }}
+        onSortChange={handleSortChange}
         defaultSort='createdAt'
         textSortFields={['title', 'artist', 'album']}
         filterTags={filterTags}
         filterSources={filterSources}
-        onAddTag={(tag) => {
-          const normalized = tag.toLowerCase();
-          if (filterTags.includes(normalized)) {
-            return;
-          }
-          updateParam('tags', [...filterTags, normalized].join(','));
-        }}
-        onRemoveTag={(tag) =>
-          updateParam('tags', filterTags.filter((t) => t !== tag).join(',') || null)
-        }
-        onAddSource={(s) => {
-          if (filterSources.includes(s)) {
-            return;
-          }
-          updateParam('source', [...filterSources, s].join(','));
-        }}
-        onRemoveSource={(s) =>
-          updateParam('source', filterSources.filter((x) => x !== s).join(',') || null)
-        }
+        onAddTag={handleAddTag}
+        onRemoveTag={handleRemoveTag}
+        onAddSource={handleAddSource}
+        onRemoveSource={handleRemoveSource}
         showBulkToggle={canBulk}
         selectionMode={selectionMode}
-        onToggleSelectionMode={() => {
-          if (selectionMode) {
-            bulk.clearAll();
-          }
-          setSelectionMode((v) => !v);
-        }}
+        onToggleSelectionMode={handleToggleSelectionMode}
         viewMode={viewMode}
-        onViewModeChange={(mode) => {
-          localStorage.setItem('alfira-song-view', mode);
-          setViewMode(mode);
-        }}
+        onViewModeChange={handleViewModeChange}
       />
 
       {/* Content */}
@@ -507,8 +555,8 @@ export default function SongsPage() {
       {deleteId && (
         <DeleteConfirmDialog
           song={items.find((s) => s.id === deleteId)}
-          onConfirm={() => handleDelete(deleteId)}
-          onCancel={() => setDeleteId(null)}
+          onConfirm={handleConfirmDelete}
+          onCancel={handleCancelDelete}
         />
       )}
 
@@ -526,7 +574,7 @@ export default function SongsPage() {
           }
           confirmLabel='Delete'
           onConfirm={executeBulkDelete}
-          onCancel={() => setBulkDeleteConfirm(false)}
+          onCancel={handleCancelBulkDelete}
         />
       )}
 
@@ -544,8 +592,8 @@ export default function SongsPage() {
           canDelete={canDelete}
           canTag={canEdit}
           onDelete={handleBulkDelete}
-          onTag={() => setBulkEditingOpen(true)}
-          onSelectAll={() => bulk.selectAll(items.map((s) => s.id))}
+          onTag={handleBulkTag}
+          onSelectAll={handleSelectAll}
           onDeselectAll={bulk.clearAll}
           isDeleting={bulkDeleting}
         />
@@ -556,7 +604,7 @@ export default function SongsPage() {
         <BulkEditModal
           count={bulk.count}
           onApply={handleBulkEdit}
-          onClose={() => setBulkEditingOpen(false)}
+          onClose={handleCloseBulkEdit}
           isApplying={bulkEditingApplying}
         />
       )}


### PR DESCRIPTION
## Summary

Fix all react-perf warnings (`jsx-no-new-function-as-prop`, `jsx-no-new-object-as-prop`) in 6 of the 8 files in the temporary override block. **138 warnings eliminated** — 6 files down, 2 remain.

## Changes

- **AddSongModal.tsx** (15 warnings): Wrapped 8 handler functions in `useCallback`, extracted 7 inline handlers + `volumeSliderValue`/`volumeRangeStyle` to `useMemo`, replaced per-tag inline `onClick` with `data-tag` + event delegation
- **BulkEditModal.tsx** (16 warnings): Same pattern — `useCallback` for handlers, `data-*` attributes for `.map()` callbacks, `useMemo` for field lookup and volume range style
- **SongEditPanel.tsx** (20 warnings): Extracted `handleEnterSave` (shared across 4 Field + 1 VolumeSlider), rewrote VolumeSlider/Field/TagDropdown sub-components with memoized handlers, added `RoleColorDot` helper
- **SetupWizard.tsx** (24 warnings): Converted 4 `async function` declarations to `useCallback`, added `SourceCheckbox`/`RoleCheckbox`/`RoleColorDot` helpers for the Checkbox abstraction, used `data-step` attribute on all navigation buttons via a single `handleGoToStep` handler
- **SongsPage.tsx** (15 warnings): Extracted all `ListToolbar` callbacks and modal `onConfirm`/`onCancel` handlers to `useCallback`, wrapped `handleDelete` in `useCallback`
- **PlaylistDetailPage.tsx** (27 warnings): Memoized `playlistDetail`/`songItems`, extracted 20+ handlers, wrapped `handleRemoveSong`/`handleDeletePlaylist` in `useCallback`
- **oxlint.config.ts**: Removed the 6 fixed files from the react-perf temporary override block (now only QueuePanel and NowPlayingBar remain)

## Remaining

| File | Warnings |
|---|---|
| QueuePanel.tsx | 22 |
| NowPlayingBar.tsx | 14 |