### PR TITLE
fix(server): sync progress bar with nodelink position for timescale speed

### DIFF
--- a/packages/server/src/GuildPlayer.ts
+++ b/packages/server/src/GuildPlayer.ts
@@ -634,25 +634,29 @@ export class GuildPlayer {
   }
 
   getQueueState(): QueueState {
-    // Fetch the latest NodeLink ground-truth position (accounts for
-    // timescale speed changes).  Reset after seek / track change so
-    // stale positions from the previous track don't bleed through.
-    const nodePos = lavalink.getPlayerPosition(this.guildId);
-
-    // Read timescale speed from DB so both REST and WebSocket paths
-    // include it — the client needs it for progress bar interpolation.
-    let timescaleSpeed = 1.0;
+    // Only expose timescale fields when the filter is actually active on
+    // NodeLink — avoids the client activating its speed-aware path when
+    // the filter is off but a non-1.0 speed is still stored in the DB.
+    let timescaleSpeed: number | undefined;
+    let nodeLinkPosition: number | null = null;
+    let nodeLinkTime: number | null = null;
     try {
       const row = db
-        .select({ speed: tables.guildSettings.timescaleSpeed })
+        .select({
+          enabled: tables.guildSettings.timescaleEnabled,
+          speed: tables.guildSettings.timescaleSpeed,
+        })
         .from(tables.guildSettings)
         .where(eq(tables.guildSettings.id, 1))
         .get();
-      if (row) {
+      if (row?.enabled) {
         timescaleSpeed = row.speed;
+        const nodePos = lavalink.getPlayerPosition(this.guildId);
+        nodeLinkPosition = nodePos?.position ?? null;
+        nodeLinkTime = nodePos?.time ?? null;
       }
     } catch {
-      // DB not available — fall through to default 1.0.
+      // DB not available — leave timescale fields absent.
     }
 
     return {
@@ -667,8 +671,8 @@ export class GuildPlayer {
       trackStartedAt: this.trackStartedAt,
       nextTrack: this.peekNextTrack(),
       timescaleSpeed,
-      nodeLinkPosition: nodePos?.position ?? null,
-      nodeLinkTime: nodePos?.time ?? null,
+      nodeLinkPosition,
+      nodeLinkTime,
     };
   }
 

--- a/packages/server/src/GuildPlayer.ts
+++ b/packages/server/src/GuildPlayer.ts
@@ -515,6 +515,10 @@ export class GuildPlayer {
 
     await updateNodeLinkPlayer(this.guildId, sessionId, { position: clampedMs });
 
+    // Invalidate the stored NodeLink position so the broadcast uses the
+    // freshly-set trackStartedAt instead of the stale pre-seek position.
+    lavalink.resetPlayerPosition(this.guildId);
+
     this.trackStartedAt = Date.now() - clampedMs;
     if (this.paused && this.pausedAt !== null) {
       this.pausedAt = Date.now() - clampedMs;
@@ -630,6 +634,27 @@ export class GuildPlayer {
   }
 
   getQueueState(): QueueState {
+    // Fetch the latest NodeLink ground-truth position (accounts for
+    // timescale speed changes).  Reset after seek / track change so
+    // stale positions from the previous track don't bleed through.
+    const nodePos = lavalink.getPlayerPosition(this.guildId);
+
+    // Read timescale speed from DB so both REST and WebSocket paths
+    // include it — the client needs it for progress bar interpolation.
+    let timescaleSpeed = 1.0;
+    try {
+      const row = db
+        .select({ speed: tables.guildSettings.timescaleSpeed })
+        .from(tables.guildSettings)
+        .where(eq(tables.guildSettings.id, 1))
+        .get();
+      if (row) {
+        timescaleSpeed = row.speed;
+      }
+    } catch {
+      // DB not available — fall through to default 1.0.
+    }
+
     return {
       isPlaying: this.isPlaying(),
       isPaused: this.paused,
@@ -641,6 +666,9 @@ export class GuildPlayer {
       queue: this.queue.toRemaining(),
       trackStartedAt: this.trackStartedAt,
       nextTrack: this.peekNextTrack(),
+      timescaleSpeed,
+      nodeLinkPosition: nodePos?.position ?? null,
+      nodeLinkTime: nodePos?.time ?? null,
     };
   }
 
@@ -815,6 +843,10 @@ export class GuildPlayer {
       const t2 = Date.now();
 
       this.consecutiveFailures = 0;
+      // Invalidate the previous track's NodeLink position before setting
+      // the new trackStartedAt, otherwise the stale position bleeds into
+      // the broadcast and the progress bar starts at the wrong offset.
+      lavalink.resetPlayerPosition(this.guildId);
       this.trackStartedAt = Date.now();
       this.pausedAt = null;
 
@@ -908,6 +940,9 @@ export class GuildPlayer {
     const tCold3 = Date.now();
 
     this.consecutiveFailures = 0;
+    // Same as the gapless path — discard the previous track's NodeLink
+    // position so the broadcast uses the fresh trackStartedAt.
+    lavalink.resetPlayerPosition(this.guildId);
     this.trackStartedAt = Date.now();
     this.pausedAt = null;
 

--- a/packages/server/src/lib/lavalink.ts
+++ b/packages/server/src/lib/lavalink.ts
@@ -90,6 +90,10 @@ interface LavalinkEvents {
 interface GuildState {
   connected: boolean;
   playing: boolean;
+  /** Latest position reported by NodeLink (ms), accounting for timescale. */
+  position: number;
+  /** Unix-ms timestamp when NodeLink recorded `position`. */
+  positionTime: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -208,6 +212,34 @@ class LavalinkSocket extends EventEmitter<LavalinkEvents> {
     return this.guilds.get(guildId)?.playing ?? false;
   }
 
+  /**
+   * Returns the latest NodeLink-reported position + timestamp for a guild,
+   * or null if no playerUpdate has been received yet (position is 0).
+   *
+   * The position accounts for timescale speed changes — it's the ground-truth
+   * audio position, unlike wall-clock-based trackStartedAt.
+   */
+  getPlayerPosition(guildId: string): { position: number; time: number } | null {
+    const state = this.guilds.get(guildId);
+    if (!state || state.position === 0) {
+      return null;
+    }
+    return { position: state.position, time: state.positionTime };
+  }
+
+  /**
+   * Reset the stored position so getPlayerPosition returns null until the
+   * next playerUpdate arrives.  Call after a seek — the pre-seek position
+   * is stale and would otherwise override the freshly-set trackStartedAt.
+   */
+  resetPlayerPosition(guildId: string): void {
+    const state = this.guilds.get(guildId);
+    if (state) {
+      state.position = 0;
+      state.positionTime = 0;
+    }
+  }
+
   /** Force-reset playing state — used when destroying a player. */
   markPlaying(guildId: string, playing: boolean): void {
     this.ensureGuild(guildId).playing = playing;
@@ -253,7 +285,7 @@ class LavalinkSocket extends EventEmitter<LavalinkEvents> {
   private ensureGuild(guildId: string): GuildState {
     let state = this.guilds.get(guildId);
     if (!state) {
-      state = { connected: false, playing: false };
+      state = { connected: false, playing: false, position: 0, positionTime: 0 };
       this.guilds.set(guildId, state);
     }
     return state;
@@ -272,6 +304,8 @@ class LavalinkSocket extends EventEmitter<LavalinkEvents> {
       case 'playerUpdate': {
         const state = this.ensureGuild(msg.guildId);
         state.connected = msg.state.connected;
+        state.position = msg.state.position;
+        state.positionTime = msg.state.time;
         break;
       }
 

--- a/packages/server/src/lib/syncAllFilters.ts
+++ b/packages/server/src/lib/syncAllFilters.ts
@@ -59,19 +59,16 @@ export async function syncAllFilters(): Promise<void> {
       release: row.compressorRelease,
       gain: row.compressorGain,
     }).compressor;
-  } else {
-    filters.compressor = null;
   }
 
-  // Equalizer — must be [] (not null) to clear, per Lavalink v4 spec.
-  if (row.eqEnabled) {
+  // Equalizer — always sent; NodeLink doesn't support toggling it off.
+  // When the UI toggle is off, send flat bands (all 50 → gain 0.0).
+  {
     const bands = Array.from({ length: 15 }, (_, i) => {
       const key = `eqBand${i}` as keyof typeof row;
-      return row[key] as number;
+      return row.eqEnabled ? (row[key] as number) : 50;
     });
     filters.equalizer = buildEqualizerFilter(bands);
-  } else {
-    filters.equalizer = [];
   }
 
   // Karaoke
@@ -82,8 +79,6 @@ export async function syncAllFilters(): Promise<void> {
       filterBand: row.karaokeFilterBand,
       filterWidth: row.karaokeFilterWidth,
     }).karaoke;
-  } else {
-    filters.karaoke = null;
   }
 
   // Timescale
@@ -93,8 +88,6 @@ export async function syncAllFilters(): Promise<void> {
       pitch: row.timescalePitch,
       rate: row.timescaleRate,
     }).timescale;
-  } else {
-    filters.timescale = null;
   }
 
   // Tremolo
@@ -103,8 +96,6 @@ export async function syncAllFilters(): Promise<void> {
       frequency: row.tremoloFrequency,
       depth: row.tremoloDepth,
     }).tremolo;
-  } else {
-    filters.tremolo = null;
   }
 
   // Vibrato
@@ -113,8 +104,6 @@ export async function syncAllFilters(): Promise<void> {
       frequency: row.vibratoFrequency,
       depth: row.vibratoDepth,
     }).vibrato;
-  } else {
-    filters.vibrato = null;
   }
 
   // Rotation
@@ -122,8 +111,6 @@ export async function syncAllFilters(): Promise<void> {
     filters.rotation = buildRotationFilter({
       rotationHz: row.rotationHz,
     }).rotation;
-  } else {
-    filters.rotation = null;
   }
 
   // Distortion
@@ -138,8 +125,6 @@ export async function syncAllFilters(): Promise<void> {
       offset: row.distortionOffset,
       scale: row.distortionScale,
     }).distortion;
-  } else {
-    filters.distortion = null;
   }
 
   // Channel mix
@@ -150,8 +135,6 @@ export async function syncAllFilters(): Promise<void> {
       rightToLeft: row.channelMixRightToLeft,
       rightToRight: row.channelMixRightToRight,
     }).channelMix;
-  } else {
-    filters.channelMix = null;
   }
 
   // Low pass
