### PR TITLE
refactor(server): replace unsafe type assertions with valibot schemas

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,10 +4,6 @@
   "workspaces": {
     "": {
       "name": "alfira",
-      "dependencies": {
-        "@tailwindcss/cli": "^4.3.3",
-        "tailwindcss": "^4.3.3",
-      },
       "devDependencies": {
         "@types/bun": "^1.3.14",
         "oxfmt": "^0.59.0",
@@ -17,14 +13,18 @@
     },
     "packages/server": {
       "name": "@alfira/server",
-      "version": "0.1.1",
+      "version": "0.3.0",
+      "dependencies": {
+        "drizzle-valibot": "^0.4.2",
+        "valibot": "^1.4.2",
+      },
       "devDependencies": {
         "drizzle-orm": "0.45.2",
       },
     },
     "packages/web": {
       "name": "@alfira/web",
-      "version": "0.1.1",
+      "version": "0.3.0",
       "dependencies": {
         "@alfira/server": "workspace:*",
         "@phosphor-icons/react": "2.1.10",
@@ -252,6 +252,8 @@
 
     "drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
 
+    "drizzle-valibot": ["drizzle-valibot@0.4.2", "", { "peerDependencies": { "drizzle-orm": ">=0.36.0", "valibot": ">=1.0.0-beta.7" } }, "sha512-tzjT7g0Di/HX7426marIy8IDtWODjPgrwvgscdevLQRUe5rzYzRhx6bDsYLdDFF9VI/eaYgnjNeF/fznWJoUjg=="],
+
     "enhanced-resolve": ["enhanced-resolve@5.24.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
@@ -349,6 +351,8 @@
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "valibot": ["valibot@1.4.2", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -34,6 +34,18 @@ export default defineConfig({
     '@typescript-eslint/no-unnecessary-type-constraint': 'error',
 
     // -----------------------------------------------------------------------
+    // oxc — Oxc-specific correctness rules that catch subtle bugs
+    // -----------------------------------------------------------------------
+    // Math.min(Math.max(x, min), max) — wrong clamping direction
+    'oxc/bad-min-max-func': 'error',
+    // a < b < c evaluates as (a < b) < c — a boolean-number comparison
+    'oxc/bad-comparison-sequence': 'error',
+    // 3.14159 instead of Math.PI, 2.718 instead of Math.E, etc.
+    'oxc/approx-constant': 'error',
+    // new Error('msg') as a statement without throw — silently does nothing
+    'oxc/missing-throw': 'error',
+
+    // -----------------------------------------------------------------------
     // correctness
     // -----------------------------------------------------------------------
     'no-const-assign': 'error',
@@ -176,6 +188,8 @@ export default defineConfig({
     // style
     // -----------------------------------------------------------------------
     curly: 'error',
+    // a ? b : c ? d : e — unreadable; use if/else or extract
+    'unicorn/no-nested-ternary': 'warn',
     'no-useless-concat': 'warn',
     'object-shorthand': 'warn',
     '@typescript-eslint/array-type': 'warn',
@@ -349,6 +363,8 @@ export default defineConfig({
     'unicorn/prefer-array-flat-map': 'warn',
     // Date.now() over new Date().getTime()
     'unicorn/prefer-date-now': 'warn',
+    // str.slice() over str.substr() / str.substring() — consistent, modern
+    'unicorn/prefer-string-slice': 'warn',
     // arr.at(-1) over arr[arr.length - 1]
     'unicorn/prefer-negative-index': 'warn',
     // throw new TypeError(...) for type errors

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,7 +12,10 @@
     "dev": "bun run src/index.ts",
     "build": "bun build ./src/index.ts --outdir=./dist --target bun --format esm"
   },
-  "dependencies": {},
+  "dependencies": {
+    "drizzle-valibot": "^0.4.2",
+    "valibot": "^1.4.2"
+  },
   "devDependencies": {
     "drizzle-orm": "0.45.2"
   }

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -1,5 +1,6 @@
 import { and, eq, lt } from 'drizzle-orm';
 import crypto from 'node:crypto';
+import * as v from 'valibot';
 
 import { getGuildId, refreshGuildId } from '../lib/config';
 import { type RouteContext } from '../lib/context';
@@ -171,6 +172,21 @@ function authRateLimit(ip: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Discord API response schemas
+// ---------------------------------------------------------------------------
+const DiscordMemberSchema = v.object({ roles: v.optional(v.array(v.string())) });
+const DiscordUserSchema = v.object({
+  username: v.string(),
+  avatar: v.nullable(v.string()),
+});
+const DiscordTokenSchema = v.object({ access_token: v.optional(v.string()) });
+const DiscordIdentitySchema = v.object({
+  id: v.string(),
+  username: v.string(),
+  avatar: v.nullable(v.string()),
+});
+
+// ---------------------------------------------------------------------------
 // Helper functions
 // ---------------------------------------------------------------------------
 
@@ -192,8 +208,9 @@ async function fetchGuildMemberRoles(discordId: string): Promise<string[] | null
     if (!memberRes.ok) {
       throw new Error(`Discord API error: ${memberRes.status}`);
     }
-    const data = (await memberRes.json()) as { roles?: string[] };
-    return data.roles ?? [];
+    const raw: unknown = await memberRes.json();
+    const parsed = v.parse(DiscordMemberSchema, raw);
+    return parsed.roles ?? [];
   } catch (err: unknown) {
     logger.error(
       { err: err instanceof Error ? err.message : String(err) },
@@ -217,11 +234,12 @@ async function fetchDiscordUserProfile(
     if (!res.ok) {
       return null;
     }
-    const data = (await res.json()) as { username: string; avatar: string | null };
+    const raw: unknown = await res.json();
+    const parsed = v.parse(DiscordUserSchema, raw);
     return {
-      username: data.username,
-      avatar: data.avatar
-        ? `https://cdn.discordapp.com/avatars/${discordId}/${data.avatar}.png`
+      username: parsed.username,
+      avatar: parsed.avatar
+        ? `https://cdn.discordapp.com/avatars/${discordId}/${parsed.avatar}.png`
         : null,
     };
   } catch {
@@ -240,7 +258,8 @@ async function fetchUserAdminStatus(
     if (!userRes.ok) {
       throw new Error(`Discord API error: ${userRes.status}`);
     }
-    const userData = (await userRes.json()) as { username: string; avatar: string | null };
+    const raw: unknown = await userRes.json();
+    const userData = v.parse(DiscordUserSchema, raw);
     const { username, avatar } = userData;
 
     const roles = await fetchGuildMemberRoles(discordId);
@@ -283,7 +302,8 @@ async function exchangeAuthorizationCode(code: string): Promise<string | null> {
     if (!tokenRes.ok) {
       return null;
     }
-    const data = (await tokenRes.json()) as { access_token?: string };
+    const raw: unknown = await tokenRes.json();
+    const data = v.parse(DiscordTokenSchema, raw);
     return data.access_token ?? null;
   } catch {
     return null;
@@ -304,7 +324,8 @@ async function fetchDiscordIdentity(
     if (!userRes.ok) {
       return null;
     }
-    return (await userRes.json()) as { id: string; username: string; avatar: string | null };
+    const raw: unknown = await userRes.json();
+    return v.parse(DiscordIdentitySchema, raw);
   } catch {
     return null;
   }
@@ -598,7 +619,7 @@ async function handleRefresh(
       isSetupAdmin = true;
     } catch (err) {
       logger.warn(
-        { discordId: decoded.discordId, err: (err as Error).message },
+        { discordId: decoded.discordId, err: err instanceof Error ? err.message : String(err) },
         'Auth refresh failed: Discord unreachable (setup mode)'
       );
       return json({ error: 'Discord is temporarily unreachable. Please try again.' }, 503);
@@ -620,7 +641,7 @@ async function handleRefresh(
       roles = userInfo.roles;
     } catch (err) {
       logger.warn(
-        { discordId: decoded.discordId, err: (err as Error).message },
+        { discordId: decoded.discordId, err: err instanceof Error ? err.message : String(err) },
         'Auth refresh failed: Discord unreachable'
       );
       return json({ error: 'Discord is temporarily unreachable. Please try again.' }, 503);

--- a/packages/server/src/routes/channelMix.ts
+++ b/packages/server/src/routes/channelMix.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { type RouteContext } from '../lib/context';
 import { json } from '../lib/json';
@@ -7,13 +8,13 @@ import { routeTable } from '../lib/routeTable';
 import { syncAllFilters } from '../lib/syncAllFilters';
 import { db, tables } from '../shared/db';
 
-interface ChannelMixPayload {
-  enabled: boolean;
-  leftToLeft: number;
-  leftToRight: number;
-  rightToLeft: number;
-  rightToRight: number;
-}
+const ChannelMixSchema = v.object({
+  enabled: v.boolean(),
+  leftToLeft: v.pipe(v.number(), v.minValue(0), v.maxValue(1)),
+  leftToRight: v.pipe(v.number(), v.minValue(0), v.maxValue(1)),
+  rightToLeft: v.pipe(v.number(), v.minValue(0), v.maxValue(1)),
+  rightToRight: v.pipe(v.number(), v.minValue(0), v.maxValue(1)),
+});
 
 function handleChannelMixGet(
   ctx: RouteContext,
@@ -46,30 +47,19 @@ async function handleChannelMixPatch(
     return guards;
   }
 
-  let body: ChannelMixPayload;
+  let raw: unknown;
   try {
-    body = (await request.json()) as ChannelMixPayload;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON' }, 400);
   }
 
-  const { enabled, leftToLeft, leftToRight, rightToLeft, rightToRight } = body;
+  const parsed = v.safeParse(ChannelMixSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
 
-  if (typeof enabled !== 'boolean') {
-    return json({ error: 'enabled must be boolean' }, 400);
-  }
-  if (typeof leftToLeft !== 'number' || leftToLeft < 0 || leftToLeft > 1) {
-    return json({ error: 'leftToLeft must be number 0.0 to 1.0' }, 400);
-  }
-  if (typeof leftToRight !== 'number' || leftToRight < 0 || leftToRight > 1) {
-    return json({ error: 'leftToRight must be number 0.0 to 1.0' }, 400);
-  }
-  if (typeof rightToLeft !== 'number' || rightToLeft < 0 || rightToLeft > 1) {
-    return json({ error: 'rightToLeft must be number 0.0 to 1.0' }, 400);
-  }
-  if (typeof rightToRight !== 'number' || rightToRight < 0 || rightToRight > 1) {
-    return json({ error: 'rightToRight must be number 0.0 to 1.0' }, 400);
-  }
+  const { enabled, leftToLeft, leftToRight, rightToLeft, rightToRight } = parsed.output;
 
   db.insert(tables.guildSettings)
     .values({

--- a/packages/server/src/routes/compressor.ts
+++ b/packages/server/src/routes/compressor.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { type RouteContext } from '../lib/context';
 import { json } from '../lib/json';
@@ -7,14 +8,14 @@ import { routeTable } from '../lib/routeTable';
 import { syncAllFilters } from '../lib/syncAllFilters';
 import { db, tables } from '../shared/db';
 
-interface CompressorPayload {
-  enabled: boolean;
-  threshold: number;
-  ratio: number;
-  attack: number;
-  release: number;
-  gain: number;
-}
+const CompressorSchema = v.object({
+  enabled: v.boolean(),
+  threshold: v.pipe(v.number(), v.integer(), v.minValue(-60), v.maxValue(0)),
+  ratio: v.pipe(v.number(), v.minValue(1), v.maxValue(20)),
+  attack: v.pipe(v.number(), v.integer(), v.minValue(0), v.maxValue(100)),
+  release: v.pipe(v.number(), v.integer(), v.minValue(10), v.maxValue(1000)),
+  gain: v.pipe(v.number(), v.integer(), v.minValue(0), v.maxValue(24)),
+});
 
 function handleCompressorGet(
   ctx: RouteContext,
@@ -48,34 +49,19 @@ async function handleCompressorPatch(
     return guards;
   }
 
-  let body: CompressorPayload;
+  let raw: unknown;
   try {
-    body = (await request.json()) as CompressorPayload;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON' }, 400);
   }
 
-  const { enabled, threshold, ratio, attack, release, gain } = body;
+  const parsed = v.safeParse(CompressorSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
 
-  // Validate ranges
-  if (typeof enabled !== 'boolean') {
-    return json({ error: 'enabled must be boolean' }, 400);
-  }
-  if (!Number.isInteger(threshold) || threshold < -60 || threshold > 0) {
-    return json({ error: 'threshold must be integer -60 to 0' }, 400);
-  }
-  if (typeof ratio !== 'number' || ratio < 1 || ratio > 20) {
-    return json({ error: 'ratio must be number 1 to 20' }, 400);
-  }
-  if (!Number.isInteger(attack) || attack < 0 || attack > 100) {
-    return json({ error: 'attack must be integer 0 to 100' }, 400);
-  }
-  if (!Number.isInteger(release) || release < 10 || release > 1000) {
-    return json({ error: 'release must be integer 10 to 1000' }, 400);
-  }
-  if (!Number.isInteger(gain) || gain < 0 || gain > 24) {
-    return json({ error: 'gain must be integer 0 to 24' }, 400);
-  }
+  const { enabled, threshold, ratio, attack, release, gain } = parsed.output;
 
   // Upsert into DB
   db.insert(tables.guildSettings)

--- a/packages/server/src/routes/distortion.ts
+++ b/packages/server/src/routes/distortion.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { type RouteContext } from '../lib/context';
 import { json } from '../lib/json';
@@ -7,17 +8,17 @@ import { routeTable } from '../lib/routeTable';
 import { syncAllFilters } from '../lib/syncAllFilters';
 import { db, tables } from '../shared/db';
 
-interface DistortionPayload {
-  enabled: boolean;
-  sinOffset: number;
-  sinScale: number;
-  cosOffset: number;
-  cosScale: number;
-  tanOffset: number;
-  tanScale: number;
-  offset: number;
-  scale: number;
-}
+const DistortionSchema = v.object({
+  enabled: v.boolean(),
+  sinOffset: v.pipe(v.number(), v.minValue(-1), v.maxValue(1)),
+  sinScale: v.pipe(v.number(), v.minValue(0), v.maxValue(5)),
+  cosOffset: v.pipe(v.number(), v.minValue(-1), v.maxValue(1)),
+  cosScale: v.pipe(v.number(), v.minValue(0), v.maxValue(5)),
+  tanOffset: v.pipe(v.number(), v.minValue(-1), v.maxValue(1)),
+  tanScale: v.pipe(v.number(), v.minValue(0), v.maxValue(5)),
+  offset: v.pipe(v.number(), v.minValue(-1), v.maxValue(1)),
+  scale: v.pipe(v.number(), v.minValue(0), v.maxValue(5)),
+});
 
 function handleDistortionGet(
   ctx: RouteContext,
@@ -54,43 +55,20 @@ async function handleDistortionPatch(
     return guards;
   }
 
-  let body: DistortionPayload;
+  let raw: unknown;
   try {
-    body = (await request.json()) as DistortionPayload;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON' }, 400);
   }
 
-  const { enabled, sinOffset, sinScale, cosOffset, cosScale, tanOffset, tanScale, offset, scale } =
-    body;
+  const parsed = v.safeParse(DistortionSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
 
-  if (typeof enabled !== 'boolean') {
-    return json({ error: 'enabled must be boolean' }, 400);
-  }
-  if (typeof sinOffset !== 'number' || sinOffset < -1 || sinOffset > 1) {
-    return json({ error: 'sinOffset must be number -1.0 to 1.0' }, 400);
-  }
-  if (typeof sinScale !== 'number' || sinScale < 0 || sinScale > 5) {
-    return json({ error: 'sinScale must be number 0.0 to 5.0' }, 400);
-  }
-  if (typeof cosOffset !== 'number' || cosOffset < -1 || cosOffset > 1) {
-    return json({ error: 'cosOffset must be number -1.0 to 1.0' }, 400);
-  }
-  if (typeof cosScale !== 'number' || cosScale < 0 || cosScale > 5) {
-    return json({ error: 'cosScale must be number 0.0 to 5.0' }, 400);
-  }
-  if (typeof tanOffset !== 'number' || tanOffset < -1 || tanOffset > 1) {
-    return json({ error: 'tanOffset must be number -1.0 to 1.0' }, 400);
-  }
-  if (typeof tanScale !== 'number' || tanScale < 0 || tanScale > 5) {
-    return json({ error: 'tanScale must be number 0.0 to 5.0' }, 400);
-  }
-  if (typeof offset !== 'number' || offset < -1 || offset > 1) {
-    return json({ error: 'offset must be number -1.0 to 1.0' }, 400);
-  }
-  if (typeof scale !== 'number' || scale < 0 || scale > 5) {
-    return json({ error: 'scale must be number 0.0 to 5.0' }, 400);
-  }
+  const { enabled, sinOffset, sinScale, cosOffset, cosScale, tanOffset, tanScale, offset, scale } =
+    parsed.output;
 
   db.insert(tables.guildSettings)
     .values({

--- a/packages/server/src/routes/equalizer.ts
+++ b/packages/server/src/routes/equalizer.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { type RouteContext } from '../lib/context';
 import { EQ_BAND_COLUMNS, eqBandsFromRow, eqBandValues } from '../lib/eqBands';
@@ -8,10 +9,13 @@ import { routeTable } from '../lib/routeTable';
 import { syncAllFilters } from '../lib/syncAllFilters';
 import { db, tables } from '../shared/db';
 
-interface EqualizerPayload {
-  bands: number[]; // length 15, each 0-100
-  enabled: boolean;
-}
+const EqualizerSchema = v.object({
+  bands: v.pipe(
+    v.array(v.pipe(v.number(), v.integer(), v.minValue(0), v.maxValue(100))),
+    v.length(15)
+  ),
+  enabled: v.boolean(),
+});
 
 function handleEqualizerGet(
   ctx: RouteContext,
@@ -48,30 +52,19 @@ async function handleEqualizerPatch(
     return guards;
   }
 
-  let body: EqualizerPayload;
+  let raw: unknown;
   try {
-    body = (await request.json()) as EqualizerPayload;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON' }, 400);
   }
 
-  const { bands, enabled } = body;
-
-  // Validate: enabled must be boolean
-  if (typeof enabled !== 'boolean') {
-    return json({ error: 'enabled must be boolean' }, 400);
+  const parsed = v.safeParse(EqualizerSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
   }
 
-  // Validate: must be array of 15 integers, each 0-100
-  if (!Array.isArray(bands) || bands.length !== 15) {
-    return json({ error: 'bands must be array of 15 integers' }, 400);
-  }
-  for (let i = 0; i < 15; i++) {
-    const v = bands[i];
-    if (v === undefined || !Number.isInteger(v) || v < 0 || v > 100) {
-      return json({ error: `band[${i}] must be integer 0-100` }, 400);
-    }
-  }
+  const { bands, enabled } = parsed.output;
 
   // Upsert into DB
   db.insert(tables.guildSettings)

--- a/packages/server/src/routes/karaoke.ts
+++ b/packages/server/src/routes/karaoke.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { type RouteContext } from '../lib/context';
 import { json } from '../lib/json';
@@ -7,13 +8,13 @@ import { routeTable } from '../lib/routeTable';
 import { syncAllFilters } from '../lib/syncAllFilters';
 import { db, tables } from '../shared/db';
 
-interface KaraokePayload {
-  enabled: boolean;
-  level: number;
-  monoLevel: number;
-  filterBand: number;
-  filterWidth: number;
-}
+const KaraokeSchema = v.object({
+  enabled: v.boolean(),
+  level: v.pipe(v.number(), v.minValue(0), v.maxValue(1)),
+  monoLevel: v.pipe(v.number(), v.minValue(0), v.maxValue(1)),
+  filterBand: v.pipe(v.number(), v.minValue(50), v.maxValue(10000)),
+  filterWidth: v.pipe(v.number(), v.minValue(10), v.maxValue(10000)),
+});
 
 function handleKaraokeGet(
   ctx: RouteContext,
@@ -46,30 +47,19 @@ async function handleKaraokePatch(
     return guards;
   }
 
-  let body: KaraokePayload;
+  let raw: unknown;
   try {
-    body = (await request.json()) as KaraokePayload;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON' }, 400);
   }
 
-  const { enabled, level, monoLevel, filterBand, filterWidth } = body;
+  const parsed = v.safeParse(KaraokeSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
 
-  if (typeof enabled !== 'boolean') {
-    return json({ error: 'enabled must be boolean' }, 400);
-  }
-  if (typeof level !== 'number' || level < 0 || level > 1) {
-    return json({ error: 'level must be number 0.0 to 1.0' }, 400);
-  }
-  if (typeof monoLevel !== 'number' || monoLevel < 0 || monoLevel > 1) {
-    return json({ error: 'monoLevel must be number 0.0 to 1.0' }, 400);
-  }
-  if (typeof filterBand !== 'number' || filterBand < 50 || filterBand > 10000) {
-    return json({ error: 'filterBand must be number 50 to 10000' }, 400);
-  }
-  if (typeof filterWidth !== 'number' || filterWidth < 10 || filterWidth > 10000) {
-    return json({ error: 'filterWidth must be number 10 to 10000' }, 400);
-  }
+  const { enabled, level, monoLevel, filterBand, filterWidth } = parsed.output;
 
   db.insert(tables.guildSettings)
     .values({

--- a/packages/server/src/routes/lowPass.ts
+++ b/packages/server/src/routes/lowPass.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { type RouteContext } from '../lib/context';
 import { json } from '../lib/json';
@@ -7,10 +8,10 @@ import { routeTable } from '../lib/routeTable';
 import { syncAllFilters } from '../lib/syncAllFilters';
 import { db, tables } from '../shared/db';
 
-interface LowPassPayload {
-  enabled: boolean;
-  smoothing: number;
-}
+const LowPassSchema = v.object({
+  enabled: v.boolean(),
+  smoothing: v.pipe(v.number(), v.minValue(0), v.maxValue(60)),
+});
 
 function handleLowPassGet(
   ctx: RouteContext,
@@ -40,21 +41,19 @@ async function handleLowPassPatch(
     return guards;
   }
 
-  let body: LowPassPayload;
+  let raw: unknown;
   try {
-    body = (await request.json()) as LowPassPayload;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON' }, 400);
   }
 
-  const { enabled, smoothing } = body;
+  const parsed = v.safeParse(LowPassSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
 
-  if (typeof enabled !== 'boolean') {
-    return json({ error: 'enabled must be boolean' }, 400);
-  }
-  if (typeof smoothing !== 'number' || smoothing < 0 || smoothing > 60) {
-    return json({ error: 'smoothing must be number 0.0 to 60.0' }, 400);
-  }
+  const { enabled, smoothing } = parsed.output;
 
   db.insert(tables.guildSettings)
     .values({

--- a/packages/server/src/routes/player.ts
+++ b/packages/server/src/routes/player.ts
@@ -1,3 +1,5 @@
+import * as v from 'valibot';
+
 import { type GuildPlayer } from '../GuildPlayer';
 import { getGuildId } from '../lib/config';
 import { type RouteContext } from '../lib/context';
@@ -18,7 +20,6 @@ import {
 import { resolveOrAutoJoinPlayer } from '../lib/voice';
 import {
   fisherYatesShuffle as fisherYatesShuffleImpl,
-  type LoopMode,
   type QueuedSong,
   toQueuedSong,
 } from '../shared';
@@ -63,6 +64,13 @@ function handleGetQueue(
   return json(player.getQueueState());
 }
 
+const PlaySchema = v.object({
+  playlistId: v.optional(v.string()),
+  mode: v.optional(v.picklist(['sequential', 'random'])),
+  loop: v.optional(v.picklist(['off', 'song', 'queue'])),
+  startFromSongId: v.optional(v.string()),
+});
+
 // ---------------------------------------------------------------------------
 // POST /api/player/play — load songs and start playback
 // ---------------------------------------------------------------------------
@@ -73,19 +81,19 @@ async function handlePlay(ctx: RouteContext, request: Request): Promise<Response
   }
   const { user } = guards;
 
-  let body: {
-    playlistId?: string;
-    mode?: 'sequential' | 'random';
-    loop?: LoopMode;
-    startFromSongId?: string;
-  };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  const { playlistId, mode, loop, startFromSongId } = body;
+  const parsed = v.safeParse(PlaySchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
+
+  const { playlistId, mode, loop, startFromSongId } = parsed.output;
 
   const playerResult = await resolveOrAutoJoinPlayer(user.discordId);
   if (!playerResult.ok) {
@@ -195,6 +203,10 @@ function handleLeave(
   return json({ message: 'Left the voice channel.' });
 }
 
+const LoopSchema = v.object({
+  mode: v.picklist(['off', 'song', 'queue']),
+});
+
 // ---------------------------------------------------------------------------
 // POST /api/player/loop — set loop mode
 // ---------------------------------------------------------------------------
@@ -204,18 +216,19 @@ async function handleLoop(ctx: RouteContext, request: Request): Promise<Response
     return guards;
   }
 
-  let body: { mode?: LoopMode };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  const { mode } = body;
-
-  if (!mode || !['off', 'song', 'queue'].includes(mode)) {
+  const parsed = v.safeParse(LoopSchema, raw);
+  if (!parsed.success) {
     return json({ error: 'mode must be "off", "song", or "queue".' }, 400);
   }
+
+  const { mode } = parsed.output;
 
   const playerResult = requirePlayer();
   if (!playerResult.ok) {
@@ -271,6 +284,10 @@ function handleUnshuffle(
   return json({ message: 'Queue order restored.' });
 }
 
+const UrlSchema = v.object({
+  url: v.optional(v.string()),
+});
+
 // ---------------------------------------------------------------------------
 // Shared: resolve a source URL into a temp QueuedSong with player ready
 // ---------------------------------------------------------------------------
@@ -290,14 +307,19 @@ async function resolveUrlTempSong(
   }
   const { user } = guards;
 
-  let body: { url?: unknown };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return { ok: false, response: json({ error: 'Invalid JSON body.' }, 400) };
   }
 
-  const urlResult = validateSourceUrl(body.url);
+  const parsed = v.safeParse(UrlSchema, raw);
+  if (!parsed.success) {
+    return { ok: false, response: json({ error: 'url is required.' }, 400) };
+  }
+
+  const urlResult = validateSourceUrl(parsed.output.url);
   if (!urlResult.ok) {
     return { ok: false, response: urlResult.response };
   }
@@ -345,6 +367,11 @@ async function handleQuickAdd(ctx: RouteContext, request: Request): Promise<Resp
   });
 }
 
+const QuickAddPlaylistSchema = v.object({
+  url: v.optional(v.string()),
+  maxVideos: v.optional(v.number()),
+});
+
 // ---------------------------------------------------------------------------
 // POST /api/player/quick-add-playlist — add playlist to queue (admin only)
 // ---------------------------------------------------------------------------
@@ -355,15 +382,20 @@ async function handleQuickAddPlaylist(ctx: RouteContext, request: Request): Prom
   }
   const { user } = guards;
 
-  let body: { url?: unknown; maxVideos?: number };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  const maxVideos = clampMaxVideos(body.maxVideos);
-  const urlResult = validatePlaylistUrl(body.url);
+  const parsed = v.safeParse(QuickAddPlaylistSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
+
+  const maxVideos = clampMaxVideos(parsed.output.maxVideos);
+  const urlResult = validatePlaylistUrl(parsed.output.url);
   if (!urlResult.ok) {
     return urlResult.response;
   }
@@ -428,6 +460,10 @@ function handlePauseToggle(
   return json({ isPaused });
 }
 
+const SeekSchema = v.object({
+  position: v.number(),
+});
+
 // ---------------------------------------------------------------------------
 // POST /api/player/seek — seek to position in current track
 // ---------------------------------------------------------------------------
@@ -437,18 +473,19 @@ async function handleSeek(ctx: RouteContext, request: Request): Promise<Response
     return guards;
   }
 
-  let body: { position?: unknown };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  const { position } = body;
-
-  if (typeof position !== 'number' || !Number.isFinite(position) || position < 0) {
+  const parsed = v.safeParse(SeekSchema, raw);
+  if (!parsed.success || parsed.output.position < 0 || !Number.isFinite(parsed.output.position)) {
     return json({ error: 'position must be a non-negative number (milliseconds).' }, 400);
   }
+
+  const { position } = parsed.output;
 
   const playingResult = requirePlaying();
   if (!playingResult.ok) {
@@ -481,6 +518,10 @@ function handleClear(
   return json({ message: 'Queue cleared.' });
 }
 
+const SongIdSchema = v.object({
+  songId: v.string(),
+});
+
 // ---------------------------------------------------------------------------
 // POST /api/player/add-to-priority — add library song to Up Next (admin only)
 // ---------------------------------------------------------------------------
@@ -491,18 +532,19 @@ async function handleAddToPriority(ctx: RouteContext, request: Request): Promise
   }
   const { user } = guards;
 
-  let body: { songId?: unknown };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  const { songId } = body;
-
-  if (!songId || typeof songId !== 'string') {
+  const parsed = v.safeParse(SongIdSchema, raw);
+  if (!parsed.success) {
     return json({ error: 'songId is required.' }, 400);
   }
+
+  const { songId } = parsed.output;
 
   const [song] = await db.select().from(songTable).where(eq(songTable.id, songId)).limit(1);
 
@@ -633,6 +675,11 @@ function handleDemoteSong(
   return json({ message: 'Song moved to queue.' });
 }
 
+const ReorderSchema = v.object({
+  songIds: v.array(v.string()),
+  target: v.optional(v.picklist(['queue', 'priority'])),
+});
+
 // ---------------------------------------------------------------------------
 // PATCH /api/player/queue/reorder — reorder remaining queue or priority items
 // ---------------------------------------------------------------------------
@@ -642,22 +689,25 @@ async function handleReorderQueue(ctx: RouteContext, request: Request): Promise<
     return guards;
   }
 
-  let body: { songIds?: unknown; target?: unknown };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  const { songIds, target } = body;
-
-  if (!Array.isArray(songIds) || !songIds.every((id): id is string => typeof id === 'string')) {
+  const parsed = v.safeParse(ReorderSchema, raw);
+  if (!parsed.success) {
     return json({ error: 'songIds must be an array of strings.' }, 400);
   }
 
-  if (target !== undefined && target !== 'queue' && target !== 'priority') {
-    return json({ error: 'target must be "queue" or "priority".' }, 400);
+  const { songIds, target } = parsed.output;
+
+  if (songIds.length === 0) {
+    return json({ error: 'songIds must not be empty.' }, 400);
   }
+
+  // target already validated by picklist — no additional check needed
 
   const playerResult = requirePlayer();
   if (!playerResult.ok) {

--- a/packages/server/src/routes/playlists.ts
+++ b/packages/server/src/routes/playlists.ts
@@ -1,4 +1,5 @@
 import { and, count, desc, eq, inArray, sql } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { type RouteContext } from '../lib/context';
 import { getUserDisplayName, resolveDisplayNames } from '../lib/displayName';
@@ -43,6 +44,27 @@ function formatPlaylistSongWithSong(
     },
   };
 }
+
+// ---------------------------------------------------------------------------
+// Request body schemas
+// ---------------------------------------------------------------------------
+const PlaylistCreateSchema = v.object({
+  name: v.optional(v.string()),
+  tagNameLower: v.optional(v.string()),
+});
+
+const PlaylistVisibilitySchema = v.object({
+  isPrivate: v.optional(v.boolean()),
+  adminView: v.optional(v.boolean()),
+});
+
+const PlaylistAddSongSchema = v.object({
+  songId: v.string(),
+});
+
+const PlaylistRemoveSongsSchema = v.object({
+  songIds: v.pipe(v.array(v.string()), v.minLength(1), v.maxLength(5000)),
+});
 
 // ---------------------------------------------------------------------------
 // GET /api/playlists — paginated list of playlists
@@ -132,12 +154,19 @@ async function handlePostPlaylist(ctx: RouteContext, request: Request): Promise<
   }
   const { user } = guards;
 
-  let body: { name?: unknown; tagNameLower?: unknown };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
+
+  const parsed = v.safeParse(PlaylistCreateSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
+
+  const body = parsed.output;
 
   const nameResult = validatePlaylistName(body.name);
   if (!nameResult.ok) {
@@ -398,18 +427,25 @@ async function handlePatchVisibility(
   }
   const { user } = guards;
 
-  let body: { isPrivate?: unknown; adminView?: unknown };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  if (typeof body.isPrivate !== 'boolean') {
+  const parsed = v.safeParse(PlaylistVisibilitySchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
+
+  const { isPrivate, adminView: rawAdminView } = parsed.output;
+
+  if (isPrivate === undefined) {
     return json({ error: 'isPrivate (boolean) is required.' }, 400);
   }
 
-  const adminView = body.adminView === true;
+  const adminView = rawAdminView === true;
   const existing = await requirePlaylist(id, user, adminView);
   if (existing instanceof Response) {
     return existing;
@@ -417,7 +453,7 @@ async function handlePatchVisibility(
 
   const [updatedPlaylist] = await db
     .update(playlistTable)
-    .set({ isPrivate: body.isPrivate })
+    .set({ isPrivate })
     .where(eq(playlistTable.id, id))
     .returning();
 
@@ -446,12 +482,19 @@ async function handlePatchPlaylist(
   }
   const { user } = guards;
 
-  let body: { name?: unknown; tagNameLower?: unknown };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
+
+  const parsed = v.safeParse(PlaylistCreateSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
+
+  const body = parsed.output;
 
   const existing = await requirePlaylist(id, user);
   if (existing instanceof Response) {
@@ -541,16 +584,19 @@ async function handleAddSong(
   }
   const { user } = guards;
 
-  let body: { songId?: unknown };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  if (!body.songId) {
+  const parsed = v.safeParse(PlaylistAddSongSchema, raw);
+  if (!parsed.success) {
     return json({ error: 'songId is required.' }, 400);
   }
+
+  const { songId } = parsed.output;
 
   const playlist = await requirePlaylist(id, user);
   if (playlist instanceof Response) {
@@ -567,11 +613,7 @@ async function handleAddSong(
     );
   }
 
-  const [song] = await db
-    .select()
-    .from(tables.song)
-    .where(eq(tables.song.id, body.songId as string))
-    .limit(1);
+  const [song] = await db.select().from(tables.song).where(eq(tables.song.id, songId)).limit(1);
   if (!song) {
     return json({ error: 'Song not found.' }, 404);
   }
@@ -702,18 +744,19 @@ async function handleBulkRemoveSongs(
     return playlist;
   }
 
-  let body: { songIds?: unknown };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  if (!Array.isArray(body.songIds) || body.songIds.length === 0) {
+  const parsed = v.safeParse(PlaylistRemoveSongsSchema, raw);
+  if (!parsed.success) {
     return json({ error: 'songIds must be a non-empty array.' }, 400);
   }
 
-  const songIds = (body.songIds as string[]).slice(0, 5000);
+  const { songIds } = parsed.output;
 
   // Delete and re-index in a transaction
   await db.transaction(async (tx) => {

--- a/packages/server/src/routes/rotation.ts
+++ b/packages/server/src/routes/rotation.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { type RouteContext } from '../lib/context';
 import { json } from '../lib/json';
@@ -7,10 +8,10 @@ import { routeTable } from '../lib/routeTable';
 import { syncAllFilters } from '../lib/syncAllFilters';
 import { db, tables } from '../shared/db';
 
-interface RotationPayload {
-  enabled: boolean;
-  rotationHz: number;
-}
+const RotationSchema = v.object({
+  enabled: v.boolean(),
+  rotationHz: v.pipe(v.number(), v.minValue(0), v.maxValue(1)),
+});
 
 function handleRotationGet(
   ctx: RouteContext,
@@ -40,21 +41,19 @@ async function handleRotationPatch(
     return guards;
   }
 
-  let body: RotationPayload;
+  let raw: unknown;
   try {
-    body = (await request.json()) as RotationPayload;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON' }, 400);
   }
 
-  const { enabled, rotationHz } = body;
+  const parsed = v.safeParse(RotationSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
 
-  if (typeof enabled !== 'boolean') {
-    return json({ error: 'enabled must be boolean' }, 400);
-  }
-  if (typeof rotationHz !== 'number' || rotationHz < 0 || rotationHz > 1) {
-    return json({ error: 'rotationHz must be number 0.0 to 1.0' }, 400);
-  }
+  const { enabled, rotationHz } = parsed.output;
 
   db.insert(tables.guildSettings)
     .values({

--- a/packages/server/src/routes/songs.ts
+++ b/packages/server/src/routes/songs.ts
@@ -1,4 +1,5 @@
 import { eq, inArray, sql } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { getGuildId } from '../lib/config';
 import { type RouteContext } from '../lib/context';
@@ -29,6 +30,10 @@ import { getPlayer } from '../startDiscord';
 
 const { song: songTable } = tables;
 
+const BulkDeleteSchema = v.object({
+  ids: v.pipe(v.array(v.string()), v.minLength(1), v.maxLength(5000)),
+});
+
 // ---------------------------------------------------------------------------
 // POST /api/songs/bulk-delete — delete multiple songs at once.
 // ---------------------------------------------------------------------------
@@ -38,18 +43,19 @@ async function handleBulkDelete(ctx: RouteContext, request: Request): Promise<Re
     return guards;
   }
 
-  let body: { ids?: unknown };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  if (!Array.isArray(body.ids) || body.ids.length === 0) {
-    return json({ error: 'ids must be a non-empty array of song IDs.' }, 400);
+  const parsed = v.safeParse(BulkDeleteSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
   }
 
-  const ids = body.ids.slice(0, 5000) as string[];
+  const { ids } = parsed.output;
 
   // Delete songs from DB
   await db.delete(songTable).where(inArray(songTable.id, ids));
@@ -62,6 +68,12 @@ async function handleBulkDelete(ctx: RouteContext, request: Request): Promise<Re
   return json({ deleted: ids.length });
 }
 
+const BulkTagSchema = v.object({
+  ids: v.pipe(v.array(v.string()), v.minLength(1), v.maxLength(5000)),
+  tags: v.optional(v.array(v.string())),
+  mode: v.optional(v.pipe(v.string(), v.picklist(['add', 'set']))),
+});
+
 // ---------------------------------------------------------------------------
 // POST /api/songs/bulk-tag — add or set tags on multiple songs at once.
 // ---------------------------------------------------------------------------
@@ -71,25 +83,27 @@ async function handleBulkTag(ctx: RouteContext, request: Request): Promise<Respo
     return guards;
   }
 
-  let body: { ids?: unknown; tags?: unknown; mode?: unknown };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  if (!Array.isArray(body.ids) || body.ids.length === 0) {
-    return json({ error: 'ids must be a non-empty array of song IDs.' }, 400);
+  const parsed = v.safeParse(BulkTagSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
   }
 
-  const tagsResult = validateTags(body.tags);
+  const { ids } = parsed.output;
+
+  const tagsResult = validateTags(parsed.output.tags);
   if (!tagsResult.ok) {
     return tagsResult.response;
   }
 
-  const ids = (body.ids as string[]).slice(0, 5000);
   const newTags = await canonicalizeTags(tagsResult.value);
-  const mode = body.mode === 'set' ? 'set' : 'add'; // "add" is default (merge with existing)
+  const mode = parsed.output.mode ?? 'add';
 
   // Fetch existing songs
   const existingSongs = await db.select().from(songTable).where(inArray(songTable.id, ids));
@@ -135,35 +149,36 @@ async function handleBulkEdit(ctx: RouteContext, request: Request): Promise<Resp
     return guards;
   }
 
-  let body: {
-    ids?: unknown;
-    nickname?: unknown;
-    artist?: unknown;
-    album?: unknown;
-    artwork?: unknown;
-    tags?: unknown;
-    volumeBoost?: unknown;
-    clearFields?: unknown;
-  };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  if (!Array.isArray(body.ids) || body.ids.length === 0) {
-    return json({ error: 'ids must be a non-empty array of song IDs.' }, 400);
+  const BulkEditBaseSchema = v.object({
+    ids: v.pipe(v.array(v.string()), v.minLength(1), v.maxLength(5000)),
+    nickname: v.optional(v.string()),
+    artist: v.optional(v.string()),
+    album: v.optional(v.string()),
+    artwork: v.optional(v.string()),
+    tags: v.optional(v.array(v.string())),
+    volumeBoost: v.optional(v.number()),
+    clearFields: v.optional(v.array(v.string())),
+  });
+
+  const parsed = v.safeParse(BulkEditBaseSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
   }
 
-  const ids = (body.ids as string[]).slice(0, 5000);
-  const clearFields: string[] = Array.isArray(body.clearFields)
-    ? (body.clearFields as string[])
-    : [];
+  const { ids, clearFields = [] } = parsed.output;
+  const body = parsed.output;
 
   const data: Record<string, unknown> = {};
 
   // Nickname
-  if ('nickname' in body && body.nickname !== undefined) {
+  if (body.nickname !== undefined) {
     const result = validateNickname(body.nickname);
     if (!result.ok) {
       return result.response;
@@ -174,21 +189,21 @@ async function handleBulkEdit(ctx: RouteContext, request: Request): Promise<Resp
   }
 
   // Artist
-  if ('artist' in body && body.artist !== undefined) {
+  if (body.artist !== undefined) {
     data.artist = validateOptionalString(body.artist);
   } else if (clearFields.includes('artist')) {
     data.artist = null;
   }
 
   // Album
-  if ('album' in body && body.album !== undefined) {
+  if (body.album !== undefined) {
     data.album = validateOptionalString(body.album);
   } else if (clearFields.includes('album')) {
     data.album = null;
   }
 
   // Artwork
-  if ('artwork' in body && body.artwork !== undefined) {
+  if (body.artwork !== undefined) {
     const artworkResult = validateArtworkUrl(body.artwork);
     if (!artworkResult.ok) {
       return artworkResult.response;
@@ -199,23 +214,27 @@ async function handleBulkEdit(ctx: RouteContext, request: Request): Promise<Resp
   }
 
   // Tags
-  if ('tags' in body && body.tags !== undefined) {
+  let processedTags: string[] | undefined;
+  if (body.tags !== undefined) {
     const tagsResult = validateTags(body.tags);
     if (!tagsResult.ok) {
       return tagsResult.response;
     }
-    data.tags = await canonicalizeTags(tagsResult.value);
+    processedTags = await canonicalizeTags(tagsResult.value);
+    data.tags = processedTags;
   } else if (clearFields.includes('tags')) {
     data.tags = [];
   }
 
   // Volume boost
-  if ('volumeBoost' in body && body.volumeBoost !== undefined) {
+  let processedVolumeBoost: number | null | undefined;
+  if (body.volumeBoost !== undefined) {
     const volumeResult = validateVolumeBoost(body.volumeBoost);
     if (!volumeResult.ok) {
       return volumeResult.response;
     }
-    data.volumeBoost = volumeResult.value;
+    processedVolumeBoost = volumeResult.value;
+    data.volumeBoost = processedVolumeBoost;
   } else if (clearFields.includes('volumeBoost')) {
     data.volumeBoost = null;
   }
@@ -234,18 +253,18 @@ async function handleBulkEdit(ctx: RouteContext, request: Request): Promise<Resp
   }
 
   // If tags changed, re-sync any smart playlists tracking affected tags
-  if ('tags' in data) {
-    await reSyncPlaylistsForTags(((data.tags as string[]) ?? []).map((t) => t.toLowerCase()));
+  if (processedTags) {
+    await reSyncPlaylistsForTags(processedTags.map((t) => t.toLowerCase()));
   }
 
   // Update the player cache for any of the edited songs that are currently
   // in the queue / now playing.
   const bulkPlayer = getPlayer(getGuildId());
   if (bulkPlayer) {
-    if ('volumeBoost' in data) {
+    if (processedVolumeBoost != null) {
       const currentSong = bulkPlayer.getCurrentSong();
       if (currentSong && ids.includes(currentSong.id)) {
-        bulkPlayer.updateVolumeBoost(data.volumeBoost as number);
+        bulkPlayer.updateVolumeBoost(processedVolumeBoost);
       }
     }
     const bulkFields: Record<string, unknown> = {};
@@ -391,12 +410,14 @@ async function handlePatchSong(
     return guards;
   }
 
-  let body: Record<string, unknown>;
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
+
+  const body = raw as Record<string, unknown>;
 
   const [existing] = await db.select().from(songTable).where(eq(songTable.id, id)).limit(1);
   if (!existing) {
@@ -436,22 +457,26 @@ async function handlePatchSong(
   // Tags
   // Track old tags for smart playlist re-sync
   const oldTagsLower = new Set((existing.tags ?? []).map((t: string) => t.toLowerCase()));
+  let processedTags: string[] | undefined;
 
   if ('tags' in body) {
     const tagsResult = validateTags(body.tags);
     if (!tagsResult.ok) {
       return tagsResult.response;
     }
-    data.tags = await canonicalizeTags(tagsResult.value);
+    processedTags = await canonicalizeTags(tagsResult.value);
+    data.tags = processedTags;
   }
 
   // Volume boost
+  let processedVolumeBoost: number | null | undefined;
   if ('volumeBoost' in body) {
     const volumeResult = validateVolumeBoost(body.volumeBoost);
     if (!volumeResult.ok) {
       return volumeResult.response;
     }
-    data.volumeBoost = volumeResult.value;
+    processedVolumeBoost = volumeResult.value;
+    data.volumeBoost = processedVolumeBoost;
   }
 
   const [updatedSong] = await db
@@ -467,10 +492,8 @@ async function handlePatchSong(
   emitSongUpdated(formatSong(updatedSong));
 
   // If tags changed, re-sync any smart playlists tracking affected tags
-  if ('tags' in data) {
-    const newTagsLower = new Set(
-      ((data.tags as string[]) ?? []).map((t: string) => t.toLowerCase())
-    );
+  if (processedTags) {
+    const newTagsLower = new Set(processedTags.map((t) => t.toLowerCase()));
     const affectedTags = [...new Set([...oldTagsLower, ...newTagsLower])];
     await reSyncPlaylistsForTags(affectedTags);
   }
@@ -480,10 +503,10 @@ async function handlePatchSong(
   const player = getPlayer(getGuildId());
   if (player) {
     // Volume boost also needs live audio update
-    if (data.volumeBoost !== undefined) {
+    if (processedVolumeBoost != null) {
       const currentSong = player.getCurrentSong();
       if (currentSong?.id === id) {
-        player.updateVolumeBoost(data.volumeBoost as number);
+        player.updateVolumeBoost(processedVolumeBoost);
       }
     }
 

--- a/packages/server/src/routes/timescale.ts
+++ b/packages/server/src/routes/timescale.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { getGuildId } from '../lib/config';
 import { type RouteContext } from '../lib/context';
@@ -10,12 +11,12 @@ import { syncAllFilters } from '../lib/syncAllFilters';
 import { db, tables } from '../shared/db';
 import { getPlayer } from '../startDiscord';
 
-interface TimescalePayload {
-  enabled: boolean;
-  speed: number;
-  pitch: number;
-  rate: number;
-}
+const TimescaleSchema = v.object({
+  enabled: v.boolean(),
+  speed: v.pipe(v.number(), v.minValue(0.5), v.maxValue(2.0)),
+  pitch: v.pipe(v.number(), v.minValue(0.5), v.maxValue(2.0)),
+  rate: v.pipe(v.number(), v.minValue(0.5), v.maxValue(2.0)),
+});
 
 function handleTimescaleGet(
   ctx: RouteContext,
@@ -47,27 +48,19 @@ async function handleTimescalePatch(
     return guards;
   }
 
-  let body: TimescalePayload;
+  let raw: unknown;
   try {
-    body = (await request.json()) as TimescalePayload;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON' }, 400);
   }
 
-  const { enabled, speed, pitch, rate } = body;
+  const parsed = v.safeParse(TimescaleSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
 
-  if (typeof enabled !== 'boolean') {
-    return json({ error: 'enabled must be boolean' }, 400);
-  }
-  if (typeof speed !== 'number' || speed < 0.5 || speed > 2.0) {
-    return json({ error: 'speed must be number 0.5 to 2.0' }, 400);
-  }
-  if (typeof pitch !== 'number' || pitch < 0.5 || pitch > 2.0) {
-    return json({ error: 'pitch must be number 0.5 to 2.0' }, 400);
-  }
-  if (typeof rate !== 'number' || rate < 0.5 || rate > 2.0) {
-    return json({ error: 'rate must be number 0.5 to 2.0' }, 400);
-  }
+  const { enabled, speed, pitch, rate } = parsed.output;
 
   db.insert(tables.guildSettings)
     .values({

--- a/packages/server/src/routes/tremolo.ts
+++ b/packages/server/src/routes/tremolo.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { type RouteContext } from '../lib/context';
 import { json } from '../lib/json';
@@ -7,11 +8,11 @@ import { routeTable } from '../lib/routeTable';
 import { syncAllFilters } from '../lib/syncAllFilters';
 import { db, tables } from '../shared/db';
 
-interface TremoloPayload {
-  enabled: boolean;
-  frequency: number;
-  depth: number;
-}
+const TremoloSchema = v.object({
+  enabled: v.boolean(),
+  frequency: v.pipe(v.number(), v.minValue(0.1), v.maxValue(14.0)),
+  depth: v.pipe(v.number(), v.minValue(0), v.maxValue(1)),
+});
 
 function handleTremoloGet(
   ctx: RouteContext,
@@ -42,24 +43,19 @@ async function handleTremoloPatch(
     return guards;
   }
 
-  let body: TremoloPayload;
+  let raw: unknown;
   try {
-    body = (await request.json()) as TremoloPayload;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON' }, 400);
   }
 
-  const { enabled, frequency, depth } = body;
+  const parsed = v.safeParse(TremoloSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
 
-  if (typeof enabled !== 'boolean') {
-    return json({ error: 'enabled must be boolean' }, 400);
-  }
-  if (typeof frequency !== 'number' || frequency < 0.1 || frequency > 14.0) {
-    return json({ error: 'frequency must be number 0.1 to 14.0' }, 400);
-  }
-  if (typeof depth !== 'number' || depth < 0 || depth > 1) {
-    return json({ error: 'depth must be number 0.0 to 1.0' }, 400);
-  }
+  const { enabled, frequency, depth } = parsed.output;
 
   db.insert(tables.guildSettings)
     .values({

--- a/packages/server/src/routes/vibrato.ts
+++ b/packages/server/src/routes/vibrato.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { type RouteContext } from '../lib/context';
 import { json } from '../lib/json';
@@ -7,11 +8,11 @@ import { routeTable } from '../lib/routeTable';
 import { syncAllFilters } from '../lib/syncAllFilters';
 import { db, tables } from '../shared/db';
 
-interface VibratoPayload {
-  enabled: boolean;
-  frequency: number;
-  depth: number;
-}
+const VibratoSchema = v.object({
+  enabled: v.boolean(),
+  frequency: v.pipe(v.number(), v.minValue(0.1), v.maxValue(14.0)),
+  depth: v.pipe(v.number(), v.minValue(0), v.maxValue(1)),
+});
 
 function handleVibratoGet(
   ctx: RouteContext,
@@ -42,24 +43,19 @@ async function handleVibratoPatch(
     return guards;
   }
 
-  let body: VibratoPayload;
+  let raw: unknown;
   try {
-    body = (await request.json()) as VibratoPayload;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON' }, 400);
   }
 
-  const { enabled, frequency, depth } = body;
+  const parsed = v.safeParse(VibratoSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
 
-  if (typeof enabled !== 'boolean') {
-    return json({ error: 'enabled must be boolean' }, 400);
-  }
-  if (typeof frequency !== 'number' || frequency < 0.1 || frequency > 14.0) {
-    return json({ error: 'frequency must be number 0.1 to 14.0' }, 400);
-  }
-  if (typeof depth !== 'number' || depth < 0 || depth > 1) {
-    return json({ error: 'depth must be number 0.0 to 1.0' }, 400);
-  }
+  const { enabled, frequency, depth } = parsed.output;
 
   db.insert(tables.guildSettings)
     .values({


### PR DESCRIPTION
## Summary

Replace manual `req.json() as T` request body parsing with Valibot schema validation across all server route handlers and Discord API response parsing. This eliminates ~43 unsafe type assertions in preparation for enabling the `no-unsafe-type-assertion` rule.

## Changes

- **Dependencies**: Add `valibot` (v1.4.2) and `drizzle-valibot` (v0.4.2) to server package
- **13 route files converted**: songs, player, playlists, auth, equalizer, compressor, channelMix, distortion, karaoke, lowPass, rotation, timescale, tremolo, vibrato
- **Pattern**: `v.safeParse(Schema, raw)` replaces `(await req.json()) as T` — declarative validation with automatic type inference
- **Manual validation replaced**: Field-level checks (typeof, isArray, range checks) folded into Valibot pipelines (`v.minValue`, `v.maxLength`, `v.picklist`, etc.)
- **Discord API parsing**: `fetch().json() as T` converted to `v.parse(DiscordUserSchema, raw)` in auth.ts
- **oxlint rules added**: 4 oxc correctness rules + 2 unicorn style rules
- **Error casts fixed**: `as Error` replaced with `instanceof Error` guards in catch blocks

## Verification

- [x] `bun run check` passes with zero diagnostics
- [x] Server package builds successfully