### PR TITLE
feat: expose all NodeLink audio filters on Audio page

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -13,16 +13,24 @@ import { SECURITY_HEADERS } from './lib/securityHeaders';
 import { closeAllClients, registerClient, unregisterClient, type WsClient } from './lib/socket';
 import { verifySessionToken } from './middleware/requireAuth';
 import { handleAuth } from './routes/auth';
+import { handleChannelMix } from './routes/channelMix';
 import { handleCompressor } from './routes/compressor';
+import { handleDistortion } from './routes/distortion';
 import { handleEqualizer } from './routes/equalizer';
 import { handleGeneralSettings } from './routes/generalSettings';
+import { handleKaraoke } from './routes/karaoke';
+import { handleLowPass } from './routes/lowPass';
 import { handlePermissions } from './routes/permissions';
 import { handlePlayer } from './routes/player';
 import { handlePlaylists } from './routes/playlists';
 import { handleRequests } from './routes/requests';
+import { handleRotation } from './routes/rotation';
 import { handleSetup } from './routes/setup';
 import { handleSongs } from './routes/songs';
 import { handleTags } from './routes/tags';
+import { handleTimescale } from './routes/timescale';
+import { handleTremolo } from './routes/tremolo';
+import { handleVibrato } from './routes/vibrato';
 import { $client, db } from './shared/db';
 import { logger } from './shared/logger';
 import { destroyAllPlayers, initEnabledSources, startDiscord } from './startDiscord';
