### PR TITLE
feat(web): add clay press animation system with motion

### DIFF
--- a/packages/web/src/components/VirtualList.tsx
+++ b/packages/web/src/components/VirtualList.tsx
@@ -230,7 +230,6 @@ function VirtualListInner<T>({
                     width: '100%',
                     height: `${virtualRow.size}px`,
                     transform: `translateY(${virtualRow.start}px)`,
-                    overflow: 'hidden',
                   }}
                 >
                   <m.div layout initial='initial' animate='animate' variants={listItemVariants}>

--- a/packages/web/src/components/ui/Card.tsx
+++ b/packages/web/src/components/ui/Card.tsx
@@ -1,5 +1,6 @@
 import { type HTMLAttributes, memo } from 'react';
 
+import { ClayPressable } from './ClayPressable';
 import { SpringUp } from './SpringUp';
 
 interface CardProps extends HTMLAttributes<HTMLDivElement> {
@@ -16,15 +17,14 @@ export const Card = memo(function Card({
   children,
   ...rest
 }: CardProps) {
-  const hoverClasses = hoverable
-    ? 'hover:clay-raised hover:-translate-y-px [&:active:not(:has(button:active))]:clay-flat [&:active:not(:has(button:active))]:translate-y-0'
-    : '';
+  const baseClass = `bg-elevated overflow-hidden ${className}`;
 
-  const card = (
-    <div
-      className={`bg-elevated clay-resting transition-all duration-100 ${hoverClasses} ${className}`}
-      {...rest}
-    >
+  const card = hoverable ? (
+    <ClayPressable depth='medium' className={baseClass} {...rest}>
+      {children}
+    </ClayPressable>
+  ) : (
+    <div className={`clay-resting ${baseClass}`} {...rest}>
       {children}
     </div>
   );

--- a/packages/web/src/components/ui/ClayPressable.tsx
+++ b/packages/web/src/components/ui/ClayPressable.tsx
@@ -1,0 +1,197 @@
+import * as m from 'motion/react-m';
+import { useCallback, useEffect, useMemo, useState, type HTMLAttributes } from 'react';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type ClayDepth = 'shallow' | 'medium' | 'deep';
+
+interface ClayPressableProps extends HTMLAttributes<HTMLElement> {
+  /** Render as a different element (default: div). Use "button" for interactive buttons. */
+  as?: 'div' | 'button';
+  /** Depth preset controlling how much the surface lifts and presses. */
+  depth?: ClayDepth;
+  /** Disables the hover/press animation entirely. */
+  disabled?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Depth presets — y offset per state
+// ---------------------------------------------------------------------------
+
+const depthPresets: Record<ClayDepth, { hoverY: number; tapY: number }> = {
+  shallow: { hoverY: -0.5, tapY: 1 },
+  medium: { hoverY: -1, tapY: 2 },
+  deep: { hoverY: -1, tapY: 3 },
+};
+
+// ---------------------------------------------------------------------------
+// Spring config — firm clay: fast settle, minimal bounce
+// ---------------------------------------------------------------------------
+
+const claySpring = { type: 'spring' as const, stiffness: 600, damping: 30, mass: 0.8 };
+
+// ---------------------------------------------------------------------------
+// Shadows
+// ---------------------------------------------------------------------------
+// All shadow values are hardcoded per mode to bypass Tailwind CSS v4 tree-shaking
+// and to ensure the correct physical illusion:
+//
+//   Resting / Hover → outward drop shadows (button floats above the page)
+//   Pressed          → inward inset shadows  (button is sunken into the page)
+//
+// The active mode is detected at runtime via document.documentElement.dataset.mode.
+// ---------------------------------------------------------------------------
+
+// ── Dark mode ──────────────────────────────────────────────────────────
+
+const DARK_RESTING =
+  '0 2px 0 0 color-mix(in srgb, var(--color-surface) 60%, black), 0 2px 6px 0 rgba(0, 0, 0, 0.2)';
+const DARK_HOVERING =
+  '0 4px 0 0 color-mix(in srgb, var(--color-surface) 60%, black), 0 4px 10px 0 rgba(0, 0, 0, 0.25)';
+const DARK_PRESSING =
+  '0 1px 0 0 color-mix(in srgb, var(--color-surface) 80%, black), inset 0 2px 3px 0 rgba(0, 0, 0, 0.18), inset 0 1px 1px 0 rgba(0, 0, 0, 0.08)';
+
+// ── Light mode ─────────────────────────────────────────────────────────
+
+// No negative-spread shadows — they cause corner flattening on rounded elements.
+// A subtle 1px ring defines all edges so the top corners don't blend into the
+// background, and a white inset highlight at the top edge sells the raised surface.
+
+const LIGHT_RESTING =
+  '0 2px 0 0 color-mix(in srgb, var(--color-surface) 60%, black), 0 2px 6px 0 rgba(0, 0, 0, 0.1), 0 0 0 1px rgba(0, 0, 0, 0.06)';
+const LIGHT_HOVERING =
+  '0 4px 0 0 color-mix(in srgb, var(--color-surface) 60%, black), 0 4px 6px 0 rgba(0, 0, 0, 0.14), 0 0 0 1px rgba(0, 0, 0, 0.1)';
+const LIGHT_PRESSING =
+  '0 1px 0 0 color-mix(in srgb, var(--color-surface) 80%, black), inset 0 2px 3px 0 rgba(0, 0, 0, 0.1), inset 0 1px 1px 0 rgba(0, 0, 0, 0.06)';
+
+// ── Mode detection ─────────────────────────────────────────────────────
+
+function useColorMode(): 'dark' | 'light' {
+  const [mode, setMode] = useState<'dark' | 'light'>(() => {
+    if (typeof document === 'undefined') {
+      return 'dark';
+    }
+    const m = document.documentElement.dataset.mode;
+    return m === 'light' ? 'light' : 'dark';
+  });
+
+  useEffect(() => {
+    const el = document.documentElement;
+    const observer = new MutationObserver(() => {
+      const m = el.dataset.mode;
+      if (m === 'light' || m === 'dark') {
+        setMode(m);
+      }
+    });
+    observer.observe(el, { attributes: true, attributeFilter: ['data-mode'] });
+    const current = el.dataset.mode;
+    if (current === 'light' || current === 'dark') {
+      setMode(current);
+    }
+    return () => observer.disconnect();
+  }, []);
+
+  return mode;
+}
+
+// ── Shadow lookup ──────────────────────────────────────────────────────
+
+const shadows: Record<'dark' | 'light', Record<'resting' | 'hovering' | 'pressing', string>> = {
+  dark: { resting: DARK_RESTING, hovering: DARK_HOVERING, pressing: DARK_PRESSING },
+  light: { resting: LIGHT_RESTING, hovering: LIGHT_HOVERING, pressing: LIGHT_PRESSING },
+};
+
+function clayShadowStyle(
+  state: 'resting' | 'hovering' | 'pressing',
+  mode: 'dark' | 'light'
+): React.CSSProperties {
+  return {
+    boxShadow: shadows[mode][state],
+    transition: `box-shadow ${state === 'pressing' ? '0.08s' : '0.15s'} ease-out`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function ClayPressable({
+  as: Element = 'div',
+  depth = 'medium',
+  disabled = false,
+  className = '',
+  children,
+  ...rest
+}: ClayPressableProps) {
+  const [clayState, setClayState] = useState<'resting' | 'hovering' | 'pressing'>('resting');
+  const preset = depthPresets[depth];
+  const mode = useColorMode();
+
+  // ── Event handlers — track clay state for CSS shadow ──────────────────
+
+  const handleHoverStart = useCallback(() => {
+    if (disabled) {
+      return;
+    }
+    setClayState('hovering');
+  }, [disabled]);
+
+  const handleHoverEnd = useCallback(() => {
+    if (disabled) {
+      return;
+    }
+    setClayState('resting');
+  }, [disabled]);
+
+  const handleTapStart = useCallback(() => {
+    if (disabled) {
+      return;
+    }
+    setClayState('pressing');
+  }, [disabled]);
+
+  const handleTapEnd = useCallback(() => {
+    if (disabled) {
+      return;
+    }
+    setClayState('resting');
+  }, [disabled]);
+
+  // ── Motion props ──────────────────────────────────────────────────────
+
+  const whileHover = useMemo(
+    () => (disabled ? undefined : { y: preset.hoverY }),
+    [disabled, preset.hoverY]
+  );
+  const whileTap = useMemo(
+    () => (disabled ? undefined : { y: preset.tapY }),
+    [disabled, preset.tapY]
+  );
+
+  // ── Render ────────────────────────────────────────────────────────────
+
+  const Component = Element === 'button' ? m.button : m.div;
+
+  return (
+    // @ts-expect-error motion component props are compatible but TypeScript can't infer
+    <Component
+      className={className}
+      style={clayShadowStyle(clayState, mode)}
+      whileHover={whileHover}
+      whileTap={whileTap}
+      transition={claySpring}
+      onHoverStart={handleHoverStart}
+      onHoverEnd={handleHoverEnd}
+      onTapStart={handleTapStart}
+      onTap={handleTapEnd}
+      onTapCancel={handleTapEnd}
+      {...rest}
+    >
+      {children}
+    </Component>
+  );
+}
+
+export default ClayPressable;

--- a/packages/web/src/components/ui/ClayPressable.tsx
+++ b/packages/web/src/components/ui/ClayPressable.tsx
@@ -103,13 +103,21 @@ const shadows: Record<'dark' | 'light', Record<'resting' | 'hovering' | 'pressin
   light: { resting: LIGHT_RESTING, hovering: LIGHT_HOVERING, pressing: LIGHT_PRESSING },
 };
 
-function clayShadowStyle(
+function clayStyle(
   state: 'resting' | 'hovering' | 'pressing',
   mode: 'dark' | 'light'
 ): React.CSSProperties {
+  const bg =
+    state === 'resting'
+      ? undefined
+      : state === 'hovering'
+        ? 'color-mix(in srgb, var(--color-elevated) 88%, white)'
+        : 'color-mix(in srgb, var(--color-elevated) 92%, black)';
+
   return {
     boxShadow: shadows[mode][state],
-    transition: `box-shadow ${state === 'pressing' ? '0.08s' : '0.15s'} ease-out`,
+    backgroundColor: bg,
+    transition: `box-shadow ${state === 'pressing' ? '0.08s' : '0.15s'} ease-out, background-color 0.15s ease-out`,
   };
 }
 
@@ -178,7 +186,7 @@ export function ClayPressable({
     // @ts-expect-error motion component props are compatible but TypeScript can't infer
     <Component
       className={className}
-      style={clayShadowStyle(clayState, mode)}
+      style={clayStyle(clayState, mode)}
       whileHover={whileHover}
       whileTap={whileTap}
       transition={claySpring}

--- a/packages/web/src/components/ui/ClayPressable.tsx
+++ b/packages/web/src/components/ui/ClayPressable.tsx
@@ -56,13 +56,13 @@ const DARK_PRESSING =
 // ── Light mode ─────────────────────────────────────────────────────────
 
 // No negative-spread shadows — they cause corner flattening on rounded elements.
-// A subtle 1px ring defines all edges so the top corners don't blend into the
-// background, and a white inset highlight at the top edge sells the raised surface.
+// A subtle blurred shadow above and below defines all edges without the harsh
+// 1px ring that can alias at corners on light backgrounds.
 
 const LIGHT_RESTING =
-  '0 2px 0 0 color-mix(in srgb, var(--color-surface) 60%, black), 0 2px 6px 0 rgba(0, 0, 0, 0.1), 0 0 0 1px rgba(0, 0, 0, 0.06)';
+  '0 2px 0 0 color-mix(in srgb, var(--color-surface) 60%, black), 0 2px 6px 0 rgba(0, 0, 0, 0.1), 0 0 1px 1px rgba(0, 0, 0, 0.06)';
 const LIGHT_HOVERING =
-  '0 4px 0 0 color-mix(in srgb, var(--color-surface) 60%, black), 0 4px 6px 0 rgba(0, 0, 0, 0.14), 0 0 0 1px rgba(0, 0, 0, 0.1)';
+  '0 4px 0 0 color-mix(in srgb, var(--color-surface) 60%, black), 0 4px 6px 0 rgba(0, 0, 0, 0.14), 0 0 1px 1px rgba(0, 0, 0, 0.1)';
 const LIGHT_PRESSING =
   '0 1px 0 0 color-mix(in srgb, var(--color-surface) 80%, black), inset 0 2px 3px 0 rgba(0, 0, 0, 0.1), inset 0 1px 1px 0 rgba(0, 0, 0, 0.06)';
 

--- a/packages/web/src/components/ui/ClayPressable.tsx
+++ b/packages/web/src/components/ui/ClayPressable.tsx
@@ -1,5 +1,6 @@
+import { useAnimate } from 'motion/react';
 import * as m from 'motion/react-m';
-import { useCallback, useEffect, useMemo, useState, type HTMLAttributes } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type HTMLAttributes } from 'react';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -137,7 +138,12 @@ export function ClayPressable({
   const preset = depthPresets[depth];
   const mode = useColorMode();
 
-  // ── Event handlers — track clay state for CSS shadow ──────────────────
+  // Imperative tap animation — gated on target so buttons inside don't sink the card.
+  const [scope, animate] = useAnimate();
+  const didPressRef = useRef(false);
+  const isHoveringRef = useRef(false);
+
+  // ── Event handlers ────────────────────────────────────────────────────
 
   const handleHoverStart = useCallback(() => {
     if (disabled) {
@@ -153,29 +159,51 @@ export function ClayPressable({
     setClayState('resting');
   }, [disabled]);
 
-  const handleTapStart = useCallback(() => {
-    if (disabled) {
-      return;
-    }
-    setClayState('pressing');
-  }, [disabled]);
+  const handleTapStart = useCallback(
+    (e: MouseEvent | TouchEvent | PointerEvent) => {
+      if (disabled) {
+        return;
+      }
+      const target = e.target as HTMLElement;
+      if (target.closest('button')) {
+        didPressRef.current = false;
+        return;
+      }
+      didPressRef.current = true;
+      setClayState('pressing');
+      animate(scope.current, { y: preset.tapY }, claySpring);
+    },
+    [disabled, animate, scope, preset.tapY]
+  );
 
   const handleTapEnd = useCallback(() => {
-    if (disabled) {
+    if (disabled || !didPressRef.current) {
       return;
     }
-    setClayState('resting');
-  }, [disabled]);
+    // If the pointer is still over the card after the tap, go back to hovering
+    // instead of resting — the cursor never left, so it should still look active.
+    if (isHoveringRef.current) {
+      setClayState('hovering');
+      animate(scope.current, { y: preset.hoverY }, claySpring);
+    } else {
+      setClayState('resting');
+      animate(scope.current, { y: 0 }, claySpring);
+    }
+  }, [disabled, animate, scope, preset.hoverY]);
+
+  const handleMouseEnter = useCallback(() => {
+    isHoveringRef.current = true;
+  }, []);
+
+  const handleMouseLeave = useCallback(() => {
+    isHoveringRef.current = false;
+  }, []);
 
   // ── Motion props ──────────────────────────────────────────────────────
 
   const whileHover = useMemo(
     () => (disabled ? undefined : { y: preset.hoverY }),
     [disabled, preset.hoverY]
-  );
-  const whileTap = useMemo(
-    () => (disabled ? undefined : { y: preset.tapY }),
-    [disabled, preset.tapY]
   );
 
   // ── Render ────────────────────────────────────────────────────────────
@@ -185,16 +213,18 @@ export function ClayPressable({
   return (
     // @ts-expect-error motion component props are compatible but TypeScript can't infer
     <Component
+      ref={scope}
       className={className}
       style={clayStyle(clayState, mode)}
       whileHover={whileHover}
-      whileTap={whileTap}
       transition={claySpring}
       onHoverStart={handleHoverStart}
       onHoverEnd={handleHoverEnd}
       onTapStart={handleTapStart}
       onTap={handleTapEnd}
       onTapCancel={handleTapEnd}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
       {...rest}
     >
       {children}

--- a/packages/web/src/components/ui/ClayPressable.tsx
+++ b/packages/web/src/components/ui/ClayPressable.tsx
@@ -64,7 +64,7 @@ const LIGHT_RESTING =
 const LIGHT_HOVERING =
   '0 4px 0 0 color-mix(in srgb, var(--color-surface) 60%, black), 0 4px 6px 0 rgba(0, 0, 0, 0.14), 0 0 1px 1px rgba(0, 0, 0, 0.1)';
 const LIGHT_PRESSING =
-  '0 1px 0 0 color-mix(in srgb, var(--color-surface) 80%, black), inset 0 2px 3px 0 rgba(0, 0, 0, 0.1), inset 0 1px 1px 0 rgba(0, 0, 0, 0.06)';
+  '0 1px 0 0 color-mix(in srgb, var(--color-surface) 80%, black), inset 0 2px 3px 0 rgba(0, 0, 0, 0.1), inset 0 -2px 3px 0 rgba(0, 0, 0, 0.08)';
 
 // ── Mode detection ─────────────────────────────────────────────────────
 

--- a/packages/web/src/components/ui/ClayPressable.tsx
+++ b/packages/web/src/components/ui/ClayPressable.tsx
@@ -131,6 +131,7 @@ export function ClayPressable({
   depth = 'medium',
   disabled = false,
   className = '',
+  style: outerStyle,
   children,
   ...rest
 }: ClayPressableProps) {
@@ -206,6 +207,11 @@ export function ClayPressable({
     [disabled, preset.hoverY]
   );
 
+  const mergedStyle = useMemo(
+    () => Object.assign({}, outerStyle, clayStyle(clayState, mode)),
+    [outerStyle, clayState, mode]
+  );
+
   // ── Render ────────────────────────────────────────────────────────────
 
   const Component = Element === 'button' ? m.button : m.div;
@@ -215,7 +221,7 @@ export function ClayPressable({
     <Component
       ref={scope}
       className={className}
-      style={clayStyle(clayState, mode)}
+      style={mergedStyle}
       whileHover={whileHover}
       transition={claySpring}
       onHoverStart={handleHoverStart}

--- a/packages/web/src/pages/PermissionsPage.tsx
+++ b/packages/web/src/pages/PermissionsPage.tsx
@@ -5,6 +5,7 @@ import { fetchPermissions, type PermissionsResponse, updatePermission } from '..
 import ConfirmModal from '../components/ConfirmModal';
 import EmptyState from '../components/EmptyState';
 import { Button } from '../components/ui/Button';
+import { Card } from '../components/ui/Card';
 import Checkbox from '../components/ui/Checkbox';
 import { ErrorBanner } from '../components/ui/ErrorBanner';
 import { PageHeader } from '../components/ui/PageHeader';
@@ -389,7 +390,7 @@ function RoleCard({
   );
 
   return (
-    <div className='bg-elevated clay-resting rounded-xl overflow-hidden hover:clay-raised hover:-translate-y-px active:clay-flat active:translate-y-0 transition-all duration-100'>
+    <Card hoverable className='rounded-xl overflow-hidden'>
       {/* Header row — clickable to toggle expand */}
       <button
         type='button'
@@ -445,7 +446,7 @@ function RoleCard({
           </div>
         </div>
       )}
-    </div>
+    </Card>
   );
 }
 


### PR DESCRIPTION
## Summary

Replaces CSS-based hover/active 3D press effects on cards with a Motion-powered `ClayPressable` component that uses spring physics, mode-aware shadows, and background color shifts.

## Changes

- **New** `ClayPressable` — Motion-based wrapper with `whileHover` and imperative tap animation, three depth presets, and per-mode shadow strings. Outward drop shadows at rest/hover, inward inset shadows on press. Background lightens on hover and darkens on press.
- **Refactor** `Card` — uses `ClayPressable` internally when `hoverable`. Adds `overflow-hidden` for clean rounded corners.
- **Refactor** `PermissionsPage` — replaces ad-hoc clay CSS with `<Card hoverable>`.
- **Fix** — remove `overflow: hidden` from virtual list row wrapper that was clipping card shadows at the top edges.
- **Fix** — child button clicks no longer sink the entire card. Hover state is restored after a tap if the pointer is still over the card.
- **Fix** — parent `style` prop no longer overrides clay shadow via destructure and merge.