### PR TITLE
chore: tighten oxlint rules and add oxfmt sortPackageJson

### DIFF
--- a/docs/oxlint-setup.md
+++ b/docs/oxlint-setup.md
@@ -85,6 +85,24 @@ bun run format
 - `oxlint.config.ts` — linter rules, plugins, overrides, globals
 - `oxfmt.config.ts` — formatter options (print width, quotes, semicolons, etc.)
 
+## Design Philosophy
+
+### Explicit rules over categories
+
+Every rule in the config is individually listed rather than using Oxlint's category-based defaults (correctness, suspicious, pedantic, etc.). This trades verbosity for full control:
+
+- **Every rule is a deliberate choice.** The config serves as documentation of what we enforce and why.
+- **No surprises from upstream.** New rules added to categories won't silently start flagging code.
+- **Overrides are surgical.** File-level exceptions have clear justifications in comments.
+
+### Warnings are errors
+
+The `check` script runs with `--deny-warnings`, so `warn` and `error` are equivalent in CI. The distinction is for editor experience: errors are red squiggles (must fix now), warnings are yellow (should fix, but the build won't break locally until you run `check`).
+
+### Type-aware by default
+
+Type-aware rules (`--type-aware --type-check`) run everywhere. This catches a class of bugs that purely syntactic linting misses — type assertions that don't hold, unreachable conditions, unsafe coercions. Some files suppress specific type-aware rules (e.g., `no-unnecessary-condition` on Drizzle query results) where the rule has known false positives for defensive runtime guards.
+
 ## Resources
 
 - [oxlint Documentation](https://oxc.rs/docs/guide/usage/linter.html)

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
   quoteProps: 'as-needed',
   insertFinalNewline: true,
   sortTailwindcss: true,
+  sortPackageJson: true,
   sortImports: {
     groups: [
       'type-import',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -81,7 +81,7 @@ export default defineConfig({
     'unicorn/throw-new-error': 'error',
     'unicorn/error-message': 'error',
     // Reassigning parameters is confusing — mutate properties instead
-    'no-param-reassign': 'warn',
+    'no-param-reassign': 'error',
     // Comma operator outside for-loops is almost always a mistake
     'no-sequences': 'error',
     // Assignment in return (e.g. return x = 5) is never intentional
@@ -110,6 +110,20 @@ export default defineConfig({
     'react/jsx-no-script-url': 'error',
     'react/no-danger': 'error',
     'react/jsx-no-target-blank': 'error',
+
+    // -----------------------------------------------------------------------
+    // type safety — catch TypeScript type-level mistakes
+    // -----------------------------------------------------------------------
+    // {} means "any non-nullish value", not "empty object" — use Record<string, never>
+    '@typescript-eslint/no-empty-object-type': 'error',
+    // Function type is unsafe — use (...args: unknown[]) => unknown
+    '@typescript-eslint/no-unsafe-function-type': 'error',
+    // String / Number / Boolean as types (uppercase wrappers) — use primitives
+    '@typescript-eslint/no-wrapper-object-types': 'error',
+    // Duplicate enum members are ambiguous and confusing
+    '@typescript-eslint/no-duplicate-enum-values': 'error',
+    // void in unions or intersections is a type-level mistake
+    '@typescript-eslint/no-invalid-void-type': 'error',
 
     // -----------------------------------------------------------------------
     // suspicious
@@ -172,7 +186,8 @@ export default defineConfig({
     // imports
     // -----------------------------------------------------------------------
     'import/first': 'warn',
-    'import/no-cycle': 'warn',
+    // Circular imports cause subtle ordering bugs — always a problem
+    'import/no-cycle': 'error',
     'unicorn/prefer-node-protocol': 'warn',
     // export let can cause cross-module side-channel bugs
     'import/no-mutable-exports': 'warn',
@@ -193,6 +208,8 @@ export default defineConfig({
     'promise/always-return': 'warn',
     // Enforce resolve/reject naming in new Promise() callbacks
     'promise/param-names': 'warn',
+    // Promise created in a callback but never returned or awaited — dangling promise
+    'promise/no-promise-in-callback': 'error',
 
     // -----------------------------------------------------------------------
     // style
@@ -313,6 +330,8 @@ export default defineConfig({
     '@typescript-eslint/no-meaningless-void-operator': 'warn',
     // Unnecessary namespace qualifier on a type that's already in scope
     '@typescript-eslint/no-unnecessary-qualifier': 'warn',
+    // Type parameters that can be inferred — dead weight
+    '@typescript-eslint/no-unnecessary-type-parameters': 'warn',
     // `Promise.reject(nonError)` — loses stack trace info
     '@typescript-eslint/prefer-promise-reject-errors': 'warn',
     // `arr.filter(fn)[0]` → `arr.find(fn)` — O(n) vs early-exit
@@ -393,6 +412,10 @@ export default defineConfig({
     'unicorn/prefer-modern-dom-apis': 'warn',
     // Number.isNaN() over isNaN(), Number.isFinite() over isFinite(), etc.
     'unicorn/prefer-number-properties': 'warn',
+    // structuredClone(x) over JSON.parse(JSON.stringify(x))
+    'unicorn/prefer-structured-clone': 'warn',
+    // String.raw over escaping backslashes in regex / path strings
+    'unicorn/prefer-string-raw': 'warn',
     // Enforce kebab-case, PascalCase, or camelCase filenames
     'unicorn/filename-case': [
       'warn',
@@ -615,6 +638,22 @@ export default defineConfig({
       ],
       rules: {
         '@typescript-eslint/no-unnecessary-condition': 'off',
+      },
+    },
+
+    // API wrappers + generic utilities: T used only in return type is necessary
+    // for caller-side type inference. no-unnecessary-type-parameters fires on
+    // single-use type params even when they're essential (e.g. get<T>(url): Promise<T>).
+    {
+      files: [
+        'packages/server/src/shared/api.ts',
+        'packages/server/src/shared/shuffle.ts',
+        'packages/server/src/lib/jwt.ts',
+        'packages/web/src/api/client.ts',
+        'packages/web/src/hooks/useSocket.ts',
+      ],
+      rules: {
+        '@typescript-eslint/no-unnecessary-type-parameters': 'off',
       },
     },
 


### PR DESCRIPTION
## Summary

Adds 11 new lint rules, promotes 2 warnings to errors, adds `sortPackageJson` to the formatter, and documents the design philosophy.

## Changes

### New rules (oxlint)

**Error severity:**
- `@typescript-eslint/no-empty-object-type` — `{}` doesn't mean "empty object"
- `@typescript-eslint/no-unsafe-function-type` — `Function` type is unsafe
- `@typescript-eslint/no-wrapper-object-types` — uppercase wrapper types (`String`, `Number`, etc.)
- `@typescript-eslint/no-duplicate-enum-values` — ambiguous enum members
- `@typescript-eslint/no-invalid-void-type` — `void` in unions/intersections
- `promise/no-promise-in-callback` — unreturned promises in callbacks

**Warn severity:**
- `@typescript-eslint/no-unnecessary-type-parameters` — inferrable type params (with per-file overrides for API wrappers)
- `unicorn/prefer-structured-clone` — `structuredClone()` over `JSON.parse(JSON.stringify())`
- `unicorn/prefer-string-raw` — `String.raw` for backslash-heavy strings

### Promoted warn → error
- `no-param-reassign`
- `import/no-cycle`

### Formatter
- Added `sortPackageJson: true` to `oxfmt.config.ts`

### Documentation
- Added Design Philosophy section to `docs/oxlint-setup.md` explaining explicit rules, warn-vs-error semantics, and type-aware defaults