### PR TITLE
docs: update changelog and readme for unreleased changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,80 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Expanded audio filters** — All NodeLink filter types are now exposed on the Audio page: karaoke, timescale (speed/pitch/rate), tremolo, vibrato, rotation, distortion, channel mix, low pass, and rate. Previously only the 15-band equalizer and compressor were available (#717).
+- **Clay press animation system** — Interactive elements (buttons, cards, list items) now have tactile click/tap press animations powered by motion, replacing the previous CSS-only approach (#714).
+- **Requester on song cards** — The user who requested a song is now shown directly on song cards instead of buried in the context menu (#725).
+- **Admin toggle hint animation** — The admin settings toggle button in the sidebar now has a subtle hint animation to improve discoverability (#728).
+
+### Changed
+
+- **CSS animations → motion** — All CSS keyframe animations have been replaced with motion (Framer Motion v12), giving smoother, interruptible transitions across the UI (#715).
+- **Linting overhaul** — oxlint configuration has been significantly strengthened:
+  - 53 new rules covering security, correctness, and modern JS/TS patterns (#707)
+  - React performance lint rules enabled, with fixes across 33 components (#709, #710, #711, #712)
+  - Type-aware lint rules via tsgolint (#713)
+  - Strict mode enabled with zero tolerated violations (#705, #706, #708)
+- **Typechecking via oxlint** — `bun run check` now includes type-aware type checking via oxlint's `--type-aware --type-check` flag (backed by tsgo). No separate `typescript` dependency needed (#700).
+
+### Fixed
+
+- **Progress bar timing** — Progress bar now correctly syncs with the audio server position, including when timescale speed filters are active (#719, #722).
+- **Voice state seeding** — Voice channel states are now seeded from Discord's `READY` and `GUILD_CREATE` gateway events on connect, fixing stale voice state after reconnection (#721).
+- **Grid view selection mode** — Selection checkboxes now work correctly in grid/masonry view (#716).
+- **Request page race conditions** — Fixed a tab flash and empty-state flicker when navigating to the Requests page (#727).
+- **React performance warnings** — Resolved missing `useCallback`/`useMemo` warnings across the codebase: NowPlayingBar, QueuePanel, and 45+ other components (#709, #710, #711, #712).
+- **oxfmt config** — Corrected the oxfmt configuration key and disabled a conflicting TypeScript language server setting (#703).
+- **Release tag timing** — Release tags are now pushed after the PR merge completes, not before (#701).
+- **All oxlint warnings resolved** — Zero warnings, zero stale disable directives (#702).
+
+### Dependencies
+
+- Bumped `tailwindcss` from 4.3.2 to 4.3.3 (#726)
+- Bumped `@tailwindcss/cli` from 4.3.2 to 4.3.3 (#726)
+
+### Docs
+
+- Added agent operating mode guidelines to AGENTS.md (#720)
+
+## [0.2.2] - 2026-07-19
+
+### Changed
+
+- **Scroll ownership refactored** — Each page now owns its own scroll container instead of a shared `<main>` element, giving pages independent scroll behavior and fixing layout conflicts between the now-playing bar and virtualized lists (#690, #694, #695, #696, #697).
+- **NowPlayingBar in normal flow** — The now-playing bar is no longer fixed-positioned. It sits in the normal document flow at root level, full-width, eliminating layout jank when the queue panel opens and closes (#695, #696).
+- **Virtual list polish** — Spacing tightened and a scroll fade effect added at the bottom of virtualized lists for a cleaner look (#694).
+
+### Fixed
+
+- **Portal menu flash** — Context menus no longer flash at the top-left corner of the viewport on Chromium before positioning (#695).
+- **Queue panel close jank** — Eliminated visual jank when closing the queue panel, and fixed a grid view layout flash on mount (#697).
+- **Page padding restored** — Full page padding restored across all virtualized views after the scroll refactor. Bottom padding removed from virtualized page wrappers and end spacers removed from VirtualList in favor of explicit page-level padding (#696).
+- **Horizontal scrollbar** — List item animation overflow is now clipped, preventing an unwanted horizontal scrollbar from appearing (#696).
+- **Flexbox fill** — Virtualized views now use flexbox fill instead of hardcoded `maxHeight`, adapting properly to available space (#690).
+
+### Docs
+
+- Updated release workflow documentation with version bump and release notes steps (#693).
+
+## [0.2.1] - 2026-07-19
+
+### Added
+
+- **Grid view** — Song library grid view re-added with a responsive masonic masonry layout (#689).
+
+### Changed
+
+- **Proper virtual lists** — Replaced the homegrown fake virtualization with `@tanstack/react-virtual` for all song, playlist, and tag lists, with spring animation on mount (#687).
+- **Hover-only actions** — Play and more-actions buttons on song cards are now hidden until hover, reducing visual noise (#688).
+
+### Fixed
+
+- **Gapless playback silence** — Fixed an audio desync that caused a brief silence between gaplessly preloaded tracks (#690).
+- **Song edit panel overlap** — The expanded inline song editor no longer overlaps adjacent cards in virtualized lists (#687).
+- **Missing `hasMore` on PlaylistsPage** — Fixed the playlists page not detecting when more playlists were available to load (#687).
+
 ## [0.2.0] - 2026-07-22
 
 ### Added
@@ -158,7 +232,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - UI actions now properly gated by granular permissions rather than a simple admin check.
 - Inherited pointer cursor on modal cards.
 
-[Unreleased]: https://github.com/ebears/alfira/compare/v0.2.0...dev
+[Unreleased]: https://github.com/ebears/alfira/compare/v0.2.2...dev
+[0.2.2]: https://github.com/ebears/alfira/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/ebears/alfira/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/ebears/alfira/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/ebears/alfira/releases/tag/v0.1.1
 [0.1.0]: https://github.com/ebears/alfira/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -106,13 +106,13 @@
 ## Features
 
 - **Import songs** — Paste a link from YouTube, SoundCloud, Spotify, Apple Music, Tidal, or Google Drive. Metadata auto-fills from the source, and admins pick which sources to enable.
-- **Playback** — Play, pause, seek, skip, loop, and shuffle. Reorder the queue, promote songs to play next, or remove them. Optional server-wide 15-band equalizer and compressor.
+- **Playback** — Play, pause, seek, skip, loop, and shuffle. Reorder the queue, promote songs to play next, or remove them. Full audio filter suite: 15-band equalizer, compressor, karaoke, timescale, tremolo, vibrato, rotation, distortion, channel mix, low pass, and rate.
 - **Metadata editing** — Customize title, artist, album, cover art, tags (with colors), and per-song volume boost — all from the web UI.
 - **Playlists** — Create private or public playlists. Smart playlists auto-populate from tags: tag a song and it joins that tag's playlist.
 - **Song requests** — Users request songs, reviewers approve or deny in the web UI with optional DM notifications.
 - **Permissions** — Role-based access: control who can play, manage the queue, review requests, or administer settings.
 - **Setup wizard** — Guided first-run setup picks your server, admin roles, and sources so you're ready to go.
-- **Web UI** — Real-time player and queue updates over WebSocket, custom themes, responsive layout, and Discord avatar menu.
+- **Web UI** — Real-time player and queue updates over WebSocket, custom themes, responsive layout, motion-powered animations with tactile clay press effects, and Discord avatar menu.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

Documentation update catching up the changelog and README with all commits since the last documented release (v0.2.0).

## Changes

- **CHANGELOG.md**: Added v0.2.1, v0.2.2, and [Unreleased] sections with categorized entries for 53 commits
- **CHANGELOG.md**: Fixed v0.2.0 release date (was 2026-07-22, corrected to 2026-07-18)
- **CHANGELOG.md**: Updated comparison link references for all new versions
- **README.md**: Expanded playback features bullet to mention full audio filter suite
- **README.md**: Added motion-powered animations and clay press effects to Web UI feature bullet