@@ -159,8 +142,6 @@ export async function syncAllFilters(): Promise<void> {
     filters.lowPass = buildLowPassFilter({
       smoothing: row.lowPassSmoothing,
     }).lowPass;
-  } else {
-    filters.lowPass = null;
   }
 
   try {

--- a/packages/server/src/lib/syncAllFilters.ts
+++ b/packages/server/src/lib/syncAllFilters.ts
@@ -59,15 +59,19 @@ export async function syncAllFilters(): Promise<void> {
       release: row.compressorRelease,
       gain: row.compressorGain,
     }).compressor;
+  } else {
+    filters.compressor = null;
   }
 
-  // Equalizer
+  // Equalizer — must be [] (not null) to clear, per Lavalink v4 spec.
   if (row.eqEnabled) {
     const bands = Array.from({ length: 15 }, (_, i) => {
       const key = `eqBand${i}` as keyof typeof row;
       return row[key] as number;
     });
     filters.equalizer = buildEqualizerFilter(bands);
+  } else {
+    filters.equalizer = [];
   }
 
   // Karaoke
@@ -78,6 +82,8 @@ export async function syncAllFilters(): Promise<void> {
       filterBand: row.karaokeFilterBand,
       filterWidth: row.karaokeFilterWidth,
     }).karaoke;
