### PR TITLE
refactor(web): replace css keyframe animations with motion

### DIFF
--- a/packages/web/src/components/AddSongsModal.tsx
+++ b/packages/web/src/components/AddSongsModal.tsx
@@ -7,6 +7,7 @@ import { addSongToPlaylist, getSongsPage } from '../api/api';
 import { Backdrop } from './Backdrop';
 import { ArtworkImage } from './ui/ArtworkImage';
 import { Button } from './ui/Button';
+import { Skeleton } from './ui/Skeleton';
 import { SpringUp } from './ui/SpringUp';
 
 const PAGE_SIZE = 30;
@@ -167,8 +168,8 @@ export default function AddSongsModal({
             <div className='p-4 md:p-6 space-y-2'>
               {[1, 2, 3, 4, 5].map((n) => (
                 <div key={`skeleton-${n}`} className='flex items-center gap-3'>
-                  <div className='skeleton w-12 h-8 md:w-10 md:h-7 rounded' />
-                  <div className='skeleton h-3 flex-1' />
+                  <Skeleton className='w-12 h-8 md:w-10 md:h-7 rounded' />
+                  <Skeleton className='h-3 flex-1' />
                 </div>
               ))}
             </div>

--- a/packages/web/src/components/NowPlayingBar.tsx
+++ b/packages/web/src/components/NowPlayingBar.tsx
@@ -20,7 +20,7 @@ import { usePlayer } from '../context/PlayerContext';
 import { useQueuePanel } from '../context/QueuePanelContext';
 import { useCooldownGuard, type CooldownState } from '../hooks/useCooldownGuard';
 import { useMutationHandler } from '../hooks/useMutationHandler';
-import { metadataTransition, metadataVariants } from '../lib/motion';
+import { metadataTransition, metadataVariants, slideUp, slideUpTransition } from '../lib/motion';
 import { getSourceKey } from '../utils/source';
 import { BarButton } from './BarButton';
 import QueuePanel from './QueuePanel';
@@ -727,9 +727,16 @@ export function NowPlayingBar() {
             onClick={handleQueueClose}
             role='presentation'
           />
-          <div className='absolute bottom-0 left-0 right-0 max-h-[85vh] bg-surface rounded-t-2xl flex flex-col clay-floating animate-slide-up'>
+          <m.div
+            className='absolute bottom-0 left-0 right-0 max-h-[85vh] bg-surface rounded-t-2xl flex flex-col clay-floating'
+            initial='initial'
+            animate='animate'
+            exit='exit'
+            variants={slideUp}
+            transition={slideUpTransition}
+          >
             <QueuePanel mobileQuickControls={mobileQuickControls} />
-          </div>
+          </m.div>
         </div>
       )}
     </div>

--- a/packages/web/src/components/QueuePanel.tsx
+++ b/packages/web/src/components/QueuePanel.tsx
@@ -44,6 +44,7 @@ import { ArtworkImage } from './ui/ArtworkImage';
 import { Button } from './ui/Button';
 import { cooldownButtonProps } from './ui/cooldownButtonProps';
 import { DurationBadge } from './ui/DurationBadge';
+import { Skeleton } from './ui/Skeleton';
 import { VolumeBoostBadge } from './ui/VolumeBoostBadge';
 
 /* --------------------------------------------------------------------------
@@ -332,10 +333,10 @@ export default function QueuePanel({
           showActions={false}
         />
         <div className='flex-1 p-4 space-y-3'>
-          <div className='skeleton h-5 w-48 rounded' />
-          <div className='skeleton h-12 w-full rounded' />
-          <div className='skeleton h-12 w-full rounded' />
-          <div className='skeleton h-12 w-full rounded' />
+          <Skeleton className='h-5 w-48 rounded' />
+          <Skeleton className='h-12 w-full rounded' />
+          <Skeleton className='h-12 w-full rounded' />
+          <Skeleton className='h-12 w-full rounded' />
         </div>
       </div>
     );

--- a/packages/web/src/components/TagTicker.tsx
+++ b/packages/web/src/components/TagTicker.tsx
@@ -1,4 +1,5 @@
-import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { animate, type AnimationPlaybackControls } from 'motion/react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useTagColors } from '../context/TagsContext';
 import { getTagColorClasses } from '../utils/tagColors';
@@ -8,42 +9,116 @@ interface TagTickerProps {
   isHovered?: boolean;
 }
 
+/** Scroll speed factor — duration = contentWidth × factor. Lower = faster scroll. */
+const SCROLL_SPEED_FACTOR = 0.003;
+
+/** Return spring — snappy with a visible bounce. */
+const RETURN_SPRING = { type: 'spring' as const, stiffness: 250, damping: 12, mass: 0.3 };
+
 const TagTicker = memo(({ tags, isHovered: externalHovered }: TagTickerProps) => {
   const outerRef = useRef<HTMLDivElement>(null);
   const innerRef = useRef<HTMLDivElement>(null);
   const [shouldScroll, setShouldScroll] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
-  const [duration, setDuration] = useState(15);
-  const prevHoveredRef = useRef(false);
-  const durationRef = useRef(15);
   const { tagColorMap } = useTagColors();
+
+  // Computed at measure time — how far to scroll and how long to take.
+  const targetOffsetRef = useRef(0);
+  const scrollDurationRef = useRef(3);
+
+  // Tracks the currently-running animation so we can cancel it.
+  const controlsRef = useRef<AnimationPlaybackControls | null>(null);
+  // Tracks whether we are mid-return (animating back to 0).
+  const isReturning = useRef(false);
 
   const dedupedTags = useMemo(() => [...new Set(tags)], [tags]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: re-run when tags change to remeasure overflow
-  useEffect(() => {
-    if (outerRef.current && innerRef.current && outerRef.current.clientWidth > 0) {
-      const overflow = innerRef.current.scrollWidth > outerRef.current.clientWidth;
-      setShouldScroll(overflow);
+  // ── Overflow detection ──────────────────────────────────────────────────
 
-      if (overflow) {
-        const contentWidth = innerRef.current.scrollWidth;
-        const d = Math.max(10, contentWidth * 0.02);
-        setDuration(d);
-        durationRef.current = d;
-      }
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-run when tags change to remeasure
+  useEffect(() => {
+    const outer = outerRef.current;
+    const inner = innerRef.current;
+    if (!outer || !inner || outer.clientWidth <= 0) {
+      return;
+    }
+
+    const overflow = inner.scrollWidth - outer.clientWidth;
+    if (overflow > 0) {
+      setShouldScroll(true);
+      targetOffsetRef.current = overflow;
+      scrollDurationRef.current = Math.max(3, inner.scrollWidth * SCROLL_SPEED_FACTOR);
+    } else {
+      setShouldScroll(false);
+      controlsRef.current?.stop();
     }
   }, [tags]);
 
+  // ── Scroll control ──────────────────────────────────────────────────────
+
+  const startScroll = useCallback(() => {
+    const el = innerRef.current;
+    if (!el || targetOffsetRef.current <= 0) {
+      return;
+    }
+    isReturning.current = false;
+    controlsRef.current?.stop();
+    const controls = animate(
+      el,
+      { x: -targetOffsetRef.current },
+      { duration: scrollDurationRef.current, ease: 'linear' }
+    );
+    controlsRef.current = controls;
+  }, []);
+
+  const returnToStart = useCallback(() => {
+    const el = innerRef.current;
+    if (!el || isReturning.current) {
+      return;
+    }
+    isReturning.current = true;
+    controlsRef.current?.stop();
+    const controls = animate(el, { x: 0 }, RETURN_SPRING);
+    controlsRef.current = controls;
+  }, []);
+
+  // ── Hover-driven pause / resume ────────────────────────────────────────
+
+  const effectiveHovered = externalHovered ?? isHovered;
+  const prevHovered = useRef(false);
+
+  useEffect(() => {
+    if (!shouldScroll) {
+      return;
+    }
+
+    const wasHovered = prevHovered.current;
+    prevHovered.current = effectiveHovered;
+
+    if (wasHovered && !effectiveHovered) {
+      returnToStart();
+    } else if (!wasHovered && effectiveHovered) {
+      startScroll();
+    }
+  }, [effectiveHovered, shouldScroll, startScroll, returnToStart]);
+
+  // ── Lifecycle ───────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    return () => controlsRef.current?.stop();
+  }, []);
+
+  // ── Tag rendering ──────────────────────────────────────────────────────
+
   const renderTags = useCallback(
-    (prefix: string) =>
+    () =>
       dedupedTags.map((tag) => {
         const tagKey = tag.toLowerCase();
         const explicitColor = tagColorMap[tagKey];
         const colors = getTagColorClasses(tag, explicitColor);
         return (
           <span
-            key={`${prefix}-${tag}`}
+            key={tag}
             className={`inline-flex items-center px-1.5 py-0 rounded text-[11px] font-medium whitespace-nowrap ${colors.bg} ${colors.text}`}
           >
             {tag}
@@ -53,73 +128,7 @@ const TagTicker = memo(({ tags, isHovered: externalHovered }: TagTickerProps) =>
     [dedupedTags, tagColorMap]
   );
 
-  const effectiveHovered = externalHovered ?? isHovered;
-
-  // Smooth return on de-hover: pause animation at current position, then transition back to 0
-  useLayoutEffect(() => {
-    if (!shouldScroll) {
-      return undefined;
-    }
-
-    const prev = prevHoveredRef.current;
-    prevHoveredRef.current = effectiveHovered;
-
-    if (prev && !effectiveHovered) {
-      // De-hovered: capture paused position and transition back to start
-      const el = innerRef.current;
-      if (!el) {
-        return undefined;
-      }
-
-      const computed = getComputedStyle(el);
-      const matrix = new DOMMatrixReadOnly(computed.transform);
-      const x = matrix.m41;
-
-      // Replace animation with static transform at captured position
-      el.style.animation = 'none';
-      el.style.transform = `translateX(${x}px)`;
-      // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- force layout reflow
-      el.offsetHeight;
-
-      // Transition back to 0
-      el.style.transition = 'transform 0.5s ease-out';
-      el.style.transform = 'translateX(0)';
-
-      const onEnd = () => {
-        el.style.transition = '';
-        el.style.transform = '';
-        el.style.animation = '';
-        el.removeEventListener('transitionend', onEnd);
-      };
-      el.addEventListener('transitionend', onEnd);
-
-      return () => el.removeEventListener('transitionend', onEnd);
-    }
-
-    if (!prev && effectiveHovered) {
-      // Re-hovered: cancel any in-progress return and restart animation
-      const el = innerRef.current;
-      if (el) {
-        el.style.transition = '';
-        el.style.transform = '';
-        el.style.animation = `ticker-scroll ${durationRef.current}s linear infinite`;
-      }
-    }
-
-    return undefined;
-  }, [effectiveHovered, shouldScroll]);
-
-  const animationStyle: React.CSSProperties = useMemo(
-    () =>
-      shouldScroll
-        ? {
-            width: 'max-content',
-            animation: `ticker-scroll ${duration}s linear infinite`,
-            animationPlayState: effectiveHovered ? 'running' : 'paused',
-          }
-        : {},
-    [shouldScroll, duration, effectiveHovered]
-  );
+  // ── Mask style ─────────────────────────────────────────────────────────
 
   const maskStyle: React.CSSProperties = useMemo(
     () =>
@@ -133,6 +142,8 @@ const TagTicker = memo(({ tags, isHovered: externalHovered }: TagTickerProps) =>
     [shouldScroll]
   );
 
+  // ── Event handlers ─────────────────────────────────────────────────────
+
   const handleMouseEnter = useCallback(() => {
     if (externalHovered === undefined) {
       setIsHovered(true);
@@ -145,12 +156,14 @@ const TagTicker = memo(({ tags, isHovered: externalHovered }: TagTickerProps) =>
     }
   }, [externalHovered]);
 
+  // ── Render ────────────────────────────────────────────────────────────
+
   if (dedupedTags.length === 0) {
     return null;
   }
 
   return (
-    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- hover state pauses ticker; marquee has dedicated role
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- hover state controls ticker; marquee has dedicated role
     <div
       role='marquee'
       className='overflow-hidden py-0 max-w-[60%]'
@@ -159,9 +172,8 @@ const TagTicker = memo(({ tags, isHovered: externalHovered }: TagTickerProps) =>
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
-      <div className='flex gap-1' ref={innerRef} style={animationStyle}>
-        {renderTags('a')}
-        {shouldScroll && renderTags('b')}
+      <div className='flex gap-1 w-max' ref={innerRef}>
+        {renderTags()}
       </div>
     </div>
   );

--- a/packages/web/src/components/VirtualList.tsx
+++ b/packages/web/src/components/VirtualList.tsx
@@ -197,7 +197,7 @@ function VirtualListInner<T>({
                         {Array.from({ length: 3 }).map((_, i) => (
                           <div
                             key={`loading-dot-${i}`}
-                            className='skeleton h-3 w-3 rounded-full animate-pulse'
+                            className='h-3 w-3 rounded-full bg-border animate-pulse'
                           />
                         ))}
                       </div>

--- a/packages/web/src/components/VirtualPlaylistList.tsx
+++ b/packages/web/src/components/VirtualPlaylistList.tsx
@@ -2,6 +2,7 @@ import { type Playlist } from '@alfira/server/shared';
 import { memo, useCallback, useMemo } from 'react';
 
 import PlaylistRow from './PlaylistRow';
+import { Skeleton } from './ui/Skeleton';
 import { VirtualList } from './VirtualList';
 
 // ---------------------------------------------------------------------------
@@ -32,10 +33,10 @@ function SkeletonList() {
       {Array.from({ length: 4 }).map((_, i) => (
         // eslint-disable-next-line react/no-array-index-key -- static skeleton placeholders
         <div key={`skeleton-${i}`} className='card flex items-center gap-4 px-5 py-4'>
-          <div className='skeleton w-10 h-10 rounded' />
+          <Skeleton className='w-10 h-10 rounded' />
           <div className='flex-1 space-y-2'>
-            <div className='skeleton h-3 w-48' />
-            <div className='skeleton h-2.5 w-24' />
+            <Skeleton className='h-3 w-48' />
+            <Skeleton className='h-2.5 w-24' />
           </div>
         </div>
       ))}

--- a/packages/web/src/components/VirtualRequestList.tsx
+++ b/packages/web/src/components/VirtualRequestList.tsx
@@ -2,6 +2,7 @@ import { type SongRequest } from '@alfira/server/shared';
 import { memo, useCallback, useMemo } from 'react';
 
 import RequestCard from './RequestCard';
+import { Skeleton } from './ui/Skeleton';
 import { VirtualList } from './VirtualList';
 
 // ---------------------------------------------------------------------------
@@ -38,12 +39,12 @@ function SkeletonList() {
           key={`skel-${i}`}
           className='flex items-center gap-4 p-4 rounded-xl bg-elevated clay-resting'
         >
-          <div className='skeleton w-14 h-14 rounded-lg shrink-0' />
+          <Skeleton className='w-14 h-14 rounded-lg shrink-0' />
           <div className='flex-1 min-w-0 space-y-2'>
-            <div className='skeleton h-3 w-3/4' />
-            <div className='skeleton h-2 w-1/2' />
+            <Skeleton className='h-3 w-3/4' />
+            <Skeleton className='h-2 w-1/2' />
           </div>
-          <div className='skeleton h-4 w-16 rounded-full shrink-0' />
+          <Skeleton className='h-4 w-16 rounded-full shrink-0' />
         </div>
       ))}
     </div>

--- a/packages/web/src/components/VirtualSongGrid.tsx
+++ b/packages/web/src/components/VirtualSongGrid.tsx
@@ -4,6 +4,7 @@ import { memo, useCallback, useMemo, useRef } from 'react';
 
 import { useScrollObserver } from '../hooks/useScrollObserver';
 import SongCard from './SongCard';
+import { Skeleton } from './ui/Skeleton';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -55,11 +56,11 @@ function SkeletonGrid() {
             key={`skeleton-${i}`}
             className='rounded-lg bg-elevated clay-resting overflow-hidden'
           >
-            <div className='skeleton aspect-square m-3 rounded-lg' />
+            <Skeleton className='aspect-square m-3 rounded-lg' />
             <div className='p-4 flex flex-col gap-2'>
-              <div className='skeleton h-3.5 w-3/5' />
-              <div className='skeleton h-3 w-4/5' />
-              <div className='skeleton h-3 w-2/5' />
+              <Skeleton className='h-3.5 w-3/5' />
+              <Skeleton className='h-3 w-4/5' />
+              <Skeleton className='h-3 w-2/5' />
             </div>
           </div>
         ))}
@@ -276,7 +277,10 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
       {isContentReady && isFetching && (
         <div className='flex justify-center py-4 gap-2'>
           {Array.from({ length: 3 }).map((_, i) => (
-            <div key={`loading-dot-${i}`} className='skeleton h-3 w-3 rounded-full animate-pulse' />
+            <div
+              key={`loading-dot-${i}`}
+              className='h-3 w-3 rounded-full bg-border animate-pulse'
+            />
           ))}
         </div>
       )}

--- a/packages/web/src/components/VirtualSongList.tsx
+++ b/packages/web/src/components/VirtualSongList.tsx
@@ -3,6 +3,7 @@ import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useSongEdit } from '../context/SongEditContext';
 import SongCard from './SongCard';
+import { Skeleton } from './ui/Skeleton';
 import { VirtualList } from './VirtualList';
 
 /** Height allocated to an expanded row (card + edit panel + spacer). */
@@ -49,13 +50,13 @@ function SkeletonList() {
           key={`skeleton-${i}`}
           className='flex items-center gap-3 md:gap-4 px-4 py-4 rounded-lg bg-elevated clay-resting'
         >
-          <div className='skeleton w-16 h-16 rounded border border-border shrink-0' />
+          <Skeleton className='w-16 h-16 rounded border border-border shrink-0' />
           <div className='flex-1 min-w-0 flex flex-col gap-2'>
-            <div className='skeleton h-3.5 w-2/5' />
-            <div className='skeleton h-3 w-3/5' />
+            <Skeleton className='h-3.5 w-2/5' />
+            <Skeleton className='h-3 w-3/5' />
           </div>
-          <div className='skeleton h-6 w-6 shrink-0' />
-          <div className='skeleton h-4 w-4 shrink-0' />
+          <Skeleton className='h-6 w-6 shrink-0' />
+          <Skeleton className='h-4 w-4 shrink-0' />
         </div>
       ))}
     </div>

--- a/packages/web/src/components/ui/Skeleton.tsx
+++ b/packages/web/src/components/ui/Skeleton.tsx
@@ -1,0 +1,59 @@
+import * as m from 'motion/react-m';
+
+// ---------------------------------------------------------------------------
+// Shared shimmer gradient — matches the old .skeleton CSS class
+// ---------------------------------------------------------------------------
+
+const SHIMMER_GRADIENT =
+  'linear-gradient(90deg, var(--color-elevated) 25%, var(--color-border) 50%, var(--color-elevated) 75%)';
+
+// ---------------------------------------------------------------------------
+// Static animation config — identical for every skeleton instance,
+// so we define them at module scope to avoid per-render object allocations.
+// ---------------------------------------------------------------------------
+
+const SKELETON_STYLE: React.CSSProperties = {
+  background: SHIMMER_GRADIENT,
+  backgroundSize: '400px 100%',
+};
+
+const SKELETON_INITIAL = { opacity: 0, backgroundPosition: '-400px 0' } as const;
+const SKELETON_ANIMATE = { opacity: 1, backgroundPosition: '400px 0' } as const;
+
+const SKELETON_TRANSITION = {
+  opacity: { duration: 0, delay: 0.2 },
+  backgroundPosition: { duration: 1.4, delay: 0.2, repeat: Infinity, ease: 'linear' } as const,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface SkeletonProps {
+  /** Tailwind sizing / spacing / rounding classes passed through to the element. */
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/**
+ * Motion-powered skeleton placeholder.
+ *
+ * Fades in after a brief delay then shimmers indefinitely — same visual as the
+ * old CSS `.skeleton` class but driven entirely by Motion.
+ */
+export function Skeleton({ className }: SkeletonProps) {
+  return (
+    <m.div
+      className={className}
+      style={SKELETON_STYLE}
+      initial={SKELETON_INITIAL}
+      animate={SKELETON_ANIMATE}
+      transition={SKELETON_TRANSITION}
+    />
+  );
+}
+
+export default Skeleton;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -41,49 +41,6 @@
   src: url(/fonts/jetbrains-mono-500-latin.woff2) format('woff2');
 }
 
-@keyframes slideUp {
-  0% {
-    transform: translateY(100%);
-  }
-  100% {
-    transform: translateY(0);
-  }
-}
-
-@keyframes skeleton-appear {
-  to {
-    opacity: 1;
-  }
-}
-
-@keyframes shimmer {
-  0% {
-    background-position: -400px 0;
-  }
-  100% {
-    background-position: 400px 0;
-  }
-}
-
-@keyframes pulseGentle {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.55;
-  }
-}
-
-@keyframes ticker-scroll {
-  from {
-    transform: translateX(0);
-  }
-  to {
-    transform: translateX(-50%);
-  }
-}
-
 /* ============================================
    COLOR THEME DEFINITIONS
    Each theme defines accent colors and palette
@@ -502,9 +459,6 @@
   --font-display: 'Cherry Bomb One', regular;
   --font-body: 'Chiron GoRound TC', regular;
   --font-mono: 'JetBrains Mono', monospace;
-  /* Animations */
-  --animate-slide-up: slideUp 0.3s ease forwards;
-  --animate-pulse-gentle: pulseGentle 2.4s ease-in-out infinite;
   /* Clay radius tokens — consistent "pebble" proportions */
   --clay-radius-sm: 9px;
   --clay-radius-md: 12px;
@@ -609,21 +563,6 @@
 }
 
 @layer components {
-  .skeleton {
-    opacity: 0;
-    background: linear-gradient(
-      90deg,
-      var(--color-elevated) 25%,
-      var(--color-border) 50%,
-      var(--color-elevated) 75%
-    );
-    background-size: 400px 100%;
-    animation:
-      skeleton-appear 0s 0.2s forwards,
-      shimmer 1.4s 0.2s infinite linear;
-    border-radius: 4px;
-  }
-
   .btn-primary {
     @apply font-body text-sm px-4 py-2.5 md:py-2
            transition-all duration-150 cursor-pointer disabled:opacity-40

--- a/packages/web/src/lib/motion.ts
+++ b/packages/web/src/lib/motion.ts
@@ -61,6 +61,20 @@ export const metadataTransition: Transition = {
   ease: 'easeOut',
 };
 
+/** Slide-up from bottom — used for mobile bottom sheets. */
+export const slideUp: Variants = {
+  initial: { y: '100%' },
+  animate: { y: 0 },
+  exit: { y: '100%' },
+};
+
+export const slideUpTransition: Transition = {
+  type: 'spring',
+  stiffness: 500,
+  damping: 28,
+  mass: 0.6,
+};
+
 /** Shared crossfade transition used for page and view mode changes. */
 export const viewTransition: Transition = {
   duration: 0.125,

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -40,6 +40,7 @@ import ListToolbar from '../components/ListToolbar';
 import NotificationToast from '../components/NotificationToast';
 import { Button } from '../components/ui/Button';
 import { cooldownButtonProps } from '../components/ui/cooldownButtonProps';
+import { Skeleton } from '../components/ui/Skeleton';
 import { VirtualSongGrid } from '../components/VirtualSongGrid';
 import { VirtualSongList } from '../components/VirtualSongList';
 import { useAdminView } from '../context/AdminViewContext';
@@ -1027,15 +1028,15 @@ export default function PlaylistDetailPage() {
 function DetailSkeleton() {
   return (
     <div className='p-8'>
-      <div className='skeleton h-3 w-20 mb-6 rounded' />
-      <div className='skeleton h-12 w-64 mb-2 rounded' />
-      <div className='skeleton h-3 w-24 mb-8 rounded' />
+      <Skeleton className='h-3 w-20 mb-6 rounded' />
+      <Skeleton className='h-12 w-64 mb-2 rounded' />
+      <Skeleton className='h-3 w-24 mb-8 rounded' />
       {Array.from({ length: 5 }).map((_, i) => (
         <div key={`skeleton-${i}`} className='flex items-center gap-4 py-3'>
-          <div className='skeleton w-6 h-3 rounded' />
-          <div className='skeleton w-10 h-7 rounded' />
-          <div className='skeleton h-3 flex-1 rounded' />
-          <div className='skeleton h-3 w-12 rounded' />
+          <Skeleton className='w-6 h-3 rounded' />
+          <Skeleton className='w-10 h-7 rounded' />
+          <Skeleton className='h-3 flex-1 rounded' />
+          <Skeleton className='h-3 w-12 rounded' />
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary

Replaces all 4 remaining custom CSS `@keyframes` animations with Motion, eliminating every custom keyframe from `index.css`.

## Changes

- **New `<Skeleton>` component** — replaces the `.skeleton` CSS class. Uses Motion for the fade-in + shimmer animation instead of `skeleton-appear` / `shimmer` keyframes. Applied across 8 components (~30 replacement sites).
- **`slideUp` → Motion variant** — mobile queue bottom sheet now uses a spring-driven `m.div` with shared `slideUp` variant instead of the CSS `animate-slide-up` class.
- **`ticker-scroll` → `animate()`** — TagTicker rewritten to use Motion's imperative `animate()` API. Eliminates ~25 lines of imperative DOM manipulation (`getComputedStyle`, `DOMMatrixReadOnly`, manual `transitionend` listeners). Now scrolls the overflow distance and springs back on release — no duplication, no loop glitch.
- **`pulseGentle` removed** — dead code, zero usages.
- **Removed** `--animate-slide-up` and `--animate-pulse-gentle` custom properties, `.skeleton` CSS class.