### PR TITLE
feat(web): add drag-and-drop playlist song reorder

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,9 @@
       "version": "0.3.0",
       "dependencies": {
         "@alfira/server": "workspace:*",
+        "@atlaskit/pragmatic-drag-and-drop": "^2.0.1",
+        "@atlaskit/pragmatic-drag-and-drop-auto-scroll": "^3.0.0",
+        "@atlaskit/pragmatic-drag-and-drop-hitbox": "^2.0.0",
         "@phosphor-icons/react": "2.1.10",
         "@tanstack/react-virtual": "3.14.6",
         "masonic": "^4.1.0",
@@ -47,6 +50,14 @@
     "@alfira/server": ["@alfira/server@workspace:packages/server"],
 
     "@alfira/web": ["@alfira/web@workspace:packages/web"],
+
+    "@atlaskit/pragmatic-drag-and-drop": ["@atlaskit/pragmatic-drag-and-drop@2.0.1", "", { "dependencies": { "@babel/runtime": "^7.0.0", "bind-event-listener": "^3.0.0", "raf-schd": "^4.0.3" } }, "sha512-5iSbCveKuWYh0HijDxfSsYKD2VE0UPObI9jO1pqq+RBk9LzaoOYeKyW0Fobv/6db8HAPcyT3vhRy8bmk5TMcMw=="],
+
+    "@atlaskit/pragmatic-drag-and-drop-auto-scroll": ["@atlaskit/pragmatic-drag-and-drop-auto-scroll@3.0.0", "", { "dependencies": { "@atlaskit/pragmatic-drag-and-drop": "^2.0.0", "@babel/runtime": "^7.0.0" } }, "sha512-8TlkMi417zIPrTnCpbNV0Ce63JTKBn3dGkqiadkGQROvzDAox7Y9TYRHpvbQiEdtPoHWnmyRBi+RsGDxXsQxgQ=="],
+
+    "@atlaskit/pragmatic-drag-and-drop-hitbox": ["@atlaskit/pragmatic-drag-and-drop-hitbox@2.0.0", "", { "dependencies": { "@atlaskit/pragmatic-drag-and-drop": "^2.0.0", "@babel/runtime": "^7.0.0" } }, "sha512-vkXCB/23pT8YgYU8biGmR9uu0fr9oWoaq2GMSKyiNPk3reA12XVrCdgB2SLBoB24Ic1FOm9PdaQJ9ZSUQdCVpw=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
     "@essentials/memoize-one": ["@essentials/memoize-one@1.1.0", "", {}, "sha512-HMkuIkKNe0EWSUpZhlaq9+5Yp47YhrMhxLMnXTRnEyE5N4xKLspAvMGjUFdi794VnEF1EcOZFS8rdROeujrgag=="],
 
@@ -239,6 +250,8 @@
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "bind-event-listener": ["bind-event-listener@3.0.0", "", {}, "sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 

--- a/packages/server/src/routes/playlists.ts
+++ b/packages/server/src/routes/playlists.ts
@@ -66,6 +66,10 @@ const PlaylistRemoveSongsSchema = v.object({
   songIds: v.pipe(v.array(v.string()), v.minLength(1), v.maxLength(5000)),
 });
 
+const PlaylistReorderSchema = v.object({
+  songIds: v.pipe(v.array(v.string()), v.minLength(1), v.maxLength(5000)),
+});
+
 // ---------------------------------------------------------------------------
 // GET /api/playlists — paginated list of playlists
 // ---------------------------------------------------------------------------
@@ -790,6 +794,87 @@ async function handleBulkRemoveSongs(
 }
 
 // ---------------------------------------------------------------------------
+// PATCH /api/playlists/:id/reorder — reorder songs in a playlist
+// ---------------------------------------------------------------------------
+async function handleReorderSongs(
+  ctx: RouteContext,
+  request: Request,
+  params: Record<string, string>
+): Promise<Response> {
+  const { id: playlistId } = params;
+  const guards = checkGuards(ctx);
+  if (guards instanceof Response) {
+    return guards;
+  }
+  const { user } = guards;
+
+  const playlist = await requirePlaylist(playlistId, user);
+  if (playlist instanceof Response) {
+    return playlist;
+  }
+
+  // Smart playlists are auto-managed — reject manual reorder
+  if (playlist.tagNameLower) {
+    return json({ error: 'Cannot reorder a smart playlist. It is managed by its tag.' }, 409);
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return json({ error: 'Invalid JSON body.' }, 400);
+  }
+
+  const parsed = v.safeParse(PlaylistReorderSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'songIds must be a non-empty array.' }, 400);
+  }
+
+  const { songIds } = parsed.output;
+
+  // Verify all songIds belong to this playlist and the count matches
+  const existing = await db
+    .select({ songId: playlistSongTable.songId })
+    .from(playlistSongTable)
+    .where(eq(playlistSongTable.playlistId, playlistId));
+
+  const existingIds = new Set(existing.map((e) => e.songId));
+
+  if (songIds.length !== existingIds.size) {
+    return json(
+      {
+        error: `songIds count (${songIds.length}) does not match playlist song count (${existingIds.size}).`,
+      },
+      400
+    );
+  }
+
+  for (const id of songIds) {
+    if (!existingIds.has(id)) {
+      return json({ error: `Song ${id} is not in this playlist.` }, 400);
+    }
+  }
+
+  // Delete all and re-insert with new positions in a transaction
+  await db.transaction(async (tx) => {
+    await tx.delete(playlistSongTable).where(eq(playlistSongTable.playlistId, playlistId));
+
+    const rows = songIds.map((songId, index) => ({
+      playlistId,
+      songId,
+      position: index,
+    }));
+
+    await tx.insert(playlistSongTable).values(rows);
+  });
+
+  const value = await getPlaylistSongCount(playlistId);
+  emitPlaylistUpdated(formatPlaylist(playlist, value));
+
+  return json({ message: 'Playlist reordered.' });
+}
+
+// ---------------------------------------------------------------------------
 export const handlePlaylists = routeTable('/api/playlists', {
   rateLimit: { windowMs: 60_000, maxRequests: 20, bucket: 'playlists-mutations' },
   routes: [
@@ -801,6 +886,7 @@ export const handlePlaylists = routeTable('/api/playlists', {
     ['PATCH', '/:id/visibility', handlePatchVisibility],
     ['GET', '/:id', handleGetPlaylist],
     ['PATCH', '/:id', handlePatchPlaylist],
+    ['PATCH', '/:id/reorder', handleReorderSongs],
     ['DELETE', '/:id', handleDeletePlaylist],
   ],
 });

--- a/packages/server/src/shared/api.ts
+++ b/packages/server/src/shared/api.ts
@@ -381,6 +381,10 @@ export function togglePlaylistVisibility(
   return patch(`/api/playlists/${playlistId}/visibility${params}`, { isPrivate });
 }
 
+export function reorderPlaylistSongs(playlistId: string, songIds: string[]): Promise<void> {
+  return patch(`/api/playlists/${playlistId}/reorder`, { songIds });
+}
+
 // ---------------------------------------------------------------------------
 // Player API Functions
 // ---------------------------------------------------------------------------

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -10,6 +10,9 @@
   },
   "dependencies": {
     "@alfira/server": "workspace:*",
+    "@atlaskit/pragmatic-drag-and-drop": "^2.0.1",
+    "@atlaskit/pragmatic-drag-and-drop-auto-scroll": "^3.0.0",
+    "@atlaskit/pragmatic-drag-and-drop-hitbox": "^2.0.0",
     "@phosphor-icons/react": "2.1.10",
     "@tanstack/react-virtual": "3.14.6",
     "masonic": "^4.1.0",

--- a/packages/web/src/api/api.ts
+++ b/packages/web/src/api/api.ts
@@ -60,6 +60,7 @@ export {
   type RequestCreateData,
   removeSongFromPlaylist,
   renamePlaylist,
+  reorderPlaylistSongs,
   startPlayback,
   togglePlaylistVisibility,
   updateGeneralSettings,

--- a/packages/web/src/components/SortableVirtualSongList.tsx
+++ b/packages/web/src/components/SortableVirtualSongList.tsx
@@ -1,0 +1,267 @@
+import { type Playlist, type Song } from '@alfira/server/shared';
+import { DotsSixVerticalIcon } from '@phosphor-icons/react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { useSongEdit } from '../context/SongEditContext';
+import { SortableListProvider, useSortableItem } from '../hooks/useSortableVirtualList';
+import SongCard from './SongCard';
+import { VirtualList } from './VirtualList';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface SortableVirtualSongListProps {
+  items: Song[];
+  isAdminView: boolean;
+  playlists: Playlist[];
+  isLoading: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  hasMore: boolean;
+  hasLoaded: boolean;
+  playingId: string | null;
+  onRetry: () => void;
+  onFetchMore: () => void;
+  onDelete?: (id: string) => void;
+  onPlay: (id: string) => void;
+  onAddToQueue: (id: string) => void;
+  onReorder: (orderedIds: string[]) => Promise<void>;
+  emptyTitle: string;
+  emptyMessage?: string;
+  // Bulk selection
+  selectionMode?: boolean;
+  isSelected?: (id: string) => boolean;
+  onToggleSelect?: (id: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Item wrapper with drag handle
+// ---------------------------------------------------------------------------
+
+/** Height of an expanded row (card + edit panel + spacer). */
+const EXPANDED_ROW_HEIGHT = 540;
+/** Height of a collapsed song row (card + spacer). */
+const COLLAPSED_ROW_HEIGHT = 105;
+
+interface SortableSongItemProps {
+  song: Song;
+  index: number;
+  isAdminView: boolean;
+  playlists: Playlist[];
+  playingId: string | null;
+  selectionMode: boolean;
+  isSelected: boolean;
+  onDelete?: (id: string) => void;
+  onPlay: (id: string) => void;
+  onAddToQueue: (id: string) => void;
+  onToggleSelect?: (id: string) => void;
+}
+
+const SortableSongItem = memo(function SortableSongItem({
+  song,
+  index,
+  isAdminView,
+  playlists,
+  playingId,
+  selectionMode,
+  isSelected,
+  onDelete,
+  onPlay,
+  onAddToQueue,
+  onToggleSelect,
+}: SortableSongItemProps) {
+  const { itemRef, dragHandleRef, isDragging, isAnyDragging, isDropTarget } = useSortableItem(
+    song.id,
+    index
+  );
+
+  const handlePlay = useCallback(() => {
+    onPlay(song.id);
+  }, [onPlay, song.id]);
+  const handleAddToQueue = useCallback(() => {
+    onAddToQueue(song.id);
+  }, [onAddToQueue, song.id]);
+  const handleToggleSelect = useCallback(
+    () => onToggleSelect?.(song.id),
+    [onToggleSelect, song.id]
+  );
+
+  return (
+    <div ref={itemRef} className='group relative flex items-center'>
+      {/* Drop target highlight */}
+      {isDropTarget && (
+        <div className='bg-accent/10 pointer-events-none absolute inset-0 z-10 rounded-lg' />
+      )}
+
+      {/* Drag handle — visible on row hover, always visible during any drag */}
+      <button
+        ref={dragHandleRef}
+        type='button'
+        className={`text-faint hover:text-muted -mr-0.5 ml-0.5 shrink-0 cursor-grab rounded opacity-0 transition-opacity active:cursor-grabbing ${isAnyDragging ? 'opacity-100' : 'group-hover:opacity-100'}`}
+        aria-label={`Drag to reorder "${song.nickname ?? song.title}"`}
+      >
+        <DotsSixVerticalIcon size={18} weight='bold' />
+      </button>
+
+      <div className={`min-w-0 flex-1 transition-opacity ${isDragging ? 'opacity-50' : ''}`}>
+        <SongCard
+          song={song}
+          variant='list'
+          isAdminView={isAdminView}
+          playlists={playlists}
+          onDelete={onDelete}
+          onPlay={handlePlay}
+          isPlaying={playingId === song.id}
+          onAddToQueue={handleAddToQueue}
+          selectionMode={selectionMode}
+          isSelected={isSelected}
+          onToggleSelect={onToggleSelect ? handleToggleSelect : undefined}
+        />
+      </div>
+    </div>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Skeleton
+// ---------------------------------------------------------------------------
+
+const SKELETON_KEYS = ['sk-0', 'sk-1', 'sk-2', 'sk-3', 'sk-4', 'sk-5', 'sk-6', 'sk-7'];
+
+function SkeletonList() {
+  return (
+    <div className='flex flex-col gap-1.5'>
+      {SKELETON_KEYS.map((key) => (
+        <div
+          key={key}
+          className='bg-elevated clay-resting flex items-center gap-3 rounded-lg px-4 py-4 md:gap-4'
+        >
+          <div className='bg-surface h-16 w-16 shrink-0 animate-pulse rounded border' />
+          <div className='flex min-w-0 flex-1 flex-col gap-2'>
+            <div className='bg-surface h-3.5 w-2/5 animate-pulse rounded' />
+            <div className='bg-surface h-3 w-3/5 animate-pulse rounded' />
+          </div>
+          <div className='bg-surface h-6 w-6 shrink-0 animate-pulse rounded' />
+          <div className='bg-surface h-4 w-4 shrink-0 animate-pulse rounded' />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export const SortableVirtualSongList = memo(function SortableVirtualSongList({
+  items,
+  isAdminView,
+  playlists,
+  isLoading,
+  isFetching,
+  isError,
+  hasMore,
+  hasLoaded,
+  playingId,
+  onRetry,
+  onFetchMore,
+  onDelete,
+  onPlay,
+  onAddToQueue,
+  onReorder,
+  emptyTitle,
+  emptyMessage,
+  selectionMode = false,
+  isSelected,
+  onToggleSelect,
+}: SortableVirtualSongListProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const { openSongId } = useSongEdit();
+
+  // Track the "effective" open song for layout — same pattern as VirtualSongList.
+  const [effectiveOpenId, setEffectiveOpenId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (openSongId) {
+      setEffectiveOpenId(openSongId);
+    } else {
+      const timeout = setTimeout(() => {
+        setEffectiveOpenId(null);
+      }, 300);
+      return () => {
+        clearTimeout(timeout);
+      };
+    }
+  }, [openSongId]);
+
+  // Build the ordered ID list for the provider
+  const songIds = useMemo(() => items.map((s) => s.id), [items]);
+
+  const getItemKey = useCallback((song: Song) => song.id, []);
+
+  const renderItem = useCallback(
+    (song: Song, index: number) => (
+      <SortableSongItem
+        song={song}
+        index={index}
+        isAdminView={isAdminView}
+        playlists={playlists}
+        playingId={playingId}
+        selectionMode={selectionMode}
+        isSelected={isSelected?.(song.id) ?? false}
+        onDelete={onDelete}
+        onPlay={onPlay}
+        onAddToQueue={onAddToQueue}
+        onToggleSelect={onToggleSelect}
+      />
+    ),
+    [
+      isAdminView,
+      playlists,
+      playingId,
+      selectionMode,
+      isSelected,
+      onDelete,
+      onPlay,
+      onAddToQueue,
+      onToggleSelect,
+    ]
+  );
+
+  const estimateSize = useCallback(
+    (index: number) => {
+      return (items[index] as Song | undefined)?.id === effectiveOpenId
+        ? EXPANDED_ROW_HEIGHT
+        : COLLAPSED_ROW_HEIGHT;
+    },
+    [items, effectiveOpenId]
+  );
+
+  const skeleton = useMemo(() => <SkeletonList />, []);
+
+  return (
+    <SortableListProvider itemIds={songIds} onReorder={onReorder} scrollContainerRef={scrollRef}>
+      <VirtualList
+        items={items}
+        getItemKey={getItemKey}
+        renderItem={renderItem}
+        estimateSize={estimateSize}
+        scrollRef={scrollRef}
+        itemClassName='pb-3'
+        isLoading={isLoading}
+        hasLoaded={hasLoaded}
+        isFetching={isFetching}
+        isError={isError}
+        hasMore={hasMore}
+        onRetry={onRetry}
+        onFetchMore={onFetchMore}
+        skeleton={skeleton}
+        emptyTitle={emptyTitle}
+        emptyMessage={emptyMessage}
+      />
+    </SortableListProvider>
+  );
+});
+
+export default SortableVirtualSongList;

--- a/packages/web/src/components/VirtualList.tsx
+++ b/packages/web/src/components/VirtualList.tsx
@@ -39,6 +39,9 @@ export interface VirtualListProps<T> {
   skeleton: React.ReactNode;
   emptyTitle: string;
   emptyMessage?: string;
+  /** Optional external scroll container ref. When provided, the component
+   *  uses it instead of creating its own. Useful for DnD auto-scroll. */
+  scrollRef?: React.RefObject<HTMLDivElement | null>;
 }
 
 // ---------------------------------------------------------------------------
@@ -62,8 +65,10 @@ function VirtualListInner<T>({
   skeleton,
   emptyTitle,
   emptyMessage,
+  scrollRef: externalScrollRef,
 }: VirtualListProps<T>) {
-  const scrollRef = useRef<HTMLDivElement>(null);
+  const internalScrollRef = useRef<HTMLDivElement>(null);
+  const scrollRef = externalScrollRef ?? internalScrollRef;
   const containerRef = useRef<HTMLDivElement>(null);
 
   // Keep the user-provided getItemKey in a ref so the virtualizer's

--- a/packages/web/src/hooks/useSortableVirtualList.ts
+++ b/packages/web/src/hooks/useSortableVirtualList.ts
@@ -1,0 +1,280 @@
+import { autoScrollForElements } from '@atlaskit/pragmatic-drag-and-drop-auto-scroll/element';
+import { type Edge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
+import {
+  draggable,
+  dropTargetForElements,
+  monitorForElements,
+} from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import React, {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface SortableItemData {
+  id: string;
+  index: number;
+  instanceId: symbol;
+}
+
+export interface DragState {
+  isDragging: boolean;
+  draggingId: string | null;
+  dropIndicatorIndex: number | null;
+}
+
+interface SortableListContextValue {
+  instanceId: symbol;
+  dragState: DragState;
+}
+
+interface SortableListProviderProps {
+  itemIds: string[];
+  onReorder: (orderedIds: string[]) => Promise<void>;
+  scrollContainerRef: React.RefObject<HTMLElement | null>;
+  children: ReactNode;
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+const SortableListContext = createContext<SortableListContextValue | null>(null);
+
+export function useSortableListContext(): SortableListContextValue {
+  const ctx = useContext(SortableListContext);
+  if (!ctx) {
+    throw new Error('useSortableListContext must be used within SortableListProvider');
+  }
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getItemData(item: SortableItemData) {
+  return { id: item.id, index: item.index, instanceId: item.instanceId };
+}
+
+function isItemData(data: unknown): data is SortableItemData {
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
+  const record = data as unknown as Record<string, unknown>;
+  return 'id' in record && 'instanceId' in record && typeof record.instanceId === 'symbol';
+}
+
+function computeDestination(
+  startIndex: number,
+  targetIndex: number,
+  closestEdge: Edge | null
+): number {
+  if (closestEdge === 'bottom') {
+    return startIndex < targetIndex ? targetIndex : targetIndex + 1;
+  }
+  return startIndex < targetIndex ? targetIndex - 1 : targetIndex;
+}
+
+// ---------------------------------------------------------------------------
+// Module-level callbacks + edge map
+// ---------------------------------------------------------------------------
+
+let gSetDropTarget: ((index: number) => void) | null = null;
+let gClearDropTarget: (() => void) | null = null;
+const gEdgeMap = new Map<symbol, { index: number; edge: Edge }>();
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export function SortableListProvider({
+  itemIds,
+  onReorder,
+  scrollContainerRef,
+  children,
+}: SortableListProviderProps) {
+  const instanceId = useMemo(() => Symbol('sortable-list'), []);
+
+  const itemIdsRef = useRef(itemIds);
+  itemIdsRef.current = itemIds;
+
+  const [dragState, setDragState] = useState<DragState>({
+    isDragging: false,
+    draggingId: null,
+    dropIndicatorIndex: null,
+  });
+
+  // ── Auto-scroll ─────────────────────────────────────────────────────
+  useEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el) {
+      return;
+    }
+    return autoScrollForElements({ element: el });
+  }, [scrollContainerRef]);
+
+  // ── Drop target callbacks ───────────────────────────────────────────
+  const handleSetDropTarget = useCallback((index: number) => {
+    setDragState((prev) =>
+      prev.dropIndicatorIndex === index ? prev : { ...prev, dropIndicatorIndex: index }
+    );
+  }, []);
+
+  const handleClearDropTarget = useCallback(() => {
+    setDragState((prev) =>
+      prev.dropIndicatorIndex === null ? prev : { ...prev, dropIndicatorIndex: null }
+    );
+  }, []);
+
+  // ── Global drag monitor ─────────────────────────────────────────────
+  useEffect(() => {
+    gSetDropTarget = handleSetDropTarget;
+    gClearDropTarget = handleClearDropTarget;
+
+    return monitorForElements({
+      canMonitor({ source }) {
+        return isItemData(source.data) && source.data.instanceId === instanceId;
+      },
+      onDragStart({ source }) {
+        const data = source.data as unknown as SortableItemData;
+        setDragState({
+          isDragging: true,
+          draggingId: data.id,
+          dropIndicatorIndex: null,
+        });
+      },
+      onDrop({ source }) {
+        const srcData = source.data as unknown as SortableItemData;
+        const target = gEdgeMap.get(instanceId) ?? null;
+        gEdgeMap.delete(instanceId);
+
+        setDragState({
+          isDragging: false,
+          draggingId: null,
+          dropIndicatorIndex: null,
+        });
+
+        if (!target) {
+          return;
+        }
+
+        const currentIds = itemIdsRef.current;
+        const dest = computeDestination(srcData.index, target.index, target.edge);
+
+        if (dest === srcData.index) {
+          return;
+        }
+
+        const newIds = [...currentIds];
+        const [removed] = newIds.splice(srcData.index, 1);
+        newIds.splice(dest, 0, removed);
+
+        void onReorder(newIds);
+      },
+    });
+  }, [instanceId, onReorder, handleSetDropTarget, handleClearDropTarget]);
+
+  // Clean up
+  useEffect(() => {
+    return () => {
+      gSetDropTarget = null;
+      gClearDropTarget = null;
+    };
+  }, []);
+
+  const value: SortableListContextValue = useMemo(
+    () => ({ instanceId, dragState }),
+    [instanceId, dragState]
+  );
+
+  return React.createElement(SortableListContext.Provider, { value }, children);
+}
+
+// ---------------------------------------------------------------------------
+// Per-item hook
+// ---------------------------------------------------------------------------
+
+export function useSortableItem(id: string, index: number) {
+  const { instanceId, dragState } = useSortableListContext();
+
+  const itemEl = useRef<HTMLElement | null>(null);
+  const handleEl = useRef<HTMLElement | null>(null);
+
+  const setItemRef = (el: HTMLElement | null) => {
+    itemEl.current = el;
+  };
+  const setHandleRef = (el: HTMLElement | null) => {
+    handleEl.current = el;
+  };
+
+  useLayoutEffect(() => {
+    const element = itemEl.current;
+    if (!element) {
+      return;
+    }
+
+    return dropTargetForElements({
+      element,
+      canDrop({ source }) {
+        return isItemData(source.data) && source.data.instanceId === instanceId;
+      },
+      getData({ input }) {
+        const rect = element.getBoundingClientRect();
+        const edge: Edge = input.clientY < rect.top + rect.height / 2 ? 'top' : 'bottom';
+        return { index, edge };
+      },
+      onDragEnter() {
+        gSetDropTarget?.(index);
+      },
+      onDrag({ self }) {
+        const data = self.data as Record<string, unknown>;
+        const edge = (data.edge as Edge | undefined) ?? 'bottom';
+        gEdgeMap.set(instanceId, { index, edge });
+        gSetDropTarget?.(index);
+      },
+      onDragLeave() {
+        gClearDropTarget?.();
+        gEdgeMap.delete(instanceId);
+      },
+    });
+  }, [id, index, instanceId]);
+
+  useLayoutEffect(() => {
+    const handle = handleEl.current;
+    if (!handle) {
+      return;
+    }
+
+    return draggable({
+      element: handle,
+      getInitialData: () => getItemData({ id, index, instanceId }),
+      onGenerateDragPreview({ nativeSetDragImage }) {
+        const item = itemEl.current;
+        if (item && nativeSetDragImage) {
+          nativeSetDragImage(item, 0, 0);
+        }
+      },
+    });
+  }, [id, index, instanceId]);
+
+  return {
+    itemRef: setItemRef,
+    dragHandleRef: setHandleRef,
+    isDragging: dragState.draggingId === id,
+    isAnyDragging: dragState.isDragging,
+    isDropTarget: dragState.dropIndicatorIndex === index,
+  };
+}
+
+export type { SortableListContextValue, SortableListProviderProps };

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -26,6 +26,7 @@ import {
   getPlaylistPage,
   removeSongFromPlaylist,
   renamePlaylist,
+  reorderPlaylistSongs,
   startPlayback,
   togglePlaylistVisibility,
 } from '../api/api';
@@ -38,6 +39,7 @@ import { ContextMenu, ContextMenuTrigger } from '../components/ContextMenu';
 import EmptyState from '../components/EmptyState';
 import ListToolbar from '../components/ListToolbar';
 import NotificationToast from '../components/NotificationToast';
+import { SortableVirtualSongList } from '../components/SortableVirtualSongList';
 import { Button } from '../components/ui/Button';
 import { cooldownButtonProps } from '../components/ui/cooldownButtonProps';
 import { Skeleton } from '../components/ui/Skeleton';
@@ -355,6 +357,18 @@ export default function PlaylistDetailPage() {
   const handleCloseBulkEdit = useCallback(() => {
     setBulkEditingOpen(false);
   }, []);
+
+  // ── Reorder callback for drag-and-drop ─────────────────────────────
+  const handleReorder = useCallback(
+    async (orderedIds: string[]) => {
+      if (!playlistDetailRef.current) {
+        return;
+      }
+      await reorderPlaylistSongs(playlistDetailRef.current.id, orderedIds);
+      refetch();
+    },
+    [refetch]
+  );
 
   // ── Socket: playlist updated (rename, visibility, song count changes) ──
   useEffect(() => {
@@ -886,27 +900,52 @@ export default function PlaylistDetailPage() {
               exit='exit'
               transition={viewTransition}
             >
-              <VirtualSongList
-                items={songItems}
-                isAdminView={isAdminView}
-                playlists={[]}
-                isLoading={isLoading}
-                isFetching={isFetching}
-                isError={isError}
-                hasMore={hasMore}
-                hasLoaded={!isLoading}
-                playingId={playingSongId}
-                onRetry={retry}
-                onFetchMore={fetchNextPage}
-                onDelete={selectionMode ? undefined : handleSongDelete}
-                onPlay={handlePlayFromSong}
-                onAddToQueue={handleAddToQueue}
-                selectionMode={selectionMode}
-                isSelected={bulk.isSelected}
-                onToggleSelect={bulk.toggle}
-                emptyTitle='No Songs'
-                emptyMessage='Add songs to this playlist'
-              />
+              {sort === 'position' && !isSmart && (isAdminView || isOwner) ? (
+                <SortableVirtualSongList
+                  items={songItems}
+                  isAdminView={isAdminView}
+                  playlists={[]}
+                  isLoading={isLoading}
+                  isFetching={isFetching}
+                  isError={isError}
+                  hasMore={hasMore}
+                  hasLoaded={!isLoading}
+                  playingId={playingSongId}
+                  onRetry={retry}
+                  onFetchMore={fetchNextPage}
+                  onDelete={selectionMode ? undefined : handleSongDelete}
+                  onPlay={handlePlayFromSong}
+                  onAddToQueue={handleAddToQueue}
+                  onReorder={handleReorder}
+                  selectionMode={selectionMode}
+                  isSelected={bulk.isSelected}
+                  onToggleSelect={bulk.toggle}
+                  emptyTitle='No Songs'
+                  emptyMessage='Add songs to this playlist'
+                />
+              ) : (
+                <VirtualSongList
+                  items={songItems}
+                  isAdminView={isAdminView}
+                  playlists={[]}
+                  isLoading={isLoading}
+                  isFetching={isFetching}
+                  isError={isError}
+                  hasMore={hasMore}
+                  hasLoaded={!isLoading}
+                  playingId={playingSongId}
+                  onRetry={retry}
+                  onFetchMore={fetchNextPage}
+                  onDelete={selectionMode ? undefined : handleSongDelete}
+                  onPlay={handlePlayFromSong}
+                  onAddToQueue={handleAddToQueue}
+                  selectionMode={selectionMode}
+                  isSelected={bulk.isSelected}
+                  onToggleSelect={bulk.toggle}
+                  emptyTitle='No Songs'
+                  emptyMessage='Add songs to this playlist'
+                />
+              )}
             </m.div>
           ) : (
             <m.div


### PR DESCRIPTION
## Summary

Adds drag-and-drop reordering for songs within playlists using Pragmatic Drag and Drop. Only available in list view with "Playlist Order" sort, and gated behind admin view or playlist ownership.

## Changes

- **New hook** `useSortableVirtualList` — integrates Pragmatic DnD with TanStack Virtual for both playlist songs and (future) queue panel
- **New component** `SortableVirtualSongList` — DnD-enabled song list with drag handles, drop target highlighting, and drag preview
- **New endpoint** `PATCH /api/playlists/:id/reorder` — rewrites song positions in a transaction; returns the new order
- **API** — added `reorderPlaylistSongs()` to shared API module
- **VirtualList** — added optional `scrollRef` prop for external scroll container access (needed for DnD auto-scroll)
- **Dependencies** — added `@atlaskit/pragmatic-drag-and-drop`, `...-auto-scroll`, `...-hitbox`