### PR TITLE
chore(lint): add tsgolint type-aware rules and fix violations

### DIFF
--- a/nodelink-config/config.js
+++ b/nodelink-config/config.js
@@ -139,12 +139,12 @@ export default {
     },
     spotify: {
       enabled: !!(process.env.SPOTIFY_CLIENT_ID && process.env.SPOTIFY_CLIENT_SECRET),
-      clientId: process.env.SPOTIFY_CLIENT_ID || '',
-      clientSecret: process.env.SPOTIFY_CLIENT_SECRET || '',
+      clientId: process.env.SPOTIFY_CLIENT_ID ?? '',
+      clientSecret: process.env.SPOTIFY_CLIENT_SECRET ?? '',
     },
     applemusic: {
       enabled: !!process.env.APPLE_MUSIC_MEDIA_API_TOKEN,
-      mediaApiToken: process.env.APPLE_MUSIC_MEDIA_API_TOKEN || 'token_here',
+      mediaApiToken: process.env.APPLE_MUSIC_MEDIA_API_TOKEN ?? 'token_here',
     },
     deezer: {
       enabled: false,
@@ -239,7 +239,7 @@ export default {
     },
     tidal: {
       enabled: !!process.env.TIDAL_TOKEN,
-      token: process.env.TIDAL_TOKEN || 'token_here',
+      token: process.env.TIDAL_TOKEN ?? 'token_here',
     },
     pandora: {
       enabled: false,

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -240,6 +240,81 @@ export default defineConfig({
     '@typescript-eslint/no-unnecessary-condition': 'warn',
 
     // -----------------------------------------------------------------------
+    // type-aware safety — tsgolint rules that catch runtime bugs
+    // -----------------------------------------------------------------------
+    // `x as Type` assertion that contradicts known types — silent type lie
+    // TODO: fix 148 violations, then change to 'warn'
+    '@typescript-eslint/no-unsafe-type-assertion': 'off',
+    // String coercion of an object without .toString() — produces "[object Object]"
+    '@typescript-eslint/no-base-to-string': 'warn',
+    // `for (const k in arr)` — iterates string indices, a classic footgun
+    '@typescript-eslint/no-for-in-array': 'warn',
+    // `delete arr[0]` — leaves a sparse-hole, TypeScript doesn't catch it
+    '@typescript-eslint/no-array-delete': 'warn',
+    // `${maybeNull}` when it could be null/undefined — produces "null" string
+    '@typescript-eslint/restrict-template-expressions': 'warn',
+    // `a + b` where both sides are not strings or numbers — type-unsafe coercion
+    '@typescript-eslint/restrict-plus-operands': 'warn',
+    // `await` on a value whose type has no `.then()` — wasted microtask
+    '@typescript-eslint/await-thenable': 'warn',
+    // `return await` vs `return` — matters for stack traces and try/catch
+    '@typescript-eslint/return-await': 'warn',
+    // Passing `obj.method` as a callback — loses `this` binding
+    '@typescript-eslint/unbound-method': 'warn',
+    // Using a deprecated type or function from your own codebase
+    '@typescript-eslint/no-deprecated': 'warn',
+    // Spreading a non-iterable, or into a non-object — type-level nonsense
+    '@typescript-eslint/no-misused-spread': 'warn',
+    // Mixing string and numeric enum members breaks reverse mapping
+    '@typescript-eslint/no-mixed-enums': 'warn',
+    // `` `${'string literal'}` `` — pointless template expression
+    '@typescript-eslint/no-unnecessary-template-expression': 'warn',
+    // `Number(x)` when x is already `number` — pure noise
+    '@typescript-eslint/no-unnecessary-type-conversion': 'warn',
+    // Duplicate constituents in a union (`string | string`)
+    '@typescript-eslint/no-duplicate-type-constituents': 'warn',
+    // Redundant constituents (`string & unknown` simplifies to `string`)
+    '@typescript-eslint/no-redundant-type-constituents': 'warn',
+    // `x === true` or `x === false` when `x` is already `boolean`
+    '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'warn',
+    // Comparing enums from different types — always `false`
+    '@typescript-eslint/no-unsafe-enum-comparison': 'warn',
+    // Default `= undefined` when the type says the param is always passed
+    '@typescript-eslint/no-useless-default-assignment': 'warn',
+    // `x!` non-null assertion where the type already excludes null
+    '@typescript-eslint/non-nullable-type-assertion-style': 'warn',
+    // `void` operator used meaninglessly (`void console.log(x)`)
+    '@typescript-eslint/no-meaningless-void-operator': 'warn',
+    // Unnecessary namespace qualifier on a type that's already in scope
+    '@typescript-eslint/no-unnecessary-qualifier': 'warn',
+    // `Promise.reject(nonError)` — loses stack trace info
+    '@typescript-eslint/prefer-promise-reject-errors': 'warn',
+    // `arr.filter(fn)[0]` → `arr.find(fn)` — O(n) vs early-exit
+    '@typescript-eslint/prefer-find': 'warn',
+    // `arr.sort()` without a compare function — lexicographic sort of numbers
+    '@typescript-eslint/require-array-sort-compare': 'warn',
+    // Getters and setters should come in pairs when one exists
+    '@typescript-eslint/related-getter-setter-pairs': 'warn',
+    // Prefer nullish coalescing over `||` for null/undefined checks
+    '@typescript-eslint/prefer-nullish-coalescing': 'warn',
+    // `unknown` in catch callback variables rather than `any`
+    '@typescript-eslint/use-unknown-in-catch-callback-variable': 'warn',
+    // `String#match` over `RegExp#exec` when no global flag
+    '@typescript-eslint/prefer-regexp-exec': 'warn',
+    // `x.startsWith('a')` over `x[0] === 'a'` — clearer intent
+    '@typescript-eslint/prefer-string-starts-ends-with': 'warn',
+    // Return type of `.reduce()` should match the type parameter
+    '@typescript-eslint/prefer-reduce-type-parameter': 'warn',
+    // Returning `this` from a method should use `this` as the return type
+    '@typescript-eslint/prefer-return-this-type': 'warn',
+    // Explicit dot notation for property access when the key is a static name
+    '@typescript-eslint/dot-notation': 'warn',
+    // Consistent return — all code paths should return a value (or none)
+    '@typescript-eslint/consistent-return': 'warn',
+    // `export type { Foo }` over re-exporting types as values
+    '@typescript-eslint/consistent-type-exports': 'warn',
+
+    // -----------------------------------------------------------------------
     // style consistency — enforce one idiomatic pattern
     // -----------------------------------------------------------------------
     // Require `interface` over `type` for object types (or vice versa)
@@ -495,6 +570,30 @@ export default defineConfig({
       ],
       rules: {
         '@typescript-eslint/no-unnecessary-condition': 'off',
+      },
+    },
+
+    // nodelink.ts: intentional || undefined to normalize empty strings to undefined
+    {
+      files: ['packages/server/src/utils/nodelink.ts'],
+      rules: {
+        'prefer-nullish-coalescing': 'off',
+      },
+    },
+
+    // displayName.ts: intentional || for empty-string fallthrough chain
+    {
+      files: ['packages/server/src/lib/displayName.ts'],
+      rules: {
+        'prefer-nullish-coalescing': 'off',
+      },
+    },
+
+    // useSocket.ts: as WebSocket is clearer intent than !
+    {
+      files: ['packages/web/src/hooks/useSocket.ts'],
+      rules: {
+        'non-nullable-type-assertion-style': 'off',
       },
     },
   ],

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -120,8 +120,8 @@ function getSessionUser(cookieHeader: string): ReturnType<typeof verifySessionTo
 }
 
 function createContext(request: Request): RouteContext {
-  const parsedCookies = parseCookies(request.headers.get('cookie') || '');
-  const user = getSessionUser(request.headers.get('cookie') || '');
+  const parsedCookies = parseCookies(request.headers.get('cookie') ?? '');
+  const user = getSessionUser(request.headers.get('cookie') ?? '');
   const cookies: Record<string, string> = {};
   for (const [key, value] of Object.entries(parsedCookies)) {
     if (value !== undefined) {
@@ -228,7 +228,7 @@ function startServer(): void {
       // WebSocket upgrade — auth is handled here before upgrade.
       // `server` is passed as the second argument to fetch (Bun 1.2+).
       if (url.pathname === '/ws') {
-        const user = getSessionUser(request.headers.get('cookie') || '');
+        const user = getSessionUser(request.headers.get('cookie') ?? '');
         if (!user) {
           return new Response('Unauthorized', { status: 401 });
         }

--- a/packages/server/src/lib/config.ts
+++ b/packages/server/src/lib/config.ts
@@ -18,7 +18,7 @@ function resolveVersion(): string {
   // Dev — try to read the commit hash from the mounted .git directory.
   try {
     const head = readFileSync('/app/.git/HEAD', 'utf-8').trim();
-    const match = head.match(/^ref: (.+)$/);
+    const match = /^ref: (.+)$/.exec(head);
     const hash = match
       ? readFileSync(`/app/.git/${match[1]}`, 'utf-8').trim().slice(0, 7)
       : head.slice(0, 7);

--- a/packages/server/src/lib/jwt.ts
+++ b/packages/server/src/lib/jwt.ts
@@ -26,7 +26,7 @@ function base64urlDecode(input: string): string {
 
 /** Parse an expiresIn string like "1h", "30d", "15m" to seconds. */
 function parseExpiresIn(expiresIn: string): number {
-  const match = expiresIn.match(/^(\d+)([smhd])$/);
+  const match = /^(\d+)([smhd])$/.exec(expiresIn);
   if (!match?.[1] || !match[2]) {
     throw new Error(`Invalid expiresIn format: ${expiresIn}`);
   }

--- a/packages/server/src/lib/search.ts
+++ b/packages/server/src/lib/search.ts
@@ -25,6 +25,7 @@ export function parseSongSortField(raw: string): SongSortField | null {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle column refs are not assignable to SQL<unknown> but are valid sql`` interpolations
 type SqlInterpolatable = any;
 
+// eslint-disable-next-line typescript/consistent-return
 export function buildSongOrderBy(
   sortField: SongSortField,
   sortOrder: 'ASC' | 'DESC',

--- a/packages/server/src/lib/validation.ts
+++ b/packages/server/src/lib/validation.ts
@@ -95,7 +95,7 @@ async function wrapBotCall<T>(
 
     // If it's a fetch error with response status, propagate the actual status
     if (error instanceof Error && error.message.startsWith('NodeLink REST')) {
-      const match = error.message.match(/NodeLink REST (\d+):/);
+      const match = /NodeLink REST (\d+):/.exec(error.message);
       if (match?.[1]) {
         const status = parseInt(match[1], 10);
         return { ok: false, response: json({ error: error.message }, status) };
@@ -173,7 +173,7 @@ export function validateNickname(nickname: unknown): ValidationResult<string | n
   if (nickname !== undefined && nickname !== null && typeof nickname !== 'string') {
     return { ok: false, response: json({ error: 'nickname must be a string.' }, 400) };
   }
-  const trimmed = nickname ? String(nickname).trim() || null : null;
+  const trimmed = nickname ? nickname.trim() || null : null;
   if (trimmed && trimmed.length > MAX_NICKNAME_LENGTH) {
     return {
       ok: false,

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -90,7 +90,7 @@ const ACCESS_COOKIE_NAME = 'session';
 const REFRESH_COOKIE_NAME = 'refresh_token';
 
 const REFRESH_TOKEN_MAX_AGE = (() => {
-  const match = REFRESH_TOKEN_EXPIRES_IN.match(/^(\d+)([dhms])$/);
+  const match = /^(\d+)([dhms])$/.exec(REFRESH_TOKEN_EXPIRES_IN);
   if (!match) {
     logger.warn(`Invalid JWT_EXPIRES_IN format "${REFRESH_TOKEN_EXPIRES_IN}", defaulting to 30d`);
     return 30 * 24 * 60 * 60 * 1000;

--- a/packages/server/src/routes/player.ts
+++ b/packages/server/src/routes/player.ts
@@ -525,7 +525,7 @@ async function handleAddToPriority(ctx: RouteContext, request: Request): Promise
   await player.addToPriorityQueue(queuedSong);
 
   return json({
-    message: `Added "${song.nickname || song.title}" to Up Next.`,
+    message: `Added "${song.nickname ?? song.title}" to Up Next.`,
     song: queuedSong,
   });
 }

--- a/packages/server/src/shared/db/index.ts
+++ b/packages/server/src/shared/db/index.ts
@@ -17,8 +17,8 @@ if (!DATABASE_URL) {
 }
 
 const sqliteDb = new Database(DATABASE_URL, { create: true, strict: true });
-sqliteDb.exec('PRAGMA journal_mode=WAL;');
-sqliteDb.exec('PRAGMA foreign_keys=ON;');
+sqliteDb.run('PRAGMA journal_mode=WAL;');
+sqliteDb.run('PRAGMA foreign_keys=ON;');
 export const db = drizzle(sqliteDb, { schema });
 
 export type * from './schema';

--- a/packages/web/src/components/AddSongModal.tsx
+++ b/packages/web/src/components/AddSongModal.tsx
@@ -59,6 +59,7 @@ export default function AddSongModal({
       const id = setTimeout(() => onClose(), 1500);
       return () => clearTimeout(id);
     }
+    return undefined;
   }, [successMsg, onClose]);
 
   const handleFetch = useCallback(async () => {
@@ -351,10 +352,10 @@ export default function AddSongModal({
           <div className='flex flex-col gap-3'>
             {/* Thumbnail + title + duration + source */}
             <div className='flex items-center gap-3 -mb-1'>
-              {(preview.artworkUrl || preview.thumbnailUrl) && (
+              {(preview.artworkUrl ?? preview.thumbnailUrl) && (
                 <div className='w-12 h-12 rounded border border-border shrink-0 overflow-hidden bg-elevated'>
                   <ArtworkImage
-                    src={preview.artworkUrl || preview.thumbnailUrl}
+                    src={preview.artworkUrl ?? preview.thumbnailUrl}
                     alt='Album art'
                     className='w-full h-full'
                   />

--- a/packages/web/src/components/AddSongsModal.tsx
+++ b/packages/web/src/components/AddSongsModal.tsx
@@ -97,7 +97,7 @@ export default function AddSongsModal({
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) {
-      return;
+      return undefined;
     }
     const check = () => {
       if (el.scrollHeight - el.scrollTop - el.clientHeight < 300) {
@@ -238,13 +238,13 @@ const SongRow = memo(function SongRow({
       <div className='overflow-hidden w-10 h-10 md:w-8 md:h-8 rounded border border-border shrink-0 bg-elevated'>
         <ArtworkImage
           src={song.artwork ?? song.thumbnailUrl}
-          alt={song.nickname || song.title}
+          alt={song.nickname ?? song.title}
           className='w-full h-full'
           imageClassName='scale-[1.33]'
         />
       </div>
       <span className='flex-1 font-body text-sm text-fg truncate'>
-        {song.nickname || song.title}
+        {song.nickname ?? song.title}
       </span>
       <span className='font-mono text-xs text-muted hidden sm:block'>
         {formatDuration(song.duration)}

--- a/packages/web/src/components/BulkEditModal.tsx
+++ b/packages/web/src/components/BulkEditModal.tsx
@@ -46,7 +46,7 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
   // Close tag dropdown when clicking outside
   useEffect(() => {
     if (!showDropdown) {
-      return;
+      return undefined;
     }
     const handler = (e: MouseEvent) => {
       const target = e.target as Node;

--- a/packages/web/src/components/ContextMenu.tsx
+++ b/packages/web/src/components/ContextMenu.tsx
@@ -151,7 +151,7 @@ export function ContextMenu({
   // Position calculation — useLayoutEffect runs before paint, preventing a (0,0) flash.
   useLayoutEffect(() => {
     if (!isOpen || !triggerRef.current) {
-      return;
+      return undefined;
     }
 
     const lastUpdateRef = { current: 0 };
@@ -210,7 +210,7 @@ export function ContextMenu({
   // Close on outside click
   useEffect(() => {
     if (!isOpen) {
-      return;
+      return undefined;
     }
 
     const handler = (e: MouseEvent | TouchEvent) => {
@@ -232,7 +232,7 @@ export function ContextMenu({
   // Close on Escape (or go back from submenu)
   useEffect(() => {
     if (!isOpen) {
-      return;
+      return undefined;
     }
 
     const handler = (e: KeyboardEvent) => {

--- a/packages/web/src/components/ContextMenu/MenuItemButton.tsx
+++ b/packages/web/src/components/ContextMenu/MenuItemButton.tsx
@@ -34,7 +34,7 @@ export function MenuItemButton({ item, onClick }: MenuItemButtonProps) {
     >
       {item.icon && <span className='shrink-0'>{item.icon}</span>}
       <span className='truncate flex-1'>{item.label}</span>
-      {(item.submenu || item.editSubmenu) && (
+      {(item.submenu ?? item.editSubmenu) && (
         <CaretRightIcon size={12} weight='duotone' className='shrink-0 ml-auto opacity-50' />
       )}
     </button>

--- a/packages/web/src/components/ListToolbar.tsx
+++ b/packages/web/src/components/ListToolbar.tsx
@@ -122,7 +122,7 @@ export default function ListToolbar({
   // Close dropdown on outside click
   useEffect(() => {
     if (!sortOpen) {
-      return;
+      return undefined;
     }
     const handler = (e: MouseEvent) => {
       if (sortRef.current && !sortRef.current.contains(e.target as Node)) {

--- a/packages/web/src/components/MobileNav.tsx
+++ b/packages/web/src/components/MobileNav.tsx
@@ -31,7 +31,7 @@ export default function MobileNav() {
   // Close drawer on escape key
   useEffect(() => {
     if (!isOpen) {
-      return;
+      return undefined;
     }
 
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -59,7 +59,7 @@ export default function MobileNav() {
   // Close drawer when clicking outside
   useEffect(() => {
     if (!isOpen) {
-      return;
+      return undefined;
     }
 
     const handleClickOutside = (e: MouseEvent) => {

--- a/packages/web/src/components/NowPlayingBar.tsx
+++ b/packages/web/src/components/NowPlayingBar.tsx
@@ -444,7 +444,7 @@ const MetadataSection = memo(function MetadataSection({
     );
   }
 
-  const displayName = currentSong.nickname || currentSong.title;
+  const displayName = currentSong.nickname ?? currentSong.title;
   const sourceKey = getSourceKey(currentSong.sourceUrl);
   const songKey = currentSong.id;
 
@@ -678,7 +678,7 @@ export function NowPlayingBar() {
                 transition={metadataTransition}
               >
                 <p className='font-body text-sm font-semibold text-fg truncate text-right'>
-                  {currentSong.nickname || currentSong.title}
+                  {currentSong.nickname ?? currentSong.title}
                 </p>
                 {currentSong.artist && (
                   <p className='font-body text-xs text-muted truncate text-right'>

--- a/packages/web/src/components/QueuePanel.tsx
+++ b/packages/web/src/components/QueuePanel.tsx
@@ -646,7 +646,7 @@ const QueueSongItem = memo(function QueueSongItem({
         <div className='overflow-hidden w-10 h-10 rounded border border-border shrink-0 bg-elevated'>
           <ArtworkImage
             src={song.artwork ?? song.thumbnailUrl}
-            alt={song.nickname || song.title}
+            alt={song.nickname ?? song.title}
             className='w-full h-full'
             imageClassName='scale-[1.33]'
           />
@@ -656,7 +656,7 @@ const QueueSongItem = memo(function QueueSongItem({
         <div className='flex-1 min-w-0 flex flex-col justify-center gap-0.5'>
           <p className='text-xs font-semibold text-fg leading-tight flex items-center gap-1.5 min-w-0'>
             <MusicNoteIcon size={13} weight='fill' className='shrink-0 text-muted' />
-            <span className='truncate'>{song.nickname || song.title}</span>
+            <span className='truncate'>{song.nickname ?? song.title}</span>
           </p>
           <div className='flex items-center gap-2 text-[11px] text-muted min-w-0'>
             {song.artist && (
@@ -776,11 +776,11 @@ const PanelHeader = memo(function PanelHeader({
                 disabled: !mqc.currentSong || mqc.loopBusy,
                 title: `Loop: ${mqc.loopMode}`,
               })}
-              className={`${
+              className={
                 isLoopActive
                   ? 'pressed text-accent hover:text-accent-muted'
                   : 'text-muted hover:text-fg'
-              }`}
+              }
             >
               {mqc.loopBusy ? (
                 <CircleNotchIcon size={18} weight='bold' className='animate-spin' />
@@ -797,11 +797,11 @@ const PanelHeader = memo(function PanelHeader({
                 disabled: !mqc.currentSong || mqc.shuffleBusy,
                 title: mqc.isShuffled ? 'Unshuffle queue' : 'Shuffle queue',
               })}
-              className={`${
+              className={
                 mqc.isShuffled
                   ? 'pressed text-accent hover:text-accent-muted'
                   : 'text-muted hover:text-fg'
-              }`}
+              }
             >
               {mqc.shuffleBusy ? (
                 <CircleNotchIcon size={18} weight='bold' className='animate-spin' />
@@ -821,7 +821,7 @@ const PanelHeader = memo(function PanelHeader({
             aria-expanded={menuOpen}
             title='More actions'
             surface='elevated'
-            className={`${menuOpen ? 'pressed text-accent' : ''}`}
+            className={menuOpen ? 'pressed text-accent' : ''}
             onClick={onToggleMenu}
           >
             <DotsThreeOutlineVerticalIcon size={18} weight='duotone' />
@@ -850,7 +850,7 @@ const NowPlayingCard = memo(function NowPlayingCard({
         <div className='relative shrink-0 overflow-hidden rounded-xl bg-elevated'>
           <ArtworkImage
             src={song.artwork ?? song.thumbnailUrl}
-            alt={song.nickname || song.title}
+            alt={song.nickname ?? song.title}
             className='w-20 h-20 rounded-xl border border-border'
             imageClassName='scale-[1.33]'
           />
@@ -865,7 +865,7 @@ const NowPlayingCard = memo(function NowPlayingCard({
             className='text-xs font-semibold text-fg hover:text-accent leading-tight flex items-center gap-1.5 min-w-0'
           >
             <MusicNoteIcon size={13} weight='fill' className='shrink-0 text-muted' />
-            <span className='truncate'>{song.nickname || song.title}</span>
+            <span className='truncate'>{song.nickname ?? song.title}</span>
           </a>
           <div className='flex items-center gap-2 text-[11px] text-muted min-w-0'>
             {song.artist && (

--- a/packages/web/src/components/RequestCard.tsx
+++ b/packages/web/src/components/RequestCard.tsx
@@ -34,8 +34,8 @@ export const RequestCard = memo(function RequestCard({
   const isPending = req.status === 'pending';
   const isPlaylist = req.type === 'playlist';
   const thumbnailUrl = isPlaylist
-    ? req.playlistData?.thumbnailUrl || req.thumbnailUrl
-    : req.artworkUrl || req.thumbnailUrl;
+    ? (req.playlistData?.thumbnailUrl ?? req.thumbnailUrl)
+    : (req.artworkUrl ?? req.thumbnailUrl);
   const dateLabel = new Date(req.createdAt).toLocaleDateString();
 
   const handleCancel = useCallback(() => onCancel(req.id), [onCancel, req.id]);

--- a/packages/web/src/components/SongCard.tsx
+++ b/packages/web/src/components/SongCard.tsx
@@ -64,8 +64,8 @@ const SongCardInner = ({
   const [isRowHovered, setIsRowHovered] = useState(false);
   const sourceKey = useMemo(() => getSourceKey(song.sourceUrl), [song.sourceUrl]);
 
-  const canEdit = isAdminView || hasPermission('songs.edit');
-  const canDelete = isAdminView || hasPermission('songs.delete');
+  const canEdit = isAdminView ?? hasPermission('songs.edit');
+  const canDelete = isAdminView ?? hasPermission('songs.delete');
 
   // Stable wrapper for onDelete callback — song.id is stable per render cycle
   const handleDelete = useCallback(() => onDelete?.(song.id), [onDelete, song.id]);
@@ -174,7 +174,7 @@ const SongCardInner = ({
           <div className='flex items-center justify-between gap-2'>
             <p className='text-sm font-semibold text-fg leading-tight flex items-center gap-1.5 min-w-0'>
               <MusicNoteIcon size={13} weight='fill' className='shrink-0 text-muted' />
-              <span className='line-clamp-2'>{song.nickname || song.title}</span>
+              <span className='line-clamp-2'>{song.nickname ?? song.title}</span>
             </p>
             {sourceKey && (
               <span className='flex items-center shrink-0 [&_svg]:w-3.5 [&_svg]:h-3.5'>
@@ -279,7 +279,7 @@ const SongCardInner = ({
         <div className='overflow-hidden w-16 h-16 rounded border border-border shrink-0 bg-elevated'>
           <ArtworkImage
             src={song.artwork ?? song.thumbnailUrl}
-            alt={song.nickname || song.title}
+            alt={song.nickname ?? song.title}
             className='w-full h-full'
             imageClassName='scale-[1.33]'
           />
@@ -287,7 +287,7 @@ const SongCardInner = ({
         <div className='flex-1 min-w-0 flex flex-col justify-center gap-1.5'>
           <p className='text-sm font-semibold text-fg leading-tight flex items-center gap-1.5 min-w-0'>
             <MusicNoteIcon size={13} weight='fill' className='shrink-0 text-muted' />
-            <span className='truncate'>{song.nickname || song.title}</span>
+            <span className='truncate'>{song.nickname ?? song.title}</span>
           </p>
           <div className='flex items-center gap-2.5 flex-wrap text-xs text-muted min-w-0'>
             {song.artist && (

--- a/packages/web/src/components/TagTicker.tsx
+++ b/packages/web/src/components/TagTicker.tsx
@@ -58,7 +58,7 @@ const TagTicker = memo(({ tags, isHovered: externalHovered }: TagTickerProps) =>
   // Smooth return on de-hover: pause animation at current position, then transition back to 0
   useLayoutEffect(() => {
     if (!shouldScroll) {
-      return;
+      return undefined;
     }
 
     const prev = prevHoveredRef.current;
@@ -68,7 +68,7 @@ const TagTicker = memo(({ tags, isHovered: externalHovered }: TagTickerProps) =>
       // De-hovered: capture paused position and transition back to start
       const el = innerRef.current;
       if (!el) {
-        return;
+        return undefined;
       }
 
       const computed = getComputedStyle(el);
@@ -105,6 +105,8 @@ const TagTicker = memo(({ tags, isHovered: externalHovered }: TagTickerProps) =>
         el.style.animation = `ticker-scroll ${durationRef.current}s linear infinite`;
       }
     }
+
+    return undefined;
   }, [effectiveHovered, shouldScroll]);
 
   const animationStyle: React.CSSProperties = useMemo(

--- a/packages/web/src/components/UserMenu.tsx
+++ b/packages/web/src/components/UserMenu.tsx
@@ -51,7 +51,7 @@ export default function UserMenu({ user, collapsed, onLogout }: UserMenuProps) {
   // Position before paint (useLayoutEffect) to avoid a (0,0) flash.
   useLayoutEffect(() => {
     if (!open) {
-      return;
+      return undefined;
     }
     updatePosition();
     window.addEventListener('resize', updatePosition);
@@ -65,7 +65,7 @@ export default function UserMenu({ user, collapsed, onLogout }: UserMenuProps) {
   // Close on click outside
   useEffect(() => {
     if (!open) {
-      return;
+      return undefined;
     }
     const handler = (e: MouseEvent | TouchEvent) => {
       const target = e.target as Node;
@@ -85,7 +85,7 @@ export default function UserMenu({ user, collapsed, onLogout }: UserMenuProps) {
   // Close on Escape
   useEffect(() => {
     if (!open) {
-      return;
+      return undefined;
     }
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {

--- a/packages/web/src/components/VirtualSongList.tsx
+++ b/packages/web/src/components/VirtualSongList.tsx
@@ -152,6 +152,7 @@ export const VirtualSongList = memo(function VirtualSongList({
     if (openSongId) {
       // Expand immediately — allocate space before the transition starts.
       setEffectiveOpenId(openSongId);
+      return undefined;
     } else {
       // Collapse: wait for the CSS transition to finish before releasing space.
       const timeout = setTimeout(() => setEffectiveOpenId(null), 300);

--- a/packages/web/src/components/settings/CompressorSection.tsx
+++ b/packages/web/src/components/settings/CompressorSection.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 
-import { ArrowCounterClockwise, FloppyDisk } from '@phosphor-icons/react';
+import { ArrowCounterClockwiseIcon, FloppyDiskIcon } from '@phosphor-icons/react';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useAdminView } from '../../context/AdminViewContext';
@@ -187,7 +187,7 @@ export default function CompressorSection() {
           disabled={!hasChanges || saving}
           title={saving ? 'Saving…' : 'Save Changes'}
         >
-          <FloppyDisk size={16} weight='duotone' />
+          <FloppyDiskIcon size={16} weight='duotone' />
         </Button>
         <Button
           variant='inherit'
@@ -196,7 +196,7 @@ export default function CompressorSection() {
           onClick={handleReset}
           title='Reset to Defaults'
         >
-          <ArrowCounterClockwise size={16} weight='duotone' />
+          <ArrowCounterClockwiseIcon size={16} weight='duotone' />
         </Button>
       </div>
     </div>

--- a/packages/web/src/components/settings/EqualizerSection.tsx
+++ b/packages/web/src/components/settings/EqualizerSection.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 
-import { ArrowCounterClockwise, FloppyDisk } from '@phosphor-icons/react';
+import { ArrowCounterClockwiseIcon, FloppyDiskIcon } from '@phosphor-icons/react';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useAdminView } from '../../context/AdminViewContext';
@@ -252,7 +252,7 @@ export default function EqualizerSection() {
           disabled={!hasChanges || saving}
           title={saving ? 'Saving…' : 'Save Changes'}
         >
-          <FloppyDisk size={16} weight='duotone' />
+          <FloppyDiskIcon size={16} weight='duotone' />
         </Button>
         <Button
           variant='inherit'
@@ -261,7 +261,7 @@ export default function EqualizerSection() {
           onClick={handleReset}
           title='Reset to Defaults'
         >
-          <ArrowCounterClockwise size={16} weight='duotone' />
+          <ArrowCounterClockwiseIcon size={16} weight='duotone' />
         </Button>
       </div>
     </div>

--- a/packages/web/src/components/ui/Button.tsx
+++ b/packages/web/src/components/ui/Button.tsx
@@ -53,7 +53,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
     () =>
       variant === 'inherit'
         ? ({ ...style, '--btn-surface': surfaceVars[surface] } as React.CSSProperties)
-        : style || {},
+        : (style ?? {}),
     [variant, style, surface]
   );
 

--- a/packages/web/src/components/ui/Checkbox.tsx
+++ b/packages/web/src/components/ui/Checkbox.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 
-import { Check } from '@phosphor-icons/react';
+import { CheckIcon } from '@phosphor-icons/react';
 import { useCallback } from 'react';
 
 interface CheckboxProps {
@@ -64,7 +64,7 @@ export default function Checkbox({
           ${checked ? variantChecked[variant] : 'border-border bg-surface'}
         `}
       >
-        <Check
+        <CheckIcon
           size={s.icon}
           weight='bold'
           className={`transition-all duration-150 ease-out ${

--- a/packages/web/src/components/ui/RoleComboBox.tsx
+++ b/packages/web/src/components/ui/RoleComboBox.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 
-import { CaretDown } from '@phosphor-icons/react';
+import { CaretDownIcon } from '@phosphor-icons/react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 interface RoleOption {
@@ -105,7 +105,7 @@ export default function RoleComboBox({
   // Click outside to close
   useEffect(() => {
     if (!isOpen) {
-      return;
+      return undefined;
     }
     const handler = (e: MouseEvent) => {
       if (
@@ -196,7 +196,7 @@ export default function RoleComboBox({
                      focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-accent/30
                      transition-colors'
         />
-        <CaretDown
+        <CaretDownIcon
           size={16}
           weight='bold'
           className='absolute right-3 top-1/2 -translate-y-1/2 text-muted pointer-events-none transition-transform'

--- a/packages/web/src/context/SongEditContext.tsx
+++ b/packages/web/src/context/SongEditContext.tsx
@@ -74,7 +74,7 @@ export function SongEditProvider({ children }: { children: ReactNode }) {
   // Close panel when clicking outside any song edit container
   useEffect(() => {
     if (openSongId == null) {
-      return;
+      return undefined;
     }
 
     const handleMouseDown = (e: MouseEvent) => {

--- a/packages/web/src/hooks/useCreatePlaylist.tsx
+++ b/packages/web/src/hooks/useCreatePlaylist.tsx
@@ -34,7 +34,7 @@ export function CreatePlaylistSubmitButton({
 }) {
   const { pending } = useFormStatus();
   return (
-    <Button variant='primary' type='submit' disabled={disabled || pending}>
+    <Button variant='primary' type='submit' disabled={disabled ?? pending}>
       {children}
     </Button>
   );

--- a/packages/web/src/hooks/useProgressBar.ts
+++ b/packages/web/src/hooks/useProgressBar.ts
@@ -133,7 +133,7 @@ export function useProgressBar(
         }
       }
 
-      return;
+      return undefined;
     }
 
     // ---- Starting loops ----

--- a/packages/web/src/hooks/useScrollObserver.ts
+++ b/packages/web/src/hooks/useScrollObserver.ts
@@ -56,7 +56,7 @@ export function useScrollObserver(
   useEffect(() => {
     const el = elementRef.current;
     if (!el) {
-      return;
+      return undefined;
     }
 
     const onScroll = () => {
@@ -128,7 +128,7 @@ export function useScrollObserver(
   useLayoutEffect(() => {
     const el = elementRef.current;
     if (!el) {
-      return;
+      return undefined;
     }
 
     setHeight(el.clientHeight);

--- a/packages/web/src/hooks/useSongActions.tsx
+++ b/packages/web/src/hooks/useSongActions.tsx
@@ -80,7 +80,7 @@ export function useSongActions({
         ? [
             {
               id: 'remove',
-              label: removeLabel || 'Remove',
+              label: removeLabel ?? 'Remove',
               icon: <BombIcon size={14} weight='duotone' />,
               danger: true,
               onClick: onRemove,
@@ -128,7 +128,7 @@ export function useSongActions({
                     label: '',
                     icon: <UserIcon size={14} weight='duotone' />,
                     info: {
-                      label: song.addedByDisplayName || song.addedBy || '',
+                      label: (song.addedByDisplayName ?? song.addedBy) || '',
                       icon: <UserIcon size={14} weight='duotone' />,
                     },
                     separatorBefore: true,

--- a/packages/web/src/pages/AudioPage.tsx
+++ b/packages/web/src/pages/AudioPage.tsx
@@ -1,4 +1,4 @@
-import { ArrowsDownUp, SlidersHorizontal } from '@phosphor-icons/react';
+import { ArrowsDownUpIcon, SlidersHorizontalIcon } from '@phosphor-icons/react';
 
 import CompressorSection from '../components/settings/CompressorSection';
 import EqualizerSection from '../components/settings/EqualizerSection';
@@ -15,7 +15,7 @@ export default function AudioPage() {
   return (
     <div className='p-4 md:p-8 h-full overflow-y-auto'>
       <PageHeader
-        icon={SlidersHorizontal}
+        icon={SlidersHorizontalIcon}
         title='Audio'
         subtitle='Equalizer and compressor settings'
       />
@@ -33,7 +33,7 @@ export default function AudioPage() {
           {/* Equalizer */}
           <section className='mb-8 lg:mb-0'>
             <h2 className='font-mono text-xs text-muted uppercase tracking-wider mb-4 flex items-center gap-2'>
-              <SlidersHorizontal size={14} weight='duotone' />
+              <SlidersHorizontalIcon size={14} weight='duotone' />
               Equalizer
             </h2>
             <div className='bg-elevated clay-resting rounded-lg p-5'>
@@ -44,7 +44,7 @@ export default function AudioPage() {
           {/* Compressor */}
           <section>
             <h2 className='font-mono text-xs text-muted uppercase tracking-wider mb-4 flex items-center gap-2'>
-              <ArrowsDownUp size={14} weight='duotone' />
+              <ArrowsDownUpIcon size={14} weight='duotone' />
               Compressor
             </h2>
             <div className='bg-elevated clay-resting rounded-lg p-5'>

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -7,7 +7,7 @@ import {
   GhostIcon,
   LockIcon,
   LockOpenIcon,
-  PencilSimple,
+  PencilSimpleIcon,
   PlayCircleIcon,
   PlayIcon,
   PlusCircleIcon,
@@ -168,13 +168,13 @@ export default function PlaylistDetailPage() {
       switch (sort) {
         case 'title': {
           // Sort by display name: nickname if set, otherwise title
-          const aName = a.song.nickname || a.song.title || '';
-          const bName = b.song.nickname || b.song.title || '';
+          const aName = (a.song.nickname ?? a.song.title) || '';
+          const bName = (b.song.nickname ?? b.song.title) || '';
           return dir * aName.localeCompare(bName, undefined, { sensitivity: 'base' });
         }
         case 'artist': {
-          const aArt = a.song.artist || '';
-          const bArt = b.song.artist || '';
+          const aArt = a.song.artist ?? '';
+          const bArt = b.song.artist ?? '';
           if (!aArt && !bArt) {
             return 0;
           }
@@ -187,8 +187,8 @@ export default function PlaylistDetailPage() {
           return dir * aArt.localeCompare(bArt, undefined, { sensitivity: 'base' });
         }
         case 'album': {
-          const aAlb = a.song.album || '';
-          const bAlb = b.song.album || '';
+          const aAlb = a.song.album ?? '';
+          const bAlb = b.song.album ?? '';
           if (!aAlb && !bAlb) {
             return 0;
           }
@@ -628,7 +628,7 @@ export default function PlaylistDetailPage() {
           {
             id: 'rename',
             label: 'Rename',
-            icon: <PencilSimple size={14} weight='duotone' />,
+            icon: <PencilSimpleIcon size={14} weight='duotone' />,
             editSubmenu: {
               title: 'Rename',
               value: renameValue,
@@ -757,7 +757,7 @@ export default function PlaylistDetailPage() {
                 {' • '}
                 {isOwner
                   ? 'Created by you'
-                  : `Created by ${playlistDetail.createdByDisplayName || playlistDetail.createdBy}`}
+                  : `Created by ${playlistDetail.createdByDisplayName ?? playlistDetail.createdBy}`}
               </>
             )}
           </p>

--- a/packages/web/src/pages/SetupWizard.tsx
+++ b/packages/web/src/pages/SetupWizard.tsx
@@ -147,7 +147,7 @@ export default function SetupWizard() {
   // Auto-refresh guild list when on the guild step and no guilds are found.
   useEffect(() => {
     if (step !== 'guild' || guilds.length > 0) {
-      return;
+      return undefined;
     }
 
     let cancelled = false;

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -153,17 +153,18 @@ export default function SongsPage() {
   // ── Comparator for re-sorting after real-time mutations ──────────────
   const songCompareFn = useMemo(() => {
     const dir = order === 'asc' ? 1 : -1;
+    // eslint-disable-next-line typescript/consistent-return
     return (a: Song, b: Song): number => {
       switch (sort) {
         case 'title': {
           // Sort by display name: nickname if set, otherwise title
-          const aName = a.nickname || a.title || '';
-          const bName = b.nickname || b.title || '';
+          const aName = (a.nickname ?? a.title) || '';
+          const bName = (b.nickname ?? b.title) || '';
           return dir * aName.localeCompare(bName, undefined, { sensitivity: 'base' });
         }
         case 'artist': {
-          const aArt = a.artist || '';
-          const bArt = b.artist || '';
+          const aArt = a.artist ?? '';
+          const bArt = b.artist ?? '';
           // nulls last, regardless of direction
           if (!aArt && !bArt) {
             return 0;
@@ -177,8 +178,8 @@ export default function SongsPage() {
           return dir * aArt.localeCompare(bArt, undefined, { sensitivity: 'base' });
         }
         case 'album': {
-          const aAlb = a.album || '';
-          const bAlb = b.album || '';
+          const aAlb = a.album ?? '';
+          const bAlb = b.album ?? '';
           if (!aAlb && !bAlb) {
             return 0;
           }
@@ -629,7 +630,7 @@ function DeleteConfirmDialog({
       title='Delete Song'
       message={
         <>
-          Remove <span className='text-fg font-semibold'>"{song.nickname || song.title}"</span> from
+          Remove <span className='text-fg font-semibold'>"{song.nickname ?? song.title}"</span> from
           the library?{' '}
           <span className='font-mono text-xs text-danger/70'>
             this will remove it from all playlists too.

--- a/packages/web/src/pages/TagsPage.tsx
+++ b/packages/web/src/pages/TagsPage.tsx
@@ -398,7 +398,7 @@ const TagSongItem = memo(function TagSongItem({
       </div>
       <div className='flex-1 min-w-0'>
         <p className='font-body text-sm text-fg truncate leading-snug'>
-          {song.nickname || song.title}
+          {song.nickname ?? song.title}
         </p>
         <div className='flex items-center gap-2 flex-wrap'>
           {song.artist && (


### PR DESCRIPTION
## Summary

Add 34 new tsgolint type-aware lint rules (Phase 1) and fix 140+ resulting violations across the codebase.

## Changes

- **oxlint.config.ts**: Add 34 tsgolint rules at warn/error severity covering runtime safety, promise correctness, type assertion safety, and code clarity
- **Icon deprecations**: Replace deprecated Phosphor icon names (`Check`, `FloppyDisk`, `ArrowCounterClockwise`, `SlidersHorizontal`, `ArrowsDownUp`, `CaretDown`, `PencilSimple`) with `*Icon` suffix variants
- **consistent-return**: Add `return undefined` to React `useEffect`/`useLayoutEffect` early-exit branches for consistent return types
- **Database**: Replace `exec()` with `run()` for SQLite PRAGMA statements
- **Auto-fixes**: Apply `prefer-nullish-coalescing`, `prefer-regexp-exec`, `no-unnecessary-template-expression`, `no-unnecessary-type-conversion`, and `non-nullable-type-assertion-style` fixes
- **Overrides**: Add targeted rule overrides for intentional `||` fallthrough patterns (displayName, nodelink) and assertion style (useSocket)
- **Suppressed for Phase 2**: `no-unsafe-type-assertion` (148 violations remaining)

## Rules added

| Category | Rules |
|----------|-------|
| Runtime safety | `no-base-to-string`, `no-for-in-array`, `await-thenable`, `restrict-template-expressions`, `restrict-plus-operands`, `no-misused-spread`, `no-mixed-enums`, `no-array-delete`, `no-unsafe-enum-comparison` |
| Promise correctness | `prefer-promise-reject-errors`, `return-await`, `require-array-sort-compare` |
| Type assertions | `no-useless-default-assignment`, `no-meaningless-void-operator`, `no-unnecessary-qualifier`, `no-unnecessary-boolean-literal-compare`, `no-duplicate-type-constituents`, `no-redundant-type-constituents` |
| Code clarity | `dot-notation`, `consistent-return`, `consistent-type-exports`, `non-nullable-type-assertion-style`, `no-unnecessary-template-expression`, `no-unnecessary-type-conversion` |
| Performance | `prefer-find`, `prefer-regexp-exec`, `prefer-string-starts-ends-with`, `prefer-reduce-type-parameter`, `prefer-return-this-type`, `related-getter-setter-pairs` |
| Null handling | `prefer-nullish-coalescing`, `use-unknown-in-catch-callback-variable`