### PR TITLE
test(server): add unit test suite and CI integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,7 +7,11 @@ dist/
 build/
 .vscode/
 .idea/
+**/*.test.ts
+**/*.test.tsx
 .claude/
 .superpowers/
 .github/
 .worktrees/
+.pi/
+.zed/

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -6,6 +6,12 @@
     "use_new_terminal": true
   },
   {
+    "label": "test",
+    "command": "bun test",
+    "cwd": "$ZED_WORKTREE_ROOT",
+    "use_new_terminal": true
+  },
+  {
     "label": "check",
     "command": "bun run check",
     "cwd": "$ZED_WORKTREE_ROOT",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ The bot and API run in a **single Bun process**. For detailed architecture (star
 | Frontend     | React 19 + Tailwind CSS 4                     |
 | Linting      | oxlint + oxfmt                                |
 | Typechecking | oxlint (--type-aware --type-check, uses tsgo) |
+| Testing      | Bun's built-in test runner                    |
 
 ## Design Principles
 
@@ -33,7 +34,7 @@ Every decision in this project traces back to one of these. The agent should fol
 - **Web UI as primary interface** — The Discord bot is the playback engine; the web app is the control plane. This avoids Discord's rate limits and UX constraints.
 - **Audio is audio — no assumptions about content** — Works equally as a music bot or tabletop audio player. The data model (songs, playlists, tags) is content-type-agnostic: a pop song and an hour-long dungeon ambience are the same shape.
 - **Single source of truth** — Every concept, pattern, and piece of knowledge has one canonical home. Before creating something new, check if it already exists or can be extended. If nothing fits and your change would duplicate what already exists across files, extract the commonality into a shared location first. This applies as much to UI patterns (one toast, one button variant, one data-fetching hook) as it does to types and utilities. Copy-pasting is a last resort, not a first move.
-- **Strict linting — zero warnings, zero excuses** — The linter is configured for maximum correctness signal with minimal noise. Warnings are errors (`--deny-warnings`). Stale disable directives are errors (`reportUnusedDisableDirectives`). Type-aware rules run everywhere. Every PR must pass `bun run check` with zero diagnostics. This isn't pedantry — it's a quality ratchet that prevents drift and catches real bugs before they reach production.
+- **Strict linting — zero warnings, zero excuses** — The linter is configured for maximum correctness signal with minimal noise. Warnings are errors (`--deny-warnings`). Stale disable directives are errors (`reportUnusedDisableDirectives`). Type-aware rules run everywhere. Every PR must pass `bun run check` (lint, format, typecheck, and tests) with zero diagnostics. This isn't pedantry — it's a quality ratchet that prevents drift and catches real bugs before they reach production.
 
 ## Development Commands
 
@@ -44,8 +45,11 @@ bun run dev
 # Build the web UI (needed after web/src changes before docker compose restart)
 bun run web:build
 
-# Lint + typecheck + format (run before committing)
+# Lint + typecheck + format + tests (run before committing)
 bun run check
+
+# Run tests only
+bun test
 
 # Typecheck only
 bun run typecheck
@@ -178,7 +182,7 @@ refactor(server): extract shared audio filter builders
 
 ### Before Committing
 
-Always run `bun run check` and resolve any lint/format issues before committing.
+Always run `bun run check` and resolve any lint, format, or test failures before committing.
 
 ## Agent Operating Mode
 

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
     "lint:fix": "oxlint --fix .",
     "format": "oxfmt --write .",
     "format:check": "oxfmt --check .",
-    "check": "oxlint --type-aware --type-check --deny-warnings . && oxfmt --check .",
-    "typecheck": "oxlint --type-aware --type-check --deny-warnings ."
+    "check": "oxlint --type-aware --type-check --deny-warnings . && oxfmt --check . && bun test",
+    "typecheck": "oxlint --type-aware --type-check --deny-warnings .",
+    "test": "bun test"
   },
   "devDependencies": {
     "@types/bun": "^1.3.14",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "dev": "bun run src/index.ts",
-    "build": "bun build ./src/index.ts --outdir=./dist --target bun --format esm"
+    "build": "bun build ./src/index.ts --outdir=./dist --target bun --format esm",
+    "test": "bun test"
   },
   "dependencies": {
     "drizzle-valibot": "^0.4.2",

--- a/packages/server/src/lib/applyNodeLinkFilter.test.ts
+++ b/packages/server/src/lib/applyNodeLinkFilter.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+// The filter builders are pure, but the module also imports heavy runtime
+// dependencies for the applyNodeLinkFilter function. Mock them out.
+void mock.module('../shared/logger', () => ({
+  logger: { warn: mock(() => {}), error: mock(() => {}) },
+}));
+void mock.module('../utils/nodelink', () => ({
+  updateNodeLinkPlayer: mock(() => Promise.resolve()),
+}));
+void mock.module('./config', () => ({
+  getGuildId: mock(() => null),
+}));
+void mock.module('./lavalink', () => ({
+  lavalink: { isGuildConnected: mock(() => false), getSessionId: mock(() => null) },
+}));
+
+const {
+  buildCompressorFilter,
+  buildKaraokeFilter,
+  buildTimescaleFilter,
+  buildTremoloFilter,
+  buildVibratoFilter,
+  buildRotationFilter,
+  buildDistortionFilter,
+  buildChannelMixFilter,
+  buildLowPassFilter,
+} = await import('./applyNodeLinkFilter');
+
+describe('buildCompressorFilter', () => {
+  test('passes through all params under "compressor" key', () => {
+    const result = buildCompressorFilter({
+      threshold: -20,
+      ratio: 4,
+      attack: 10,
+      release: 100,
+      gain: 5,
+    });
+    expect(result).toEqual({
+      compressor: { threshold: -20, ratio: 4, attack: 10, release: 100, gain: 5 },
+    });
+  });
+
+  test('handles zero values', () => {
+    const result = buildCompressorFilter({
+      threshold: 0,
+      ratio: 0,
+      attack: 0,
+      release: 0,
+      gain: 0,
+    });
+    expect(result.compressor.gain).toBe(0);
+  });
+});
+
+describe('buildKaraokeFilter', () => {
+  test('passes through all params under "karaoke" key', () => {
+    const result = buildKaraokeFilter({
+      level: 0.8,
+      monoLevel: 0.5,
+      filterBand: 220,
+      filterWidth: 100,
+    });
+    expect(result).toEqual({
+      karaoke: { level: 0.8, monoLevel: 0.5, filterBand: 220, filterWidth: 100 },
+    });
+  });
+});
+
+describe('buildTimescaleFilter', () => {
+  test('passes through all params under "timescale" key', () => {
+    const result = buildTimescaleFilter({ speed: 1.5, pitch: 1.2, rate: 1 });
+    expect(result).toEqual({
+      timescale: { speed: 1.5, pitch: 1.2, rate: 1 },
+    });
+  });
+
+  test('normal speed is identity', () => {
+    const result = buildTimescaleFilter({ speed: 1, pitch: 1, rate: 1 });
+    expect(result.timescale.speed).toBe(1);
+  });
+});
+
+describe('buildTremoloFilter', () => {
+  test('passes through frequency and depth under "tremolo" key', () => {
+    const result = buildTremoloFilter({ frequency: 5, depth: 0.7 });
+    expect(result).toEqual({ tremolo: { frequency: 5, depth: 0.7 } });
+  });
+});
+
+describe('buildVibratoFilter', () => {
+  test('passes through frequency and depth under "vibrato" key', () => {
+    const result = buildVibratoFilter({ frequency: 6, depth: 0.4 });
+    expect(result).toEqual({ vibrato: { frequency: 6, depth: 0.4 } });
+  });
+});
+
+describe('buildRotationFilter', () => {
+  test('passes through rotationHz under "rotation" key', () => {
+    const result = buildRotationFilter({ rotationHz: 0.2 });
+    expect(result).toEqual({ rotation: { rotationHz: 0.2 } });
+  });
+});
+
+describe('buildDistortionFilter', () => {
+  test('passes through all 8 params under "distortion" key', () => {
+    const result = buildDistortionFilter({
+      sinOffset: 0,
+      sinScale: 1,
+      cosOffset: 0,
+      cosScale: 1,
+      tanOffset: 0,
+      tanScale: 1,
+      offset: 0,
+      scale: 1,
+    });
+    expect(result).toEqual({
+      distortion: {
+        sinOffset: 0,
+        sinScale: 1,
+        cosOffset: 0,
+        cosScale: 1,
+        tanOffset: 0,
+        tanScale: 1,
+        offset: 0,
+        scale: 1,
+      },
+    });
+  });
+});
+
+describe('buildChannelMixFilter', () => {
+  test('passes through all 4 params under "channelMix" key', () => {
+    const result = buildChannelMixFilter({
+      leftToLeft: 1,
+      leftToRight: 0,
+      rightToLeft: 0,
+      rightToRight: 1,
+    });
+    expect(result).toEqual({
+      channelMix: { leftToLeft: 1, leftToRight: 0, rightToLeft: 0, rightToRight: 1 },
+    });
+  });
+
+  test('mono mix sets equal left and right', () => {
+    const result = buildChannelMixFilter({
+      leftToLeft: 0.5,
+      leftToRight: 0.5,
+      rightToLeft: 0.5,
+      rightToRight: 0.5,
+    });
+    expect(result.channelMix.leftToLeft).toBe(0.5);
+    expect(result.channelMix.rightToRight).toBe(0.5);
+  });
+});
+
+describe('buildLowPassFilter', () => {
+  test('passes through smoothing under "lowPass" key', () => {
+    const result = buildLowPassFilter({ smoothing: 20 });
+    expect(result).toEqual({ lowPass: { smoothing: 20 } });
+  });
+
+  test('zero smoothing is allowed', () => {
+    const result = buildLowPassFilter({ smoothing: 0 });
+    expect(result.lowPass.smoothing).toBe(0);
+  });
+});

--- a/packages/server/src/lib/eqBands.test.ts
+++ b/packages/server/src/lib/eqBands.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, mock, test } from 'bun:test';
 // eqBands imports from ../shared/db which requires DATABASE_URL at module
 // level. Mock it before the module is loaded (static imports are hoisted,
 // so we must use dynamic import after the mock call).
+// NOTE: search.test.ts also mocks ../shared/db (with $client). Bun shares
+// mock.module registrations across test files, so all mocks must export a
+// superset of keys to avoid "export not found" errors.
 void mock.module('../shared/db', () => ({
   tables: {
     guildSettings: {
@@ -23,6 +26,8 @@ void mock.module('../shared/db', () => ({
       eqBand14: {},
     },
   },
+  $client: { query: mock(() => ({ all: mock(() => []) })) },
+  db: {},
 }));
 
 const { buildEqualizerFilter, eqBandsFromRow, eqBandValues } = await import('./eqBands');

--- a/packages/server/src/lib/eqBands.test.ts
+++ b/packages/server/src/lib/eqBands.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+// eqBands imports from ../shared/db which requires DATABASE_URL at module
+// level. Mock it before the module is loaded (static imports are hoisted,
+// so we must use dynamic import after the mock call).
+void mock.module('../shared/db', () => ({
+  tables: {
+    guildSettings: {
+      eqBand0: {},
+      eqBand1: {},
+      eqBand2: {},
+      eqBand3: {},
+      eqBand4: {},
+      eqBand5: {},
+      eqBand6: {},
+      eqBand7: {},
+      eqBand8: {},
+      eqBand9: {},
+      eqBand10: {},
+      eqBand11: {},
+      eqBand12: {},
+      eqBand13: {},
+      eqBand14: {},
+    },
+  },
+}));
+
+const { buildEqualizerFilter, eqBandsFromRow, eqBandValues } = await import('./eqBands');
+
+describe('eqBandsFromRow', () => {
+  test('returns defaults (all 50) for null or undefined', () => {
+    const fromNull = eqBandsFromRow(null);
+    expect(fromNull).toHaveLength(15);
+    expect(fromNull.every((v) => v === 50)).toBe(true);
+
+    // eslint-disable-next-line unicorn/no-useless-undefined
+    const fromUndefined = eqBandsFromRow(undefined);
+    expect(fromUndefined).toHaveLength(15);
+    expect(fromUndefined.every((v) => v === 50)).toBe(true);
+  });
+
+  test('extracts band values from a row', () => {
+    const row = {
+      eqBand0: 60,
+      eqBand1: 45,
+      eqBand2: 50,
+      eqBand3: 50,
+      eqBand4: 50,
+      eqBand5: 50,
+      eqBand6: 50,
+      eqBand7: 50,
+      eqBand8: 50,
+      eqBand9: 50,
+      eqBand10: 50,
+      eqBand11: 50,
+      eqBand12: 50,
+      eqBand13: 50,
+      eqBand14: 50,
+    };
+    const result = eqBandsFromRow(row);
+    expect(result[0]).toBe(60);
+    expect(result[1]).toBe(45);
+    expect(result[2]).toBe(50);
+    expect(result).toHaveLength(15);
+  });
+});
+
+describe('eqBandValues', () => {
+  test('converts a 15-element array to a record', () => {
+    const bands = Array.from({ length: 15 }, (_, i) => i * 10);
+    const result = eqBandValues(bands);
+    expect(result.eqBand0).toBe(0);
+    expect(result.eqBand7).toBe(70);
+    expect(result.eqBand14).toBe(140);
+  });
+});
+
+describe('buildEqualizerFilter', () => {
+  const flat: number[] = Array.from({ length: 15 }, () => 50);
+
+  test('neutral band (50) maps to gain 0', () => {
+    const result = buildEqualizerFilter(flat);
+    expect(result).toHaveLength(15);
+    expect(result.every((f) => f.gain === 0)).toBe(true);
+  });
+
+  test('minimum band (0) maps to gain -0.5', () => {
+    const bands: number[] = [0, ...flat.slice(1)];
+    const result = buildEqualizerFilter(bands);
+    expect(result[0]?.gain).toBe(-0.5);
+  });
+
+  test('maximum band (100) maps to gain 0.5', () => {
+    const bands: number[] = [100, ...flat.slice(1)];
+    const result = buildEqualizerFilter(bands);
+    expect(result[0]?.gain).toBe(0.5);
+  });
+
+  test('bands are zero-indexed', () => {
+    const result = buildEqualizerFilter(flat);
+    for (const [i, f] of result.entries()) {
+      expect(f.band).toBe(i);
+    }
+  });
+
+  test('mid-scale value maps correctly', () => {
+    const bands: number[] = [75, ...flat.slice(1)];
+    const result = buildEqualizerFilter(bands);
+    expect(result[0]?.gain).toBe(0.25);
+  });
+});

--- a/packages/server/src/lib/pagination.test.ts
+++ b/packages/server/src/lib/pagination.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test';
+
+import { parsePagination } from './pagination';
+
+describe('parsePagination', () => {
+  test('returns defaults when no params provided', () => {
+    const url = new URL('http://localhost/');
+    const result = parsePagination(url);
+    expect(result).toEqual({ page: 1, limit: 30, skip: 0 });
+  });
+
+  test('returns custom default limit', () => {
+    const url = new URL('http://localhost/');
+    const result = parsePagination(url, 50);
+    expect(result).toEqual({ page: 1, limit: 50, skip: 0 });
+  });
+
+  test('parses page and limit from query params', () => {
+    const url = new URL('http://localhost/?page=3&limit=10');
+    const result = parsePagination(url);
+    expect(result).toEqual({ page: 3, limit: 10, skip: 20 });
+  });
+
+  test('clamps negative page to 1', () => {
+    const url = new URL('http://localhost/?page=-5');
+    expect(parsePagination(url).page).toBe(1);
+  });
+
+  test('clamps page of 0 to 1', () => {
+    const url = new URL('http://localhost/?page=0');
+    expect(parsePagination(url).page).toBe(1);
+  });
+
+  test('clamps limit above 100', () => {
+    const url = new URL('http://localhost/?limit=200');
+    expect(parsePagination(url).limit).toBe(100);
+  });
+
+  test('limit of 0 falls back to default (falsy)', () => {
+    const url = new URL('http://localhost/?limit=0');
+    expect(parsePagination(url).limit).toBe(30);
+  });
+
+  test('clamps negative limit', () => {
+    const url = new URL('http://localhost/?limit=-10');
+    expect(parsePagination(url).limit).toBe(1);
+  });
+
+  test('handles non-numeric values gracefully', () => {
+    const url = new URL('http://localhost/?page=abc&limit=xyz');
+    const result = parsePagination(url);
+    // NaN || fallback → falls back to defaults
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(30);
+  });
+
+  test('skip is computed correctly', () => {
+    const url = new URL('http://localhost/?page=4&limit=25');
+    expect(parsePagination(url).skip).toBe(75);
+  });
+});

--- a/packages/server/src/lib/search.test.ts
+++ b/packages/server/src/lib/search.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+// search.ts imports drizzle-orm's `sql` tagged-template and the DB client.
+// Full fidelity mocking of sql.raw() / nested sql chunks is brittle without
+// the real drizzle-orm.  Test pure functions exhaustively; query builders
+// get structural assertions (shape, null/undefined guards, sort direction).
+
+interface SqlFragment {
+  strings: string[];
+  values: unknown[];
+}
+
+function makeSqlResult(strings: string[], values: unknown[]): SqlFragment {
+  return { strings: [...strings], values };
+}
+
+const sqlMock = (strings: TemplateStringsArray, ...values: unknown[]): SqlFragment =>
+  makeSqlResult([...strings], values);
+sqlMock.raw = (value: string) => value;
+// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+(sqlMock as unknown as Record<string, unknown>).join = (
+  items: unknown[],
+  sep: unknown
+): SqlFragment => makeSqlResult(['(', ')'], [items, sep]);
+
+// NOTE: eqBands.test.ts also mocks ../shared/db (with tables). Bun shares
+// mock.module registrations across test files, so both mocks must export a
+// superset of keys to avoid "export not found" errors in either file.
+void mock.module('drizzle-orm', () => ({
+  sql: sqlMock,
+}));
+void mock.module('../shared/db', () => ({
+  $client: { query: mock(() => ({ all: mock(() => []) })) },
+  tables: {},
+}));
+
+const { parseSongSortField, buildSongOrderBy, buildSongFilterClause, SONG_SORT_FIELDS } =
+  await import('./search');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Cast a drizzle SQL result to our mock shape so we can inspect fragments. */
+function asSqlFragment(s: unknown): SqlFragment {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  return s as SqlFragment;
+}
+
+// ---------------------------------------------------------------------------
+// SONG_SORT_FIELDS
+// ---------------------------------------------------------------------------
+
+describe('SONG_SORT_FIELDS', () => {
+  test('contains expected fields', () => {
+    expect(SONG_SORT_FIELDS).toContain('createdAt');
+    expect(SONG_SORT_FIELDS).toContain('title');
+    expect(SONG_SORT_FIELDS).toContain('artist');
+    expect(SONG_SORT_FIELDS).toContain('album');
+    expect(SONG_SORT_FIELDS).toContain('duration');
+  });
+
+  test('has exactly 5 fields', () => {
+    expect(SONG_SORT_FIELDS).toHaveLength(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseSongSortField
+// ---------------------------------------------------------------------------
+
+describe('parseSongSortField', () => {
+  test('returns the field for every valid input', () => {
+    for (const field of SONG_SORT_FIELDS) {
+      expect(parseSongSortField(field)).toBe(field);
+    }
+  });
+
+  test('returns null for unrecognized strings', () => {
+    expect(parseSongSortField('bpm')).toBeNull();
+    expect(parseSongSortField('')).toBeNull();
+    expect(parseSongSortField('genre')).toBeNull();
+  });
+
+  test('returns null for injection-looking strings', () => {
+    expect(parseSongSortField('DROP TABLE songs')).toBeNull();
+    expect(parseSongSortField('1; SELECT *')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSongOrderBy  (structural — full SQL content requires real drizzle-orm)
+// ---------------------------------------------------------------------------
+
+describe('buildSongOrderBy', () => {
+  test('returns an object with strings and values arrays', () => {
+    const result = asSqlFragment(buildSongOrderBy('title', 'ASC'));
+    expect(result).toHaveProperty('strings');
+    expect(result).toHaveProperty('values');
+    expect(Array.isArray(result.strings)).toBe(true);
+    expect(Array.isArray(result.values)).toBe(true);
+  });
+
+  test('every sort field produces a non-empty result', () => {
+    for (const field of SONG_SORT_FIELDS) {
+      const asc = asSqlFragment(buildSongOrderBy(field, 'ASC'));
+      const desc = asSqlFragment(buildSongOrderBy(field, 'DESC'));
+      expect(asc.strings.length).toBeGreaterThan(0);
+      expect(desc.strings.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('accepts custom column references', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cols: any = {
+      title: 't.custom_title',
+      nickname: 't.nickname',
+      artist: 't.artist',
+      album: 't.album',
+      duration: 't.duration',
+      createdAt: 't.created_at',
+    };
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    const result = asSqlFragment(buildSongOrderBy('title', 'ASC', cols));
+    expect(result).toHaveProperty('strings');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSongFilterClause  (structural)
+// ---------------------------------------------------------------------------
+
+describe('buildSongFilterClause', () => {
+  test('returns undefined when no tags or sources are provided', () => {
+    expect(buildSongFilterClause([], [])).toBeUndefined();
+  });
+
+  test('returns a clause object when tags are provided', () => {
+    const result = asSqlFragment(buildSongFilterClause(['rock'], []));
+    expect(result).toHaveProperty('strings');
+    expect(result).toHaveProperty('values');
+  });
+
+  test('returns a clause object when sources are provided', () => {
+    const result = asSqlFragment(buildSongFilterClause([], ['youtube']));
+    expect(result).toHaveProperty('strings');
+  });
+
+  test('returns a clause object when both tags and sources are provided', () => {
+    const result = buildSongFilterClause(['rock', 'jazz'], ['youtube', 'soundcloud']);
+    expect(result).not.toBeUndefined();
+  });
+
+  test('unknown source produces undefined (no matching patterns)', () => {
+    const result = buildSongFilterClause([], ['nonexistent']);
+    expect(result).toBeUndefined();
+  });
+
+  test('accepts custom column references', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cols: any = {
+      tags: 't.tags',
+      sourceUrl: 't.url',
+    };
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    const result = asSqlFragment(buildSongFilterClause(['rock'], [], cols));
+    expect(result).toHaveProperty('strings');
+  });
+});

--- a/packages/server/src/lib/serialization.test.ts
+++ b/packages/server/src/lib/serialization.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+
+import { formatSong, type SerializedSong } from './serialization';
+
+describe('formatSong', () => {
+  test('converts Date createdAt to ISO string', () => {
+    const date = new Date('2024-06-15T12:00:00.000Z');
+    const result = formatSong({ createdAt: date });
+    expect(result.createdAt).toBe('2024-06-15T12:00:00.000Z');
+  });
+
+  test('passes through string createdAt unchanged', () => {
+    const result = formatSong({ createdAt: '2024-01-01T00:00:00.000Z' });
+    expect(result.createdAt).toBe('2024-01-01T00:00:00.000Z');
+  });
+
+  test('defaults tags to empty array when null', () => {
+    const result = formatSong({ createdAt: '2024-01-01T00:00:00.000Z', tags: null });
+    expect(result.tags).toEqual([]);
+  });
+
+  test('defaults tags to empty array when undefined', () => {
+    const result = formatSong({ createdAt: '2024-01-01T00:00:00.000Z' });
+    expect(result.tags).toEqual([]);
+  });
+
+  test('preserves existing tags', () => {
+    const result = formatSong({
+      createdAt: '2024-01-01T00:00:00.000Z',
+      tags: ['rock', 'jazz'],
+    });
+    expect(result.tags).toEqual(['rock', 'jazz']);
+  });
+
+  test('output satisfies SerializedSong type', () => {
+    const result: SerializedSong = formatSong({
+      createdAt: new Date(),
+    });
+    expect(result).toHaveProperty('createdAt');
+    expect(result).toHaveProperty('tags');
+  });
+});

--- a/packages/server/src/lib/validation.test.ts
+++ b/packages/server/src/lib/validation.test.ts
@@ -1,0 +1,383 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+// validation.ts imports heavy runtime modules. The functions we test are pure
+// validation logic, so mock the side-effect-heavy imports.
+void mock.module('../shared/logger', () => ({
+  logger: { error: mock(() => {}), warn: mock(() => {}) },
+}));
+void mock.module('../startDiscord', () => ({
+  isValidSourceUrl: mock((url: string) => url.startsWith('https://')),
+  isPlaylistUrl: mock((url: string) => url.includes('playlist')),
+  getEnabledSourceDisplayNames: mock(() => ['YouTube', 'SoundCloud']),
+  getMetadata: mock(() => Promise.resolve({})),
+  getPlaylistMetadataWithVideos: mock(() => Promise.resolve({})),
+}));
+void mock.module('./json', () => ({
+  json: mock((data: unknown, status: number) => new Response(JSON.stringify(data), { status })),
+}));
+
+const {
+  clampMaxVideos,
+  youTubeUrl,
+  validateArtworkUrl,
+  validateNickname,
+  validateOptionalString,
+  validatePlaylistName,
+  validatePlaylistUrl,
+  validateSourceUrl,
+  validateTags,
+  validateVolumeBoost,
+} = await import('./validation');
+
+describe('clampMaxVideos', () => {
+  test('returns undefined when input is undefined', () => {
+    // eslint-disable-next-line unicorn/no-useless-undefined
+    expect(clampMaxVideos(undefined)).toBeUndefined();
+  });
+
+  test('clamps below 1', () => {
+    expect(clampMaxVideos(0)).toBe(1);
+    expect(clampMaxVideos(-5)).toBe(1);
+  });
+
+  test('clamps above 100', () => {
+    expect(clampMaxVideos(101)).toBe(100);
+    expect(clampMaxVideos(500)).toBe(100);
+  });
+
+  test('passes through values in range', () => {
+    expect(clampMaxVideos(1)).toBe(1);
+    expect(clampMaxVideos(50)).toBe(50);
+    expect(clampMaxVideos(100)).toBe(100);
+  });
+});
+
+describe('youTubeUrl', () => {
+  test('builds a canonical YouTube watch URL', () => {
+    expect(youTubeUrl('dQw4w9WgXcQ')).toBe('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+  });
+
+  test('handles empty string', () => {
+    expect(youTubeUrl('')).toBe('https://www.youtube.com/watch?v=');
+  });
+});
+
+describe('validateSourceUrl', () => {
+  test('rejects non-strings', () => {
+    const result = validateSourceUrl(123);
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects empty string', () => {
+    const result = validateSourceUrl('');
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects null', () => {
+    const result = validateSourceUrl(null);
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects sourceUrl that isValidSourceUrl rejects', () => {
+    const result = validateSourceUrl('ftp://not-https.com/video');
+    expect(result.ok).toBe(false);
+  });
+
+  test('accepts valid HTTPS URL', () => {
+    const result = validateSourceUrl('https://youtube.com/watch?v=abc');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe('https://youtube.com/watch?v=abc');
+    }
+  });
+
+  test('trims whitespace', () => {
+    const result = validateSourceUrl('  https://youtube.com/watch?v=abc  ');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe('https://youtube.com/watch?v=abc');
+    }
+  });
+});
+
+describe('validatePlaylistUrl', () => {
+  test('rejects non-strings', () => {
+    const result = validatePlaylistUrl(456);
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects URL that isPlaylistUrl rejects', () => {
+    const result = validatePlaylistUrl('https://youtube.com/watch?v=abc');
+    expect(result.ok).toBe(false);
+  });
+
+  test('accepts URL containing "playlist"', () => {
+    const result = validatePlaylistUrl('https://youtube.com/playlist?list=abc');
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('validatePlaylistName', () => {
+  test('rejects non-strings', () => {
+    const result = validatePlaylistName(123);
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects empty string', () => {
+    const result = validatePlaylistName('');
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects whitespace-only string', () => {
+    const result = validatePlaylistName('   ');
+    expect(result.ok).toBe(false);
+  });
+
+  test('accepts valid name and trims', () => {
+    const result = validatePlaylistName('  My Playlist  ');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe('My Playlist');
+    }
+  });
+
+  test('rejects null', () => {
+    const result = validatePlaylistName(null);
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('validateNickname', () => {
+  test('returns null for undefined', () => {
+    // eslint-disable-next-line unicorn/no-useless-undefined
+    const result = validateNickname(undefined);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBeNull();
+    }
+  });
+
+  test('returns null for null', () => {
+    const result = validateNickname(null);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBeNull();
+    }
+  });
+
+  test('returns null for empty string', () => {
+    const result = validateNickname('');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBeNull();
+    }
+  });
+
+  test('returns null for whitespace-only', () => {
+    const result = validateNickname('   ');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBeNull();
+    }
+  });
+
+  test('trims and returns valid nickname', () => {
+    const result = validateNickname('  Cool Song  ');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe('Cool Song');
+    }
+  });
+
+  test('rejects non-string values', () => {
+    const result = validateNickname(42);
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('validateOptionalString', () => {
+  test('returns null for undefined', () => {
+    // eslint-disable-next-line unicorn/no-useless-undefined
+    expect(validateOptionalString(undefined)).toBeNull();
+  });
+
+  test('returns null for null', () => {
+    expect(validateOptionalString(null)).toBeNull();
+  });
+
+  test('returns null for non-string', () => {
+    expect(validateOptionalString(42)).toBeNull();
+  });
+
+  test('trims and returns string', () => {
+    expect(validateOptionalString('  hello  ')).toBe('hello');
+  });
+
+  test('returns null for whitespace-only', () => {
+    expect(validateOptionalString('   ')).toBeNull();
+  });
+});
+
+describe('validateArtworkUrl', () => {
+  test('returns null for undefined', () => {
+    // eslint-disable-next-line unicorn/no-useless-undefined
+    const result = validateArtworkUrl(undefined);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBeNull();
+    }
+  });
+
+  test('returns null for null', () => {
+    const result = validateArtworkUrl(null);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBeNull();
+    }
+  });
+
+  test('returns null for empty string', () => {
+    const result = validateArtworkUrl('');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBeNull();
+    }
+  });
+
+  test('rejects non-string values', () => {
+    const result = validateArtworkUrl(123);
+    expect(result.ok).toBe(false);
+  });
+
+  test('accepts and trims valid URL', () => {
+    const result = validateArtworkUrl('  https://example.com/art.jpg  ');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe('https://example.com/art.jpg');
+    }
+  });
+
+  test('rejects invalid URL', () => {
+    const result = validateArtworkUrl('not-a-url');
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('validateTags', () => {
+  test('returns empty array for undefined', () => {
+    // eslint-disable-next-line unicorn/no-useless-undefined
+    const result = validateTags(undefined);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual([]);
+    }
+  });
+
+  test('returns empty array for null', () => {
+    const result = validateTags(null);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual([]);
+    }
+  });
+
+  test('rejects non-array values', () => {
+    const result = validateTags('not-an-array');
+    expect(result.ok).toBe(false);
+  });
+
+  test('filters non-strings and empty strings', () => {
+    const result = validateTags(['rock', '', 123, '  ', 'jazz']);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual(['rock', 'jazz']);
+    }
+  });
+
+  test('deduplicates tags', () => {
+    const result = validateTags(['rock', 'rock', 'jazz']);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual(['rock', 'jazz']);
+    }
+  });
+
+  test('replaces spaces with hyphens', () => {
+    const result = validateTags(['alt rock', 'drum and bass']);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual(['alt-rock', 'drum-and-bass']);
+    }
+  });
+
+  test('empty array returns empty', () => {
+    const result = validateTags([]);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual([]);
+    }
+  });
+});
+
+describe('validateVolumeBoost', () => {
+  test('returns undefined for undefined (PATCH skips)', () => {
+    // eslint-disable-next-line unicorn/no-useless-undefined
+    const result = validateVolumeBoost(undefined);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBeUndefined();
+    }
+  });
+
+  test('returns null for null (explicitly cleared)', () => {
+    const result = validateVolumeBoost(null);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBeNull();
+    }
+  });
+
+  test('rejects non-integer numbers', () => {
+    const result = validateVolumeBoost(1.5);
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects non-numbers', () => {
+    const result = validateVolumeBoost('loud');
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects below -100', () => {
+    const result = validateVolumeBoost(-101);
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects above 200', () => {
+    const result = validateVolumeBoost(201);
+    expect(result.ok).toBe(false);
+  });
+
+  test('accepts -100', () => {
+    const result = validateVolumeBoost(-100);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe(-100);
+    }
+  });
+
+  test('accepts 0', () => {
+    const result = validateVolumeBoost(0);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe(0);
+    }
+  });
+
+  test('accepts 200', () => {
+    const result = validateVolumeBoost(200);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe(200);
+    }
+  });
+});

--- a/packages/server/src/shared/format.test.ts
+++ b/packages/server/src/shared/format.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test';
+
+import { formatDuration } from './format';
+
+describe('formatDuration', () => {
+  test('formats whole minutes', () => {
+    expect(formatDuration(60)).toBe('1:00');
+    expect(formatDuration(120)).toBe('2:00');
+    expect(formatDuration(600)).toBe('10:00');
+  });
+
+  test('formats seconds under a minute', () => {
+    expect(formatDuration(0)).toBe('0:00');
+    expect(formatDuration(1)).toBe('0:01');
+    expect(formatDuration(30)).toBe('0:30');
+    expect(formatDuration(59)).toBe('0:59');
+  });
+
+  test('formats mixed minutes and seconds', () => {
+    expect(formatDuration(65)).toBe('1:05');
+    expect(formatDuration(125)).toBe('2:05');
+    expect(formatDuration(3661)).toBe('61:01');
+  });
+
+  test('pads seconds to two digits', () => {
+    expect(formatDuration(5)).toBe('0:05');
+    expect(formatDuration(65)).toBe('1:05');
+  });
+
+  test('rounds fractional seconds', () => {
+    expect(formatDuration(0.4)).toBe('0:00');
+    expect(formatDuration(0.5)).toBe('0:01');
+    expect(formatDuration(59.9)).toBe('1:00');
+  });
+
+  test('negative values produce negative output', () => {
+    // formatDuration doesn't guard against negative input — it applies
+    // Math.floor and % to the negative number directly
+    expect(formatDuration(-5)).toBe('-1:-5');
+    expect(formatDuration(-60)).toBe('-1:00');
+  });
+
+  test('handles NaN and Infinity', () => {
+    expect(formatDuration(Number.NaN)).toBe('NaN:NaN');
+    expect(formatDuration(Number.POSITIVE_INFINITY)).toBe('Infinity:NaN');
+  });
+});

--- a/packages/server/src/shared/queue.test.ts
+++ b/packages/server/src/shared/queue.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+
+import { toQueuedSong } from './queue';
+import { type Song } from './types';
+
+const baseSong: Song = {
+  id: 'abc-123',
+  title: 'Test Song',
+  sourceUrl: 'https://example.com/video',
+  sourceId: 'video-1',
+  duration: 180,
+  thumbnailUrl: 'https://example.com/thumb.jpg',
+  addedBy: 'user-1',
+  createdAt: '2024-01-01T00:00:00.000Z',
+};
+
+describe('toQueuedSong', () => {
+  test('preserves all song properties', () => {
+    const result = toQueuedSong(baseSong, 'TestUser');
+    expect(result.id).toBe(baseSong.id);
+    expect(result.title).toBe(baseSong.title);
+    expect(result.sourceUrl).toBe(baseSong.sourceUrl);
+    expect(result.sourceId).toBe(baseSong.sourceId);
+    expect(result.duration).toBe(baseSong.duration);
+    expect(result.thumbnailUrl).toBe(baseSong.thumbnailUrl);
+    expect(result.addedBy).toBe(baseSong.addedBy);
+    expect(result.createdAt).toBe(baseSong.createdAt);
+  });
+
+  test('attaches requestedBy', () => {
+    const result = toQueuedSong(baseSong, 'DJ Foobar');
+    expect(result.requestedBy).toBe('DJ Foobar');
+  });
+
+  test('preserves optional fields', () => {
+    const songWithOptionals: Song = {
+      ...baseSong,
+      nickname: 'Custom Name',
+      artist: 'Some Artist',
+      album: 'Some Album',
+      tags: ['rock', 'chill'],
+      volumeBoost: 1.5,
+    };
+    const result = toQueuedSong(songWithOptionals, 'User');
+    expect(result.nickname).toBe('Custom Name');
+    expect(result.artist).toBe('Some Artist');
+    expect(result.album).toBe('Some Album');
+    expect(result.tags).toEqual(['rock', 'chill']);
+    expect(result.volumeBoost).toBe(1.5);
+  });
+});

--- a/packages/server/src/shared/shuffle.test.ts
+++ b/packages/server/src/shared/shuffle.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+import { fisherYatesShuffle } from './shuffle';
+
+describe('fisherYatesShuffle', () => {
+  test('preserves array length', () => {
+    const arr = [1, 2, 3, 4, 5];
+    fisherYatesShuffle(arr);
+    expect(arr).toHaveLength(5);
+  });
+
+  test('preserves all original elements', () => {
+    const arr = [1, 2, 3, 4, 5];
+    fisherYatesShuffle(arr);
+    const sorted = [...arr].sort((a, b) => a - b);
+    expect(sorted).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  test('handles empty array', () => {
+    const arr: number[] = [];
+    fisherYatesShuffle(arr);
+    expect(arr).toEqual([]);
+  });
+
+  test('handles single-element array', () => {
+    const arr = [42];
+    fisherYatesShuffle(arr);
+    expect(arr).toEqual([42]);
+  });
+
+  test('mutates the array in place (returns void)', () => {
+    const arr = [1, 2, 3];
+    fisherYatesShuffle(arr);
+    // fisherYatesShuffle returns void — if it returned a value,
+    // we'd have a confusing void expression. We verify it doesn't throw.
+    expect(arr).toHaveLength(3);
+  });
+
+  test('produces a deterministic shuffle with mocked random', () => {
+    const originalRandom = Math.random;
+    Math.random = mock(() => 0);
+
+    const arr = [1, 2, 3, 4, 5];
+    fisherYatesShuffle(arr);
+
+    Math.random = originalRandom;
+
+    // With Math.random always 0, each iteration swaps with index 0,
+    // resulting in a specific deterministic order
+    expect(arr).toHaveLength(5);
+    expect(arr.sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5]);
+  });
+});


### PR DESCRIPTION
## Summary

Add 120 unit tests across 9 test files for pure utility functions and filter builders, using Bun's built-in test runner. Integrate `bun test` into the `check` pipeline so tests run on every commit, PR, and CI run.

## Changes

- **9 test files** covering 28 functions from `lib/` and `shared/`:
  - `applyNodeLinkFilter.test.ts` — 9 audio filter builders (compressor, karaoke, timescale, etc.)
  - `validation.test.ts` — 10 validators (URLs, names, tags, volume boost, pagination clamping)
  - `search.test.ts` — sort field parsing, query builder structural assertions
  - `eqBands.test.ts` — EQ band extraction, gain mapping, band value conversion
  - `pagination.test.ts` — page/limit parsing with clamping edge cases
  - `format.test.ts` — duration formatting with rounding, negatives, NaN/Infinity
  - `shuffle.test.ts` — Fisher-Yates invariance properties, deterministic mocking
  - `queue.test.ts` — song-to-queued-song transformation
  - `serialization.test.ts` — Date/string serialization, tag defaults
- **Scripts**: Added `test` script to root and server `package.json`, added `bun test` to `check` pipeline
- **Config**: `.dockerignore` excludes test files from images, `.zed/tasks.json` adds standalone test task, `AGENTS.md` documents testing workflow
- **Zero new dependencies** — uses Bun's built-in `bun:test`