@@ -209,10 +217,26 @@ function startServer(): void {
       '/api/playlists/*': apiRoute(handlePlaylists),
       '/api/player': apiRoute(handlePlayer),
       '/api/player/*': apiRoute(handlePlayer),
+      '/api/settings/channelmix': apiRoute(handleChannelMix),
+      '/api/settings/channelmix/*': apiRoute(handleChannelMix),
       '/api/settings/compressor': apiRoute(handleCompressor),
       '/api/settings/compressor/*': apiRoute(handleCompressor),
+      '/api/settings/distortion': apiRoute(handleDistortion),
+      '/api/settings/distortion/*': apiRoute(handleDistortion),
       '/api/settings/equalizer': apiRoute(handleEqualizer),
       '/api/settings/equalizer/*': apiRoute(handleEqualizer),
+      '/api/settings/karaoke': apiRoute(handleKaraoke),
+      '/api/settings/karaoke/*': apiRoute(handleKaraoke),
+      '/api/settings/lowpass': apiRoute(handleLowPass),
+      '/api/settings/lowpass/*': apiRoute(handleLowPass),
+      '/api/settings/rotation': apiRoute(handleRotation),
+      '/api/settings/rotation/*': apiRoute(handleRotation),
+      '/api/settings/timescale': apiRoute(handleTimescale),
+      '/api/settings/timescale/*': apiRoute(handleTimescale),
+      '/api/settings/tremolo': apiRoute(handleTremolo),
+      '/api/settings/tremolo/*': apiRoute(handleTremolo),
+      '/api/settings/vibrato': apiRoute(handleVibrato),
+      '/api/settings/vibrato/*': apiRoute(handleVibrato),
       '/api/permissions': apiRoute(handlePermissions),
       '/api/permissions/*': apiRoute(handlePermissions),
       '/api/settings/general': apiRoute(handleGeneralSettings),

--- a/packages/server/src/lib/applyNodeLinkFilter.ts
+++ b/packages/server/src/lib/applyNodeLinkFilter.ts
@@ -3,7 +3,11 @@ import { updateNodeLinkPlayer } from '../utils/nodelink';
 import { getGuildId } from './config';
 import { lavalink } from './lavalink';
 
-interface CompressorFilterParams {
+// ---------------------------------------------------------------------------
+// Filter parameter types
+// ---------------------------------------------------------------------------
+
+export interface CompressorFilterParams {
   threshold: number;
   ratio: number;
   attack: number;
@@ -11,10 +15,59 @@ interface CompressorFilterParams {
   gain: number;
 }
 
-/**
- * Build a NodeLink compressor filter payload from numeric parameters.
- * Does not send anything; purely a data transform.
- */
+export interface KaraokeFilterParams {
+  level: number;
+  monoLevel: number;
+  filterBand: number;
+  filterWidth: number;
+}
+
+export interface TimescaleFilterParams {
+  speed: number;
+  pitch: number;
+  rate: number;
+}
+
+export interface TremoloFilterParams {
+  frequency: number;
+  depth: number;
+}
+
+export interface VibratoFilterParams {
+  frequency: number;
+  depth: number;
+}
+
+export interface RotationFilterParams {
+  rotationHz: number;
+}
+
+export interface DistortionFilterParams {
+  sinOffset: number;
+  sinScale: number;
+  cosOffset: number;
+  cosScale: number;
+  tanOffset: number;
+  tanScale: number;
+  offset: number;
+  scale: number;
+}
+
+export interface ChannelMixFilterParams {
+  leftToLeft: number;
+  leftToRight: number;
+  rightToLeft: number;
+  rightToRight: number;
+}
+
+export interface LowPassFilterParams {
+  smoothing: number;
+}
+
+// ---------------------------------------------------------------------------
+// Filter builders — pure data transforms, no side effects
+// ---------------------------------------------------------------------------
+
 export function buildCompressorFilter(params: CompressorFilterParams) {
   return {
     compressor: {
@@ -26,6 +79,91 @@ export function buildCompressorFilter(params: CompressorFilterParams) {
     },
   };
 }
+
+export function buildKaraokeFilter(params: KaraokeFilterParams) {
+  return {
+    karaoke: {
+      level: params.level,
+      monoLevel: params.monoLevel,
+      filterBand: params.filterBand,
+      filterWidth: params.filterWidth,
+    },
+  };
+}
+
+export function buildTimescaleFilter(params: TimescaleFilterParams) {
+  return {
+    timescale: {
+      speed: params.speed,
+      pitch: params.pitch,
+      rate: params.rate,
+    },
+  };
+}
+
+export function buildTremoloFilter(params: TremoloFilterParams) {
+  return {
+    tremolo: {
+      frequency: params.frequency,
+      depth: params.depth,
+    },
+  };
+}
+
+export function buildVibratoFilter(params: VibratoFilterParams) {
+  return {
+    vibrato: {
+      frequency: params.frequency,
+      depth: params.depth,
+    },
+  };
+}
+
+export function buildRotationFilter(params: RotationFilterParams) {
+  return {
+    rotation: {
+      rotationHz: params.rotationHz,
+    },
+  };
+}
+
+export function buildDistortionFilter(params: DistortionFilterParams) {
+  return {
+    distortion: {
+      sinOffset: params.sinOffset,
+      sinScale: params.sinScale,
+      cosOffset: params.cosOffset,
+      cosScale: params.cosScale,
+      tanOffset: params.tanOffset,
+      tanScale: params.tanScale,
+      offset: params.offset,
+      scale: params.scale,
+    },
+  };
+}
+
+export function buildChannelMixFilter(params: ChannelMixFilterParams) {
+  return {
+    channelMix: {
+      leftToLeft: params.leftToLeft,
+      leftToRight: params.leftToRight,
+      rightToLeft: params.rightToLeft,
+      rightToRight: params.rightToRight,
+    },
+  };
+}
+
+export function buildLowPassFilter(params: LowPassFilterParams) {
+  return {
+    lowPass: {
+      smoothing: params.smoothing,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Legacy — kept for any external callers, but prefer syncAllFilters()
+// ---------------------------------------------------------------------------
 
 /**
  * Applies audio filters to the live NodeLink player for the configured guild.

--- a/packages/server/src/lib/syncAllFilters.ts
+++ b/packages/server/src/lib/syncAllFilters.ts
@@ -1,0 +1,151 @@
+import { eq } from 'drizzle-orm';
+
+import { db, tables } from '../shared/db';
+import { logger } from '../shared/logger';
+import { updateNodeLinkPlayer } from '../utils/nodelink';
+import {
+  buildChannelMixFilter,
+  buildCompressorFilter,
+  buildDistortionFilter,
+  buildKaraokeFilter,
+  buildLowPassFilter,
+  buildRotationFilter,
+  buildTimescaleFilter,
+  buildTremoloFilter,
+  buildVibratoFilter,
+} from './applyNodeLinkFilter';
+import { getGuildId } from './config';
+import { buildEqualizerFilter } from './eqBands';
+import { lavalink } from './lavalink';
+
+/**
+ * Read all filter settings from the database, build a combined NodeLink
+ * Filters object for every enabled filter, and send a single PATCH to the
+ * live player.
+ *
+ * This is the single point of truth for filter application — every filter
+ * route calls this after saving its own settings.  It guarantees that
+ * enabling multiple filters at once sends everything in one payload rather
+ * than one filter overwriting the others.
+ */
+export async function syncAllFilters(): Promise<void> {
+  const guildId = getGuildId();
+  if (!guildId) {
+    return;
+  }
+  if (!lavalink.isGuildConnected(guildId)) {
+    return;
+  }
+
+  const sessionId = lavalink.getSessionId();
+  if (!sessionId) {
+    return;
+  }
+
+  const row = db.select().from(tables.guildSettings).where(eq(tables.guildSettings.id, 1)).get();
+
+  if (!row) {
+    return;
+  }
+
+  const filters: Record<string, unknown> = {};
+
+  // Compressor
+  if (row.compressorEnabled) {
+    filters.compressor = buildCompressorFilter({
+      threshold: row.compressorThreshold,
+      ratio: row.compressorRatio,
+      attack: row.compressorAttack,
+      release: row.compressorRelease,
+      gain: row.compressorGain,
+    }).compressor;
+  }
+
+  // Equalizer
+  if (row.eqEnabled) {
+    const bands = Array.from({ length: 15 }, (_, i) => {
+      const key = `eqBand${i}` as keyof typeof row;
+      return row[key] as number;
+    });
+    filters.equalizer = buildEqualizerFilter(bands);
+  }
+
+  // Karaoke
+  if (row.karaokeEnabled) {
+    filters.karaoke = buildKaraokeFilter({
+      level: row.karaokeLevel,
+      monoLevel: row.karaokeMonoLevel,
+      filterBand: row.karaokeFilterBand,
+      filterWidth: row.karaokeFilterWidth,
+    }).karaoke;
+  }
+
+  // Timescale
+  if (row.timescaleEnabled) {
+    filters.timescale = buildTimescaleFilter({
+      speed: row.timescaleSpeed,
+      pitch: row.timescalePitch,
+      rate: row.timescaleRate,
+    }).timescale;
+  }
+
+  // Tremolo
+  if (row.tremoloEnabled) {
+    filters.tremolo = buildTremoloFilter({
+      frequency: row.tremoloFrequency,
+      depth: row.tremoloDepth,
+    }).tremolo;
+  }
+
+  // Vibrato
+  if (row.vibratoEnabled) {
+    filters.vibrato = buildVibratoFilter({
+      frequency: row.vibratoFrequency,
+      depth: row.vibratoDepth,
+    }).vibrato;
+  }
+
+  // Rotation
+  if (row.rotationEnabled) {
+    filters.rotation = buildRotationFilter({
+      rotationHz: row.rotationHz,
+    }).rotation;
+  }
+
+  // Distortion
+  if (row.distortionEnabled) {
+    filters.distortion = buildDistortionFilter({
+      sinOffset: row.distortionSinOffset,
+      sinScale: row.distortionSinScale,
+      cosOffset: row.distortionCosOffset,
+      cosScale: row.distortionCosScale,
+      tanOffset: row.distortionTanOffset,
+      tanScale: row.distortionTanScale,
+      offset: row.distortionOffset,
+      scale: row.distortionScale,
+    }).distortion;
+  }
+
+  // Channel mix
+  if (row.channelMixEnabled) {
+    filters.channelMix = buildChannelMixFilter({
+      leftToLeft: row.channelMixLeftToLeft,
+      leftToRight: row.channelMixLeftToRight,
+      rightToLeft: row.channelMixRightToLeft,
+      rightToRight: row.channelMixRightToRight,
+    }).channelMix;
+  }
+
+  // Low pass
+  if (row.lowPassEnabled) {
+    filters.lowPass = buildLowPassFilter({
+      smoothing: row.lowPassSmoothing,
+    }).lowPass;
+  }
+
+  try {
+    await updateNodeLinkPlayer(guildId, sessionId, { filters });
+  } catch (err) {
+    logger.error({ err }, 'Failed to sync audio filters to NodeLink');
+  }
+}

--- a/packages/server/src/routes/channelMix.ts
+++ b/packages/server/src/routes/channelMix.ts
@@ -1,0 +1,105 @@
+import { eq } from 'drizzle-orm';
+
+import { type RouteContext } from '../lib/context';
+import { json } from '../lib/json';
+import { checkGuards } from '../lib/routeGuards';
+import { routeTable } from '../lib/routeTable';
+import { syncAllFilters } from '../lib/syncAllFilters';
+import { db, tables } from '../shared/db';
+
+interface ChannelMixPayload {
+  enabled: boolean;
+  leftToLeft: number;
+  leftToRight: number;
+  rightToLeft: number;
+  rightToRight: number;
+}
+
+function handleChannelMixGet(
+  ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Response {
+  const guards = checkGuards(ctx, { admin: true, permission: 'audio.manage' });
+  if (guards instanceof Response) {
+    return guards;
+  }
+
+  const row = db.select().from(tables.guildSettings).where(eq(tables.guildSettings.id, 1)).get();
+
+  return json({
+    enabled: row?.channelMixEnabled ?? false,
+    leftToLeft: row?.channelMixLeftToLeft ?? 1.0,
+    leftToRight: row?.channelMixLeftToRight ?? 0.0,
+    rightToLeft: row?.channelMixRightToLeft ?? 0.0,
+    rightToRight: row?.channelMixRightToRight ?? 1.0,
+  });
+}
+
+async function handleChannelMixPatch(
+  ctx: RouteContext,
+  request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
+  const guards = checkGuards(ctx, { admin: true, permission: 'audio.manage' });
+  if (guards instanceof Response) {
+    return guards;
+  }
+
+  let body: ChannelMixPayload;
+  try {
+    body = (await request.json()) as ChannelMixPayload;
+  } catch {
+    return json({ error: 'Invalid JSON' }, 400);
+  }
+
+  const { enabled, leftToLeft, leftToRight, rightToLeft, rightToRight } = body;
+
+  if (typeof enabled !== 'boolean') {
+    return json({ error: 'enabled must be boolean' }, 400);
+  }
+  if (typeof leftToLeft !== 'number' || leftToLeft < 0 || leftToLeft > 1) {
+    return json({ error: 'leftToLeft must be number 0.0 to 1.0' }, 400);
+  }
+  if (typeof leftToRight !== 'number' || leftToRight < 0 || leftToRight > 1) {
+    return json({ error: 'leftToRight must be number 0.0 to 1.0' }, 400);
+  }
+  if (typeof rightToLeft !== 'number' || rightToLeft < 0 || rightToLeft > 1) {
+    return json({ error: 'rightToLeft must be number 0.0 to 1.0' }, 400);
+  }
+  if (typeof rightToRight !== 'number' || rightToRight < 0 || rightToRight > 1) {
+    return json({ error: 'rightToRight must be number 0.0 to 1.0' }, 400);
+  }
+
+  db.insert(tables.guildSettings)
+    .values({
+      id: 1,
+      channelMixEnabled: enabled,
+      channelMixLeftToLeft: leftToLeft,
+      channelMixLeftToRight: leftToRight,
+      channelMixRightToLeft: rightToLeft,
+      channelMixRightToRight: rightToRight,
+    })
+    .onConflictDoUpdate({
+      target: tables.guildSettings.id,
+      set: {
+        channelMixEnabled: enabled,
+        channelMixLeftToLeft: leftToLeft,
+        channelMixLeftToRight: leftToRight,
+        channelMixRightToLeft: rightToLeft,
+        channelMixRightToRight: rightToRight,
+      },
+    })
+    .run();
+
+  await syncAllFilters();
+
+  return json({ enabled, leftToLeft, leftToRight, rightToLeft, rightToRight });
+}
+
+export const handleChannelMix = routeTable('/api/settings/channelmix', {
+  routes: [
+    ['GET', '/', handleChannelMixGet],
+    ['PATCH', '/', handleChannelMixPatch],
+  ],
+});

--- a/packages/server/src/routes/compressor.ts
+++ b/packages/server/src/routes/compressor.ts
@@ -1,8 +1,10 @@
-import { applyNodeLinkFilter, buildCompressorFilter } from '../lib/applyNodeLinkFilter';
+import { eq } from 'drizzle-orm';
+
 import { type RouteContext } from '../lib/context';
 import { json } from '../lib/json';
 import { checkGuards } from '../lib/routeGuards';
 import { routeTable } from '../lib/routeTable';
+import { syncAllFilters } from '../lib/syncAllFilters';
 import { db, tables } from '../shared/db';
 
 interface CompressorPayload {
@@ -14,7 +16,29 @@ interface CompressorPayload {
   gain: number;
 }
 
-async function handleCompressorRequest(
+function handleCompressorGet(
+  ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Response {
+  const guards = checkGuards(ctx, { admin: true, permission: 'audio.manage' });
+  if (guards instanceof Response) {
+    return guards;
+  }
+
+  const row = db.select().from(tables.guildSettings).where(eq(tables.guildSettings.id, 1)).get();
+
+  return json({
+    enabled: row?.compressorEnabled ?? false,
+    threshold: row?.compressorThreshold ?? -6,
+    ratio: row?.compressorRatio ?? 4.0,
+    attack: row?.compressorAttack ?? 5,
+    release: row?.compressorRelease ?? 50,
+    gain: row?.compressorGain ?? 3,
+  });
+}
+
+async function handleCompressorPatch(
   ctx: RouteContext,
   request: Request,
   _params: Record<string, string>
@@ -77,15 +101,15 @@ async function handleCompressorRequest(
     })
     .run();
 
-  // Apply to live NodeLink player if connected
-  await applyNodeLinkFilter(enabled ? buildCompressorFilter(body) : {}, 'compressor');
+  // Apply all enabled filters to live NodeLink player
+  await syncAllFilters();
 
   return json({ enabled, threshold, ratio, attack, release, gain });
 }
 
 export const handleCompressor = routeTable('/api/settings/compressor', {
   routes: [
-    ['GET', '/', handleCompressorRequest],
-    ['PATCH', '/', handleCompressorRequest],
+    ['GET', '/', handleCompressorGet],
+    ['PATCH', '/', handleCompressorPatch],
   ],
 });

--- a/packages/server/src/routes/distortion.ts
+++ b/packages/server/src/routes/distortion.ts
@@ -1,0 +1,144 @@
+import { eq } from 'drizzle-orm';
+
+import { type RouteContext } from '../lib/context';
+import { json } from '../lib/json';
+import { checkGuards } from '../lib/routeGuards';
+import { routeTable } from '../lib/routeTable';
+import { syncAllFilters } from '../lib/syncAllFilters';
+import { db, tables } from '../shared/db';
+
+interface DistortionPayload {
+  enabled: boolean;
+  sinOffset: number;
+  sinScale: number;
+  cosOffset: number;
+  cosScale: number;
+  tanOffset: number;
+  tanScale: number;
+  offset: number;
+  scale: number;
+}
+
+function handleDistortionGet(
+  ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Response {
+  const guards = checkGuards(ctx, { admin: true, permission: 'audio.manage' });
+  if (guards instanceof Response) {
+    return guards;
+  }
+
+  const row = db.select().from(tables.guildSettings).where(eq(tables.guildSettings.id, 1)).get();
+
+  return json({
+    enabled: row?.distortionEnabled ?? false,
+    sinOffset: row?.distortionSinOffset ?? 0.0,
+    sinScale: row?.distortionSinScale ?? 1.0,
+    cosOffset: row?.distortionCosOffset ?? 0.0,
+    cosScale: row?.distortionCosScale ?? 1.0,
+    tanOffset: row?.distortionTanOffset ?? 0.0,
+    tanScale: row?.distortionTanScale ?? 1.0,
+    offset: row?.distortionOffset ?? 0.0,
+    scale: row?.distortionScale ?? 1.0,
+  });
+}
+
+async function handleDistortionPatch(
+  ctx: RouteContext,
+  request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
+  const guards = checkGuards(ctx, { admin: true, permission: 'audio.manage' });
+  if (guards instanceof Response) {
+    return guards;
+  }
+
+  let body: DistortionPayload;
+  try {
+    body = (await request.json()) as DistortionPayload;
+  } catch {
+    return json({ error: 'Invalid JSON' }, 400);
+  }
+
+  const { enabled, sinOffset, sinScale, cosOffset, cosScale, tanOffset, tanScale, offset, scale } =
+    body;
+
+  if (typeof enabled !== 'boolean') {
+    return json({ error: 'enabled must be boolean' }, 400);
+  }
+  if (typeof sinOffset !== 'number' || sinOffset < -1 || sinOffset > 1) {
+    return json({ error: 'sinOffset must be number -1.0 to 1.0' }, 400);
+  }
+  if (typeof sinScale !== 'number' || sinScale < 0 || sinScale > 5) {
+    return json({ error: 'sinScale must be number 0.0 to 5.0' }, 400);
+  }
+  if (typeof cosOffset !== 'number' || cosOffset < -1 || cosOffset > 1) {
+    return json({ error: 'cosOffset must be number -1.0 to 1.0' }, 400);
+  }
+  if (typeof cosScale !== 'number' || cosScale < 0 || cosScale > 5) {
+    return json({ error: 'cosScale must be number 0.0 to 5.0' }, 400);
+  }
+  if (typeof tanOffset !== 'number' || tanOffset < -1 || tanOffset > 1) {
+    return json({ error: 'tanOffset must be number -1.0 to 1.0' }, 400);
+  }
+  if (typeof tanScale !== 'number' || tanScale < 0 || tanScale > 5) {
+    return json({ error: 'tanScale must be number 0.0 to 5.0' }, 400);
+  }
+  if (typeof offset !== 'number' || offset < -1 || offset > 1) {
+    return json({ error: 'offset must be number -1.0 to 1.0' }, 400);
+  }
+  if (typeof scale !== 'number' || scale < 0 || scale > 5) {
+    return json({ error: 'scale must be number 0.0 to 5.0' }, 400);
+  }
+
+  db.insert(tables.guildSettings)
+    .values({
+      id: 1,
+      distortionEnabled: enabled,
+      distortionSinOffset: sinOffset,
+      distortionSinScale: sinScale,
+      distortionCosOffset: cosOffset,
+      distortionCosScale: cosScale,
+      distortionTanOffset: tanOffset,
+      distortionTanScale: tanScale,
+      distortionOffset: offset,
+      distortionScale: scale,
+    })
+    .onConflictDoUpdate({
+      target: tables.guildSettings.id,
+      set: {
+        distortionEnabled: enabled,
+        distortionSinOffset: sinOffset,
+        distortionSinScale: sinScale,
+        distortionCosOffset: cosOffset,
+        distortionCosScale: cosScale,
+        distortionTanOffset: tanOffset,
+        distortionTanScale: tanScale,
+        distortionOffset: offset,
+        distortionScale: scale,
+      },
+    })
+    .run();
+
+  await syncAllFilters();
+
+  return json({
+    enabled,
+    sinOffset,
+    sinScale,
+    cosOffset,
+    cosScale,
+    tanOffset,
+    tanScale,
+    offset,
+    scale,
+  });
+}
+
+export const handleDistortion = routeTable('/api/settings/distortion', {
+  routes: [
+    ['GET', '/', handleDistortionGet],
+    ['PATCH', '/', handleDistortionPatch],
+  ],
+});

--- a/packages/server/src/routes/equalizer.ts
+++ b/packages/server/src/routes/equalizer.ts
@@ -1,16 +1,11 @@
 import { eq } from 'drizzle-orm';
 
-import { applyNodeLinkFilter } from '../lib/applyNodeLinkFilter';
 import { type RouteContext } from '../lib/context';
-import {
-  buildEqualizerFilter,
-  EQ_BAND_COLUMNS,
-  eqBandsFromRow,
-  eqBandValues,
-} from '../lib/eqBands';
+import { EQ_BAND_COLUMNS, eqBandsFromRow, eqBandValues } from '../lib/eqBands';
 import { json } from '../lib/json';
 import { checkGuards } from '../lib/routeGuards';
 import { routeTable } from '../lib/routeTable';
+import { syncAllFilters } from '../lib/syncAllFilters';
 import { db, tables } from '../shared/db';
 
 interface EqualizerPayload {
@@ -87,8 +82,8 @@ async function handleEqualizerPatch(
     })
     .run();
 
-  // Apply to live NodeLink player if connected
-  await applyNodeLinkFilter({ equalizer: buildEqualizerFilter(bands) }, 'equalizer');
+  // Apply all enabled filters to live NodeLink player
+  await syncAllFilters();
 
   return json({ bands, enabled });
 }

--- a/packages/server/src/routes/karaoke.ts
+++ b/packages/server/src/routes/karaoke.ts
@@ -1,0 +1,105 @@
+import { eq } from 'drizzle-orm';
+
+import { type RouteContext } from '../lib/context';
+import { json } from '../lib/json';
+import { checkGuards } from '../lib/routeGuards';
+import { routeTable } from '../lib/routeTable';
+import { syncAllFilters } from '../lib/syncAllFilters';
+import { db, tables } from '../shared/db';
+
+interface KaraokePayload {
+  enabled: boolean;
+  level: number;
+  monoLevel: number;
+  filterBand: number;
+  filterWidth: number;
+}
+
+function handleKaraokeGet(
+  ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Response {
+  const guards = checkGuards(ctx, { admin: true, permission: 'audio.manage' });
+  if (guards instanceof Response) {
+    return guards;
+  }
+
+  const row = db.select().from(tables.guildSettings).where(eq(tables.guildSettings.id, 1)).get();
+
+  return json({
+    enabled: row?.karaokeEnabled ?? false,
+    level: row?.karaokeLevel ?? 1.0,
+    monoLevel: row?.karaokeMonoLevel ?? 1.0,
+    filterBand: row?.karaokeFilterBand ?? 220.0,
+    filterWidth: row?.karaokeFilterWidth ?? 100.0,
+  });
+}
+
+async function handleKaraokePatch(
+  ctx: RouteContext,
+  request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
+  const guards = checkGuards(ctx, { admin: true, permission: 'audio.manage' });
+  if (guards instanceof Response) {
+    return guards;
+  }
+
+  let body: KaraokePayload;
+  try {
+    body = (await request.json()) as KaraokePayload;
+  } catch {
+    return json({ error: 'Invalid JSON' }, 400);
+  }
+
+  const { enabled, level, monoLevel, filterBand, filterWidth } = body;
+
+  if (typeof enabled !== 'boolean') {
+    return json({ error: 'enabled must be boolean' }, 400);
+  }
+  if (typeof level !== 'number' || level < 0 || level > 1) {
+    return json({ error: 'level must be number 0.0 to 1.0' }, 400);
+  }
+  if (typeof monoLevel !== 'number' || monoLevel < 0 || monoLevel > 1) {
+    return json({ error: 'monoLevel must be number 0.0 to 1.0' }, 400);
+  }
+  if (typeof filterBand !== 'number' || filterBand < 50 || filterBand > 10000) {
+    return json({ error: 'filterBand must be number 50 to 10000' }, 400);
+  }
+  if (typeof filterWidth !== 'number' || filterWidth < 10 || filterWidth > 10000) {
+    return json({ error: 'filterWidth must be number 10 to 10000' }, 400);
+  }
+
+  db.insert(tables.guildSettings)
+    .values({
+      id: 1,
+      karaokeEnabled: enabled,
+      karaokeLevel: level,
+      karaokeMonoLevel: monoLevel,
+      karaokeFilterBand: filterBand,
+      karaokeFilterWidth: filterWidth,
+    })
+    .onConflictDoUpdate({
+      target: tables.guildSettings.id,
+      set: {
+        karaokeEnabled: enabled,
+        karaokeLevel: level,
+        karaokeMonoLevel: monoLevel,
+        karaokeFilterBand: filterBand,
+        karaokeFilterWidth: filterWidth,
+      },
+    })
+    .run();
+
+  await syncAllFilters();
+
+  return json({ enabled, level, monoLevel, filterBand, filterWidth });
+}
+
+export const handleKaraoke = routeTable('/api/settings/karaoke', {
+  routes: [
+    ['GET', '/', handleKaraokeGet],
+    ['PATCH', '/', handleKaraokePatch],
+  ],
+});

--- a/packages/server/src/routes/lowPass.ts
+++ b/packages/server/src/routes/lowPass.ts
@@ -1,0 +1,84 @@
+import { eq } from 'drizzle-orm';
+
+import { type RouteContext } from '../lib/context';
+import { json } from '../lib/json';
+import { checkGuards } from '../lib/routeGuards';
+import { routeTable } from '../lib/routeTable';
+import { syncAllFilters } from '../lib/syncAllFilters';
+import { db, tables } from '../shared/db';
+
+interface LowPassPayload {
+  enabled: boolean;
+  smoothing: number;
+}
+
+function handleLowPassGet(
+  ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Response {
+  const guards = checkGuards(ctx, { admin: true, permission: 'audio.manage' });
+  if (guards instanceof Response) {
+    return guards;
+  }
+
+  const row = db.select().from(tables.guildSettings).where(eq(tables.guildSettings.id, 1)).get();
+
+  return json({
+    enabled: row?.lowPassEnabled ?? false,
+    smoothing: row?.lowPassSmoothing ?? 20.0,
+  });
+}
+
+async function handleLowPassPatch(
+  ctx: RouteContext,
+  request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
+  const guards = checkGuards(ctx, { admin: true, permission: 'audio.manage' });
+  if (guards instanceof Response) {
+    return guards;
+  }
+
+  let body: LowPassPayload;
+  try {
+    body = (await request.json()) as LowPassPayload;
+  } catch {
+    return json({ error: 'Invalid JSON' }, 400);
+  }
+
+  const { enabled, smoothing } = body;
+
+  if (typeof enabled !== 'boolean') {
+    return json({ error: 'enabled must be boolean' }, 400);
+  }
+  if (typeof smoothing !== 'number' || smoothing < 0 || smoothing > 60) {
+    return json({ error: 'smoothing must be number 0.0 to 60.0' }, 400);
+  }
+
+  db.insert(tables.guildSettings)
+    .values({
+      id: 1,
+      lowPassEnabled: enabled,
+      lowPassSmoothing: smoothing,
+    })
+    .onConflictDoUpdate({
+      target: tables.guildSettings.id,
+      set: {
+        lowPassEnabled: enabled,
+        lowPassSmoothing: smoothing,
+      },
+    })
+    .run();
+
+  await syncAllFilters();
+
+  return json({ enabled, smoothing });
+}
+
+export const handleLowPass = routeTable('/api/settings/lowpass', {
+  routes: [
+    ['GET', '/', handleLowPassGet],
+    ['PATCH', '/', handleLowPassPatch],
+  ],
+});

--- a/packages/server/src/routes/rotation.ts
+++ b/packages/server/src/routes/rotation.ts
@@ -1,0 +1,84 @@
+import { eq } from 'drizzle-orm';
+
+import { type RouteContext } from '../lib/context';
+import { json } from '../lib/json';
+import { checkGuards } from '../lib/routeGuards';
+import { routeTable } from '../lib/routeTable';
+import { syncAllFilters } from '../lib/syncAllFilters';
+import { db, tables } from '../shared/db';
+
+interface RotationPayload {
+  enabled: boolean;
+  rotationHz: number;
+}
+
+function handleRotationGet(
+  ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Response {
+  const guards = checkGuards(ctx, { admin: true, permission: 'audio.manage' });
+  if (guards instanceof Response) {
+    return guards;
+  }
+
+  const row = db.select().from(tables.guildSettings).where(eq(tables.guildSettings.id, 1)).get();
+
+  return json({
+    enabled: row?.rotationEnabled ?? false,
+    rotationHz: row?.rotationHz ?? 0.0,
+  });
+}
+
+async function handleRotationPatch(
+  ctx: RouteContext,
+  request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
+  const guards = checkGuards(ctx, { admin: true, permission: 'audio.manage' });
+  if (guards instanceof Response) {
+    return guards;
+  }
+
+  let body: RotationPayload;
+  try {
+    body = (await request.json()) as RotationPayload;
+  } catch {
+    return json({ error: 'Invalid JSON' }, 400);
+  }
+
+  const { enabled, rotationHz } = body;
+
+  if (typeof enabled !== 'boolean') {
+    return json({ error: 'enabled must be boolean' }, 400);
+  }
+  if (typeof rotationHz !== 'number' || rotationHz < 0 || rotationHz > 1) {
+    return json({ error: 'rotationHz must be number 0.0 to 1.0' }, 400);
+  }
+
+  db.insert(tables.guildSettings)
+    .values({
+      id: 1,
+      rotationEnabled: enabled,
+      rotationHz,
+    })
+    .onConflictDoUpdate({
+      target: tables.guildSettings.id,
+      set: {
+        rotationEnabled: enabled,
+        rotationHz,
+      },
+    })
+    .run();
+
+  await syncAllFilters();
+
+  return json({ enabled, rotationHz });
+}
+
+export const handleRotation = routeTable('/api/settings/rotation', {
+  routes: [
+    ['GET', '/', handleRotationGet],
+    ['PATCH', '/', handleRotationPatch],
+  ],
+});

--- a/packages/server/src/routes/timescale.ts
+++ b/packages/server/src/routes/timescale.ts
@@ -1,0 +1,98 @@
+import { eq } from 'drizzle-orm';
+
+import { type RouteContext } from '../lib/context';
+import { json } from '../lib/json';
+import { checkGuards } from '../lib/routeGuards';
+import { routeTable } from '../lib/routeTable';
+import { syncAllFilters } from '../lib/syncAllFilters';
+import { db, tables } from '../shared/db';
+
+interface TimescalePayload {
+  enabled: boolean;
+  speed: number;
+  pitch: number;
+  rate: number;
+}
+
+function handleTimescaleGet(
+  ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Response {
+  const guards = checkGuards(ctx, { admin: true, permission: 'audio.manage' });
+  if (guards instanceof Response) {
+    return guards;
+  }
+
+  const row = db.select().from(tables.guildSettings).where(eq(tables.guildSettings.id, 1)).get();
+
+  return json({
+    enabled: row?.timescaleEnabled ?? false,
+    speed: row?.timescaleSpeed ?? 1.0,
+    pitch: row?.timescalePitch ?? 1.0,
+    rate: row?.timescaleRate ?? 1.0,
+  });
+}
+
+async function handleTimescalePatch(
+  ctx: RouteContext,
+  request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
+  const guards = checkGuards(ctx, { admin: true, permission: 'audio.manage' });
+  if (guards instanceof Response) {
+    return guards;
+  }
+
+  let body: TimescalePayload;
+  try {
+    body = (await request.json()) as TimescalePayload;
+  } catch {
+    return json({ error: 'Invalid JSON' }, 400);
+  }
+
+  const { enabled, speed, pitch, rate } = body;
+
+  if (typeof enabled !== 'boolean') {
+    return json({ error: 'enabled must be boolean' }, 400);
+  }
+  if (typeof speed !== 'number' || speed < 0.5 || speed > 2.0) {
+    return json({ error: 'speed must be number 0.5 to 2.0' }, 400);
+  }
+  if (typeof pitch !== 'number' || pitch < 0.5 || pitch > 2.0) {
+    return json({ error: 'pitch must be number 0.5 to 2.0' }, 400);
+  }
+  if (typeof rate !== 'number' || rate < 0.5 || rate > 2.0) {
+    return json({ error: 'rate must be number 0.5 to 2.0' }, 400);
+  }
+
+  db.insert(tables.guildSettings)
+    .values({
+      id: 1,
+      timescaleEnabled: enabled,
+      timescaleSpeed: speed,
+      timescalePitch: pitch,
+      timescaleRate: rate,
+    })
+    .onConflictDoUpdate({
+      target: tables.guildSettings.id,
+      set: {
+        timescaleEnabled: enabled,
+        timescaleSpeed: speed,
+        timescalePitch: pitch,
+        timescaleRate: rate,
+      },
+    })
+    .run();
+
+  await syncAllFilters();
+
+  return json({ enabled, speed, pitch, rate });
+}
+
+export const handleTimescale = routeTable('/api/settings/timescale', {
+  routes: [
+    ['GET', '/', handleTimescaleGet],
+    ['PATCH', '/', handleTimescalePatch],
+  ],
+});

--- a/packages/server/src/routes/tremolo.ts
+++ b/packages/server/src/routes/tremolo.ts
@@ -1,0 +1,91 @@
+import { eq } from 'drizzle-orm';
+
+import { type RouteContext } from '../lib/context';
+import { json } from '../lib/json';
+import { checkGuards } from '../lib/routeGuards';
+import { routeTable } from '../lib/routeTable';
+import { syncAllFilters } from '../lib/syncAllFilters';
+import { db, tables } from '../shared/db';
+
+interface TremoloPayload {
+  enabled: boolean;
+  frequency: number;
+  depth: number;
+}
+
+function handleTremoloGet(
+  ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Response {
+  const guards = checkGuards(ctx, { admin: true, permission: 'audio.manage' });
+  if (guards instanceof Response) {
+    return guards;
+  }
+
+  const row = db.select().from(tables.guildSettings).where(eq(tables.guildSettings.id, 1)).get();
+
+  return json({
+    enabled: row?.tremoloEnabled ?? false,
+    frequency: row?.tremoloFrequency ?? 2.0,
+    depth: row?.tremoloDepth ?? 0.5,
+  });
+}
+
+async function handleTremoloPatch(
+  ctx: RouteContext,
+  request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
+  const guards = checkGuards(ctx, { admin: true, permission: 'audio.manage' });
+  if (guards instanceof Response) {
+    return guards;
+  }
+
+  let body: TremoloPayload;
+  try {
+    body = (await request.json()) as TremoloPayload;
+  } catch {
+    return json({ error: 'Invalid JSON' }, 400);
+  }
+
+  const { enabled, frequency, depth } = body;
+
+  if (typeof enabled !== 'boolean') {
+    return json({ error: 'enabled must be boolean' }, 400);
+  }
+  if (typeof frequency !== 'number' || frequency < 0.1 || frequency > 14.0) {
+    return json({ error: 'frequency must be number 0.1 to 14.0' }, 400);
+  }
+  if (typeof depth !== 'number' || depth < 0 || depth > 1) {
+    return json({ error: 'depth must be number 0.0 to 1.0' }, 400);
+  }
+
+  db.insert(tables.guildSettings)
+    .values({
+      id: 1,
+      tremoloEnabled: enabled,
+      tremoloFrequency: frequency,
+      tremoloDepth: depth,
+    })
+    .onConflictDoUpdate({
+      target: tables.guildSettings.id,
+      set: {
+        tremoloEnabled: enabled,
+        tremoloFrequency: frequency,
+        tremoloDepth: depth,
+      },
+    })
+    .run();
+
+  await syncAllFilters();
+
+  return json({ enabled, frequency, depth });
+}
+
+export const handleTremolo = routeTable('/api/settings/tremolo', {
+  routes: [
+    ['GET', '/', handleTremoloGet],
+    ['PATCH', '/', handleTremoloPatch],
+  ],
+});

--- a/packages/server/src/routes/vibrato.ts
+++ b/packages/server/src/routes/vibrato.ts
@@ -1,0 +1,91 @@
+import { eq } from 'drizzle-orm';
+
+import { type RouteContext } from '../lib/context';
+import { json } from '../lib/json';
+import { checkGuards } from '../lib/routeGuards';
+import { routeTable } from '../lib/routeTable';
+import { syncAllFilters } from '../lib/syncAllFilters';
+import { db, tables } from '../shared/db';
+
+interface VibratoPayload {
+  enabled: boolean;
+  frequency: number;
+  depth: number;
+}
+
+function handleVibratoGet(
+  ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Response {
+  const guards = checkGuards(ctx, { admin: true, permission: 'audio.manage' });
+  if (guards instanceof Response) {
+    return guards;
+  }
+
+  const row = db.select().from(tables.guildSettings).where(eq(tables.guildSettings.id, 1)).get();
+
+  return json({
+    enabled: row?.vibratoEnabled ?? false,
+    frequency: row?.vibratoFrequency ?? 2.0,
+    depth: row?.vibratoDepth ?? 0.5,
+  });
+}
+
+async function handleVibratoPatch(
+  ctx: RouteContext,
+  request: Request,
+  _params: Record<string, string>
+): Promise<Response> {
+  const guards = checkGuards(ctx, { admin: true, permission: 'audio.manage' });
+  if (guards instanceof Response) {
+    return guards;
+  }
+
+  let body: VibratoPayload;
+  try {
+    body = (await request.json()) as VibratoPayload;
+  } catch {
+    return json({ error: 'Invalid JSON' }, 400);
+  }
+
+  const { enabled, frequency, depth } = body;
+
+  if (typeof enabled !== 'boolean') {
+    return json({ error: 'enabled must be boolean' }, 400);
+  }
+  if (typeof frequency !== 'number' || frequency < 0.1 || frequency > 14.0) {
+    return json({ error: 'frequency must be number 0.1 to 14.0' }, 400);
+  }
+  if (typeof depth !== 'number' || depth < 0 || depth > 1) {
+    return json({ error: 'depth must be number 0.0 to 1.0' }, 400);
+  }
+
+  db.insert(tables.guildSettings)
+    .values({
+      id: 1,
+      vibratoEnabled: enabled,
+      vibratoFrequency: frequency,
+      vibratoDepth: depth,
+    })
+    .onConflictDoUpdate({
+      target: tables.guildSettings.id,
+      set: {
+        vibratoEnabled: enabled,
+        vibratoFrequency: frequency,
+        vibratoDepth: depth,
+      },
+    })
+    .run();
+
+  await syncAllFilters();
+
+  return json({ enabled, frequency, depth });
+}
+
+export const handleVibrato = routeTable('/api/settings/vibrato', {
+  routes: [
+    ['GET', '/', handleVibratoGet],
+    ['PATCH', '/', handleVibratoPatch],
+  ],
+});

--- a/packages/server/src/shared/db/migrations/0013_add_audio_filters.sql
+++ b/packages/server/src/shared/db/migrations/0013_add_audio_filters.sql
@@ -1,0 +1,65 @@
+ALTER TABLE `guildSettings` ADD COLUMN `karaokeEnabled` integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `karaokeLevel` real NOT NULL DEFAULT 1.0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `karaokeMonoLevel` real NOT NULL DEFAULT 1.0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `karaokeFilterBand` real NOT NULL DEFAULT 220.0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `karaokeFilterWidth` real NOT NULL DEFAULT 100.0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `timescaleEnabled` integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `timescaleSpeed` real NOT NULL DEFAULT 1.0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `timescalePitch` real NOT NULL DEFAULT 1.0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `timescaleRate` real NOT NULL DEFAULT 1.0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `tremoloEnabled` integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `tremoloFrequency` real NOT NULL DEFAULT 2.0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `tremoloDepth` real NOT NULL DEFAULT 0.5;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `vibratoEnabled` integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `vibratoFrequency` real NOT NULL DEFAULT 2.0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `vibratoDepth` real NOT NULL DEFAULT 0.5;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `rotationEnabled` integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `rotationHz` real NOT NULL DEFAULT 0.0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `distortionEnabled` integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `distortionSinOffset` real NOT NULL DEFAULT 0.0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `distortionSinScale` real NOT NULL DEFAULT 1.0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `distortionCosOffset` real NOT NULL DEFAULT 0.0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `distortionCosScale` real NOT NULL DEFAULT 1.0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `distortionTanOffset` real NOT NULL DEFAULT 0.0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `distortionTanScale` real NOT NULL DEFAULT 1.0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `distortionOffset` real NOT NULL DEFAULT 0.0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `distortionScale` real NOT NULL DEFAULT 1.0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `channelMixEnabled` integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `channelMixLeftToLeft` real NOT NULL DEFAULT 1.0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `channelMixLeftToRight` real NOT NULL DEFAULT 0.0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `channelMixRightToLeft` real NOT NULL DEFAULT 0.0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `channelMixRightToRight` real NOT NULL DEFAULT 1.0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `lowPassEnabled` integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE `guildSettings` ADD COLUMN `lowPassSmoothing` real NOT NULL DEFAULT 20.0;

--- a/packages/server/src/shared/db/schema.ts
+++ b/packages/server/src/shared/db/schema.ts
@@ -111,6 +111,55 @@ export const guildSettings = sqliteTable('guildSettings', {
   eqBand13: integer('eqBand13').notNull().default(50),
   eqBand14: integer('eqBand14').notNull().default(50),
 
+  // Karaoke filter
+  karaokeEnabled: integer('karaokeEnabled', { mode: 'boolean' }).notNull().default(false),
+  karaokeLevel: real('karaokeLevel').notNull().default(1.0),
+  karaokeMonoLevel: real('karaokeMonoLevel').notNull().default(1.0),
+  karaokeFilterBand: real('karaokeFilterBand').notNull().default(220.0),
+  karaokeFilterWidth: real('karaokeFilterWidth').notNull().default(100.0),
+
+  // Timescale filter
+  timescaleEnabled: integer('timescaleEnabled', { mode: 'boolean' }).notNull().default(false),
+  timescaleSpeed: real('timescaleSpeed').notNull().default(1.0),
+  timescalePitch: real('timescalePitch').notNull().default(1.0),
+  timescaleRate: real('timescaleRate').notNull().default(1.0),
+
+  // Tremolo filter
+  tremoloEnabled: integer('tremoloEnabled', { mode: 'boolean' }).notNull().default(false),
+  tremoloFrequency: real('tremoloFrequency').notNull().default(2.0),
+  tremoloDepth: real('tremoloDepth').notNull().default(0.5),
+
+  // Vibrato filter
+  vibratoEnabled: integer('vibratoEnabled', { mode: 'boolean' }).notNull().default(false),
+  vibratoFrequency: real('vibratoFrequency').notNull().default(2.0),
+  vibratoDepth: real('vibratoDepth').notNull().default(0.5),
+
+  // Rotation filter
+  rotationEnabled: integer('rotationEnabled', { mode: 'boolean' }).notNull().default(false),
+  rotationHz: real('rotationHz').notNull().default(0.0),
+
+  // Distortion filter
+  distortionEnabled: integer('distortionEnabled', { mode: 'boolean' }).notNull().default(false),
+  distortionSinOffset: real('distortionSinOffset').notNull().default(0.0),
+  distortionSinScale: real('distortionSinScale').notNull().default(1.0),
+  distortionCosOffset: real('distortionCosOffset').notNull().default(0.0),
+  distortionCosScale: real('distortionCosScale').notNull().default(1.0),
+  distortionTanOffset: real('distortionTanOffset').notNull().default(0.0),
+  distortionTanScale: real('distortionTanScale').notNull().default(1.0),
+  distortionOffset: real('distortionOffset').notNull().default(0.0),
+  distortionScale: real('distortionScale').notNull().default(1.0),
+
+  // Channel mix filter
+  channelMixEnabled: integer('channelMixEnabled', { mode: 'boolean' }).notNull().default(false),
+  channelMixLeftToLeft: real('channelMixLeftToLeft').notNull().default(1.0),
+  channelMixLeftToRight: real('channelMixLeftToRight').notNull().default(0.0),
+  channelMixRightToLeft: real('channelMixRightToLeft').notNull().default(0.0),
+  channelMixRightToRight: real('channelMixRightToRight').notNull().default(1.0),
+
+  // Low pass filter
+  lowPassEnabled: integer('lowPassEnabled', { mode: 'boolean' }).notNull().default(false),
+  lowPassSmoothing: real('lowPassSmoothing').notNull().default(20.0),
+
   // General setup / admin settings
   guildId: text('guildId'),
   setupCompleted: integer('setupCompleted', { mode: 'boolean' }).notNull().default(false),

--- a/packages/web/src/components/settings/ChannelMixSection.tsx
+++ b/packages/web/src/components/settings/ChannelMixSection.tsx
@@ -1,0 +1,199 @@
+import type React from 'react';
+
+import { ArrowCounterClockwiseIcon, FloppyDiskIcon } from '@phosphor-icons/react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useAdminView } from '../../context/AdminViewContext';
+import { usePermissions } from '../../context/PermissionsContext';
+import { Button } from '../ui/Button';
+
+const DEFAULTS = {
+  enabled: false,
+  leftToLeft: 1.0,
+  leftToRight: 0.0,
+  rightToLeft: 0.0,
+  rightToRight: 1.0,
+};
+
+const SLIDERS = [
+  { key: 'leftToLeft', label: 'L → L', min: 0.0, max: 1.0, step: 0.05, unit: '' },
+  { key: 'leftToRight', label: 'L → R', min: 0.0, max: 1.0, step: 0.05, unit: '' },
+  { key: 'rightToLeft', label: 'R → L', min: 0.0, max: 1.0, step: 0.05, unit: '' },
+  { key: 'rightToRight', label: 'R → R', min: 0.0, max: 1.0, step: 0.05, unit: '' },
+] as const;
+
+type SliderKey = (typeof SLIDERS)[number]['key'];
+
+interface ChannelMixSliderProps {
+  config: (typeof SLIDERS)[number];
+  value: number;
+  onChange: (key: SliderKey, value: number) => void;
+}
+
+const ChannelMixSlider = memo(function ChannelMixSlider({
+  config: { key, label, min, max, step },
+  value,
+  onChange,
+}: ChannelMixSliderProps) {
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => onChange(key, parseFloat(e.target.value)),
+    [onChange, key]
+  );
+
+  const rangePct = ((value - min) / (max - min)) * 100;
+  const sliderStyle = useMemo(
+    () => ({ '--range-pct': `${rangePct}%` }) as React.CSSProperties,
+    [rangePct]
+  );
+
+  return (
+    <div className='flex items-center gap-3'>
+      <span className='font-mono text-[11px] text-muted w-16 shrink-0'>{label}</span>
+      <span className='font-mono text-[11px] text-fg w-12 shrink-0'>{value.toFixed(2)}</span>
+      <input
+        type='range'
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={handleChange}
+        className='flex-1 range-input range-input-h'
+        style={sliderStyle}
+      />
+    </div>
+  );
+});
+
+interface ChannelMixValues {
+  enabled: boolean;
+  leftToLeft: number;
+  leftToRight: number;
+  rightToLeft: number;
+  rightToRight: number;
+}
+
+export default function ChannelMixSection() {
+  const { isAdminView } = useAdminView();
+  const { hasPermission } = usePermissions();
+
+  const canManage = isAdminView || hasPermission('audio.manage');
+  const [values, setValues] = useState<ChannelMixValues>(DEFAULTS);
+  const [savedValues, setSavedValues] = useState<ChannelMixValues>(DEFAULTS);
+  const [saving, setSaving] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/settings/channelmix');
+        if (res.ok) {
+          const data = (await res.json()) as ChannelMixValues;
+          setValues(data);
+          setSavedValues(data);
+        }
+      } catch {
+        // silently fail
+      } finally {
+        setLoaded(true);
+      }
+    }
+    if (canManage) {
+      void load();
+    } else {
+      setLoaded(true);
+    }
+  }, [canManage]);
+
+  const hasChanges = JSON.stringify(values) !== JSON.stringify(savedValues);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      const res = await fetch('/api/settings/channelmix', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values),
+      });
+      if (res.ok) {
+        setSavedValues(values);
+      } else {
+        // eslint-disable-next-line no-console
+        console.error('Failed to save channel mix settings:', res.status);
+      }
+    } finally {
+      setSaving(false);
+    }
+  }, [values]);
+
+  const handleReset = useCallback(() => {
+    setValues({ ...DEFAULTS, enabled: values.enabled });
+  }, [values.enabled]);
+
+  const updateValue = useCallback((key: SliderKey, value: number) => {
+    setValues((v) => ({ ...v, [key]: value }));
+  }, []);
+
+  const handleToggle = useCallback(() => setValues((v) => ({ ...v, enabled: !v.enabled })), []);
+
+  const dimmed = !canManage;
+
+  if (!loaded) {
+    return null;
+  }
+
+  return (
+    <div className={`space-y-3 ${dimmed ? 'opacity-40 pointer-events-none' : ''}`}>
+      <div className='flex items-center gap-3'>
+        <span className='font-mono text-[11px] text-muted w-20 shrink-0'>Enabled</span>
+        <button
+          type='button'
+          role='switch'
+          aria-checked={values.enabled}
+          aria-label='Enable channel mix'
+          onClick={handleToggle}
+          className={`relative shrink-0 w-9 h-5 rounded-full transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface ${
+            values.enabled ? 'bg-accent' : 'bg-border'
+          }`}
+        >
+          <span
+            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform bg-elevated ${
+              values.enabled ? 'translate-x-4' : 'translate-x-0'
+            }`}
+          />
+        </button>
+      </div>
+
+      <div className={`space-y-2 ${!values.enabled ? 'opacity-40' : ''}`}>
+        {SLIDERS.map((config) => (
+          <ChannelMixSlider
+            key={config.key}
+            config={config}
+            value={values[config.key]}
+            onChange={updateValue}
+          />
+        ))}
+      </div>
+
+      <div className='flex gap-2 pt-1 justify-end'>
+        <Button
+          variant='primary'
+          size='icon'
+          onClick={handleSave}
+          disabled={!hasChanges || saving}
+          title={saving ? 'Saving…' : 'Save Changes'}
+        >
+          <FloppyDiskIcon size={16} weight='duotone' />
+        </Button>
+        <Button
+          variant='inherit'
+          size='icon'
+          surface='elevated'
+          onClick={handleReset}
+          title='Reset to Defaults'
+        >
+          <ArrowCounterClockwiseIcon size={16} weight='duotone' />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/DistortionSection.tsx
+++ b/packages/web/src/components/settings/DistortionSection.tsx
@@ -1,0 +1,211 @@
+import type React from 'react';
+
+import { ArrowCounterClockwiseIcon, FloppyDiskIcon } from '@phosphor-icons/react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useAdminView } from '../../context/AdminViewContext';
+import { usePermissions } from '../../context/PermissionsContext';
+import { Button } from '../ui/Button';
+
+const DEFAULTS = {
+  enabled: false,
+  sinOffset: 0.0,
+  sinScale: 1.0,
+  cosOffset: 0.0,
+  cosScale: 1.0,
+  tanOffset: 0.0,
+  tanScale: 1.0,
+  offset: 0.0,
+  scale: 1.0,
+};
+
+const SLIDERS = [
+  { key: 'sinOffset', label: 'Sin Offset', min: -1.0, max: 1.0, step: 0.05, unit: '' },
+  { key: 'sinScale', label: 'Sin Scale', min: 0.0, max: 5.0, step: 0.1, unit: '' },
+  { key: 'cosOffset', label: 'Cos Offset', min: -1.0, max: 1.0, step: 0.05, unit: '' },
+  { key: 'cosScale', label: 'Cos Scale', min: 0.0, max: 5.0, step: 0.1, unit: '' },
+  { key: 'tanOffset', label: 'Tan Offset', min: -1.0, max: 1.0, step: 0.05, unit: '' },
+  { key: 'tanScale', label: 'Tan Scale', min: 0.0, max: 5.0, step: 0.1, unit: '' },
+  { key: 'offset', label: 'Offset', min: -1.0, max: 1.0, step: 0.05, unit: '' },
+  { key: 'scale', label: 'Scale', min: 0.0, max: 5.0, step: 0.1, unit: '' },
+] as const;
+
+type SliderKey = (typeof SLIDERS)[number]['key'];
+
+interface DistortionSliderProps {
+  config: (typeof SLIDERS)[number];
+  value: number;
+  onChange: (key: SliderKey, value: number) => void;
+}
+
+const DistortionSlider = memo(function DistortionSlider({
+  config: { key, label, min, max, step },
+  value,
+  onChange,
+}: DistortionSliderProps) {
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => onChange(key, parseFloat(e.target.value)),
+    [onChange, key]
+  );
+
+  const rangePct = ((value - min) / (max - min)) * 100;
+  const sliderStyle = useMemo(
+    () => ({ '--range-pct': `${rangePct}%` }) as React.CSSProperties,
+    [rangePct]
+  );
+
+  return (
+    <div className='flex items-center gap-3'>
+      <span className='font-mono text-[11px] text-muted w-20 shrink-0'>{label}</span>
+      <span className='font-mono text-[11px] text-fg w-14 shrink-0'>{value.toFixed(2)}</span>
+      <input
+        type='range'
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={handleChange}
+        className='flex-1 range-input range-input-h'
+        style={sliderStyle}
+      />
+    </div>
+  );
+});
+
+interface DistortionValues {
+  enabled: boolean;
+  sinOffset: number;
+  sinScale: number;
+  cosOffset: number;
+  cosScale: number;
+  tanOffset: number;
+  tanScale: number;
+  offset: number;
+  scale: number;
+}
+
+export default function DistortionSection() {
+  const { isAdminView } = useAdminView();
+  const { hasPermission } = usePermissions();
+
+  const canManage = isAdminView || hasPermission('audio.manage');
+  const [values, setValues] = useState<DistortionValues>(DEFAULTS);
+  const [savedValues, setSavedValues] = useState<DistortionValues>(DEFAULTS);
+  const [saving, setSaving] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/settings/distortion');
+        if (res.ok) {
+          const data = (await res.json()) as DistortionValues;
+          setValues(data);
+          setSavedValues(data);
+        }
+      } catch {
+        // silently fail
+      } finally {
+        setLoaded(true);
+      }
+    }
+    if (canManage) {
+      void load();
+    } else {
+      setLoaded(true);
+    }
+  }, [canManage]);
+
+  const hasChanges = JSON.stringify(values) !== JSON.stringify(savedValues);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      const res = await fetch('/api/settings/distortion', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values),
+      });
+      if (res.ok) {
+        setSavedValues(values);
+      } else {
+        // eslint-disable-next-line no-console
+        console.error('Failed to save distortion settings:', res.status);
+      }
+    } finally {
+      setSaving(false);
+    }
+  }, [values]);
+
+  const handleReset = useCallback(() => {
+    setValues({ ...DEFAULTS, enabled: values.enabled });
+  }, [values.enabled]);
+
+  const updateValue = useCallback((key: SliderKey, value: number) => {
+    setValues((v) => ({ ...v, [key]: value }));
+  }, []);
+
+  const handleToggle = useCallback(() => setValues((v) => ({ ...v, enabled: !v.enabled })), []);
+
+  const dimmed = !canManage;
+
+  if (!loaded) {
+    return null;
+  }
+
+  return (
+    <div className={`space-y-3 ${dimmed ? 'opacity-40 pointer-events-none' : ''}`}>
+      <div className='flex items-center gap-3'>
+        <span className='font-mono text-[11px] text-muted w-20 shrink-0'>Enabled</span>
+        <button
+          type='button'
+          role='switch'
+          aria-checked={values.enabled}
+          aria-label='Enable distortion'
+          onClick={handleToggle}
+          className={`relative shrink-0 w-9 h-5 rounded-full transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface ${
+            values.enabled ? 'bg-accent' : 'bg-border'
+          }`}
+        >
+          <span
+            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform bg-elevated ${
+              values.enabled ? 'translate-x-4' : 'translate-x-0'
+            }`}
+          />
+        </button>
+      </div>
+
+      <div className={`space-y-2 ${!values.enabled ? 'opacity-40' : ''}`}>
+        {SLIDERS.map((config) => (
+          <DistortionSlider
+            key={config.key}
+            config={config}
+            value={values[config.key]}
+            onChange={updateValue}
+          />
+        ))}
+      </div>
+
+      <div className='flex gap-2 pt-1 justify-end'>
+        <Button
+          variant='primary'
+          size='icon'
+          onClick={handleSave}
+          disabled={!hasChanges || saving}
+          title={saving ? 'Saving…' : 'Save Changes'}
+        >
+          <FloppyDiskIcon size={16} weight='duotone' />
+        </Button>
+        <Button
+          variant='inherit'
+          size='icon'
+          surface='elevated'
+          onClick={handleReset}
+          title='Reset to Defaults'
+        >
+          <ArrowCounterClockwiseIcon size={16} weight='duotone' />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/KaraokeSection.tsx
+++ b/packages/web/src/components/settings/KaraokeSection.tsx
@@ -1,0 +1,201 @@
+import type React from 'react';
+
+import { ArrowCounterClockwiseIcon, FloppyDiskIcon } from '@phosphor-icons/react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useAdminView } from '../../context/AdminViewContext';
+import { usePermissions } from '../../context/PermissionsContext';
+import { Button } from '../ui/Button';
+
+const DEFAULTS = {
+  enabled: false,
+  level: 1.0,
+  monoLevel: 1.0,
+  filterBand: 220.0,
+  filterWidth: 100.0,
+};
+
+const SLIDERS = [
+  { key: 'level', label: 'Level', min: 0, max: 1, step: 0.05, unit: '' },
+  { key: 'monoLevel', label: 'Mono Level', min: 0, max: 1, step: 0.05, unit: '' },
+  { key: 'filterBand', label: 'Filter Band', min: 50, max: 10000, step: 10, unit: 'Hz' },
+  { key: 'filterWidth', label: 'Filter Width', min: 10, max: 10000, step: 10, unit: 'Hz' },
+] as const;
+
+type SliderKey = (typeof SLIDERS)[number]['key'];
+
+interface KaraokeSliderProps {
+  config: (typeof SLIDERS)[number];
+  value: number;
+  onChange: (key: SliderKey, value: number) => void;
+}
+
+const KaraokeSlider = memo(function KaraokeSlider({
+  config: { key, label, min, max, step, unit },
+  value,
+  onChange,
+}: KaraokeSliderProps) {
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => onChange(key, parseFloat(e.target.value)),
+    [onChange, key]
+  );
+
+  const rangePct = ((value - min) / (max - min)) * 100;
+  const sliderStyle = useMemo(
+    () => ({ '--range-pct': `${rangePct}%` }) as React.CSSProperties,
+    [rangePct]
+  );
+
+  return (
+    <div className='flex items-center gap-3'>
+      <span className='font-mono text-[11px] text-muted w-24 shrink-0'>{label}</span>
+      <span className='font-mono text-[11px] text-fg w-20 shrink-0'>
+        {unit ? `${value.toFixed(2)} ${unit}` : value.toFixed(2)}
+      </span>
+      <input
+        type='range'
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={handleChange}
+        className='flex-1 range-input range-input-h'
+        style={sliderStyle}
+      />
+    </div>
+  );
+});
+
+interface KaraokeValues {
+  enabled: boolean;
+  level: number;
+  monoLevel: number;
+  filterBand: number;
+  filterWidth: number;
+}
+
+export default function KaraokeSection() {
+  const { isAdminView } = useAdminView();
+  const { hasPermission } = usePermissions();
+
+  const canManage = isAdminView || hasPermission('audio.manage');
+  const [values, setValues] = useState<KaraokeValues>(DEFAULTS);
+  const [savedValues, setSavedValues] = useState<KaraokeValues>(DEFAULTS);
+  const [saving, setSaving] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/settings/karaoke');
+        if (res.ok) {
+          const data = (await res.json()) as KaraokeValues;
+          setValues(data);
+          setSavedValues(data);
+        }
+      } catch {
+        // silently fail
+      } finally {
+        setLoaded(true);
+      }
+    }
+    if (canManage) {
+      void load();
+    } else {
+      setLoaded(true);
+    }
+  }, [canManage]);
+
+  const hasChanges = JSON.stringify(values) !== JSON.stringify(savedValues);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      const res = await fetch('/api/settings/karaoke', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values),
+      });
+      if (res.ok) {
+        setSavedValues(values);
+      } else {
+        // eslint-disable-next-line no-console
+        console.error('Failed to save karaoke settings:', res.status);
+      }
+    } finally {
+      setSaving(false);
+    }
+  }, [values]);
+
+  const handleReset = useCallback(() => {
+    setValues({ ...DEFAULTS, enabled: values.enabled });
+  }, [values.enabled]);
+
+  const updateValue = useCallback((key: SliderKey, value: number) => {
+    setValues((v) => ({ ...v, [key]: value }));
+  }, []);
+
+  const handleToggle = useCallback(() => setValues((v) => ({ ...v, enabled: !v.enabled })), []);
+
+  const dimmed = !canManage;
+
+  if (!loaded) {
+    return null;
+  }
+
+  return (
+    <div className={`space-y-3 ${dimmed ? 'opacity-40 pointer-events-none' : ''}`}>
+      <div className='flex items-center gap-3'>
+        <span className='font-mono text-[11px] text-muted w-20 shrink-0'>Enabled</span>
+        <button
+          type='button'
+          role='switch'
+          aria-checked={values.enabled}
+          aria-label='Enable karaoke'
+          onClick={handleToggle}
+          className={`relative shrink-0 w-9 h-5 rounded-full transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface ${
+            values.enabled ? 'bg-accent' : 'bg-border'
+          }`}
+        >
+          <span
+            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform bg-elevated ${
+              values.enabled ? 'translate-x-4' : 'translate-x-0'
+            }`}
+          />
+        </button>
+      </div>
+
+      <div className={`space-y-2 ${!values.enabled ? 'opacity-40' : ''}`}>
+        {SLIDERS.map((config) => (
+          <KaraokeSlider
+            key={config.key}
+            config={config}
+            value={values[config.key]}
+            onChange={updateValue}
+          />
+        ))}
+      </div>
+
+      <div className='flex gap-2 pt-1 justify-end'>
+        <Button
+          variant='primary'
+          size='icon'
+          onClick={handleSave}
+          disabled={!hasChanges || saving}
+          title={saving ? 'Saving…' : 'Save Changes'}
+        >
+          <FloppyDiskIcon size={16} weight='duotone' />
+        </Button>
+        <Button
+          variant='inherit'
+          size='icon'
+          surface='elevated'
+          onClick={handleReset}
+          title='Reset to Defaults'
+        >
+          <ArrowCounterClockwiseIcon size={16} weight='duotone' />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/LowPassSection.tsx
+++ b/packages/web/src/components/settings/LowPassSection.tsx
@@ -1,0 +1,187 @@
+import type React from 'react';
+
+import { ArrowCounterClockwiseIcon, FloppyDiskIcon } from '@phosphor-icons/react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useAdminView } from '../../context/AdminViewContext';
+import { usePermissions } from '../../context/PermissionsContext';
+import { Button } from '../ui/Button';
+
+const DEFAULTS = { enabled: false, smoothing: 20.0 };
+
+const SLIDERS = [
+  { key: 'smoothing', label: 'Smoothing', min: 0.0, max: 60.0, step: 0.5, unit: '' },
+] as const;
+
+type SliderKey = (typeof SLIDERS)[number]['key'];
+
+interface LowPassSliderProps {
+  config: (typeof SLIDERS)[number];
+  value: number;
+  onChange: (key: SliderKey, value: number) => void;
+}
+
+const LowPassSlider = memo(function LowPassSlider({
+  config: { key, label, min, max, step },
+  value,
+  onChange,
+}: LowPassSliderProps) {
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => onChange(key, parseFloat(e.target.value)),
+    [onChange, key]
+  );
+
+  const rangePct = ((value - min) / (max - min)) * 100;
+  const sliderStyle = useMemo(
+    () => ({ '--range-pct': `${rangePct}%` }) as React.CSSProperties,
+    [rangePct]
+  );
+
+  return (
+    <div className='flex items-center gap-3'>
+      <span className='font-mono text-[11px] text-muted w-20 shrink-0'>{label}</span>
+      <span className='font-mono text-[11px] text-fg w-16 shrink-0'>{value.toFixed(1)}</span>
+      <input
+        type='range'
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={handleChange}
+        className='flex-1 range-input range-input-h'
+        style={sliderStyle}
+      />
+    </div>
+  );
+});
+
+interface LowPassValues {
+  enabled: boolean;
+  smoothing: number;
+}
+
+export default function LowPassSection() {
+  const { isAdminView } = useAdminView();
+  const { hasPermission } = usePermissions();
+
+  const canManage = isAdminView || hasPermission('audio.manage');
+  const [values, setValues] = useState<LowPassValues>(DEFAULTS);
+  const [savedValues, setSavedValues] = useState<LowPassValues>(DEFAULTS);
+  const [saving, setSaving] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/settings/lowpass');
+        if (res.ok) {
+          const data = (await res.json()) as LowPassValues;
+          setValues(data);
+          setSavedValues(data);
+        }
+      } catch {
+        // silently fail
+      } finally {
+        setLoaded(true);
+      }
+    }
+    if (canManage) {
+      void load();
+    } else {
+      setLoaded(true);
+    }
+  }, [canManage]);
+
+  const hasChanges = JSON.stringify(values) !== JSON.stringify(savedValues);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      const res = await fetch('/api/settings/lowpass', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values),
+      });
+      if (res.ok) {
+        setSavedValues(values);
+      } else {
+        // eslint-disable-next-line no-console
+        console.error('Failed to save low pass settings:', res.status);
+      }
+    } finally {
+      setSaving(false);
+    }
+  }, [values]);
+
+  const handleReset = useCallback(() => {
+    setValues({ ...DEFAULTS, enabled: values.enabled });
+  }, [values.enabled]);
+
+  const updateValue = useCallback((key: SliderKey, value: number) => {
+    setValues((v) => ({ ...v, [key]: value }));
+  }, []);
+
+  const handleToggle = useCallback(() => setValues((v) => ({ ...v, enabled: !v.enabled })), []);
+
+  const dimmed = !canManage;
+
+  if (!loaded) {
+    return null;
+  }
+
+  return (
+    <div className={`space-y-3 ${dimmed ? 'opacity-40 pointer-events-none' : ''}`}>
+      <div className='flex items-center gap-3'>
+        <span className='font-mono text-[11px] text-muted w-20 shrink-0'>Enabled</span>
+        <button
+          type='button'
+          role='switch'
+          aria-checked={values.enabled}
+          aria-label='Enable low pass'
+          onClick={handleToggle}
+          className={`relative shrink-0 w-9 h-5 rounded-full transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface ${
+            values.enabled ? 'bg-accent' : 'bg-border'
+          }`}
+        >
+          <span
+            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform bg-elevated ${
+              values.enabled ? 'translate-x-4' : 'translate-x-0'
+            }`}
+          />
+        </button>
+      </div>
+
+      <div className={`space-y-2 ${!values.enabled ? 'opacity-40' : ''}`}>
+        {SLIDERS.map((config) => (
+          <LowPassSlider
+            key={config.key}
+            config={config}
+            value={values[config.key]}
+            onChange={updateValue}
+          />
+        ))}
+      </div>
+
+      <div className='flex gap-2 pt-1 justify-end'>
+        <Button
+          variant='primary'
+          size='icon'
+          onClick={handleSave}
+          disabled={!hasChanges || saving}
+          title={saving ? 'Saving…' : 'Save Changes'}
+        >
+          <FloppyDiskIcon size={16} weight='duotone' />
+        </Button>
+        <Button
+          variant='inherit'
+          size='icon'
+          surface='elevated'
+          onClick={handleReset}
+          title='Reset to Defaults'
+        >
+          <ArrowCounterClockwiseIcon size={16} weight='duotone' />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/RotationSection.tsx
+++ b/packages/web/src/components/settings/RotationSection.tsx
@@ -1,0 +1,189 @@
+import type React from 'react';
+
+import { ArrowCounterClockwiseIcon, FloppyDiskIcon } from '@phosphor-icons/react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useAdminView } from '../../context/AdminViewContext';
+import { usePermissions } from '../../context/PermissionsContext';
+import { Button } from '../ui/Button';
+
+const DEFAULTS = { enabled: false, rotationHz: 0.0 };
+
+const SLIDERS = [
+  { key: 'rotationHz', label: 'Rotation Hz', min: 0.0, max: 1.0, step: 0.01, unit: 'Hz' },
+] as const;
+
+type SliderKey = (typeof SLIDERS)[number]['key'];
+
+interface RotationSliderProps {
+  config: (typeof SLIDERS)[number];
+  value: number;
+  onChange: (key: SliderKey, value: number) => void;
+}
+
+const RotationSlider = memo(function RotationSlider({
+  config: { key, label, min, max, step, unit },
+  value,
+  onChange,
+}: RotationSliderProps) {
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => onChange(key, parseFloat(e.target.value)),
+    [onChange, key]
+  );
+
+  const rangePct = ((value - min) / (max - min)) * 100;
+  const sliderStyle = useMemo(
+    () => ({ '--range-pct': `${rangePct}%` }) as React.CSSProperties,
+    [rangePct]
+  );
+
+  return (
+    <div className='flex items-center gap-3'>
+      <span className='font-mono text-[11px] text-muted w-20 shrink-0'>{label}</span>
+      <span className='font-mono text-[11px] text-fg w-16 shrink-0'>
+        {value.toFixed(2)} {unit}
+      </span>
+      <input
+        type='range'
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={handleChange}
+        className='flex-1 range-input range-input-h'
+        style={sliderStyle}
+      />
+    </div>
+  );
+});
+
+interface RotationValues {
+  enabled: boolean;
+  rotationHz: number;
+}
+
+export default function RotationSection() {
+  const { isAdminView } = useAdminView();
+  const { hasPermission } = usePermissions();
+
+  const canManage = isAdminView || hasPermission('audio.manage');
+  const [values, setValues] = useState<RotationValues>(DEFAULTS);
+  const [savedValues, setSavedValues] = useState<RotationValues>(DEFAULTS);
+  const [saving, setSaving] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/settings/rotation');
+        if (res.ok) {
+          const data = (await res.json()) as RotationValues;
+          setValues(data);
+          setSavedValues(data);
+        }
+      } catch {
+        // silently fail
+      } finally {
+        setLoaded(true);
+      }
+    }
+    if (canManage) {
+      void load();
+    } else {
+      setLoaded(true);
+    }
+  }, [canManage]);
+
+  const hasChanges = JSON.stringify(values) !== JSON.stringify(savedValues);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      const res = await fetch('/api/settings/rotation', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values),
+      });
+      if (res.ok) {
+        setSavedValues(values);
+      } else {
+        // eslint-disable-next-line no-console
+        console.error('Failed to save rotation settings:', res.status);
+      }
+    } finally {
+      setSaving(false);
+    }
+  }, [values]);
+
+  const handleReset = useCallback(() => {
+    setValues({ ...DEFAULTS, enabled: values.enabled });
+  }, [values.enabled]);
+
+  const updateValue = useCallback((key: SliderKey, value: number) => {
+    setValues((v) => ({ ...v, [key]: value }));
+  }, []);
+
+  const handleToggle = useCallback(() => setValues((v) => ({ ...v, enabled: !v.enabled })), []);
+
+  const dimmed = !canManage;
+
+  if (!loaded) {
+    return null;
+  }
+
+  return (
+    <div className={`space-y-3 ${dimmed ? 'opacity-40 pointer-events-none' : ''}`}>
+      <div className='flex items-center gap-3'>
+        <span className='font-mono text-[11px] text-muted w-20 shrink-0'>Enabled</span>
+        <button
+          type='button'
+          role='switch'
+          aria-checked={values.enabled}
+          aria-label='Enable rotation'
+          onClick={handleToggle}
+          className={`relative shrink-0 w-9 h-5 rounded-full transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface ${
+            values.enabled ? 'bg-accent' : 'bg-border'
+          }`}
+        >
+          <span
+            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform bg-elevated ${
+              values.enabled ? 'translate-x-4' : 'translate-x-0'
+            }`}
+          />
+        </button>
+      </div>
+
+      <div className={`space-y-2 ${!values.enabled ? 'opacity-40' : ''}`}>
+        {SLIDERS.map((config) => (
+          <RotationSlider
+            key={config.key}
+            config={config}
+            value={values[config.key]}
+            onChange={updateValue}
+          />
+        ))}
+      </div>
+
+      <div className='flex gap-2 pt-1 justify-end'>
+        <Button
+          variant='primary'
+          size='icon'
+          onClick={handleSave}
+          disabled={!hasChanges || saving}
+          title={saving ? 'Saving…' : 'Save Changes'}
+        >
+          <FloppyDiskIcon size={16} weight='duotone' />
+        </Button>
+        <Button
+          variant='inherit'
+          size='icon'
+          surface='elevated'
+          onClick={handleReset}
+          title='Reset to Defaults'
+        >
+          <ArrowCounterClockwiseIcon size={16} weight='duotone' />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/TimescaleSection.tsx
+++ b/packages/web/src/components/settings/TimescaleSection.tsx
@@ -1,0 +1,194 @@
+import type React from 'react';
+
+import { ArrowCounterClockwiseIcon, FloppyDiskIcon } from '@phosphor-icons/react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useAdminView } from '../../context/AdminViewContext';
+import { usePermissions } from '../../context/PermissionsContext';
+import { Button } from '../ui/Button';
+
+const DEFAULTS = { enabled: false, speed: 1.0, pitch: 1.0, rate: 1.0 };
+
+const SLIDERS = [
+  { key: 'speed', label: 'Speed', min: 0.5, max: 2.0, step: 0.05, unit: '×' },
+  { key: 'pitch', label: 'Pitch', min: 0.5, max: 2.0, step: 0.05, unit: '×' },
+  { key: 'rate', label: 'Rate', min: 0.5, max: 2.0, step: 0.05, unit: '×' },
+] as const;
+
+type SliderKey = (typeof SLIDERS)[number]['key'];
+
+interface TimescaleSliderProps {
+  config: (typeof SLIDERS)[number];
+  value: number;
+  onChange: (key: SliderKey, value: number) => void;
+}
+
+const TimescaleSlider = memo(function TimescaleSlider({
+  config: { key, label, min, max, step, unit },
+  value,
+  onChange,
+}: TimescaleSliderProps) {
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => onChange(key, parseFloat(e.target.value)),
+    [onChange, key]
+  );
+
+  const rangePct = ((value - min) / (max - min)) * 100;
+  const sliderStyle = useMemo(
+    () => ({ '--range-pct': `${rangePct}%` }) as React.CSSProperties,
+    [rangePct]
+  );
+
+  return (
+    <div className='flex items-center gap-3'>
+      <span className='font-mono text-[11px] text-muted w-16 shrink-0'>{label}</span>
+      <span className='font-mono text-[11px] text-fg w-16 shrink-0'>
+        {value.toFixed(2)}
+        {unit}
+      </span>
+      <input
+        type='range'
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={handleChange}
+        className='flex-1 range-input range-input-h'
+        style={sliderStyle}
+      />
+    </div>
+  );
+});
+
+interface TimescaleValues {
+  enabled: boolean;
+  speed: number;
+  pitch: number;
+  rate: number;
+}
+
+export default function TimescaleSection() {
+  const { isAdminView } = useAdminView();
+  const { hasPermission } = usePermissions();
+
+  const canManage = isAdminView || hasPermission('audio.manage');
+  const [values, setValues] = useState<TimescaleValues>(DEFAULTS);
+  const [savedValues, setSavedValues] = useState<TimescaleValues>(DEFAULTS);
+  const [saving, setSaving] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/settings/timescale');
+        if (res.ok) {
+          const data = (await res.json()) as TimescaleValues;
+          setValues(data);
+          setSavedValues(data);
+        }
+      } catch {
+        // silently fail
+      } finally {
+        setLoaded(true);
+      }
+    }
+    if (canManage) {
+      void load();
+    } else {
+      setLoaded(true);
+    }
+  }, [canManage]);
+
+  const hasChanges = JSON.stringify(values) !== JSON.stringify(savedValues);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      const res = await fetch('/api/settings/timescale', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values),
+      });
+      if (res.ok) {
+        setSavedValues(values);
+      } else {
+        // eslint-disable-next-line no-console
+        console.error('Failed to save timescale settings:', res.status);
+      }
+    } finally {
+      setSaving(false);
+    }
+  }, [values]);
+
+  const handleReset = useCallback(() => {
+    setValues({ ...DEFAULTS, enabled: values.enabled });
+  }, [values.enabled]);
+
+  const updateValue = useCallback((key: SliderKey, value: number) => {
+    setValues((v) => ({ ...v, [key]: value }));
+  }, []);
+
+  const handleToggle = useCallback(() => setValues((v) => ({ ...v, enabled: !v.enabled })), []);
+
+  const dimmed = !canManage;
+
+  if (!loaded) {
+    return null;
+  }
+
+  return (
+    <div className={`space-y-3 ${dimmed ? 'opacity-40 pointer-events-none' : ''}`}>
+      <div className='flex items-center gap-3'>
+        <span className='font-mono text-[11px] text-muted w-20 shrink-0'>Enabled</span>
+        <button
+          type='button'
+          role='switch'
+          aria-checked={values.enabled}
+          aria-label='Enable timescale'
+          onClick={handleToggle}
+          className={`relative shrink-0 w-9 h-5 rounded-full transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface ${
+            values.enabled ? 'bg-accent' : 'bg-border'
+          }`}
+        >
+          <span
+            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform bg-elevated ${
+              values.enabled ? 'translate-x-4' : 'translate-x-0'
+            }`}
+          />
+        </button>
+      </div>
+
+      <div className={`space-y-2 ${!values.enabled ? 'opacity-40' : ''}`}>
+        {SLIDERS.map((config) => (
+          <TimescaleSlider
+            key={config.key}
+            config={config}
+            value={values[config.key]}
+            onChange={updateValue}
+          />
+        ))}
+      </div>
+
+      <div className='flex gap-2 pt-1 justify-end'>
+        <Button
+          variant='primary'
+          size='icon'
+          onClick={handleSave}
+          disabled={!hasChanges || saving}
+          title={saving ? 'Saving…' : 'Save Changes'}
+        >
+          <FloppyDiskIcon size={16} weight='duotone' />
+        </Button>
+        <Button
+          variant='inherit'
+          size='icon'
+          surface='elevated'
+          onClick={handleReset}
+          title='Reset to Defaults'
+        >
+          <ArrowCounterClockwiseIcon size={16} weight='duotone' />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/TremoloSection.tsx
+++ b/packages/web/src/components/settings/TremoloSection.tsx
@@ -1,0 +1,191 @@
+import type React from 'react';
+
+import { ArrowCounterClockwiseIcon, FloppyDiskIcon } from '@phosphor-icons/react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useAdminView } from '../../context/AdminViewContext';
+import { usePermissions } from '../../context/PermissionsContext';
+import { Button } from '../ui/Button';
+
+const DEFAULTS = { enabled: false, frequency: 2.0, depth: 0.5 };
+
+const SLIDERS = [
+  { key: 'frequency', label: 'Frequency', min: 0.1, max: 14.0, step: 0.1, unit: 'Hz' },
+  { key: 'depth', label: 'Depth', min: 0.0, max: 1.0, step: 0.05, unit: '' },
+] as const;
+
+type SliderKey = (typeof SLIDERS)[number]['key'];
+
+interface TremoloSliderProps {
+  config: (typeof SLIDERS)[number];
+  value: number;
+  onChange: (key: SliderKey, value: number) => void;
+}
+
+const TremoloSlider = memo(function TremoloSlider({
+  config: { key, label, min, max, step, unit },
+  value,
+  onChange,
+}: TremoloSliderProps) {
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => onChange(key, parseFloat(e.target.value)),
+    [onChange, key]
+  );
+
+  const rangePct = ((value - min) / (max - min)) * 100;
+  const sliderStyle = useMemo(
+    () => ({ '--range-pct': `${rangePct}%` }) as React.CSSProperties,
+    [rangePct]
+  );
+
+  return (
+    <div className='flex items-center gap-3'>
+      <span className='font-mono text-[11px] text-muted w-20 shrink-0'>{label}</span>
+      <span className='font-mono text-[11px] text-fg w-16 shrink-0'>
+        {unit ? `${value.toFixed(1)} ${unit}` : value.toFixed(2)}
+      </span>
+      <input
+        type='range'
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={handleChange}
+        className='flex-1 range-input range-input-h'
+        style={sliderStyle}
+      />
+    </div>
+  );
+});
+
+interface TremoloValues {
+  enabled: boolean;
+  frequency: number;
+  depth: number;
+}
+
+export default function TremoloSection() {
+  const { isAdminView } = useAdminView();
+  const { hasPermission } = usePermissions();
+
+  const canManage = isAdminView || hasPermission('audio.manage');
+  const [values, setValues] = useState<TremoloValues>(DEFAULTS);
+  const [savedValues, setSavedValues] = useState<TremoloValues>(DEFAULTS);
+  const [saving, setSaving] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/settings/tremolo');
+        if (res.ok) {
+          const data = (await res.json()) as TremoloValues;
+          setValues(data);
+          setSavedValues(data);
+        }
+      } catch {
+        // silently fail
+      } finally {
+        setLoaded(true);
+      }
+    }
+    if (canManage) {
+      void load();
+    } else {
+      setLoaded(true);
+    }
+  }, [canManage]);
+
+  const hasChanges = JSON.stringify(values) !== JSON.stringify(savedValues);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      const res = await fetch('/api/settings/tremolo', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values),
+      });
+      if (res.ok) {
+        setSavedValues(values);
+      } else {
+        // eslint-disable-next-line no-console
+        console.error('Failed to save tremolo settings:', res.status);
+      }
+    } finally {
+      setSaving(false);
+    }
+  }, [values]);
+
+  const handleReset = useCallback(() => {
+    setValues({ ...DEFAULTS, enabled: values.enabled });
+  }, [values.enabled]);
+
+  const updateValue = useCallback((key: SliderKey, value: number) => {
+    setValues((v) => ({ ...v, [key]: value }));
+  }, []);
+
+  const handleToggle = useCallback(() => setValues((v) => ({ ...v, enabled: !v.enabled })), []);
+
+  const dimmed = !canManage;
+
+  if (!loaded) {
+    return null;
+  }
+
+  return (
+    <div className={`space-y-3 ${dimmed ? 'opacity-40 pointer-events-none' : ''}`}>
+      <div className='flex items-center gap-3'>
+        <span className='font-mono text-[11px] text-muted w-20 shrink-0'>Enabled</span>
+        <button
+          type='button'
+          role='switch'
+          aria-checked={values.enabled}
+          aria-label='Enable tremolo'
+          onClick={handleToggle}
+          className={`relative shrink-0 w-9 h-5 rounded-full transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface ${
+            values.enabled ? 'bg-accent' : 'bg-border'
+          }`}
+        >
+          <span
+            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform bg-elevated ${
+              values.enabled ? 'translate-x-4' : 'translate-x-0'
+            }`}
+          />
+        </button>
+      </div>
+
+      <div className={`space-y-2 ${!values.enabled ? 'opacity-40' : ''}`}>
+        {SLIDERS.map((config) => (
+          <TremoloSlider
+            key={config.key}
+            config={config}
+            value={values[config.key]}
+            onChange={updateValue}
+          />
+        ))}
+      </div>
+
+      <div className='flex gap-2 pt-1 justify-end'>
+        <Button
+          variant='primary'
+          size='icon'
+          onClick={handleSave}
+          disabled={!hasChanges || saving}
+          title={saving ? 'Saving…' : 'Save Changes'}
+        >
+          <FloppyDiskIcon size={16} weight='duotone' />
+        </Button>
+        <Button
+          variant='inherit'
+          size='icon'
+          surface='elevated'
+          onClick={handleReset}
+          title='Reset to Defaults'
+        >
+          <ArrowCounterClockwiseIcon size={16} weight='duotone' />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/VibratoSection.tsx
+++ b/packages/web/src/components/settings/VibratoSection.tsx
@@ -1,0 +1,191 @@
+import type React from 'react';
+
+import { ArrowCounterClockwiseIcon, FloppyDiskIcon } from '@phosphor-icons/react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useAdminView } from '../../context/AdminViewContext';
+import { usePermissions } from '../../context/PermissionsContext';
+import { Button } from '../ui/Button';
+
+const DEFAULTS = { enabled: false, frequency: 2.0, depth: 0.5 };
+
+const SLIDERS = [
+  { key: 'frequency', label: 'Frequency', min: 0.1, max: 14.0, step: 0.1, unit: 'Hz' },
+  { key: 'depth', label: 'Depth', min: 0.0, max: 1.0, step: 0.05, unit: '' },
+] as const;
+
+type SliderKey = (typeof SLIDERS)[number]['key'];
+
+interface VibratoSliderProps {
+  config: (typeof SLIDERS)[number];
+  value: number;
+  onChange: (key: SliderKey, value: number) => void;
+}
+
+const VibratoSlider = memo(function VibratoSlider({
+  config: { key, label, min, max, step, unit },
+  value,
+  onChange,
+}: VibratoSliderProps) {
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => onChange(key, parseFloat(e.target.value)),
+    [onChange, key]
+  );
+
+  const rangePct = ((value - min) / (max - min)) * 100;
+  const sliderStyle = useMemo(
+    () => ({ '--range-pct': `${rangePct}%` }) as React.CSSProperties,
+    [rangePct]
+  );
+
+  return (
+    <div className='flex items-center gap-3'>
+      <span className='font-mono text-[11px] text-muted w-20 shrink-0'>{label}</span>
+      <span className='font-mono text-[11px] text-fg w-16 shrink-0'>
+        {unit ? `${value.toFixed(1)} ${unit}` : value.toFixed(2)}
+      </span>
+      <input
+        type='range'
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={handleChange}
+        className='flex-1 range-input range-input-h'
+        style={sliderStyle}
+      />
+    </div>
+  );
+});
+
+interface VibratoValues {
+  enabled: boolean;
+  frequency: number;
+  depth: number;
+}
+
+export default function VibratoSection() {
+  const { isAdminView } = useAdminView();
+  const { hasPermission } = usePermissions();
+
+  const canManage = isAdminView || hasPermission('audio.manage');
+  const [values, setValues] = useState<VibratoValues>(DEFAULTS);
+  const [savedValues, setSavedValues] = useState<VibratoValues>(DEFAULTS);
+  const [saving, setSaving] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/settings/vibrato');
+        if (res.ok) {
+          const data = (await res.json()) as VibratoValues;
+          setValues(data);
+          setSavedValues(data);
+        }
+      } catch {
+        // silently fail
+      } finally {
+        setLoaded(true);
+      }
+    }
+    if (canManage) {
+      void load();
+    } else {
+      setLoaded(true);
+    }
+  }, [canManage]);
+
+  const hasChanges = JSON.stringify(values) !== JSON.stringify(savedValues);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      const res = await fetch('/api/settings/vibrato', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values),
+      });
+      if (res.ok) {
+        setSavedValues(values);
+      } else {
+        // eslint-disable-next-line no-console
+        console.error('Failed to save vibrato settings:', res.status);
+      }
+    } finally {
+      setSaving(false);
+    }
+  }, [values]);
+
+  const handleReset = useCallback(() => {
+    setValues({ ...DEFAULTS, enabled: values.enabled });
+  }, [values.enabled]);
+
+  const updateValue = useCallback((key: SliderKey, value: number) => {
+    setValues((v) => ({ ...v, [key]: value }));
+  }, []);
+
+  const handleToggle = useCallback(() => setValues((v) => ({ ...v, enabled: !v.enabled })), []);
+
+  const dimmed = !canManage;
+
+  if (!loaded) {
+    return null;
+  }
+
+  return (
+    <div className={`space-y-3 ${dimmed ? 'opacity-40 pointer-events-none' : ''}`}>
+      <div className='flex items-center gap-3'>
+        <span className='font-mono text-[11px] text-muted w-20 shrink-0'>Enabled</span>
+        <button
+          type='button'
+          role='switch'
+          aria-checked={values.enabled}
+          aria-label='Enable vibrato'
+          onClick={handleToggle}
+          className={`relative shrink-0 w-9 h-5 rounded-full transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface ${
+            values.enabled ? 'bg-accent' : 'bg-border'
+          }`}
+        >
+          <span
+            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform bg-elevated ${
+              values.enabled ? 'translate-x-4' : 'translate-x-0'
+            }`}
+          />
+        </button>
+      </div>
+
+      <div className={`space-y-2 ${!values.enabled ? 'opacity-40' : ''}`}>
+        {SLIDERS.map((config) => (
+          <VibratoSlider
+            key={config.key}
+            config={config}
+            value={values[config.key]}
+            onChange={updateValue}
+          />
+        ))}
+      </div>
+
+      <div className='flex gap-2 pt-1 justify-end'>
+        <Button
+          variant='primary'
+          size='icon'
+          onClick={handleSave}
+          disabled={!hasChanges || saving}
+          title={saving ? 'Saving…' : 'Save Changes'}
+        >
+          <FloppyDiskIcon size={16} weight='duotone' />
+        </Button>
+        <Button
+          variant='inherit'
+          size='icon'
+          surface='elevated'
+          onClick={handleReset}
+          title='Reset to Defaults'
+        >
+          <ArrowCounterClockwiseIcon size={16} weight='duotone' />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/pages/AudioPage.tsx
+++ b/packages/web/src/pages/AudioPage.tsx
@@ -1,10 +1,42 @@
-import { ArrowsDownUpIcon, SlidersHorizontalIcon } from '@phosphor-icons/react';
+import {
+  ArrowsDownUpIcon,
+  BarricadeIcon,
+  ChartBarIcon,
+  CirclesFourIcon,
+  GaugeIcon,
+  GuitarIcon,
+  MicrophoneStageIcon,
+  SlidersHorizontalIcon,
+  WaveSineIcon,
+  WavesIcon,
+} from '@phosphor-icons/react';
 
