### PR TITLE
refactor(web): use VirtualList in AddSongsModal

### DIFF
--- a/packages/web/src/components/AddSongsModal.tsx
+++ b/packages/web/src/components/AddSongsModal.tsx
@@ -1,6 +1,5 @@
 import { type PlaylistDetail, type Song } from '@alfira/server/shared';
 import { formatDuration } from '@alfira/server/shared';
-import { useVirtualizer } from '@tanstack/react-virtual';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { addSongToPlaylist, getSongsPage } from '../api/api';
@@ -9,6 +8,7 @@ import { ArtworkImage } from './ui/ArtworkImage';
 import { Button } from './ui/Button';
 import { Skeleton } from './ui/Skeleton';
 import { SpringUp } from './ui/SpringUp';
+import { VirtualList } from './VirtualList';
 
 const PAGE_SIZE = 30;
 
@@ -24,44 +24,70 @@ export default function AddSongsModal({
   const [songs, setSongs] = useState<Song[]>([]);
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(true);
-  const [loading, setLoading] = useState(true);
-  const [loadingMore, setLoadingMore] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const [isFetching, setIsFetching] = useState(false);
+  const [isError, setIsError] = useState(false);
   const [adding, setAdding] = useState<Set<string>>(new Set());
   const [added, setAdded] = useState<Set<string>>(new Set(playlist.songs.map((ps) => ps.songId)));
   const [search, setSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
   // eslint-disable-next-line unicorn/no-useless-undefined
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const scrollRef = useRef<HTMLDivElement>(null);
 
-  // Stable refs to avoid recreating callbacks on every render
+  // Stable refs so callbacks don't trigger virtualizer re-indexing.
   const hasMoreRef = useRef(true);
-  const loadingMoreRef = useRef(false);
-  const debouncedSearchRef = useRef('');
+  const isFetchingRef = useRef(false);
   const pageRef = useRef(1);
+  const debouncedSearchRef = useRef('');
+  const mountedRef = useRef(true);
   hasMoreRef.current = hasMore;
-  loadingMoreRef.current = loadingMore;
-  debouncedSearchRef.current = debouncedSearch;
+  isFetchingRef.current = isFetching;
   pageRef.current = page;
+  debouncedSearchRef.current = debouncedSearch;
 
-  // Reset and fetch page 1 on search change
+  // Reset and fetch page 1 when debounced search changes.
   useEffect(() => {
+    mountedRef.current = true;
     setSongs([]);
     setPage(1);
     pageRef.current = 1;
     setHasMore(true);
-    setLoading(true);
-    debouncedSearchRef.current = debouncedSearch;
+    hasMoreRef.current = true;
+    setIsLoading(true);
+    setHasLoaded(false);
+    setIsError(false);
+
     void (async () => {
-      const result = await getSongsPage(1, PAGE_SIZE, { search: debouncedSearch || undefined });
-      setSongs(result.items);
-      setHasMore(result.items.length >= PAGE_SIZE);
-      hasMoreRef.current = result.items.length >= PAGE_SIZE;
-      setLoading(false);
+      try {
+        const result = await getSongsPage(1, PAGE_SIZE, {
+          search: debouncedSearch || undefined,
+        });
+        if (!mountedRef.current) {
+          return;
+        }
+        setSongs(result.items);
+        setHasMore(result.items.length >= PAGE_SIZE);
+        hasMoreRef.current = result.items.length >= PAGE_SIZE;
+      } catch {
+        if (!mountedRef.current) {
+          return;
+        }
+        setIsError(true);
+      } finally {
+        if (mountedRef.current) {
+          setIsLoading(false);
+          setHasLoaded(true);
+        }
+      }
     })();
+
+    return () => {
+      mountedRef.current = false;
+    };
   }, [debouncedSearch]);
 
-  // Debounce search input
+  // Debounce search input.
   useEffect(() => {
     if (timerRef.current) {
       clearTimeout(timerRef.current);
@@ -76,50 +102,44 @@ export default function AddSongsModal({
     };
   }, [search]);
 
-  const loadMore = useCallback(() => {
-    if (!hasMoreRef.current || loadingMoreRef.current) {
+  const fetchMore = useCallback(() => {
+    if (!hasMoreRef.current || isFetchingRef.current) {
       return;
     }
-    loadingMoreRef.current = true;
-    setLoadingMore(true);
+    isFetchingRef.current = true;
+    setIsFetching(true);
     const nextPage = pageRef.current + 1;
     void (async () => {
-      const result = await getSongsPage(nextPage, PAGE_SIZE, {
-        search: debouncedSearchRef.current || undefined,
-      });
-      setSongs((prev) => [...prev, ...result.items]);
-      setPage(nextPage);
-      pageRef.current = nextPage;
-      setHasMore(result.items.length >= PAGE_SIZE);
-      hasMoreRef.current = result.items.length >= PAGE_SIZE;
-      loadingMoreRef.current = false;
-      setLoadingMore(false);
+      try {
+        const result = await getSongsPage(nextPage, PAGE_SIZE, {
+          search: debouncedSearchRef.current || undefined,
+        });
+        if (!mountedRef.current) {
+          return;
+        }
+        setSongs((prev) => [...prev, ...result.items]);
+        setPage(nextPage);
+        pageRef.current = nextPage;
+        setHasMore(result.items.length >= PAGE_SIZE);
+        hasMoreRef.current = result.items.length >= PAGE_SIZE;
+      } catch {
+        if (!mountedRef.current) {
+          return;
+        }
+        setIsError(true);
+      } finally {
+        if (mountedRef.current) {
+          setIsFetching(false);
+          isFetchingRef.current = false;
+        }
+      }
     })();
   }, []);
 
-  // Check near-bottom on scroll
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) {
-      return;
-    }
-    const check = () => {
-      if (el.scrollHeight - el.scrollTop - el.clientHeight < 300) {
-        loadMore();
-      }
-    };
-    el.addEventListener('scroll', check, { passive: true });
-    return () => {
-      el.removeEventListener('scroll', check);
-    };
-  }, [loadMore]);
-
-  const virtualizer = useVirtualizer({
-    count: songs.length,
-    getScrollElement: () => scrollRef.current,
-    estimateSize: () => 60,
-    overscan: 5,
-  });
+  const retry = useCallback(() => {
+    setIsError(false);
+    fetchMore();
+  }, [fetchMore]);
 
   const handleAdd = useCallback(
     async (song: Song) => {
@@ -128,7 +148,7 @@ export default function AddSongsModal({
         await addSongToPlaylist(playlist.id, song.id);
         setAdded((prev) => new Set([...prev, song.id]));
       } catch {
-        /* already added — mark as added */
+        // Already in playlist — mark as added regardless.
         setAdded((prev) => new Set([...prev, song.id]));
       } finally {
         setAdding((prev) => {
@@ -147,12 +167,34 @@ export default function AddSongsModal({
     setSearch(e.target.value);
   }, []);
 
-  const virtualContainerStyle = useMemo(
-    () => ({
-      height: `${virtualizer.getTotalSize()}px`,
-      position: 'relative' as const,
-    }),
-    [virtualizer]
+  // Stable callbacks for VirtualList.
+  const estimateSize = useCallback(() => 60, []);
+  const getItemKey = useCallback((song: Song) => song.id, []);
+
+  const renderItem = useCallback(
+    (song: Song) => (
+      <SongRow
+        song={song}
+        isAdded={added.has(song.id)}
+        isAdding={adding.has(song.id)}
+        onAdd={handleAdd}
+      />
+    ),
+    [added, adding, handleAdd]
+  );
+
+  const skeleton = useMemo(
+    () => (
+      <div className='space-y-2 p-4 md:p-6'>
+        {[1, 2, 3, 4, 5].map((n) => (
+          <div key={`skeleton-${n}`} className='flex items-center gap-3'>
+            <Skeleton className='h-8 w-12 rounded md:h-7 md:w-10' />
+            <Skeleton className='h-3 flex-1' />
+          </div>
+        ))}
+      </div>
+    ),
+    []
   );
 
   return (
@@ -160,7 +202,7 @@ export default function AddSongsModal({
       <SpringUp className='glass-modal flex max-h-[80vh] w-full max-w-lg flex-col'>
         <div className='border-border border-b p-4 md:p-5'>
           <h2 className='font-display text-fg text-2xl tracking-wider md:text-3xl'>Add Songs</h2>
-          <p className='text-muted mt-0.5 font-mono text-xs'>to "{playlist.name}"</p>
+          <p className='text-muted mt-0.5 font-mono text-xs'>to &quot;{playlist.name}&quot;</p>
           <input
             className='input mt-3 md:mt-4'
             placeholder='Search...'
@@ -168,51 +210,23 @@ export default function AddSongsModal({
             onChange={handleSearchChange}
           />
         </div>
-        <div ref={scrollRef} className='flex-1 overflow-y-auto'>
-          {loading ? (
-            <div className='space-y-2 p-4 md:p-6'>
-              {[1, 2, 3, 4, 5].map((n) => (
-                <div key={`skeleton-${n}`} className='flex items-center gap-3'>
-                  <Skeleton className='h-8 w-12 rounded md:h-7 md:w-10' />
-                  <Skeleton className='h-3 flex-1' />
-                </div>
-              ))}
-            </div>
-          ) : songs.length === 0 ? (
-            <p className='text-muted p-4 text-center font-mono text-xs md:p-6'>no songs found</p>
-          ) : (
-            <div style={virtualContainerStyle}>
-              {virtualizer.getVirtualItems().map((virtualRow) => {
-                const song = songs[virtualRow.index];
-                if (song == null) {
-                  return null;
-                }
-                const isAdded = added.has(song.id);
-                const isAdding = adding.has(song.id);
-                return (
-                  <div
-                    key={song.id}
-                    data-index={virtualRow.index}
-                    ref={virtualizer.measureElement}
-                    /* eslint-disable-next-line react-perf/jsx-no-new-object-as-prop -- per-row dynamic transform from virtualizer */
-                    style={{
-                      position: 'absolute',
-                      top: 0,
-                      left: 0,
-                      width: '100%',
-                      transform: `translateY(${virtualRow.start}px)`,
-                    }}
-                  >
-                    <SongRow song={song} isAdded={isAdded} isAdding={isAdding} onAdd={handleAdd} />
-                  </div>
-                );
-              })}
-            </div>
-          )}
-          {loadingMore && (
-            <p className='text-muted p-3 text-center font-mono text-xs'>loading...</p>
-          )}
-        </div>
+
+        <VirtualList
+          items={songs}
+          getItemKey={getItemKey}
+          renderItem={renderItem}
+          estimateSize={estimateSize}
+          isLoading={isLoading}
+          hasLoaded={hasLoaded}
+          isFetching={isFetching}
+          isError={isError}
+          hasMore={hasMore}
+          onRetry={retry}
+          onFetchMore={fetchMore}
+          skeleton={skeleton}
+          emptyTitle='No Songs'
+          emptyMessage='No songs found matching your search.'
+        />
 
         <div className='border-border flex justify-end border-t p-4'>
           <Button variant='primary' onClick={hasAddedNew ? onAdded : onClose}>
@@ -223,6 +237,10 @@ export default function AddSongsModal({
     </Backdrop>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Row
+// ---------------------------------------------------------------------------
 
 const SongRow = memo(function SongRow({
   song,


### PR DESCRIPTION
## Summary

Replaced the hand-rolled `useVirtualizer` + custom pagination in `AddSongsModal` with the project's shared `VirtualList` component. Fixes a bug where the song list rendered blank.

## Changes

- Replaced manual `useVirtualizer`, scroll listener, and pagination with `VirtualList`
- Added proper loading states (`isLoading`, `hasLoaded`, `isFetching`, `isError`) for correct skeleton/empty/error rendering
- Added `try/catch` around API calls with `mountedRef` guard (previously unhandled fetch failures left the modal broken)
- Stable callback refs so the virtualizer doesn't re-index every render