### PR TITLE
fix(web): fix selection mode in grid view

### DIFF
--- a/packages/web/src/components/SongCard.tsx
+++ b/packages/web/src/components/SongCard.tsx
@@ -145,12 +145,16 @@ const SongCardInner = ({
 
     return (
       <Card
-        hoverable={!!isAdminView && !selectionMode}
-        className={`rounded-lg flex flex-col${(isAdminView && !selectionMode) || selectionMode ? ' cursor-pointer' : ''}${selectionMode ? ' select-none hover:ring-2 hover:ring-accent/50' : ''}${!selectionMode ? ' group' : ''}`}
+        hoverable={!!isAdminView}
+        className={`rounded-lg flex flex-col relative${(isAdminView && !selectionMode) || selectionMode ? ' cursor-pointer' : ''}${selectionMode ? ` select-none${isSelected ? ' ring-2 ring-accent' : ' hover:ring-2 hover:ring-accent/50'}` : ''}${!selectionMode ? ' group' : ''}`}
         style={gridStyle}
         data-song-edit-container
         onClick={handleGridClick}
       >
+        {isSelected && (
+          <div className='absolute inset-0 bg-accent/20 pointer-events-none rounded-lg z-10' />
+        )}
+
         {/* Clean thumbnail */}
         <div className='relative aspect-square overflow-hidden rounded-lg border border-border m-3 mb-0 bg-elevated'>
           <ArtworkImage
@@ -161,11 +165,10 @@ const SongCardInner = ({
           />
           {/* Selection checkbox overlay */}
           {selectionMode && (
-            <div className='absolute top-2 left-2 z-10' onClick={handleCheckboxOverlayClick}>
+            <div className='absolute top-2 left-2 z-20' onClick={handleCheckboxOverlayClick}>
               <Checkbox checked={isSelected} onChange={handleToggleSelect} size='md' />
             </div>
           )}
-          {isSelected && <div className='absolute inset-0 bg-accent/20 pointer-events-none' />}
         </div>
 
         {/* Info */}
@@ -254,11 +257,15 @@ const SongCardInner = ({
 
   return (
     <Card
-      hoverable={!!isAdminView && !selectionMode}
-      className={`rounded-lg flex flex-col${selectionMode ? ' select-none hover:ring-2 hover:ring-accent/50' : ''}${isSelected ? ' ring-2 ring-accent' : ''}`}
+      hoverable={!!isAdminView}
+      className={`rounded-lg flex flex-col relative${selectionMode ? ' select-none hover:ring-2 hover:ring-accent/50' : ''}${isSelected ? ' ring-2 ring-accent' : ''}`}
       data-song-id={song.id}
       data-song-edit-container
     >
+      {isSelected && (
+        <div className='absolute inset-0 bg-accent/20 pointer-events-none rounded-lg z-10' />
+      )}
+
       <div
         role='button'
         tabIndex={canEdit || selectionMode ? 0 : -1}
@@ -271,7 +278,7 @@ const SongCardInner = ({
       >
         {/* Selection checkbox */}
         {selectionMode && (
-          <span onClick={handleCheckboxOverlayClick}>
+          <span className='relative z-20' onClick={handleCheckboxOverlayClick}>
             <Checkbox checked={isSelected} onChange={handleToggleSelect} size='md' />
           </span>
         )}

--- a/packages/web/src/components/VirtualSongGrid.tsx
+++ b/packages/web/src/components/VirtualSongGrid.tsx
@@ -33,10 +33,12 @@ interface VirtualSongGridProps {
   onToggleSelect?: (id: string) => void;
 }
 
-/** Composite item passed to masonic so isPlaying changes trigger re-renders. */
+/** Composite item passed to masonic so state changes trigger re-renders. */
 interface GridSongItem {
   song: Song;
   isPlaying: boolean;
+  selectionMode: boolean;
+  isSelected: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -131,14 +133,20 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
     [items.length, hasMore, isFetching, onFetchMore]
   );
 
-  // ── Grid items (song + playing state) ──────────────────────────────
-  // Bundling isPlaying into the item data lets masonic detect playingId
-  // changes as data changes and update cards in-place (same itemKey = no
-  // unmount/remount flash). The GridCard render component stays memoized
-  // with empty deps so its identity is stable across all re-renders.
+  // ── Grid items (song + dynamic state) ───────────────────────────────
+  // Bundling isPlaying / selectionMode / isSelected into the item data
+  // lets masonic detect changes and update cards in-place (same itemKey =
+  // no unmount/remount flash). The GridCard render component stays
+  // memoized with empty deps so its identity is stable across re-renders.
   const gridItems: GridSongItem[] = useMemo(
-    () => items.map((song) => ({ song, isPlaying: playingId === song.id })),
-    [items, playingId]
+    () =>
+      items.map((song) => ({
+        song,
+        isPlaying: playingId === song.id,
+        selectionMode,
+        isSelected: isSelected?.(song.id) ?? false,
+      })),
+    [items, playingId, selectionMode, isSelected]
   );
 
   // ── Grid card renderer (stable component identity via refs) ─────────
@@ -148,17 +156,15 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
   // producing a visible flash. We store dynamic props in a ref so the
   // component type identity never changes.
   //
-  // NB: playingId is NOT in the ref because it lives in gridItems (above);
-  // masonic re-renders individual cards when isPlaying flips without
-  // changing the render function identity.
+  // NB: playingId / selectionMode / isSelected live in gridItems (above);
+  // masonic re-renders individual cards when these flip without changing
+  // the render function identity. Callbacks and stable props go in the ref.
   const cardPropsRef = useRef({
     isAdminView,
     playlists,
     onDelete,
     onPlay,
     onAddToQueue,
-    selectionMode,
-    isSelected,
     onToggleSelect,
   });
   cardPropsRef.current = {
@@ -167,8 +173,6 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
     onDelete,
     onPlay,
     onAddToQueue,
-    selectionMode,
-    isSelected,
     onToggleSelect,
   };
 
@@ -176,7 +180,7 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
     const Component = ({
       index: _index,
       width,
-      data: { song, isPlaying },
+      data: { song, isPlaying, selectionMode: sel, isSelected: selSelected },
     }: {
       index: number;
       width: number;
@@ -194,8 +198,8 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
             onPlay={() => p.onPlay(song.id)}
             isPlaying={isPlaying}
             onAddToQueue={() => p.onAddToQueue(song.id)}
-            selectionMode={p.selectionMode}
-            isSelected={p.isSelected?.(song.id) ?? false}
+            selectionMode={sel}
+            isSelected={selSelected}
             onToggleSelect={p.onToggleSelect ? () => p.onToggleSelect?.(song.id) : undefined}
           />
         </div>


### PR DESCRIPTION
## Summary

Selection mode was not working in grid view — clicking a card opened the edit panel instead of toggling selection. The root cause was that selection state was stored in a ref that masonic never read, so grid cards were never re-rendered with the correct state. Also fixed the artwork flash on mode toggle and unified selected-card highlighting across both views.

## Changes

- **VirtualSongGrid**: Moved `selectionMode` and `isSelected` from ref into `GridSongItem` data so masonic detects changes and re-renders grid cards
- **SongCard**: Decoupled `hoverable` prop from `selectionMode` to prevent `ClayPressable` ↔ `div` unmount/remount flash (both list and grid)
- **SongCard**: Added persistent `ring-2 ring-accent` to selected grid cards (matching list variant)
- **SongCard**: Replaced thumbnail-only `bg-accent/20` overlay with full-card overlay for both list and grid variants, with checkbox z-index bumped above it