### PR TITLE
fix(player): sync progress bar timing with audio server

### DIFF
--- a/packages/server/src/GuildPlayer.ts
+++ b/packages/server/src/GuildPlayer.ts
@@ -56,6 +56,10 @@ export class GuildPlayer {
   // Auto-leave idle timer.
   private idleLeaveTimer: ReturnType<typeof setTimeout> | null = null;
 
+  // Periodic sync broadcast during playback — pushes fresh NodeLink position
+  // data to clients so they can correct client-side clock drift.
+  private syncInterval: ReturnType<typeof setInterval> | null = null;
+
   private getIdleTimeoutMinutes(): number {
     // Read from DB first (set via setup wizard or admin settings).
     try {
@@ -322,6 +326,7 @@ export class GuildPlayer {
   stop(): void {
     this.stopping = true;
     this.cancelIdleLeave();
+    this.clearSyncInterval();
     this.currentSong = null;
     this.queue.clear();
     this.priorityQueue = [];
@@ -489,10 +494,12 @@ export class GuildPlayer {
       }
       await updateNodeLinkPlayer(this.guildId, sessionId, { paused: false });
       this.paused = false;
+      this.startSyncInterval();
     } else {
       this.pausedAt = Date.now();
       await updateNodeLinkPlayer(this.guildId, sessionId, { paused: true });
       this.paused = true;
+      this.clearSyncInterval();
       this.scheduleIdleLeave();
     }
 
@@ -634,13 +641,17 @@ export class GuildPlayer {
   }
 
   getQueueState(): QueueState {
-    // Only expose timescale fields when the filter is actually active on
-    // NodeLink — avoids the client activating its speed-aware path when
-    // the filter is off but a non-1.0 speed is still stored in the DB.
+    // Always include NodeLink ground-truth position so clients can correct
+    // clock drift. Timescale speed is still gated behind the filter being
+    // active — a non-1.0 speed stored in the DB is meaningless otherwise.
     let timescaleSpeed: number | undefined;
     let nodeLinkPosition: number | null = null;
     let nodeLinkTime: number | null = null;
     try {
+      const nodePos = lavalink.getPlayerPosition(this.guildId);
+      nodeLinkPosition = nodePos?.position ?? null;
+      nodeLinkTime = nodePos?.time ?? null;
+
       const row = db
         .select({
           enabled: tables.guildSettings.timescaleEnabled,
@@ -651,9 +662,6 @@ export class GuildPlayer {
         .get();
       if (row?.enabled) {
         timescaleSpeed = row.speed;
-        const nodePos = lavalink.getPlayerPosition(this.guildId);
-        nodeLinkPosition = nodePos?.position ?? null;
-        nodeLinkTime = nodePos?.time ?? null;
       }
     } catch {
       // DB not available — leave timescale fields absent.
@@ -681,6 +689,22 @@ export class GuildPlayer {
       await this.playNext();
     } else {
       this.broadcast();
+    }
+  }
+
+  private static readonly SYNC_INTERVAL_MS = 5_000;
+
+  private startSyncInterval(): void {
+    this.clearSyncInterval();
+    this.syncInterval = setInterval(() => {
+      this.broadcast();
+    }, GuildPlayer.SYNC_INTERVAL_MS);
+  }
+
+  private clearSyncInterval(): void {
+    if (this.syncInterval !== null) {
+      clearInterval(this.syncInterval);
+      this.syncInterval = null;
     }
   }
 
@@ -861,6 +885,7 @@ export class GuildPlayer {
       }
 
       this.broadcast();
+      this.startSyncInterval();
       const t3 = Date.now();
 
       logger.info(
@@ -957,6 +982,7 @@ export class GuildPlayer {
     }
 
     this.broadcast();
+    this.startSyncInterval();
 
     logger.info(
       {
@@ -1039,6 +1065,7 @@ export class GuildPlayer {
       return;
     }
 
+    this.clearSyncInterval();
     this.trackStartedAt = null;
     this.pausedAt = null;
 

--- a/packages/web/src/hooks/useProgressBar.ts
+++ b/packages/web/src/hooks/useProgressBar.ts
@@ -34,6 +34,10 @@ export function useProgressBar(
   // Prevents re-seeding (and the resulting time-text jump) when the effect
   // re-runs due to timescale fields arriving mid-song.
   const hasSeededRef = useRef(false);
+  // Tracks the last overrideElapsed value we've already applied, so periodic
+  // sync broadcasts (which re-run the effect) don't re-apply a stale override
+  // and flash the time text back to the seek target.
+  const lastOverrideRef = useRef<number | undefined>(undefined);
 
   const registerProgress = useCallback((ref: HTMLDivElement | null) => {
     if (ref) {
@@ -64,7 +68,10 @@ export function useProgressBar(
     // When overrideElapsed is provided (after a seek), sync the React
     // elapsed state immediately so that any React re-render uses the correct
     // position and doesn't fight the rAF-driven thumb placement.
-    if (overrideElapsed !== undefined) {
+    // Guarded by lastOverrideRef so periodic sync re-runs don't re-apply
+    // a stale override and flash the time text back to the seek target.
+    if (overrideElapsed !== undefined && overrideElapsed !== lastOverrideRef.current) {
+      lastOverrideRef.current = overrideElapsed;
       accumulatedMsRef.current = overrideElapsed * 1000;
       effectiveStartRef.current = Date.now() - overrideElapsed * 1000;
       setElapsed(overrideElapsed);
@@ -88,6 +95,7 @@ export function useProgressBar(
       accumulatedMsRef.current = 0;
       prevSongIdRef.current = currentSongId;
       hasSeededRef.current = false;
+      lastOverrideRef.current = undefined;
     } else if (!hasSong) {
       prevSongIdRef.current = null;
     } else if (overrideElapsed !== undefined) {
@@ -187,12 +195,12 @@ export function useProgressBar(
     const nlPos = nodeLinkPosition;
     const nlTime = nodeLinkTime;
 
-    // Compute elapsed ms.  Only use the NodeLink ground-truth anchor when
-    // speed ≠ 1.0 — at normal speed the wall-clock fallback is perfectly
-    // accurate and avoids introducing a second source of truth that can
-    // disagree with trackStartedAt.
+    // Compute elapsed ms.  Use the NodeLink ground-truth position whenever
+    // available — it's more accurate than wall-clock dead-reckoning at any
+    // speed. Fall back to wall-clock when position data isn't available yet
+    // (e.g. just after a seek, before the next periodic sync arrives).
     const computeElapsedMs = (): number => {
-      if (speed !== 1.0 && nlPos !== null && nlTime !== null && nlTime > 0) {
+      if (nlPos !== null && nlTime !== null && nlTime > 0) {
         return nlPos + (Date.now() - nlTime) * speed;
       }
       return (Date.now() - effectiveStart) * speed;
@@ -200,12 +208,12 @@ export function useProgressBar(
 
     // rAF loop — directly sets style.width on registered progress bars and
     // style.left on registered thumbs so both glide at display-native rate.
+    // Capped at 100% so the bar doesn't overflow, but the loop keeps running
+    // so it can recover when a periodic sync with fresh NodeLink position
+    // data arrives and corrects clock drift.
     const tick = () => {
       const elapsedMs = computeElapsedMs();
       const pct = Math.min((elapsedMs / (duration * 1000)) * 100, 100);
-      if (pct >= 100) {
-        return;
-      }
       const pctStr = `${pct}%`;
       for (const ref of progressBars.current) {
         ref.style.width = pctStr;


### PR DESCRIPTION
## Summary

Fixes the player bar progress display desyncing from actual audio playback. The UI was dead-reckoning from a one-shot timestamp with no correction mechanism, causing the progress bar to drift and freeze at 100% while audio continued.

## Root cause

The timing pipeline was open-loop: the client estimated elapsed time from `trackStartedAt` (wall clock) with zero ongoing synchronization against NodeLink's ground-truth audio position. NodeLink was already pushing position data every ~3 seconds — the server was discarding it at normal speed, and no updates were sent during uninterrupted playback.

## Changes

- **Server**: `getQueueState()` now always includes NodeLink's ground-truth position data (previously gated behind the timescale filter being active)
- **Server**: Added a 5-second periodic sync broadcast during active playback so clients receive fresh position data for drift correction
- **Client**: `computeElapsedMs()` uses NodeLink position at all speeds, not just when timescale is active
- **Client**: rAF progress bar loop no longer exits at 100%, so it can recover when a sync correction arrives
- **Client**: Deduplicated override-elapsed application so periodic syncs don't flash the time text back to the seek target