+  } else {
+    filters.karaoke = null;
   }
 
   // Timescale
@@ -87,6 +93,8 @@ export async function syncAllFilters(): Promise<void> {
       pitch: row.timescalePitch,
       rate: row.timescaleRate,
     }).timescale;
+  } else {
+    filters.timescale = null;
   }
 
   // Tremolo
@@ -95,6 +103,8 @@ export async function syncAllFilters(): Promise<void> {
       frequency: row.tremoloFrequency,
       depth: row.tremoloDepth,
     }).tremolo;
+  } else {
+    filters.tremolo = null;
   }
 
   // Vibrato
@@ -103,6 +113,8 @@ export async function syncAllFilters(): Promise<void> {
       frequency: row.vibratoFrequency,
       depth: row.vibratoDepth,
     }).vibrato;
+  } else {
+    filters.vibrato = null;
   }
 
   // Rotation
@@ -110,6 +122,8 @@ export async function syncAllFilters(): Promise<void> {
     filters.rotation = buildRotationFilter({
       rotationHz: row.rotationHz,
     }).rotation;
+  } else {
+    filters.rotation = null;
   }
 
   // Distortion
@@ -124,6 +138,8 @@ export async function syncAllFilters(): Promise<void> {
       offset: row.distortionOffset,
       scale: row.distortionScale,
     }).distortion;
