### PR TITLE
feat(web): add drag-and-drop reorder to playlist grid view

### DIFF
--- a/packages/web/src/components/VirtualSongGrid.tsx
+++ b/packages/web/src/components/VirtualSongGrid.tsx
@@ -1,8 +1,10 @@
 import { type Playlist, type Song } from '@alfira/server/shared';
+import { DotsSixVerticalIcon } from '@phosphor-icons/react';
 import { useMasonry, usePositioner, useResizeObserver } from 'masonic';
-import { memo, useCallback, useMemo, useRef } from 'react';
+import { memo, useCallback, useMemo, useRef, useState } from 'react';
 
 import { useScrollObserver } from '../hooks/useScrollObserver';
+import { SortableGridProvider, useSortableGridItem } from '../hooks/useSortableMasonicGrid';
 import SongCard from './SongCard';
 import { Skeleton } from './ui/Skeleton';
 
@@ -31,6 +33,9 @@ interface VirtualSongGridProps {
   selectionMode?: boolean;
   isSelected?: (id: string) => boolean;
   onToggleSelect?: (id: string) => void;
+  // Drag-and-drop reorder (masonic grid)
+  sortable?: boolean;
+  onReorder?: (orderedIds: string[]) => Promise<void>;
 }
 
 /** Composite item passed to masonic so state changes trigger re-renders. */
@@ -95,9 +100,20 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
   selectionMode = false,
   isSelected,
   onToggleSelect,
+  sortable = false,
+  onReorder,
 }: VirtualSongGridProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const masonryContainerRef = useRef<HTMLDivElement>(null);
+
+  // Refs don't trigger effect re-runs, so mirror the grid element in
+  // state. SortableGridProvider uses this state as a dep so its drop
+  // target registration fires when the masonry container mounts.
+  const [gridElement, setGridElement] = useState<HTMLElement | null>(null);
+  const gridContainerCallback = useCallback((el: HTMLElement) => {
+    masonryContainerRef.current = el as HTMLDivElement;
+    setGridElement(el);
+  }, []);
 
   // rAF-batched scroll + isScrolling + size tracking via a single
   // ResizeObserver. Width is throttled (see useScrollObserver) to avoid
@@ -122,6 +138,14 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
     columnGutter: 0, // We handle padding in the render wrapper
   });
   const resizeObserver = useResizeObserver(positioner);
