### PR TITLE
docs: clarify networking requirements and polish development choices

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,8 +19,11 @@ DISCORD_CLIENT_ID=your-client-id-here
 DISCORD_CLIENT_SECRET=your-client-secret-here
 DISCORD_BOT_TOKEN=your-bot-token-here
 
-# OAuth2 callback URL (must match what you configured in Discord Developer Portal)
-DISCORD_REDIRECT_URI=https://your-domain.com/auth/callback
+# OAuth2 callback URL. Discord redirects here after login.
+# - Same machine: http://localhost:3001/auth/callback
+# - LAN access:  http://<your-lan-ip>:3001/auth/callback (e.g., http://192.168.1.100:3001/auth/callback)
+# - Remote access (reverse proxy): https://your-domain.com/auth/callback
+DISCORD_REDIRECT_URI=http://localhost:3001/auth/callback
 
 # ===========================================
 # SECURITY (Required)

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@
 
 ## Philosophy
 
-Alfira is built to be **simple to own and operate**. One container, one config file, one database file. No external services, no cloud dependencies — just Docker and a reverse proxy. It runs on a home NAS as comfortably as on a VPS.
+Alfira is built to be **simple to own and operate**. One container, one config file, one database file. No external services, no cloud dependencies — just Docker. It runs on a home NAS as comfortably as on a VPS. If you want to share the web UI with others outside your LAN, add a reverse proxy with TLS.
 
 The **web UI is the primary interface** — the Discord bot handles playback, but the web app is where you browse your library, manage playlists, tweak your equalizer, and review song requests. This keeps the feature set rich without fighting Discord's UX limitations.
 

--- a/docs/development-choices.md
+++ b/docs/development-choices.md
@@ -136,10 +136,6 @@ This is the one area of the project explicitly designated as **out of scope**. S
 
 The original version of Alfira used `yt-dlp` + `ffmpeg` directly, which still offloaded the hard problem to an external tool (yt-dlp is community-maintained and updates frequently). NodeLink is a much smoother experience — REST API for player control, WebSocket for events, proper Opus encoding, and a feature set far beyond what a custom solution could reasonably provide. It's the perfect piece of the puzzle, and "it's their problem" is a feature, not a bug.
 
-### Why a child process, not a separate container?
-
-Alfira used to run as three or four Docker containers. Consolidating to one — backend, frontend, NodeLink, and SQLite all in the same container — was a deliberate simplification that eliminated inter-container networking, health check orchestration, and multi-service configuration. One `docker compose up` gets everything running.
-
 ---
 
 ## Discord Integration: Custom Gateway (Not discord.js)
@@ -188,13 +184,13 @@ Player state changes are broadcast to the web UI via a WebSocket pipeline. The d
 
 ### React
 
-React was, honestly, just what the project started with. There was no deep framework evaluation — it was the most familiar option at the time. After building with it, though, a few things have become genuinely appreciated:
+React was chosen for its pragmatic blend of developer experience and ecosystem maturity. A few things that turned out to be genuine advantages:
 
 - **TSX is remarkably powerful.** The combination of TypeScript and JSX — writing components as functions that return typed markup — creates a development flow where logic and presentation are co-located without ceremony. Component reuse feels natural and productive.
 - **99% of code lives in `.tsx` and `.ts` files.** Between React components and Tailwind utility classes, there's very little touching of `.html` or `.css` files. The entire UI surface is expressed in TypeScript.
-- **The ecosystem, while overwhelming, delivers.** When a specialized need arises — virtualized lists, drag-and-drop, masonry grids — there's a well-maintained library for it. Importing a library for these hard problems is pragmatic; writing them from scratch would be a distraction from the actual product.
+- **The ecosystem, while large, delivers.** When a specialized need arises — virtualized lists, drag-and-drop, masonry grids — there's a well-maintained library for it. Importing a library for these hard problems is pragmatic; writing them from scratch would be a distraction from the actual product.
 