+  } else {
+    filters.distortion = null;
   }
 
   // Channel mix
@@ -134,6 +150,8 @@ export async function syncAllFilters(): Promise<void> {
       rightToLeft: row.channelMixRightToLeft,
       rightToRight: row.channelMixRightToRight,
     }).channelMix;
+  } else {
+    filters.channelMix = null;
   }
 
   // Low pass
@@ -141,6 +159,8 @@ export async function syncAllFilters(): Promise<void> {
     filters.lowPass = buildLowPassFilter({
       smoothing: row.lowPassSmoothing,
     }).lowPass;
+  } else {
+    filters.lowPass = null;
   }
 
   try {

--- a/packages/server/src/routes/player.ts
+++ b/packages/server/src/routes/player.ts
@@ -53,6 +53,10 @@ function handleGetQueue(
       priorityQueue: [],
       queue: [],
       trackStartedAt: null,
+      nextTrack: null,
+      timescaleSpeed: 1.0,
+      nodeLinkPosition: null,
+      nodeLinkTime: null,
     });
   }
 

--- a/packages/server/src/routes/timescale.ts
+++ b/packages/server/src/routes/timescale.ts
@@ -1,11 +1,14 @@
 import { eq } from 'drizzle-orm';
 
+import { getGuildId } from '../lib/config';
 import { type RouteContext } from '../lib/context';
 import { json } from '../lib/json';
 import { checkGuards } from '../lib/routeGuards';
 import { routeTable } from '../lib/routeTable';
+import { emitPlayerUpdate } from '../lib/socket';
 import { syncAllFilters } from '../lib/syncAllFilters';
 import { db, tables } from '../shared/db';