+
+  // Store positioner in a ref so SortableGridProvider can access it for
+  // hit-testing during drag operations.
+  const positionerRef = useRef(positioner);
+  positionerRef.current = positioner;
+
+  // Stable ID array for the sortable provider
+  const songIds = useMemo(() => items.map((s) => s.id), [items]);
 
   // ── Infinite scroll trigger ────────────────────────────────────────
   const handleRender = useCallback(
@@ -156,9 +180,14 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
   // producing a visible flash. We store dynamic props in a ref so the
   // component type identity never changes.
   //
-  // NB: playingId / selectionMode / isSelected live in gridItems (above);
+  // DnB: playingId / selectionMode / isSelected live in gridItems (above);
   // masonic re-renders individual cards when these flip without changing
   // the render function identity. Callbacks and stable props go in the ref.
+  //
+  // Sortable drag-and-drop: useSortableGridItem is called unconditionally
+  // (hooks rules). When there is no SortableGridProvider in the tree
+  // (sortable=false), it returns no-op refs and isEnabled=false, so no
+  // drag handles are rendered and no draggable behaviour is attached.
   const cardPropsRef = useRef({
     isAdminView,
     playlists,
@@ -178,7 +207,7 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
 
   const GridCard = useMemo(() => {
     const Component = ({
-      index: _index,
+      index,
       width,
       data: { song, isPlaying, selectionMode: sel, isSelected: selSelected },
     }: {
@@ -187,25 +216,55 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
       data: GridSongItem;
     }) => {
       const p = cardPropsRef.current;
+      const {
+        itemRef,
+        dragHandleRef,
+        isDragging,
+        isAnyDragging,
+        isDropTarget,
+        isEnabled: isSortable,
+      } = useSortableGridItem(song.id, index);
+
       return (
-        <div style={{ width, padding: '0 6px 16px' }}>
-          <SongCard
-            song={song}
-            variant='grid'
-            isAdminView={p.isAdminView}
-            playlists={p.playlists}
-            onDelete={p.onDelete}
-            onPlay={() => {
-              p.onPlay(song.id);
-            }}
-            isPlaying={isPlaying}
-            onAddToQueue={() => {
-              p.onAddToQueue(song.id);
-            }}
-            selectionMode={sel}
-            isSelected={selSelected}
-            onToggleSelect={p.onToggleSelect ? () => p.onToggleSelect?.(song.id) : undefined}
-          />
+        <div ref={itemRef} style={{ width, padding: '0 6px 16px' }} className='group relative'>
+          {/* Drop target highlight */}
+          {isDropTarget && (
+            <div className='bg-accent/10 pointer-events-none absolute inset-0 z-10 rounded-lg' />
+          )}
+
+          {/* Drag handle — rendered only when sortable is enabled */}
+          {isSortable && (
+            <button
+              ref={dragHandleRef}
+              type='button'
+              style={{ position: 'absolute', bottom: 24, left: 8, zIndex: 20 }}
+              className={`text-faint hover:text-muted cursor-grab rounded p-1 opacity-0 transition-opacity active:cursor-grabbing ${isAnyDragging ? 'opacity-100' : 'group-hover:opacity-100'}`}
+              aria-label={`Drag to reorder "${song.nickname ?? song.title}"`}
+            >
+              <DotsSixVerticalIcon size={18} weight='bold' />
+            </button>
+          )}
+
+          {/* Card content — dimmed while this item is being dragged */}
+          <div className={`min-w-0 transition-opacity ${isDragging ? 'opacity-50' : ''}`}>
+            <SongCard
+              song={song}
+              variant='grid'
+              isAdminView={p.isAdminView}
+              playlists={p.playlists}
+              onDelete={p.onDelete}
+              onPlay={() => {
+                p.onPlay(song.id);
+              }}
+              isPlaying={isPlaying}
+              onAddToQueue={() => {
+                p.onAddToQueue(song.id);
+              }}
+              selectionMode={sel}
+              isSelected={selSelected}
+              onToggleSelect={p.onToggleSelect ? () => p.onToggleSelect?.(song.id) : undefined}
+            />
+          </div>
         </div>
       );
     };
@@ -239,7 +298,7 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
     scrollTop,
     isScrolling,
     height: containerHeight || 600,
-    containerRef: masonryContainerRef,
+    containerRef: gridContainerCallback,
     itemKey: (item: GridSongItem) => item.song.id,
     itemHeightEstimate: 330,
     overscanBy: 2,
@@ -266,7 +325,7 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
     [isContentReady]
   );
 
-  return (
+  const gridContent = (
     <div ref={scrollRefCallback} className='min-h-0 flex-1 pt-3' style={scrollStyle}>
       {showSkeleton && <SkeletonGrid />}
 
@@ -306,6 +365,25 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
       )}
     </div>
   );
+
+  // When sortable is enabled, wrap with the sortable context provider so
+  // grid cards can register draggable handles and the container acts as
+  // a drop target with positioner-based hit-testing.
+  if (sortable && onReorder) {
+    return (
+      <SortableGridProvider
+        itemIds={songIds}
+        onReorder={onReorder}
+        scrollContainerRef={scrollContainerRef}
+        positionerRef={positionerRef}
+        gridElement={gridElement}
+      >
+        {gridContent}
+      </SortableGridProvider>
+    );
+  }
+
+  return gridContent;
 });
 
 export default VirtualSongGrid;

--- a/packages/web/src/hooks/useSortableMasonicGrid.tsx
+++ b/packages/web/src/hooks/useSortableMasonicGrid.tsx
@@ -1,0 +1,346 @@
+import { autoScrollForElements } from '@atlaskit/pragmatic-drag-and-drop-auto-scroll/element';
+import { type Edge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
+import {
+  draggable,
+  dropTargetForElements,
+  monitorForElements,
+} from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import { type Positioner } from 'masonic';
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface SortableItemData {
+  id: string;
+  index: number;
+  instanceId: symbol;
+}
+
+export interface DragState {
+  isDragging: boolean;
+  draggingId: string | null;
+  dropIndicatorIndex: number | null;
+}
+
+interface SortableGridContextValue {
+  instanceId: symbol;
+  dragState: DragState;
+}
+
+interface SortableGridProviderProps {
+  itemIds: string[];
+  onReorder: (orderedIds: string[]) => Promise<void>;
+  scrollContainerRef: React.RefObject<HTMLElement | null>;
+  /** Ref to the masonic positioner — needed for hit-testing during drag. */
+  positionerRef: React.RefObject<Positioner | null>;
+  /** The grid container DOM element (masonic's containerRef target).
+   * Passed as state so the drop-target effect re-runs when the element
+   * mounts (ref identity alone doesn't trigger effect re-runs). */
+  gridElement: HTMLElement | null;
+  children: ReactNode;
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+const SortableGridContext = createContext<SortableGridContextValue | null>(null);
+
+function useSortableGridContext(): SortableGridContextValue | null {
+  return useContext(SortableGridContext);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getItemData(item: SortableItemData) {
+  return { id: item.id, index: item.index, instanceId: item.instanceId };
+}
+
+function isItemData(data: unknown): data is SortableItemData {
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
+  const record = data as unknown as Record<string, unknown>;
+  return 'id' in record && 'instanceId' in record && typeof record.instanceId === 'symbol';
+}
+
+function computeDestination(
+  startIndex: number,
+  targetIndex: number,
+  closestEdge: Edge | null
+): number {
+  // 'bottom' and 'right' mean insert after the target.
+  // 'top' and 'left' mean insert before the target.
+  if (closestEdge === 'bottom' || closestEdge === 'right') {
+    return startIndex < targetIndex ? targetIndex : targetIndex + 1;
+  }
+  return startIndex < targetIndex ? targetIndex - 1 : targetIndex;
+}
+
+/**
+ * Find the nearest item index and edge for a cursor position within the grid.
+ * Uses masonic's positioner to get item positions, then finds the item whose
+ * center is closest to the cursor.
+ */
+function hitTest(
+  cursorX: number,
+  cursorY: number,
+  positioner: Positioner
+): { index: number; edge: Edge } | null {
+  const items = positioner.all();
+  if (items.length === 0) {
+    return { index: 0, edge: 'top' };
+  }
+
+  let nearestIndex = 0;
+  let nearestDist = Infinity;
+
+  const colWidth = positioner.columnWidth;
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    const cx = item.left + colWidth / 2;
+    const cy = item.top + item.height / 2;
+    const dist = Math.sqrt((cursorX - cx) ** 2 + (cursorY - cy) ** 2);
+    if (dist < nearestDist) {
+      nearestDist = dist;
+      nearestIndex = i;
+    }
+  }
+
+  const nearestItem = items[nearestIndex];
+  // In a column-based masonry layout, left/right maps to before/after in
+  // the flat list more intuitively than top/bottom. Cursor on the left
+  // half of a card → insert before; right half → insert after.
+  const edge: Edge = cursorX > nearestItem.left + positioner.columnWidth / 2 ? 'right' : 'left';
+
+  return { index: nearestIndex, edge };
+}
+
+// ---------------------------------------------------------------------------
+// Module-level callbacks + target map
+// ---------------------------------------------------------------------------
+
+const gDropTargetCallbacks = new Map<
+  symbol,
+  {
+    setDropTarget: (index: number) => void;
+    clearDropTarget: () => void;
+  }
+>();
+const gTargetMap = new Map<symbol, { index: number; edge: Edge }>();
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export function SortableGridProvider({
+  itemIds,
+  onReorder,
+  scrollContainerRef,
+  positionerRef,
+  gridElement,
+  children,
+}: SortableGridProviderProps) {
+  const instanceId = useMemo(() => Symbol('sortable-grid'), []);
+
+  const itemIdsRef = useRef(itemIds);
+  itemIdsRef.current = itemIds;
+
+  const [dragState, setDragState] = useState<DragState>({
+    isDragging: false,
+    draggingId: null,
+    dropIndicatorIndex: null,
+  });
+
+  // ── Auto-scroll ─────────────────────────────────────────────────────
+  useEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el) {
+      return;
+    }
+    return autoScrollForElements({ element: el });
+  }, [scrollContainerRef]);
+
+  // ── Drop target callbacks ───────────────────────────────────────────
+  const handleSetDropTarget = useCallback((index: number) => {
+    setDragState((prev) =>
+      prev.dropIndicatorIndex === index ? prev : { ...prev, dropIndicatorIndex: index }
+    );
+  }, []);
+
+  const handleClearDropTarget = useCallback(() => {
+    setDragState((prev) =>
+      prev.dropIndicatorIndex === null ? prev : { ...prev, dropIndicatorIndex: null }
+    );
+  }, []);
+
+  // ── Container drop target ───────────────────────────────────────────
+  useLayoutEffect(() => {
+    if (!gridElement) {
+      return;
+    }
+
+    return dropTargetForElements({
+      element: gridElement,
+      canDrop({ source }) {
+        return isItemData(source.data) && source.data.instanceId === instanceId;
+      },
+      onDrag({ location }) {
+        const pos = positionerRef.current;
+        if (!pos) {
+          return;
+        }
+        const input = location.current.input;
+        const gridRect = gridElement.getBoundingClientRect();
+        const cursorX = input.clientX - gridRect.left;
+        const cursorY = input.clientY - gridRect.top;
+
+        const result = hitTest(cursorX, cursorY, pos);
+        if (result) {
+          gTargetMap.set(instanceId, result);
+          // The drop indicator index is the item we're hovering over
+          gDropTargetCallbacks.get(instanceId)?.setDropTarget(result.index);
+        }
+      },
+      onDragLeave() {
+        gDropTargetCallbacks.get(instanceId)?.clearDropTarget();
+        gTargetMap.delete(instanceId);
+      },
+    });
+  }, [instanceId, gridElement, positionerRef]);
+
+  // ── Global drag monitor ─────────────────────────────────────────────
+  useEffect(() => {
+    gDropTargetCallbacks.set(instanceId, {
+      setDropTarget: handleSetDropTarget,
+      clearDropTarget: handleClearDropTarget,
+    });
+
+    return monitorForElements({
+      canMonitor({ source }) {
+        return isItemData(source.data) && source.data.instanceId === instanceId;
+      },
+      onDragStart({ source }) {
+        const data = source.data as unknown as SortableItemData;
+        setDragState({
+          isDragging: true,
+          draggingId: data.id,
+          dropIndicatorIndex: null,
+        });
+      },
+      onDrop({ source }) {
+        const srcData = source.data as unknown as SortableItemData;
+        const target = gTargetMap.get(instanceId) ?? null;
+        gTargetMap.delete(instanceId);
+
+        setDragState({
+          isDragging: false,
+          draggingId: null,
+          dropIndicatorIndex: null,
+        });
+
+        if (!target) {
+          return;
+        }
+
+        const currentIds = itemIdsRef.current;
+        const dest = computeDestination(srcData.index, target.index, target.edge);
+
+        if (dest === srcData.index) {
+          return;
+        }
+
+        const newIds = [...currentIds];
+        const [removed] = newIds.splice(srcData.index, 1);
+        newIds.splice(dest, 0, removed);
+
+        void onReorder(newIds);
+      },
+    });
+  }, [instanceId, onReorder, handleSetDropTarget, handleClearDropTarget]);
+
+  // Clean up
+  useEffect(() => {
+    return () => {
+      gDropTargetCallbacks.delete(instanceId);
+    };
+  }, [instanceId]);
+
+  const value: SortableGridContextValue = useMemo(
+    () => ({ instanceId, dragState }),
+    [instanceId, dragState]
+  );
+
+  return <SortableGridContext.Provider value={value}>{children}</SortableGridContext.Provider>;
+}
+
+// ---------------------------------------------------------------------------
+// Per-item hook
+// ---------------------------------------------------------------------------
+
+export function useSortableGridItem(id: string, index: number) {
+  const ctx = useSortableGridContext();
+
+  const itemEl = useRef<HTMLElement | null>(null);
+  const handleEl = useRef<HTMLElement | null>(null);
+
+  const setItemRef = (el: HTMLElement | null) => {
+    itemEl.current = el;
+  };
+  const setHandleRef = (el: HTMLElement | null) => {
+    handleEl.current = el;
+  };
+
+  const instanceId = ctx?.instanceId ?? null;
+  const dragState = ctx?.dragState ?? null;
+  const isEnabled = ctx !== null;
+
+  // Register draggable on the drag handle
+  useLayoutEffect(() => {
+    if (!isEnabled || !instanceId) {
+      return;
+    }
+
+    const handle = handleEl.current;
+    if (!handle) {
+      return;
+    }
+
+    return draggable({
+      element: handle,
+      getInitialData: () => getItemData({ id, index, instanceId }),
+      onGenerateDragPreview({ nativeSetDragImage }) {
+        const item = itemEl.current;
+        if (item && nativeSetDragImage) {
+          nativeSetDragImage(item, 0, 0);
+        }
+      },
+    });
+  }, [id, index, instanceId, isEnabled]);
+
+  return {
+    itemRef: setItemRef,
+    dragHandleRef: setHandleRef,
+    isDragging: dragState?.draggingId === id,
+    isAnyDragging: dragState?.isDragging ?? false,
+    isDropTarget: dragState?.dropIndicatorIndex === index,
+    isEnabled,
+  };
+}
+
+export type { SortableGridContextValue, SortableGridProviderProps };

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -972,6 +972,8 @@ export default function PlaylistDetailPage() {
                 onDelete={selectionMode ? undefined : handleSongDelete}
                 onPlay={handlePlayFromSong}
                 onAddToQueue={handleAddToQueue}
+                sortable={sort === 'position' && !isSmart && (isAdminView || isOwner)}
+                onReorder={handleReorder}
                 selectionMode={selectionMode}
                 isSelected={bulk.isSelected}
                 onToggleSelect={bulk.toggle}


### PR DESCRIPTION
## Summary

Adds drag-and-drop reorder support to the playlist grid view (Masonic masonry layout), matching the existing DnD behavior in list view.

## Changes

- **New `useSortableMasonicGrid` hook** — `SortableGridProvider` + `useSortableGridItem` with positioner-based hit-testing for masonry layouts. Uses a single container-level drop target (since masonry items are virtualized) and computes the insertion index via nearest-item-center proximity with left/right edge detection.
- **`VirtualSongGrid`** — Accepts optional `sortable` and `onReorder` props. When enabled, wraps content in `SortableGridProvider`, renders drag handles on grid cards (DotsSixVertical grip, bottom-left, hover-visible), and highlights the drop target card.
- **`PlaylistDetailPage`** — Passes `sortable`/`onReorder` to grid view under the same conditions as list DnD: position sort, non-smart playlist, owner or admin.

Closes #739