+import ChannelMixSection from '../components/settings/ChannelMixSection';
 import CompressorSection from '../components/settings/CompressorSection';
+import DistortionSection from '../components/settings/DistortionSection';
 import EqualizerSection from '../components/settings/EqualizerSection';
+import KaraokeSection from '../components/settings/KaraokeSection';
+import LowPassSection from '../components/settings/LowPassSection';
+import RotationSection from '../components/settings/RotationSection';
+import TimescaleSection from '../components/settings/TimescaleSection';
+import TremoloSection from '../components/settings/TremoloSection';
+import VibratoSection from '../components/settings/VibratoSection';
 import { PageHeader } from '../components/ui/PageHeader';
 import { useAdminView } from '../context/AdminViewContext';
 import { usePermissions } from '../context/PermissionsContext';
+
+const FILTER_CARDS = [
+  { icon: SlidersHorizontalIcon, label: 'Equalizer', component: EqualizerSection, wide: true },
+  { icon: ArrowsDownUpIcon, label: 'Compressor', component: CompressorSection, wide: true },
+  { icon: MicrophoneStageIcon, label: 'Karaoke', component: KaraokeSection, wide: true },
+  { icon: GaugeIcon, label: 'Timescale', component: TimescaleSection },
+  { icon: WaveSineIcon, label: 'Tremolo', component: TremoloSection },
+  { icon: WavesIcon, label: 'Vibrato', component: VibratoSection },
+  { icon: CirclesFourIcon, label: 'Rotation', component: RotationSection },
+  { icon: GuitarIcon, label: 'Distortion', component: DistortionSection, wide: true },
+  { icon: ChartBarIcon, label: 'Channel Mix', component: ChannelMixSection, wide: true },
+  { icon: BarricadeIcon, label: 'Low Pass', component: LowPassSection },
+];
 
 export default function AudioPage() {
   const { isAdminView } = useAdminView();
@@ -17,7 +49,7 @@ export default function AudioPage() {
       <PageHeader
         icon={SlidersHorizontalIcon}
         title='Audio'
-        subtitle='Equalizer and compressor settings'
+        subtitle='Equalizer, compressor, and audio effects'
       />
 
       {!canManage ? (
@@ -25,32 +57,22 @@ export default function AudioPage() {
           <p className='text-sm text-muted mb-1'>No access to audio settings</p>
           <p className='text-xs text-muted'>
             You need the <span className='text-fg font-medium'>audio.manage</span> permission or an
-            admin role to manage equalizer and compressor settings.
+            admin role to manage audio settings.
           </p>
         </div>
       ) : (
-        <div className='lg:grid lg:grid-cols-2 lg:gap-8'>
-          {/* Equalizer */}
-          <section className='mb-8 lg:mb-0'>
-            <h2 className='font-mono text-xs text-muted uppercase tracking-wider mb-4 flex items-center gap-2'>
-              <SlidersHorizontalIcon size={14} weight='duotone' />
-              Equalizer
-            </h2>
-            <div className='bg-elevated clay-resting rounded-lg p-5'>
-              <EqualizerSection />
-            </div>
-          </section>
-
-          {/* Compressor */}
-          <section>
-            <h2 className='font-mono text-xs text-muted uppercase tracking-wider mb-4 flex items-center gap-2'>
-              <ArrowsDownUpIcon size={14} weight='duotone' />
-              Compressor
-            </h2>
-            <div className='bg-elevated clay-resting rounded-lg p-5'>
-              <CompressorSection />
-            </div>
-          </section>
+        <div className='grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6'>
+          {FILTER_CARDS.map(({ icon: Icon, label, component: Section, wide }) => (
+            <section key={label} className={wide ? 'xl:col-span-2' : ''}>
+              <h2 className='font-mono text-xs text-muted uppercase tracking-wider mb-3 flex items-center gap-2'>
+                <Icon size={14} weight='duotone' />
+                {label}
+              </h2>
+              <div className='bg-elevated clay-resting rounded-lg p-5'>
+                <Section />
+              </div>
+            </section>
+          ))}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

Exposes all 7 remaining NodeLink (Lavalink v4) audio filters on the Audio page — Karaoke, Timescale, Tremolo, Vibrato, Rotation, Distortion, Channel Mix, Low Pass — with full DB persistence, API routes, live filter sync, and responsive grid layout. Also fixes a pre-existing bug where applying one filter would silently wipe others from the live player.

Closes #619

## Changes

### Architecture fix
- **New `syncAllFilters()` helper** — reads all filter settings from DB, builds a combined NodeLink Filters object for every enabled filter, and sends a single atomic PATCH. Fixes the bug where saving compressor would wipe the equalizer (and vice versa).
- Refactored existing compressor and equalizer routes to use it.

### Server-side
- **DB schema** — 31 new columns across 7 filter types in `guildSettings` (migration `0013_add_audio_filters.sql`)
- **Filter builders** — 8 pure builder functions in `applyNodeLinkFilter.ts` (compressor + 7 new)
- **API routes** — 7 new per-filter routes (`/api/settings/karaoke`, `/timescale`, `/tremolo`, `/vibrato`, `/rotation`, `/distortion`, `/channelmix`, `/lowpass`) each with GET + PATCH, validation, and DB persistence
- Wired into `index.ts` route table

### Web
- **7 new filter section components** — following the existing CompressorSection pattern (toggle, sliders, save/reset buttons, permission dimming)
- **Responsive grid layout** on Audio page — cards auto-fill with natural widths (narrow for 1-param, wider for 4+ param filters)