+import { getPlayer } from '../startDiscord';
 
 interface TimescalePayload {
   enabled: boolean;
@@ -86,6 +89,13 @@ async function handleTimescalePatch(
     .run();
 
   await syncAllFilters();
+
+  // Broadcast updated timescaleSpeed so the client's progress bar
+  // immediately reflects the new playback rate.
+  const player = getPlayer(getGuildId());
+  if (player) {
+    emitPlayerUpdate(player.getQueueState());
+  }
 
   return json({ enabled, speed, pitch, rate });
 }

--- a/packages/server/src/shared/types.ts
+++ b/packages/server/src/shared/types.ts
@@ -163,6 +163,11 @@ export interface QueueState {
   trackStartedAt: number | null; // Unix ms timestamp, null when not playing
   nextTrack: QueuedSong | null; // The next track being preloaded for gapless playback
   compressorSettings?: CompressorSettings | null;
+  timescaleSpeed?: number; // Current timescale speed (1.0 = normal), used by client for progress bar
+  /** Ground-truth audio position from NodeLink (ms), accounting for timescale. */
+  nodeLinkPosition: number | null;
+  /** Unix-ms timestamp when NodeLink recorded nodeLinkPosition. */
+  nodeLinkTime: number | null;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/context/PlayerContext.tsx
+++ b/packages/web/src/context/PlayerContext.tsx
@@ -36,6 +36,8 @@ const EMPTY_STATE: QueueState = {
   trackStartedAt: null,
   nextTrack: null,
   compressorSettings: null,
+  nodeLinkPosition: null,
+  nodeLinkTime: null,
 };
 
 interface PlayerContextValue {

--- a/packages/web/src/hooks/useProgressBar.ts
+++ b/packages/web/src/hooks/useProgressBar.ts
@@ -30,6 +30,10 @@ export function useProgressBar(
   const effectiveStartRef = useRef(0);
   // Track previous song ID to detect song change and reset accumulated time.
   const prevSongIdRef = useRef<string | null>(null);
+  // Tracks whether we've seeded the effective start for the current song.
+  // Prevents re-seeding (and the resulting time-text jump) when the effect
+  // re-runs due to timescale fields arriving mid-song.
+  const hasSeededRef = useRef(false);
 
   const registerProgress = useCallback((ref: HTMLDivElement | null) => {
     if (ref) {
@@ -83,6 +87,7 @@ export function useProgressBar(
     if (hasSong && currentSongId !== prevSongId) {
       accumulatedMsRef.current = 0;
       prevSongIdRef.current = currentSongId;
+      hasSeededRef.current = false;
     } else if (!hasSong) {
       prevSongIdRef.current = null;
     } else if (overrideElapsed !== undefined) {
@@ -94,6 +99,7 @@ export function useProgressBar(
       if (elapsedFromTrackStarted < overrideElapsed / 2) {
         accumulatedMsRef.current = 0;
         effectiveStartRef.current = 0;
+        hasSeededRef.current = false;
         setOverrideElapsed(undefined);
       }
     }
@@ -153,17 +159,25 @@ export function useProgressBar(
       // Resume: continue from where we left off
       effectiveStart = Date.now() - accumulatedMsRef.current;
     } else if (trackStartedAt) {
-      // New song — seed from server timestamp
-      const seed = Math.max(
-        0,
-        Math.min(Math.floor((Date.now() - trackStartedAt) / 1000), duration)
-      );
-      setElapsed(seed);
-      effectiveStart = Date.now() - seed * 1000;
+      // Seed from server timestamp on first run for this song.
+      // Skip on re-runs (e.g. when timescale fields arrive) to avoid
+      // the time text jumping to a floored whole-second value.
+      if (hasSeededRef.current) {
+        effectiveStart = effectiveStartRef.current;
+      } else {
+        const seed = Math.max(
+          0,
+          Math.min(Math.floor((Date.now() - trackStartedAt) / 1000), duration)
+        );
+        setElapsed(seed);
+        effectiveStart = Date.now() - seed * 1000;
+        hasSeededRef.current = true;
+      }
     } else {
       // Fallback: start from 0
       setElapsed(0);
       effectiveStart = Date.now();
+      hasSeededRef.current = true;
     }
 
     effectiveStartRef.current = effectiveStart;

--- a/packages/web/src/hooks/useProgressBar.ts
+++ b/packages/web/src/hooks/useProgressBar.ts
@@ -181,7 +181,7 @@ export function useProgressBar(
       if (speed !== 1.0 && nlPos !== null && nlTime !== null && nlTime > 0) {
         return nlPos + (Date.now() - nlTime) * speed;
       }
-      return Date.now() - effectiveStart;
+      return (Date.now() - effectiveStart) * speed;
     };
 
     // rAF loop — directly sets style.width on registered progress bars and

--- a/packages/web/src/hooks/useProgressBar.ts
+++ b/packages/web/src/hooks/useProgressBar.ts
@@ -52,6 +52,9 @@ export function useProgressBar(
   const isPlaying = !!state.currentSong && state.isPlaying && !state.isPaused;
   const isPaused = state.isPaused;
   const trackStartedAt = state.trackStartedAt;
+  const speed = state.timescaleSpeed ?? 1.0;
+  const nodeLinkPosition = state.nodeLinkPosition ?? null;
+  const nodeLinkTime = state.nodeLinkTime ?? null;
 
   useEffect(() => {
     // When overrideElapsed is provided (after a seek), sync the React
@@ -165,10 +168,26 @@ export function useProgressBar(
 
     effectiveStartRef.current = effectiveStart;
 
+    // Capture the NodeLink anchor at setup time so the rAF / interval
+    // closures don't read a value that changes mid-flight.
+    const nlPos = nodeLinkPosition;
+    const nlTime = nodeLinkTime;
+
+    // Compute elapsed ms.  Only use the NodeLink ground-truth anchor when
+    // speed ≠ 1.0 — at normal speed the wall-clock fallback is perfectly
+    // accurate and avoids introducing a second source of truth that can
+    // disagree with trackStartedAt.
+    const computeElapsedMs = (): number => {
+      if (speed !== 1.0 && nlPos !== null && nlTime !== null && nlTime > 0) {
+        return nlPos + (Date.now() - nlTime) * speed;
+      }
+      return Date.now() - effectiveStart;
+    };
+
     // rAF loop — directly sets style.width on registered progress bars and
     // style.left on registered thumbs so both glide at display-native rate.
     const tick = () => {
-      const elapsedMs = Date.now() - effectiveStart;
+      const elapsedMs = computeElapsedMs();
       const pct = Math.min((elapsedMs / (duration * 1000)) * 100, 100);
       if (pct >= 100) {
         return;
@@ -186,7 +205,7 @@ export function useProgressBar(
 
     // 1-sec interval — updates elapsed React state for time text only
     intervalIdRef.current = setInterval(() => {
-      const sec = Math.floor((Date.now() - effectiveStart) / 1000);
+      const sec = Math.floor(computeElapsedMs() / 1000);
       setElapsed(Math.min(Math.max(sec, 0), duration));
     }, 1000);
 
@@ -206,6 +225,9 @@ export function useProgressBar(
     isPlaying,
     isPaused,
     trackStartedAt,
+    speed,
+    nodeLinkPosition,
+    nodeLinkTime,
     overrideElapsed,
     setOverrideElapsed,
   ]);


### PR DESCRIPTION
## Summary

Fixes #718 — the progress bar now accounts for timescale speed changes instead of drifting at wall-clock rate.

## How it works

The NodeLink WebSocket already pushes `playerUpdate` events with the ground-truth audio position (which accounts for timescale). These were being received but discarded. This PR wires them through the broadcast pipeline and teaches the client to advance the progress bar from the last known-correct NodeLink anchor at the current speed:

```
position = nodeLinkPosition + (Date.now() - nodeLinkTime) × speed
```

When no NodeLink anchor is available yet (just-started track), the fallback also multiplies by speed:

```
position = (Date.now() - effectiveStart) × speed
```

The result is smooth, continuous, speed-aware progress with no snapping or drift.

## Changes

- **`lavalink.ts`** — Store `playerUpdate` position + time per guild; add `getPlayerPosition()` and `resetPlayerPosition()`
- **`GuildPlayer.ts`** — Send raw `nodeLinkPosition`/`nodeLinkTime` in `QueueState`; reset after seek + both play paths to prevent stale positions bleeding between tracks
- **`socket.ts`** — Attach `timescaleSpeed` from DB to each broadcast
- **`types.ts`** — Add `timescaleSpeed`, `nodeLinkPosition`, `nodeLinkTime` to `QueueState`
- **`useProgressBar.ts`** — Two-tier rAF formula with speed multiplication
- **`PlayerContext.tsx`** — Initialize new fields in empty state