### PR TITLE
feat(web): show requester on song cards instead of context menu

### DIFF
--- a/packages/web/src/components/SongCard.tsx
+++ b/packages/web/src/components/SongCard.tsx
@@ -1,5 +1,5 @@
 import { type Playlist, type Song } from '@alfira/server/shared';
-import { DiscIcon, MusicNoteIcon, UserIcon } from '@phosphor-icons/react';
+import { DiscIcon, MicrophoneStageIcon, MusicNoteIcon, UserIcon } from '@phosphor-icons/react';
 import React, { useCallback, useMemo, useState } from 'react';
 
 import { usePermissions } from '../context/PermissionsContext';
@@ -189,7 +189,7 @@ const SongCardInner = ({
           <div className='flex items-center justify-between gap-2 text-xs text-muted overflow-hidden'>
             {song.artist ? (
               <span className='flex items-center gap-1 min-w-0'>
-                <UserIcon size={12} weight='fill' className='shrink-0' />
+                <MicrophoneStageIcon size={12} weight='fill' className='shrink-0' />
                 <span className='truncate'>{song.artist}</span>
               </span>
             ) : (
@@ -210,6 +210,17 @@ const SongCardInner = ({
             )}
             <VolumeBoostBadge volumeBoost={song.volumeBoost} />
           </div>
+
+          {/* Requested by */}
+          {song.addedBy ? (
+            <div className='flex items-center justify-between gap-2 text-xs text-muted overflow-hidden'>
+              <span className='flex items-center gap-1 min-w-0'>
+                <UserIcon size={12} weight='fill' className='shrink-0' />
+                <span className='truncate'>{song.addedByDisplayName ?? song.addedBy}</span>
+              </span>
+              <span />
+            </div>
+          ) : null}
 
           {/* Tags + Actions */}
           <div className='flex items-center justify-between gap-2 pt-1'>
@@ -299,7 +310,7 @@ const SongCardInner = ({
           <div className='flex items-center gap-2.5 flex-wrap text-xs text-muted min-w-0'>
             {song.artist && (
               <span className='max-w-[16ch] flex items-center gap-1 min-w-0'>
-                <UserIcon size={12} weight='fill' className='shrink-0' />
+                <MicrophoneStageIcon size={12} weight='fill' className='shrink-0' />
                 <span className='truncate'>{song.artist}</span>
               </span>
             )}
@@ -315,6 +326,12 @@ const SongCardInner = ({
             {sourceKey && (
               <span className='flex items-center shrink-0 [&_svg]:w-3.5 [&_svg]:h-3.5'>
                 <SourceIcon sourceKey={sourceKey} />
+              </span>
+            )}
+            {song.addedBy && (
+              <span className='max-w-[16ch] flex items-center gap-1 min-w-0'>
+                <UserIcon size={12} weight='fill' className='shrink-0' />
+                <span className='truncate'>{song.addedByDisplayName ?? song.addedBy}</span>
               </span>
             )}
             <DurationBadge seconds={song.duration} />

--- a/packages/web/src/hooks/useSongActions.tsx
+++ b/packages/web/src/hooks/useSongActions.tsx
@@ -3,7 +3,6 @@ import {
   ArrowSquareOutIcon,
   BombIcon,
   CassetteTapeIcon,
-  UserIcon,
   VinylRecordIcon,
 } from '@phosphor-icons/react';
 import { useCallback, useMemo, useOptimistic, useRef, useState } from 'react';
@@ -123,16 +122,6 @@ export function useSongActions({
                     danger: true,
                     onClick: onDelete,
                   } as MenuItem,
-                  {
-                    id: 'user-info',
-                    label: '',
-                    icon: <UserIcon size={14} weight='duotone' />,
-                    info: {
-                      label: (song.addedByDisplayName ?? song.addedBy) || '',
-                      icon: <UserIcon size={14} weight='duotone' />,
-                    },
-                    separatorBefore: true,
-                  },
                 ]
               : []),
           ]),
@@ -140,8 +129,6 @@ export function useSongActions({
     [
       onAddToQueue,
       song.sourceUrl,
-      song.addedByDisplayName,
-      song.addedBy,
       onRemove,
       removeLabel,
       onDelete,


### PR DESCRIPTION
## Summary

Moves the "requested by" info out of the context menu and onto SongCard itself, so all metadata is visible at a glance. Also swaps the artist icon to `MicrophoneStageIcon` to avoid icon collision with the requester's `UserIcon`.

Closes #622

## Changes

- Remove `user-info` menu item from `useSongActions.tsx` context menu
- Add requester row to grid SongCard variant (between Album+VolumeBoost and Tags+Actions)
- Add requester to list SongCard variant metadata row (alongside source/duration/volume boost)
- Swap artist icon from `UserIcon` to `MicrophoneStageIcon` for visual distinction
- Requester only appears when `addedBy` is present