### PR TITLE
docs: add oxc badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 <p align="center">
   <a href="https://www.docker.com/"><img src="https://img.shields.io/badge/Docker-2496ED?logo=docker&logoColor=white" alt="Docker"></a>
   <a href="https://bun.com/"><img src="https://img.shields.io/badge/Bun%20-F472B6?logo=bun&logoColor=white" alt="Bun"></a>
+  <a href="https://oxc.rs"><img src="https://img.shields.io/badge/oxc-32f0ee?logo=oxc&logoColor=white" alt="oxc"></a>
   <a href="https://react.dev/"><img src="https://img.shields.io/badge/React%20-61DAFB?logo=react&logoColor=black" alt="React"></a>
   <a href="https://tailwindcss.com/"><img src="https://img.shields.io/badge/Tailwind%20-06B6D4?logo=tailwindcss&logoColor=white" alt="Tailwind CSS"></a>
   <a href="https://www.sqlite.org/"><img src="https://img.shields.io/badge/SQLite-003B57?logo=sqlite&logoColor=white" alt="SQLite"></a>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <p align="center">
   <a href="https://www.docker.com/"><img src="https://img.shields.io/badge/Docker-2496ED?logo=docker&logoColor=white" alt="Docker"></a>
   <a href="https://bun.com/"><img src="https://img.shields.io/badge/Bun%20-F472B6?logo=bun&logoColor=white" alt="Bun"></a>
-  <a href="https://oxc.rs"><img src="https://img.shields.io/badge/oxc-32f0ee?logo=oxc&logoColor=white" alt="oxc"></a>
+  <a href="https://oxc.rs"><img src="https://img.shields.io/badge/oxc-32f0ee?logo=oxc&logoColor=black" alt="oxc"></a>
   <a href="https://react.dev/"><img src="https://img.shields.io/badge/React%20-61DAFB?logo=react&logoColor=black" alt="React"></a>
   <a href="https://tailwindcss.com/"><img src="https://img.shields.io/badge/Tailwind%20-06B6D4?logo=tailwindcss&logoColor=white" alt="Tailwind CSS"></a>
   <a href="https://www.sqlite.org/"><img src="https://img.shields.io/badge/SQLite-003B57?logo=sqlite&logoColor=white" alt="SQLite"></a>


### PR DESCRIPTION
## Summary

Add oxc badge to the tech stack row in the README, between Bun and React.

## Changes

- Add oxc badge (logo + link to oxc.rs) to README.md tech stack section