-If starting over today, [Vue](https://vuejs.org/) (also backed by VoidZero, whose tooling ecosystem is highly regarded) or [SolidJS](https://www.solidjs.com/) (TSX without a virtual DOM) would get a serious look. React isn't the only game in town, and the virtual DOM overhead is real. But React has been more than capable, and there's no compelling reason to rewrite.
+[SolidJS](https://www.solidjs.com/) (TSX without a virtual DOM, signals-based reactivity) is the only alternative that would get a serious look if starting over. Its reactivity model is genuinely compelling, and the syntax is close enough to React that the mental model transfers. But Solid's ecosystem is an order of magnitude smaller — the libraries this project depends on (`@tanstack/react-virtual`, `@atlaskit/pragmatic-drag-and-drop`, `motion`) don't have Solid equivalents at the same maturity level. React's ecosystem advantage is real, not just inertia, and it has been more than capable for everything Alfira needs.
 
 ### Pragmatic library imports
 
@@ -221,8 +217,6 @@ If starting over today, it's not clear Tailwind would be the choice again. But i
 The web build uses `bun build` directly rather than Vite (which would be the conventional choice for a React project). Vite is an excellent tool but `bun build` handles TypeScript, JSX, and tree-shaking out of the box without additional configuration. Tailwind CSS 4 is compiled separately via `@tailwindcss/cli` before the JS bundle. Two build steps, no framework.
 
 ### Why not Next.js?
-
-Next.js wasn't seriously evaluated — the project started as a React SPA because that's what made sense with the tools at hand, and it's never given a reason to look elsewhere.
 
 Next.js's headline value is **server-side rendering**: sending complete HTML to the browser before JavaScript loads, so users see content immediately rather than a loading spinner. Combined with Server Components, it lets you fetch data at render time on the server rather than in a client-side `useEffect`. These are real, meaningful benefits — for content that can be pre-rendered.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,6 +5,7 @@ This guide covers everything you need to set up Alfira for both development and 
 ## Table of Contents
 
 - [Prerequisites](#prerequisites)
+- [Networking & Access](#networking--access)
 - [Discord Application Setup](#discord-application-setup)
 - [Configuration](#configuration)
 - [Development Setup](#development-setup)
@@ -18,11 +19,10 @@ This guide covers everything you need to set up Alfira for both development and 
 
 ### For Production
 
-| Requirement       | Version | Notes                                     |
-| ----------------- | ------- | ----------------------------------------- |
-| Docker            | 20.10+  | With Docker Compose plugin                |
-| Reverse Proxy     | Any     | Caddy (recommended), Nginx, Traefik, etc. |
-| Domain (optional) | —       | For HTTPS/TLS termination                 |
+| Requirement            | Version | Notes                                    |
+| ---------------------- | ------- | ---------------------------------------- |
+| Docker                 | 20.10+  | With Docker Compose plugin               |
+| Reverse proxy + domain | Any     | Only needed for remote multi-user access |
 
 ### For Development
 
@@ -31,6 +31,49 @@ This guide covers everything you need to set up Alfira for both development and 
 | Bun         | 1.3+    | For local development                 |
 | Docker      | 20.10+  | With Docker Compose plugin (optional) |
 | Git         | Any     | For cloning the repository            |
+
+---
+
+## Networking & Access
+
+Alfira's web UI is how you browse your library, manage playlists, and control playback. The bot itself is outbound-only — it connects to Discord's gateway, no incoming ports needed. The networking requirements are purely about who can reach the web UI.
+
+| Who uses the web UI                    | What you need                                                                 |
+| -------------------------------------- | ----------------------------------------------------------------------------- |
+| Just you, same machine                 | Nothing extra — `localhost` works out of the box                              |
+| You, from other devices on your LAN    | Use your machine's LAN IP as the redirect URI                                 |
+| Multiple people, from outside your LAN | A domain, reverse proxy, and TLS (or a tunnel service like Cloudflare Tunnel) |
+
+### Local & LAN Access
+
+If you're the only one using the web UI — or accessing it from other devices on your home network — no reverse proxy or domain is needed.
+
+- **Same machine:** Set `DISCORD_REDIRECT_URI` to `http://localhost:3001/auth/callback`
+- **LAN access:** Set it to `http://<your-lan-ip>:3001/auth/callback` (e.g., `http://192.168.1.100:3001/auth/callback`)
+
+Add the matching URL to your Discord application's redirect URIs in the Developer Portal. Discord allows `localhost` and LAN IPs without TLS.
+
+### Remote Access (for sharing the web UI with others)
+
+If you want other people to use the web UI from outside your network, you'll need a public-facing HTTPS URL. The standard approach is a reverse proxy with automatic TLS:
+
+**Caddy** (recommended) — handles TLS certificates via Let's Encrypt with minimal configuration:
+
+```
+your-domain.com {
+    reverse_proxy localhost:3001
+}
+```
+
+**Cloudflare Tunnel** — if you don't have a domain, Cloudflare Tunnel (`cloudflared`) gives you a public HTTPS URL without DNS or TLS configuration:
+
+```bash
+cloudflared tunnel create alfira
+cloudflared tunnel route dns alfira alfira.example.com  # or skip for a *.cfargotunnel.com URL
+cloudflared tunnel run --url localhost:3001 alfira
+```
+
+Use the resulting URL as your `DISCORD_REDIRECT_URI`.
 
 ---
 
@@ -98,13 +141,13 @@ docker compose up -d
 
 #### Required
 
-| Variable                | Description                       | Example                                 |
-| ----------------------- | --------------------------------- | --------------------------------------- |
-| `DISCORD_CLIENT_ID`     | Discord application client ID     | `123456789012345678`                    |
-| `DISCORD_CLIENT_SECRET` | Discord application client secret | `abc123...`                             |
-| `DISCORD_BOT_TOKEN`     | Discord bot token                 | `MTAwMC4...`                            |
-| `DISCORD_REDIRECT_URI`  | OAuth2 redirect URI               | `https://your-domain.com/auth/callback` |
-| `JWT_SECRET`            | Secret for signing JWT tokens     | `your-secure-random-string`             |
+| Variable                | Description                       | Example                               |
+| ----------------------- | --------------------------------- | ------------------------------------- |
+| `DISCORD_CLIENT_ID`     | Discord application client ID     | `123456789012345678`                  |
+| `DISCORD_CLIENT_SECRET` | Discord application client secret | `abc123...`                           |
+| `DISCORD_BOT_TOKEN`     | Discord bot token                 | `MTAwMC4...`                          |
+| `DISCORD_REDIRECT_URI`  | OAuth2 redirect URI               | `http://localhost:3001/auth/callback` |
+| `JWT_SECRET`            | Secret for signing JWT tokens     | `your-secure-random-string`           |
 
 > **Security:** Use a strong, random `JWT_SECRET`. Generate one with: `openssl rand -hex 32`
 
@@ -131,15 +174,18 @@ docker compose up -d
 
 > **Music sources:** Spotify, Apple Music, and Tidal require credentials to work. Without them, these sources cannot be enabled — their checkboxes will show a warning in the setup wizard and admin settings. YouTube, SoundCloud, and Google Drive work out of the box.
 
-### Reverse Proxy
+### Configuring Your Redirect URI
 
-For use with a reverse proxy, change `DISCORD_REDIRECT_URI` to point to your custom domain:
+Set `DISCORD_REDIRECT_URI` based on how you'll access the web UI:
 
-| Variable               | Local (Docker)                        | Reverse Proxy                           |
-| ---------------------- | ------------------------------------- | --------------------------------------- |
-| `DISCORD_REDIRECT_URI` | `http://localhost:3001/auth/callback` | `https://your-domain.com/auth/callback` |
+| Access                 | Redirect URI                                             |
+| ---------------------- | -------------------------------------------------------- |
+| Same machine           | `http://localhost:3001/auth/callback`                    |
+| LAN                    | `http://192.168.1.100:3001/auth/callback`                |
+| Remote (reverse proxy) | `https://your-domain.com/auth/callback`                  |
+| Remote (tunnel)        | `https://your-tunnel-url.cfargotunnel.com/auth/callback` |
 
-> **Important:** Ensure your redirect URL in the Discord Developer Portal matches exactly. If you changed the exposed port in docker-compose.yml, use that port here.
+> **Important:** The redirect URI you set here must match exactly what you add in the Discord Developer Portal under OAuth2 → Redirects. If you changed the exposed port in docker-compose.yml, use that port.
 
 ### Discord Application Setup
 
@@ -165,9 +211,10 @@ For use with a reverse proxy, change `DISCORD_REDIRECT_URI` to point to your cus
 
 1. Navigate to **OAuth2** → **General**.
 2. Copy the **Client secret** — this is your `DISCORD_CLIENT_SECRET`.
-3. Add your redirect URL:
-   - Local (Docker): `http://localhost:3001/auth/callback`
-   - Reverse Proxy: `https://your-domain.com/auth/callback`
+3. Add your redirect URL (see [Configuring Your Redirect URI](#configuring-your-redirect-uri) above):
+   - Same machine: `http://localhost:3001/auth/callback`
+   - LAN: `http://<your-lan-ip>:3001/auth/callback`
+   - Remote: `https://your-domain.com/auth/callback`
 4. Click **"Save Changes"**.
 
 #### 4. Invite the Bot to Your Server


### PR DESCRIPTION
## Summary

Docs pass clarifying that a domain and reverse proxy are only needed for remote multi-user access — localhost and LAN work out of the box. Also tightens up the development choices document.

## Changes

- **New Networking & Access section** in installation guide — three-tier access table (localhost / LAN / remote) with Caddy and Cloudflare Tunnel examples
- **Redirect URI docs** restructured — four variants, localhost as default in `.env.example`, cross-referenced from Discord app setup steps
- **Prerequisites table** — reverse proxy + domain marked as conditional, not universal
- **README philosophy** — "just Docker" instead of "just Docker and a reverse proxy"
- **Development choices** — rewritten React section (confident tone, SolidJS as the only alternative), removed duplicate container consolidation, tightened Next.js section