### PR TITLE
fix(web): fix request tab flash and empty-state race conditions

### DIFF
--- a/packages/web/src/components/VirtualList.tsx
+++ b/packages/web/src/components/VirtualList.tsx
@@ -119,7 +119,7 @@ function VirtualListInner<T>({
 
   // Reveal the container once content is committed (avoids staggered paint).
   const showSkeleton = isLoading;
-  const showEmpty = hasLoaded && items.length === 0;
+  const showEmpty = hasLoaded && items.length === 0 && !isFetching;
   const showContent = !isLoading && hasLoaded && items.length > 0;
 
   // Stable styles for the outer containers.

--- a/packages/web/src/hooks/usePaginatedData.ts
+++ b/packages/web/src/hooks/usePaginatedData.ts
@@ -66,6 +66,19 @@ export function usePaginatedData<T, A extends unknown[], M = undefined>({
   const depsRef = useRef(deps);
   depsRef.current = deps;
 
+  // Detect dep changes synchronously during render so we can suppress
+  // stale empty states before the effect fires. Without this, there's a
+  // one-frame gap where the new tab's emptyTitle renders against the old
+  // (empty) items before isFetching is set to true in the effect.
+  const prevDepsRef = useRef<A>(deps);
+  const depsChanged =
+    hasEverLoadedRef.current &&
+    (prevDepsRef.current.length !== deps.length ||
+      prevDepsRef.current.some((d, i) => d !== deps[i]));
+  prevDepsRef.current = deps;
+
+  const effectiveIsFetching = isFetching || depsChanged;
+
   const compareFnRef = useRef(compareFn);
   compareFnRef.current = compareFn;
 
@@ -82,12 +95,18 @@ export function usePaginatedData<T, A extends unknown[], M = undefined>({
         resetInProgressRef.current = true;
         // Delay the skeleton by 200ms — if the fetch completes faster,
         // the skeleton is never rendered, avoiding a flash.
-        if (!hasEverLoadedRef.current) {
-          loadingTimerRef.current = setTimeout(() => {
-            if (isMountedRef.current) {
-              setIsLoading(true);
-            }
-          }, 200);
+        loadingTimerRef.current = setTimeout(() => {
+          if (isMountedRef.current) {
+            setIsLoading(true);
+          }
+        }, 200);
+        // On dep-change re-fetches, signal immediately that we're fetching
+        // so the empty-state guard can suppress stale empty messages from
+        // the previous deps (e.g. "No Pending Requests" when switching to
+        // History). First-ever loads don't need this — hasLoaded is still
+        // false, so the empty state is already suppressed.
+        if (hasEverLoadedRef.current) {
+          setIsFetching(true);
         }
       } else {
         setIsFetching(true);
@@ -253,7 +272,7 @@ export function usePaginatedData<T, A extends unknown[], M = undefined>({
     items,
     metadata,
     isLoading,
-    isFetching,
+    isFetching: effectiveIsFetching,
     isError,
     hasMore,
     total,

--- a/packages/web/src/pages/RequestsPage.tsx
+++ b/packages/web/src/pages/RequestsPage.tsx
@@ -20,11 +20,13 @@ const ITEMS_PER_PAGE = 48;
 export default function RequestsPage() {
   const { user } = useAuth();
   const { isAdminView } = useAdminView();
-  const [tab, setTab] = useState<Tab>('pending');
+  const [tab, setTab] = useState<Tab | null>(null);
   const [mineOnly, setMineOnly] = useState(false);
   const [showAddModal, setShowAddModal] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
-  const autoRedirected = useRef(false);
+  const tabResolved = useRef(false);
+
+  const effectiveTab = tab ?? 'pending';
 
   const {
     items,
@@ -52,7 +54,7 @@ export default function RequestsPage() {
       };
     },
     limit: ITEMS_PER_PAGE,
-    deps: [tab, mineOnly],
+    deps: [effectiveTab, mineOnly],
   });
 
   const handleApprove = useCallback(
@@ -99,22 +101,27 @@ export default function RequestsPage() {
     [user?.discordId]
   );
 
-  // Redirect to history if pending is empty after the initial fetch completes.
-  // A mount guard skips the initial render + Strict Mode double-invoke.
-  const mounted = useRef(false);
+  // Determine the initial tab after the first fetch completes.
+  // Always fetch pending first; if empty, switch to history. The tab bar
+  // stays hidden until resolution is done, preventing a flash of the wrong
+  // tab. The skeleton (now shown immediately on dep-change re-fetches)
+  // covers the transition when we redirect to history.
   useEffect(() => {
-    if (!mounted.current) {
-      mounted.current = true;
+    if (!hasLoaded || tabResolved.current) {
       return;
     }
-    if (autoRedirected.current) {
-      return;
+
+    if (tab === null) {
+      if (total > 0) {
+        setTab('pending');
+      } else {
+        setTab('closed');
+      }
+      tabResolved.current = true;
     }
-    if (tab === 'pending' && total === 0) {
-      autoRedirected.current = true;
-      setTab('closed');
-    }
-  }, [items, tab, total]);
+  }, [hasLoaded, tab, total]);
+
+  const resolved = tabResolved.current;
 
   const countLabel = hasLoaded ? `${total} request${total !== 1 ? 's' : ''}` : '—';
 
@@ -156,38 +163,42 @@ export default function RequestsPage() {
         </Button>
       </PageHeader>
 
-      {/* Tabs + filter */}
-      <div className='flex items-center gap-3 mb-4 md:mb-6'>
-        <div className='flex gap-1 bg-elevated rounded-lg p-1'>
-          <button
-            type='button'
-            onClick={handleSelectPendingTab}
-            className={`px-3 py-1.5 rounded-md text-sm font-body transition-colors cursor-pointer ${
-              tab === 'pending' ? 'bg-accent text-elevated' : 'text-muted hover:text-fg'
-            }`}
-          >
-            Pending
-          </button>
-          <button
-            type='button'
-            onClick={handleSelectHistoryTab}
-            className={`px-3 py-1.5 rounded-md text-sm font-body transition-colors cursor-pointer ${
-              tab === 'closed' ? 'bg-accent text-elevated' : 'text-muted hover:text-fg'
-            }`}
-          >
-            History
-          </button>
-        </div>
+      {/* Tabs + filter — hidden until the initial tab is resolved */}
+      {resolved && (
+        <>
+          <div className='flex items-center gap-3 mb-4 md:mb-6'>
+            <div className='flex gap-1 bg-elevated rounded-lg p-1'>
+              <button
+                type='button'
+                onClick={handleSelectPendingTab}
+                className={`px-3 py-1.5 rounded-md text-sm font-body transition-colors cursor-pointer ${
+                  tab === 'pending' ? 'bg-accent text-elevated' : 'text-muted hover:text-fg'
+                }`}
+              >
+                Pending
+              </button>
+              <button
+                type='button'
+                onClick={handleSelectHistoryTab}
+                className={`px-3 py-1.5 rounded-md text-sm font-body transition-colors cursor-pointer ${
+                  tab === 'closed' ? 'bg-accent text-elevated' : 'text-muted hover:text-fg'
+                }`}
+              >
+                History
+              </button>
+            </div>
 
-        {tab === 'pending' && (
-          <label className='flex items-center gap-2 cursor-pointer ml-auto'>
-            <Checkbox checked={mineOnly} onChange={setMineOnly} />
-            <span className='font-mono text-xs text-muted'>Only show my requests</span>
-          </label>
-        )}
-      </div>
+            {tab === 'pending' && (
+              <label className='flex items-center gap-2 cursor-pointer ml-auto'>
+                <Checkbox checked={mineOnly} onChange={setMineOnly} />
+                <span className='font-mono text-xs text-muted'>Only show my requests</span>
+              </label>
+            )}
+          </div>
 
-      {actionError && <ErrorBanner message={actionError} className='mb-4 font-mono' />}
+          {actionError && <ErrorBanner message={actionError} className='mb-4 font-mono' />}
+        </>
+      )}
 
       {/* Virtualized request list */}
       <VirtualRequestList
@@ -204,9 +215,11 @@ export default function RequestsPage() {
         onApprove={handleApprove}
         onDeny={handleDeny}
         onCancel={handleCancel}
-        emptyTitle={tab === 'pending' ? 'No Pending Requests' : 'No Request History'}
+        emptyTitle={effectiveTab === 'pending' ? 'No Pending Requests' : 'No Request History'}
         emptyMessage={
-          tab === 'pending' ? 'Nothing to review right now' : 'Submit a request to get started'
+          effectiveTab === 'pending'
+            ? 'Nothing to review right now'
+            : 'Submit a request to get started'
         }
       />
 


### PR DESCRIPTION
## Summary

Fixes two race conditions on the Requests page:
1. **Tab flips from Pending to History after page load** — the tab now starts unresolved (null), fetches pending count first, then decides which tab to show. The tab bar is hidden until resolution completes, so the user never sees the wrong tab selected.
2. **"No history" flash when switching tabs** — on dep-change re-fetches, `isFetching` is now set synchronously during render (via `prevDepsRef` comparison) and also early in the effect, so the empty state is suppressed from frame one rather than after a 200ms delay.

## Changes

- `usePaginatedData.ts` — Add synchronous dep-change detection (`depsChanged` / `effectiveIsFetching`) to suppress stale empty states before effects fire. Apply skeleton delay to all initial loads (not just first mount). Set `isFetching` immediately on dep-change re-fetches.
- `VirtualList.tsx` — Guard `showEmpty` with `&& !isFetching` so the empty state never renders during a transition.
- `RequestsPage.tsx` — Tri-state tab (`null` = unresolved) with deferred initial-tab resolution. Tab bar hidden until resolved. Use `effectiveTab` for the data-fetching deps and empty-state labels.