### PR TITLE
feat(dev): add fast local dev workflow with hot reload

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,8 @@ node_modules/
 .env*
 dist/
 build/
+data/
+.nodelink/
 .vscode/
 .idea/
 **/*.test.ts

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,10 @@ npm-debug.log*
 # -----------------------------------------------
 .cache/
 
+# Local NodeLink clone (created by `bun setup:nodelink`)
+# -----------------------------------------------
+.nodelink/
+
 # OS clutter
 # -----------------------------------------------
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,10 +39,16 @@ Every decision in this project traces back to one of these. The agent should fol
 ## Development Commands
 
 ```bash
-# Build server dist/, then start all services with Docker
-bun run dev
+# Fast local dev: check → web build → server with --watch (auto-restart on changes)
+bun dev
 
-# Build the web UI (needed after web/src changes before docker compose restart)
+# Full Docker integration test (check → build → docker compose up --build)
+bun dev:docker
+
+# One-time setup: clone and build NodeLink locally (prerequisite for bun dev)
+bun setup:nodelink
+
+# Build the web UI (also run after web/src changes during a bun dev session)
 bun run web:build
 
 # Lint + typecheck + format + tests (run before committing)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,11 +26,11 @@ This guide covers everything you need to set up Alfira for both development and 
 
 ### For Development
 
-| Requirement | Version | Notes                                   |
-| ----------- | ------- | --------------------------------------- |
-| Bun         | 1.3+    | For local development                   |
-| Docker      | 20.10+  | With Docker Compose plugin (optional)   |
-| Git         | Any     | For cloning the repository              |
+| Requirement | Version | Notes                                 |
+| ----------- | ------- | ------------------------------------- |
+| Bun         | 1.3+    | For local development                 |
+| Docker      | 20.10+  | With Docker Compose plugin (optional) |
+| Git         | Any     | For cloning the repository            |
 
 ---
 
@@ -110,22 +110,22 @@ docker compose up -d
 
 #### Optional
 
-| Variable                      | Description                                                                                         | Default                     |
-| ----------------------------- | --------------------------------------------------------------------------------------------------- | --------------------------- |
+| Variable                      | Description                                                                                         | Default                                              |
+| ----------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
 | `DATABASE_URL`                | SQLite database path                                                                                | `data/alfira.db` (local), `/data/alfira.db` (Docker) |
-| `GUILD_ID`                    | Pre-seed Discord server ID (for existing deployments)                                               | —                           |
-| `ADMIN_ROLE_IDS`              | Pre-seed admin role IDs (for existing deployments)                                                  | —                           |
-| `VOICE_IDLE_TIMEOUT_MINUTES`  | Override idle timeout (can also be set via wizard/settings)                                         | `5`                         |
-| `LOG_LEVEL`                   | Log verbosity: `debug`, `info`, `warn`, `error`, `fatal`                                            | `info`                      |
-| `LOG_FORMAT`                  | Set to `json` for machine-readable structured logging                                               | —                           |
-| `NO_COLOR`                    | Set to any value to disable colored log output                                                      | —                           |
-| `JWT_EXPIRES_IN`              | JWT refresh token expiration (e.g., `30d`, `7d`, `24h`)                                             | `30d`                       |
-| `ENABLED_SOURCES`             | Comma-separated list of music sources to enable by default                                          | `youtube,soundcloud`        |
-| `SPOTIFY_CLIENT_ID`           | Spotify API client ID (from [Spotify Developer Dashboard](https://developer.spotify.com/dashboard)) | —                           |
-| `SPOTIFY_CLIENT_SECRET`       | Spotify API client secret                                                                           | —                           |
-| `APPLE_MUSIC_MEDIA_API_TOKEN` | Apple Music developer token (set to `token_here` for auto-fetch, or provide a JWT)                  | —                           |
-| `TIDAL_TOKEN`                 | Tidal authentication token                                                                          | —                           |
-| `GOOGLE_DRIVE_COOKIES`        | Cookie header for accessing private Google Drive files                                              | —                           |
+| `GUILD_ID`                    | Pre-seed Discord server ID (for existing deployments)                                               | —                                                    |
+| `ADMIN_ROLE_IDS`              | Pre-seed admin role IDs (for existing deployments)                                                  | —                                                    |
+| `VOICE_IDLE_TIMEOUT_MINUTES`  | Override idle timeout (can also be set via wizard/settings)                                         | `5`                                                  |
+| `LOG_LEVEL`                   | Log verbosity: `debug`, `info`, `warn`, `error`, `fatal`                                            | `info`                                               |
+| `LOG_FORMAT`                  | Set to `json` for machine-readable structured logging                                               | —                                                    |
+| `NO_COLOR`                    | Set to any value to disable colored log output                                                      | —                                                    |
+| `JWT_EXPIRES_IN`              | JWT refresh token expiration (e.g., `30d`, `7d`, `24h`)                                             | `30d`                                                |
+| `ENABLED_SOURCES`             | Comma-separated list of music sources to enable by default                                          | `youtube,soundcloud`                                 |
+| `SPOTIFY_CLIENT_ID`           | Spotify API client ID (from [Spotify Developer Dashboard](https://developer.spotify.com/dashboard)) | —                                                    |
+| `SPOTIFY_CLIENT_SECRET`       | Spotify API client secret                                                                           | —                                                    |
+| `APPLE_MUSIC_MEDIA_API_TOKEN` | Apple Music developer token (set to `token_here` for auto-fetch, or provide a JWT)                  | —                                                    |
+| `TIDAL_TOKEN`                 | Tidal authentication token                                                                          | —                                                    |
+| `GOOGLE_DRIVE_COOKIES`        | Cookie header for accessing private Google Drive files                                              | —                                                    |
 
 > **Note:** `GUILD_ID` and `ADMIN_ROLE_IDS` are **not required** for new installs — these are configured through the in-app setup wizard. They're only needed for existing deployments migrating from an earlier version.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,16 +26,59 @@ This guide covers everything you need to set up Alfira for both development and 
 
 ### For Development
 
-| Requirement | Version | Notes                      |
-| ----------- | ------- | -------------------------- |
-| Docker      | 20.10+  | With Docker Compose plugin |
-| Git         | Any     | For cloning the repository |
-
-No local Node.js installation needed — Docker handles everything.
+| Requirement | Version | Notes                                   |
+| ----------- | ------- | --------------------------------------- |
+| Bun         | 1.3+    | For local development                   |
+| Docker      | 20.10+  | With Docker Compose plugin (optional)   |
+| Git         | Any     | For cloning the repository              |
 
 ---
 
-## Setup
+## Development Setup
+
+Two options — local development (fast, recommended for active development) or Docker (full production-like stack).
+
+### Option 1: Local Development (recommended)
+
+Runs the server directly with hot reload via `bun --watch`. No Docker needed for the server.
+
+```bash
+# 1. Clone and install dependencies
+git clone https://github.com/ebears/alfira.git
+cd alfira
+bun install
+
+# 2. Configure environment
+cp .env.example .env
+nano .env  # fill in required values (see table below)
+
+# 3. One-time NodeLink setup
+bun setup:nodelink
+
+# 4. Start the dev server — web UI at http://localhost:3001
+bun dev
+```
+
+The server auto-restarts on file changes. For web/frontend changes during a session, run `bun web:build` in another terminal and refresh.
+
+### Option 2: Docker Development
+
+Builds and runs the full stack in Docker — identical to production.
+
+```bash
+# 1. Clone and configure (same as above)
+git clone https://github.com/ebears/alfira.git
+cd alfira
+cp .env.example .env
+nano .env
+
+# 2. Start the full Docker stack
+bun dev:docker
+```
+
+---
+
+## Production Setup
 
 Alfira uses pre-built Docker images from the GitHub Container Registry.
 
@@ -69,7 +112,7 @@ docker compose up -d
 
 | Variable                      | Description                                                                                         | Default                     |
 | ----------------------------- | --------------------------------------------------------------------------------------------------- | --------------------------- |
-| `DATABASE_URL`                | SQLite database path                                                                                | Set automatically in Docker |
+| `DATABASE_URL`                | SQLite database path                                                                                | `data/alfira.db` (local), `/data/alfira.db` (Docker) |
 | `GUILD_ID`                    | Pre-seed Discord server ID (for existing deployments)                                               | —                           |
 | `ADMIN_ROLE_IDS`              | Pre-seed admin role IDs (for existing deployments)                                                  | —                           |
 | `VOICE_IDLE_TIMEOUT_MINUTES`  | Override idle timeout (can also be set via wizard/settings)                                         | `5`                         |

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "type": "module",
   "scripts": {
-    "dev": "bun run web:build && NODELINK_HOME=.nodelink bun --watch --env-file=.env packages/server/src/index.ts",
+    "dev": "bun run check && bun run web:build && NODELINK_HOME=.nodelink bun --watch --env-file=.env packages/server/src/index.ts",
     "dev:docker": "bun run check && bun run --filter @alfira/server build && docker compose -f docker-compose.dev.yml up --build",
     "web:build": "bun run --filter @alfira/web build",
     "discord:unregister-commands": "bun run packages/server/src/utils/unregisterCommands.ts",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
   ],
   "type": "module",
   "scripts": {
-    "dev": "bun run check && bun run --filter @alfira/server build && docker compose -f docker-compose.dev.yml up --build",
+    "dev": "bun run web:build && NODELINK_HOME=.nodelink bun --watch --env-file=.env packages/server/src/index.ts",
+    "dev:docker": "bun run check && bun run --filter @alfira/server build && docker compose -f docker-compose.dev.yml up --build",
     "web:build": "bun run --filter @alfira/web build",
     "discord:unregister-commands": "bun run packages/server/src/utils/unregisterCommands.ts",
+    "setup:nodelink": "bash scripts/setup-nodelink.sh",
     "lint": "oxlint .",
     "lint:fix": "oxlint --fix .",
     "format": "oxfmt --write .",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -61,7 +61,6 @@ const requiredVars = [
   'DISCORD_CLIENT_ID',
   'DISCORD_CLIENT_SECRET',
   'DISCORD_REDIRECT_URI',
-  'DATABASE_URL',
   'JWT_SECRET',
 ];
 const missing = requiredVars.filter((v) => !process.env[v]);
@@ -73,6 +72,8 @@ if (missing.length > 0) {
 }
 
 const PORT = 3001;
+const NODELINK_HOME = process.env.NODELINK_HOME ?? '/usr/local/nodelink';
+const WEB_DIST = join(import.meta.dir, '../../web/dist');
 
 // Re-export RouteContext for consumers that import from '../index'
 export type { RouteContext } from './lib/context';
@@ -277,7 +278,7 @@ function startServer(): void {
         url.pathname === '/registerSW.js';
 
       if (isAsset || url.pathname === '/') {
-        const filePath = `/app/packages/web/dist${url.pathname === '/' ? '/index.html' : url.pathname}`;
+        const filePath = `${WEB_DIST}${url.pathname === '/' ? '/index.html' : url.pathname}`;
         const response = serveStatic(filePath, url.pathname);
         if (response) {
           return response;
@@ -285,7 +286,7 @@ function startServer(): void {
       }
 
       return (
-        serveStatic('/app/packages/web/dist/index.html', '/index.html') ??
+        serveStatic(join(WEB_DIST, 'index.html'), '/index.html') ??
         setSecurityHeaders(json({ error: 'Not Found' }, 404))
       );
     },
@@ -387,8 +388,8 @@ function runMigrations(): void {
 // ---------------------------------------------------------------------------
 function startNodeLink(): Promise<void> {
   return new Promise((resolve) => {
-    nodelinkProcess = Bun.spawn(['/usr/local/bin/bun', 'src/index.ts'], {
-      cwd: '/usr/local/nodelink',
+    nodelinkProcess = Bun.spawn(['bun', 'src/index.ts'], {
+      cwd: NODELINK_HOME,
       stdout: 'pipe',
       stderr: 'pipe',
       env: { ...process.env, NODELINK_AUTHORIZATION: 'nodelink-internal' },

--- a/packages/server/src/shared/db/index.ts
+++ b/packages/server/src/shared/db/index.ts
@@ -1,6 +1,8 @@
 import { Database } from 'bun:sqlite';
 import { eq, sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/bun-sqlite';
+import { mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
 
 import * as schema from './schema';
 
@@ -11,10 +13,10 @@ import * as schema from './schema';
 // process, so this does not open a second physical socket.
 // ---------------------------------------------------------------------------
 
-const DATABASE_URL = process.env.DATABASE_URL;
-if (!DATABASE_URL) {
-  throw new Error('DATABASE_URL environment variable is not set');
-}
+const DATABASE_URL = process.env.DATABASE_URL ?? 'data/alfira.db';
+
+// Ensure the parent directory exists (e.g., data/ for local dev).
+mkdirSync(dirname(DATABASE_URL), { recursive: true });
 
 const sqliteDb = new Database(DATABASE_URL, { create: true, strict: true });
 sqliteDb.run('PRAGMA journal_mode=WAL;');

--- a/scripts/setup-nodelink.sh
+++ b/scripts/setup-nodelink.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# One-time setup: clone NodeLink at the pinned commit and build it locally.
+#
+# This is only needed for local development with `bun dev` (non-Docker).
+# Docker builds handle NodeLink internally in the Dockerfile.
+#
+# Usage:
+#   bun setup:nodelink
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+NODELINK_DIR="$PROJECT_ROOT/.nodelink"
+NODELINK_REPO="https://github.com/PerformanC/NodeLink.git"
+NODELINK_COMMIT="e524ed7f38c01e0fc8f031134c86ee87e0bc7ffa"
+
+echo "→ Cloning NodeLink (commit ${NODELINK_COMMIT:0:7})..."
+if [ -d "$NODELINK_DIR" ]; then
+  echo "  .nodelink/ already exists — skipping clone."
+else
+  git init "$NODELINK_DIR"
+  cd "$NODELINK_DIR"
+  git remote add origin "$NODELINK_REPO"
+  git fetch --depth 1 origin "$NODELINK_COMMIT"
+  git checkout FETCH_HEAD
+fi
+
+cd "$NODELINK_DIR"
+
+echo "→ Installing dependencies..."
+bun install
+
+echo "→ Building NodeLink..."
+bun run build
+
+# Copy our custom NodeLink config into the cloned repo
+echo "→ Copying NodeLink config..."
+cp "$PROJECT_ROOT/nodelink-config/config.js" "$NODELINK_DIR/config.js"
+
+echo "✓ NodeLink is ready at .nodelink/"
+echo "  You can now run: bun dev"


### PR DESCRIPTION
## Summary

Replaces the slow Docker-based `bun dev` with a fast local development workflow that supports hot reload via `bun --watch`. The old Docker workflow is preserved as `bun dev:docker`.

## Changes

- **New `bun dev`** — builds the web once, then runs the server with `bun --watch` for auto-restart on file changes (no Docker, no check step)
- **New `bun dev:docker`** — the old full pipeline: check → build → docker compose up
- **New `bun setup:nodelink`** — one-time script to clone and build NodeLink locally at the pinned commit
- **Configurable NodeLink path** via `NODELINK_HOME` env var (defaults to `/usr/local/nodelink` for Docker compatibility)
- **Default `DATABASE_URL`** to `data/alfira.db` instead of requiring the env var — `data/` is already gitignored
- **Static file paths** now resolve relative to `import.meta.dir` instead of hardcoded `/app/` paths
- **`.dockerignore`** — added `data/` and `.nodelink/` to prevent local dev artifacts from leaking into the Docker build context