### PR TITLE
release: v0.4.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,7 +7,11 @@ dist/
 build/
 .vscode/
 .idea/
+**/*.test.ts
+**/*.test.tsx
 .claude/
 .superpowers/
 .github/
 .worktrees/
+.pi/
+.zed/

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,8 @@ node_modules/
 .env*
 dist/
 build/
+data/
+.nodelink/
 .vscode/
 .idea/
 **/*.test.ts

--- a/.env.example
+++ b/.env.example
@@ -19,8 +19,11 @@ DISCORD_CLIENT_ID=your-client-id-here
 DISCORD_CLIENT_SECRET=your-client-secret-here
 DISCORD_BOT_TOKEN=your-bot-token-here
 
-# OAuth2 callback URL (must match what you configured in Discord Developer Portal)
-DISCORD_REDIRECT_URI=https://your-domain.com/auth/callback
+# OAuth2 callback URL. Discord redirects here after login.
+# - Same machine: http://localhost:3001/auth/callback
+# - LAN access:  http://<your-lan-ip>:3001/auth/callback (e.g., http://192.168.1.100:3001/auth/callback)
+# - Remote access (reverse proxy): https://your-domain.com/auth/callback
+DISCORD_REDIRECT_URI=http://localhost:3001/auth/callback
 
 # ===========================================
 # SECURITY (Required)

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,10 @@ npm-debug.log*
 # -----------------------------------------------
 .cache/
 
+# Local NodeLink clone (created by `bun setup:nodelink`)
+# -----------------------------------------------
+.nodelink/
+
 # OS clutter
 # -----------------------------------------------
 .DS_Store

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -6,6 +6,12 @@
     "use_new_terminal": true
   },
   {
+    "label": "test",
+    "command": "bun test",
+    "cwd": "$ZED_WORKTREE_ROOT",
+    "use_new_terminal": true
+  },
+  {
     "label": "check",
     "command": "bun run check",
     "cwd": "$ZED_WORKTREE_ROOT",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ The bot and API run in a **single Bun process**. For detailed architecture (star
 | Frontend     | React 19 + Tailwind CSS 4                     |
 | Linting      | oxlint + oxfmt                                |
 | Typechecking | oxlint (--type-aware --type-check, uses tsgo) |
+| Testing      | Bun's built-in test runner                    |
 
 ## Design Principles
 
@@ -33,7 +34,7 @@ Every decision in this project traces back to one of these. The agent should fol
 - **Web UI as primary interface** — The Discord bot is the playback engine; the web app is the control plane. This avoids Discord's rate limits and UX constraints.
 - **Audio is audio — no assumptions about content** — Works equally as a music bot or tabletop audio player. The data model (songs, playlists, tags) is content-type-agnostic: a pop song and an hour-long dungeon ambience are the same shape.
 - **Single source of truth** — Every concept, pattern, and piece of knowledge has one canonical home. Before creating something new, check if it already exists or can be extended. If nothing fits and your change would duplicate what already exists across files, extract the commonality into a shared location first. This applies as much to UI patterns (one toast, one button variant, one data-fetching hook) as it does to types and utilities. Copy-pasting is a last resort, not a first move.
-- **Strict linting — zero warnings, zero excuses** — The linter is configured for maximum correctness signal with minimal noise. Warnings are errors (`--deny-warnings`). Stale disable directives are errors (`reportUnusedDisableDirectives`). Type-aware rules run everywhere. Every PR must pass `bun run check` with zero diagnostics. This isn't pedantry — it's a quality ratchet that prevents drift and catches real bugs before they reach production.
+- **Strict linting — zero warnings, zero excuses** — The linter is configured for maximum correctness signal with minimal noise. Warnings are errors (`--deny-warnings`). Stale disable directives are errors (`reportUnusedDisableDirectives`). Type-aware rules run everywhere. Every PR must pass `bun run check` (lint, format, typecheck, and tests) with zero diagnostics. This isn't pedantry — it's a quality ratchet that prevents drift and catches real bugs before they reach production.
 
 ## Development Commands
 
@@ -44,8 +45,11 @@ bun run dev
 # Build the web UI (needed after web/src changes before docker compose restart)
 bun run web:build
 
-# Lint + typecheck + format (run before committing)
+# Lint + typecheck + format + tests (run before committing)
 bun run check
+
+# Run tests only
+bun test
 
 # Typecheck only
 bun run typecheck
@@ -178,7 +182,7 @@ refactor(server): extract shared audio filter builders
 
 ### Before Committing
 
-Always run `bun run check` and resolve any lint/format issues before committing.
+Always run `bun run check` and resolve any lint, format, or test failures before committing.
 
 ## Agent Operating Mode
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,10 @@ The bot and API run in a **single Bun process**. For detailed architecture (star
 
 ## Design Principles
 
+Every decision in this project traces back to one of these. The agent should follow them when making changes.
+
 - **Self-hosting without operational burden** — Docker + Bun + SQLite means no external managed services. One `docker compose up` gets you running. Networking (domain/reverse proxy) is the only unavoidable external dependency.
-- **Fewer, better dependencies** — Prefer Bun's built-in HTTP, WebSocket, test runner, and SQLite driver over npm packages. Drizzle gives type-safe SQL without ORM bloat.
+- **Fewer, better dependencies** — Prefer Bun's built-in HTTP, WebSocket, test runner, and SQLite driver over npm packages. Drizzle gives type-safe SQL without ORM bloat. A few hundred lines of custom code is better than importing a library for 10% of its features.
 - **Single-process by design** — Bot, API, and WebSocket run in one Bun process. Shared memory gives real-time updates without Redis or message queues. This is a deliberate tradeoff: the scope is a single self-hosted community, not multi-tenant SaaS.
 - **Web UI as primary interface** — The Discord bot is the playback engine; the web app is the control plane. This avoids Discord's rate limits and UX constraints.
 - **Audio is audio — no assumptions about content** — Works equally as a music bot or tabletop audio player. The data model (songs, playlists, tags) is content-type-agnostic: a pop song and an hour-long dungeon ambience are the same shape.
@@ -188,4 +190,5 @@ Always run `bun run check` and resolve any lint/format issues before committing.
 
 - [Installation Guide](docs/installation.md) — Setup, environment variables, Docker commands
 - [Tech Stack](docs/tech-stack.md) — Detailed architecture
+- [Development Choices](docs/development-choices.md) — Tools, architecture decisions, and the reasoning behind each choice
 - [Troubleshooting](docs/troubleshooting.md) — Common issues and solutions (also available as the `alfira-troubleshooting` skill)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,10 +39,16 @@ Every decision in this project traces back to one of these. The agent should fol
 ## Development Commands
 
 ```bash
-# Build server dist/, then start all services with Docker
-bun run dev
+# Fast local dev: check → web build → server with --watch (auto-restart on changes)
+bun dev
 
-# Build the web UI (needed after web/src changes before docker compose restart)
+# Full Docker integration test (check → build → docker compose up --build)
+bun dev:docker
+
+# One-time setup: clone and build NodeLink locally (prerequisite for bun dev)
+bun setup:nodelink
+
+# Build the web UI (also run after web/src changes during a bun dev session)
 bun run web:build
 
 # Lint + typecheck + format + tests (run before committing)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-07-21
+
+### Added
+
+- **Drag-and-drop reorder across the app** — Songs can now be reordered via drag-and-drop in playlist detail views (#737), playlist grid view (#746), and the queue panel (#745).
+- **Fast local dev workflow** — `bun dev` now provides a single-command local development experience: check → web build → server with `--watch` for auto-restart on changes (#742).
+- **Unit test suite** — Added a comprehensive unit test suite (120 tests across 9 files) with CI integration (#741).
+
+### Changed
+
+- **AddSongsModal virtualization** — The add-songs modal now uses VirtualList for efficient rendering of large song libraries (#736).
+- **Type safety improvements** — Unsafe type assertions replaced with valibot schemas across the server, and the `no-unsafe-type-assertion` lint rule enabled to prevent regression (#732).
+- **Linting tightened** — oxlint rules strengthened and all violations fixed; added oxfmt `sortPackageJson` for consistent package.json ordering (#733, #734).
+
+### Fixed
+
+- **Volume boost of 0** — Volume boost of 0 is now correctly handled (previously treated as falsy/absent), and display names are preserved on song updates (#735).
+
+### Docs
+
+- Added oxc badge to README (#744).
+- Clarified networking requirements and polished development choices documentation (#743).
+- Added development choices document and philosophy section (#740).
+
 ## [0.3.0] - 2026-07-20
 
 ### Added
@@ -234,7 +258,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - UI actions now properly gated by granular permissions rather than a simple admin check.
 - Inherited pointer cursor on modal cards.
 
-[Unreleased]: https://github.com/ebears/alfira/compare/v0.3.0...dev
+[Unreleased]: https://github.com/ebears/alfira/compare/v0.4.0...dev
+[0.4.0]: https://github.com/ebears/alfira/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/ebears/alfira/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/ebears/alfira/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/ebears/alfira/compare/v0.2.0...v0.2.1

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@
 
 ## Philosophy
 
-Alfira is built to be **simple to own and operate**. One container, one config file, one database file. No external services, no cloud dependencies — just Docker and a reverse proxy. It runs on a home NAS as comfortably as on a VPS.
+Alfira is built to be **simple to own and operate**. One container, one config file, one database file. No external services, no cloud dependencies — just Docker. It runs on a home NAS as comfortably as on a VPS. If you want to share the web UI with others outside your LAN, add a reverse proxy with TLS.
 
 The **web UI is the primary interface** — the Discord bot handles playback, but the web app is where you browse your library, manage playlists, tweak your equalizer, and review song requests. This keeps the feature set rich without fighting Discord's UX limitations.
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@
 - **Setup wizard** — Guided first-run setup picks your server, admin roles, and sources so you're ready to go.
 - **Web UI** — Real-time player and queue updates over WebSocket, custom themes, responsive layout, motion-powered animations with tactile clay press effects, and Discord avatar menu.
 
+## Philosophy
+
+Alfira is built to be **simple to own and operate**. One container, one config file, one database file. No external services, no cloud dependencies — just Docker and a reverse proxy. It runs on a home NAS as comfortably as on a VPS.
+
+The **web UI is the primary interface** — the Discord bot handles playback, but the web app is where you browse your library, manage playlists, tweak your equalizer, and review song requests. This keeps the feature set rich without fighting Discord's UX limitations.
+
+Alfira also makes **no assumptions about what you're listening to**. A pop song, an hour-long dungeon ambience, a sound effect for your TTRPG session — they're all the same shape. Use it as a music bot, a tabletop audio player, or both.
+
+See [Development Choices](docs/development-choices.md) for the full story behind the tools and architectural decisions.
+
 ## Quick Start
 
 Alfira only needs Docker.
@@ -135,11 +145,12 @@ See the **[Installation Guide](docs/installation.md)** for full details.
 
 ## Documentation
 
-| Document                                       | Description                                   |
-| ---------------------------------------------- | --------------------------------------------- |
-| **[Installation Guide](docs/installation.md)** | Setup, environment variables, Docker commands |
-| **[Tech Stack](docs/tech-stack.md)**           | Technology stack and project structure        |
-| **[Troubleshooting](docs/troubleshooting.md)** | Common issues and solutions                   |
+| Document                                               | Description                                   |
+| ------------------------------------------------------ | --------------------------------------------- |
+| **[Installation Guide](docs/installation.md)**         | Setup, environment variables, Docker commands |
+| **[Tech Stack](docs/tech-stack.md)**                   | Technology stack and project structure        |
+| **[Development Choices](docs/development-choices.md)** | Tools, architecture decisions, and their why  |
+| **[Troubleshooting](docs/troubleshooting.md)**         | Common issues and solutions                   |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 <p align="center">
   <a href="https://www.docker.com/"><img src="https://img.shields.io/badge/Docker-2496ED?logo=docker&logoColor=white" alt="Docker"></a>
   <a href="https://bun.com/"><img src="https://img.shields.io/badge/Bun%20-F472B6?logo=bun&logoColor=white" alt="Bun"></a>
+  <a href="https://oxc.rs"><img src="https://img.shields.io/badge/oxc-32f0ee?logo=oxc&logoColor=black" alt="oxc"></a>
   <a href="https://react.dev/"><img src="https://img.shields.io/badge/React%20-61DAFB?logo=react&logoColor=black" alt="React"></a>
   <a href="https://tailwindcss.com/"><img src="https://img.shields.io/badge/Tailwind%20-06B6D4?logo=tailwindcss&logoColor=white" alt="Tailwind CSS"></a>
   <a href="https://www.sqlite.org/"><img src="https://img.shields.io/badge/SQLite-003B57?logo=sqlite&logoColor=white" alt="SQLite"></a>

--- a/bun.lock
+++ b/bun.lock
@@ -4,10 +4,6 @@
   "workspaces": {
     "": {
       "name": "alfira",
-      "dependencies": {
-        "@tailwindcss/cli": "^4.3.3",
-        "tailwindcss": "^4.3.3",
-      },
       "devDependencies": {
         "@types/bun": "^1.3.14",
         "oxfmt": "^0.59.0",
@@ -17,14 +13,18 @@
     },
     "packages/server": {
       "name": "@alfira/server",
-      "version": "0.1.1",
+      "version": "0.3.0",
+      "dependencies": {
+        "drizzle-valibot": "^0.4.2",
+        "valibot": "^1.4.2",
+      },
       "devDependencies": {
         "drizzle-orm": "0.45.2",
       },
     },
     "packages/web": {
       "name": "@alfira/web",
-      "version": "0.1.1",
+      "version": "0.3.0",
       "dependencies": {
         "@alfira/server": "workspace:*",
         "@phosphor-icons/react": "2.1.10",
@@ -252,6 +252,8 @@
 
     "drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
 
+    "drizzle-valibot": ["drizzle-valibot@0.4.2", "", { "peerDependencies": { "drizzle-orm": ">=0.36.0", "valibot": ">=1.0.0-beta.7" } }, "sha512-tzjT7g0Di/HX7426marIy8IDtWODjPgrwvgscdevLQRUe5rzYzRhx6bDsYLdDFF9VI/eaYgnjNeF/fznWJoUjg=="],
+
     "enhanced-resolve": ["enhanced-resolve@5.24.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
@@ -349,6 +351,8 @@
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "valibot": ["valibot@1.4.2", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,9 @@
       "version": "0.3.0",
       "dependencies": {
         "@alfira/server": "workspace:*",
+        "@atlaskit/pragmatic-drag-and-drop": "^2.0.1",
+        "@atlaskit/pragmatic-drag-and-drop-auto-scroll": "^3.0.0",
+        "@atlaskit/pragmatic-drag-and-drop-hitbox": "^2.0.0",
         "@phosphor-icons/react": "2.1.10",
         "@tanstack/react-virtual": "3.14.6",
         "masonic": "^4.1.0",
@@ -47,6 +50,14 @@
     "@alfira/server": ["@alfira/server@workspace:packages/server"],
 
     "@alfira/web": ["@alfira/web@workspace:packages/web"],
+
+    "@atlaskit/pragmatic-drag-and-drop": ["@atlaskit/pragmatic-drag-and-drop@2.0.1", "", { "dependencies": { "@babel/runtime": "^7.0.0", "bind-event-listener": "^3.0.0", "raf-schd": "^4.0.3" } }, "sha512-5iSbCveKuWYh0HijDxfSsYKD2VE0UPObI9jO1pqq+RBk9LzaoOYeKyW0Fobv/6db8HAPcyT3vhRy8bmk5TMcMw=="],
+
+    "@atlaskit/pragmatic-drag-and-drop-auto-scroll": ["@atlaskit/pragmatic-drag-and-drop-auto-scroll@3.0.0", "", { "dependencies": { "@atlaskit/pragmatic-drag-and-drop": "^2.0.0", "@babel/runtime": "^7.0.0" } }, "sha512-8TlkMi417zIPrTnCpbNV0Ce63JTKBn3dGkqiadkGQROvzDAox7Y9TYRHpvbQiEdtPoHWnmyRBi+RsGDxXsQxgQ=="],
+
+    "@atlaskit/pragmatic-drag-and-drop-hitbox": ["@atlaskit/pragmatic-drag-and-drop-hitbox@2.0.0", "", { "dependencies": { "@atlaskit/pragmatic-drag-and-drop": "^2.0.0", "@babel/runtime": "^7.0.0" } }, "sha512-vkXCB/23pT8YgYU8biGmR9uu0fr9oWoaq2GMSKyiNPk3reA12XVrCdgB2SLBoB24Ic1FOm9PdaQJ9ZSUQdCVpw=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
     "@essentials/memoize-one": ["@essentials/memoize-one@1.1.0", "", {}, "sha512-HMkuIkKNe0EWSUpZhlaq9+5Yp47YhrMhxLMnXTRnEyE5N4xKLspAvMGjUFdi794VnEF1EcOZFS8rdROeujrgag=="],
 
@@ -239,6 +250,8 @@
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "bind-event-listener": ["bind-event-listener@3.0.0", "", {}, "sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 

--- a/docs/development-choices.md
+++ b/docs/development-choices.md
@@ -136,10 +136,6 @@ This is the one area of the project explicitly designated as **out of scope**. S
 
 The original version of Alfira used `yt-dlp` + `ffmpeg` directly, which still offloaded the hard problem to an external tool (yt-dlp is community-maintained and updates frequently). NodeLink is a much smoother experience — REST API for player control, WebSocket for events, proper Opus encoding, and a feature set far beyond what a custom solution could reasonably provide. It's the perfect piece of the puzzle, and "it's their problem" is a feature, not a bug.
 
-### Why a child process, not a separate container?
-
-Alfira used to run as three or four Docker containers. Consolidating to one — backend, frontend, NodeLink, and SQLite all in the same container — was a deliberate simplification that eliminated inter-container networking, health check orchestration, and multi-service configuration. One `docker compose up` gets everything running.
-
 ---
 
 ## Discord Integration: Custom Gateway (Not discord.js)
@@ -188,13 +184,13 @@ Player state changes are broadcast to the web UI via a WebSocket pipeline. The d
 
 ### React
 
-React was, honestly, just what the project started with. There was no deep framework evaluation — it was the most familiar option at the time. After building with it, though, a few things have become genuinely appreciated:
+React was chosen for its pragmatic blend of developer experience and ecosystem maturity. A few things that turned out to be genuine advantages:
 
 - **TSX is remarkably powerful.** The combination of TypeScript and JSX — writing components as functions that return typed markup — creates a development flow where logic and presentation are co-located without ceremony. Component reuse feels natural and productive.
 - **99% of code lives in `.tsx` and `.ts` files.** Between React components and Tailwind utility classes, there's very little touching of `.html` or `.css` files. The entire UI surface is expressed in TypeScript.
-- **The ecosystem, while overwhelming, delivers.** When a specialized need arises — virtualized lists, drag-and-drop, masonry grids — there's a well-maintained library for it. Importing a library for these hard problems is pragmatic; writing them from scratch would be a distraction from the actual product.
+- **The ecosystem, while large, delivers.** When a specialized need arises — virtualized lists, drag-and-drop, masonry grids — there's a well-maintained library for it. Importing a library for these hard problems is pragmatic; writing them from scratch would be a distraction from the actual product.
 
-If starting over today, [Vue](https://vuejs.org/) (also backed by VoidZero, whose tooling ecosystem is highly regarded) or [SolidJS](https://www.solidjs.com/) (TSX without a virtual DOM) would get a serious look. React isn't the only game in town, and the virtual DOM overhead is real. But React has been more than capable, and there's no compelling reason to rewrite.
+[SolidJS](https://www.solidjs.com/) (TSX without a virtual DOM, signals-based reactivity) is the only alternative that would get a serious look if starting over. Its reactivity model is genuinely compelling, and the syntax is close enough to React that the mental model transfers. But Solid's ecosystem is an order of magnitude smaller — the libraries this project depends on (`@tanstack/react-virtual`, `@atlaskit/pragmatic-drag-and-drop`, `motion`) don't have Solid equivalents at the same maturity level. React's ecosystem advantage is real, not just inertia, and it has been more than capable for everything Alfira needs.
 
 ### Pragmatic library imports
 
@@ -221,8 +217,6 @@ If starting over today, it's not clear Tailwind would be the choice again. But i
 The web build uses `bun build` directly rather than Vite (which would be the conventional choice for a React project). Vite is an excellent tool but `bun build` handles TypeScript, JSX, and tree-shaking out of the box without additional configuration. Tailwind CSS 4 is compiled separately via `@tailwindcss/cli` before the JS bundle. Two build steps, no framework.
 
 ### Why not Next.js?
-
-Next.js wasn't seriously evaluated — the project started as a React SPA because that's what made sense with the tools at hand, and it's never given a reason to look elsewhere.
 
 Next.js's headline value is **server-side rendering**: sending complete HTML to the browser before JavaScript loads, so users see content immediately rather than a loading spinner. Combined with Server Components, it lets you fetch data at render time on the server rather than in a client-side `useEffect`. These are real, meaningful benefits — for content that can be pre-rendered.
 

--- a/docs/development-choices.md
+++ b/docs/development-choices.md
@@ -1,0 +1,270 @@
+# Development Choices
+
+This document explains the tools and architectural decisions behind Alfira — not just _what_ is used, but _why_ each choice was made, what the alternatives were, and what tradeoffs were accepted.
+
+---
+
+## Runtime: Bun
+
+**Alfira is a Bun project first and foremost.** [Bun](https://bun.sh/) (v1.3+) is the runtime, the package manager, the bundler, and the test runner. It's the single dependency that replaces a handful of tools you'd otherwise need in a Node.js project.
+
+This is the closest thing to a win-win in the stack. Bun is flatly faster than Node.js across the board — HTTP serving, WebSocket throughput, filesystem operations, startup time — while also collapsing several concerns into one tool:
+
+| Node.js would need              | Bun provides                             |
+| ------------------------------- | ---------------------------------------- |
+| `http` / Express / Fastify      | `Bun.serve()`                            |
+| `ws` / `socket.io`              | Built-in `WebSocket` and `WebSocketPair` |
+| `better-sqlite3` (native addon) | `bun:sqlite` (built-in, no compilation)  |
+| `tsc` or `tsup` for TypeScript  | Native `.ts` execution                   |
+| `tsx` / `ts-node` for dev       | Direct `bun run file.ts`                 |
+| `vitest` / `jest` for testing   | `bun test`                               |
+
+The catch is that Bun is younger and more experimental — it's not the safe, boring choice. But for this project, the tradeoff feels more "bleeding edge" than "restrictive." Bun's API surface is stable for what Alfira uses, and the developer experience of a single tool that does everything is worth the risk of being an early adopter.
+
+---
+
+## TypeScript, Linting & Formatting: The Oxc "Supertool"
+
+Alfira uses the **[Oxc](https://oxc.rs/) toolchain** (`oxlint` + `oxfmt`) for all three code quality concerns: **linting, typechecking, and formatting**. There is no `typescript` dev dependency and no `tsconfig.json`.
+
+This is a deliberate bet on a newer toolchain that does more with less:
+
+### oxlint (linting + typechecking)
+
+`oxlint` handles both traditional lint rules (~120 enabled) **and** full type-aware checking via **tsgo** — the Go-based TypeScript compiler that just landed as the native engine in TypeScript 7. This means Alfira gets TypeScript 7-level type inference and checking without depending on the `typescript` npm package at all.
+
+```bash
+bun run check    # lint + full typecheck + format check (runs in CI)
+bun run typecheck # lint + typecheck only
+```
+
+The `--deny-warnings` flag means every rule — even `warn`-level — fails the build. There is no "fix it later" category.
+
+### oxfmt (formatting)
+
+Zero-config, runs as `oxfmt --write .`. Shares the same Rust-based parser and AST as oxlint, so there's no toolchain mismatch between "what the formatter produces" and "what the linter sees."
+
+### Why not Biome?
+
+[Biome](https://biomejs.dev/) is the closest alternative and is also excellent. But Oxc won out for a few reasons:
+
+- **ESLint rule compatibility.** `oxlint` supports a large subset of existing ESLint rules and plugins (`@typescript-eslint`, `unicorn`, `import`, `react`, `jsx-a11y`, `promise`, etc.). Biome has its own rule set that reinvents the wheel — powerful, but not what the ecosystem already speaks. Being able to carry forward ESLint knowledge and configurations is a practical advantage.
+- **Type-aware linting with tsgo.** Biome has no type-aware rules. `oxlint` with tsgo catches things like `no-unsafe-assignment`, `no-floating-promises`, `switch-exhaustiveness-check`, and ~40 other type-level issues that a purely syntactic linter can't see. This matters for a codebase that pushes hard on type safety.
+- **VoidZero backing.** Oxc is developed by [VoidZero](https://voidzero.dev/) (Evan You's company), which also builds Vite, Vue, and Rolldown. That's a serious engineering organization behind the tool.
+- **Speed.** Biome is fast. Oxc is a little faster. When the tools are otherwise close, the edge goes to the faster one.
+
+The `oxlint.config.ts` is the most detailed config file in the project (300+ lines) — a reflection of how seriously type safety and correctness are taken here. Every rule has a reason, and every file-specific override has a comment explaining why.
+
+---
+
+## Validation: Valibot
+
+Runtime schema validation uses **[Valibot](https://valibot.dev/)** via `drizzle-valibot` for API input validation. Valibot was chosen over [Zod](https://zod.dev/) for consistency with the project's dependency philosophy.
+
+Zod is the more established choice, and its API reads well. But Valibot is:
+
+- **Modular and tree-shakeable.** Valibot's design means unused validators are eliminated at bundle time. This matters more for the frontend (where the shared types are imported) than the server, but consistency across packages is valuable.
+- **Smaller.** A direct consequence of the modular design — Valibot ships less code.
+- **Philosophically aligned with Drizzle.** Both are tree-shakeable, TypeScript-first, and minimal. Using Zod alongside Drizzle would have felt like mixing two different dependency philosophies.
+
+This is a consistency choice more than a strong conviction — Zod would have worked fine. But in a project that's deliberate about every dependency, Valibot fits the pattern better.
+
+---
+
+## Database: SQLite + Drizzle ORM
+
+### Why SQLite?
+
+SQLite is the database you don't have to manage — no separate process, no connection strings, no replication. It's a single file (`/data/alfira.db`) that can be backed up with `cp`. For a single-guild music bot serving at most a few concurrent users, this is all the database you need.
+
+The alternative would be PostgreSQL, which would add a separate Docker container, connection pooling, and backup complexity — all for features (concurrent writers, horizontal scaling) that Alfira will never use at this scale.
+
+### Why Drizzle over Prisma?
+
+**[Drizzle ORM](https://orm.drizzle.team/)** was chosen over Prisma for a specific reason: **it's minimal**. Prisma takes the opposite approach — schema files, code generation, a generated client with hundreds of methods — it's a full-featured ORM. Drizzle is barely an ORM at all. It's a thin type-safe SQL builder where the schema is TypeScript and queries read like SQL:
+
+```typescript
+const songs = await db.select().from(song).where(eq(song.id, id));
+```
+
+Drizzle has tighter TypeScript integration than Prisma. Prisma's schema-first approach with code generation was built for JavaScript-first workflows and feels bolted on when you're already working in TypeScript. Drizzle's code-first approach (define your schema in `.ts`, write queries in `.ts`) is a natural fit.
+
+The combination of Drizzle + the custom migration runner has been seamless so far — 14 migrations and counting with zero issues.
+
+---
+
+## Migration Runner: Homegrown (60 Lines)
+
+Instead of Drizzle Kit, Alfira uses a custom migration runner in `index.ts`:
+
+1. Reads `.sql` files from `packages/server/src/shared/db/migrations/`
+2. Computes a SHA-256 hash of each file
+3. Tracks applied migrations in a `__drizzle_migrations` table
+4. Runs unapplied migrations at server startup, splitting multi-statement files on `--> statement-breakpoint`
+
+Migrations are handwritten SQL. This gives full control over DDL — indexes, constraints, `CREATE TABLE IF NOT EXISTS` — without an abstraction layer. The runner is trivial code (under 60 lines, no external dependencies) that does exactly what's needed and nothing more.
+
+---
+
+## Monorepo: Bun Workspaces
+
+```
+packages/
+├── server/     # API server + Discord bot (Bun)
+└── web/        # React 19 frontend (Bun build)
+```
+
+Two packages in a single Bun workspace. The server exports a `shared/` entrypoint that the web package imports directly as `"@alfira/server": "workspace:*"`. Shared types (`Song`, `Playlist`, `QueuedSong`), utilities, and the API client live in one place with zero duplication. An API schema change surfaces immediately as a type error in the frontend build.
+
+The project used to be four packages (bot, API, shared, web) but was consolidated to two when the bot and API were merged into one process. Fewer packages, fewer boundaries, simpler mental model.
+
+---
+
+## Audio Pipeline: NodeLink as the Boundary Line
+
+Audio playback runs through **[NodeLink](https://github.com/PerformanC/NodeLink)**, a Lavalink v4-compatible audio server. It's spawned as a child process inside the Docker container:
+
+```
+Bun API server
+  └── spawns: bun /usr/local/nodelink/src/index.ts
+        └── communicates via: WebSocket (opcodes) + REST (player control)
+```
+
+### NodeLink is the deliberate boundary
+
+This is the one area of the project explicitly designated as **out of scope**. Source resolution — downloading audio from YouTube, SoundCloud, and other platforms — is a constant game of whack-a-mole with APIs that don't want to be scraped. Keeping that working requires dedicated effort and rapid response to breakages.
+
+The original version of Alfira used `yt-dlp` + `ffmpeg` directly, which still offloaded the hard problem to an external tool (yt-dlp is community-maintained and updates frequently). NodeLink is a much smoother experience — REST API for player control, WebSocket for events, proper Opus encoding, and a feature set far beyond what a custom solution could reasonably provide. It's the perfect piece of the puzzle, and "it's their problem" is a feature, not a bug.
+
+### Why a child process, not a separate container?
+
+Alfira used to run as three or four Docker containers. Consolidating to one — backend, frontend, NodeLink, and SQLite all in the same container — was a deliberate simplification that eliminated inter-container networking, health check orchestration, and multi-service configuration. One `docker compose up` gets everything running.
+
+---
+
+## Discord Integration: Custom Gateway (Not discord.js)
+
+Alfira uses a **custom Discord gateway client** instead of discord.js or any other Discord library. The gateway handles WebSocket lifecycle (identify, heartbeat, resume), voice state updates, and slash command registration — about 10% of what a full library provides.
+
+### Why not discord.js?
+
+discord.js is a full-featured library. Alfira used it early on, and also tried [Seyfert](https://seyfert.dev/) as an alternative. Both were eventually dropped in favor of a custom gateway built directly on Bun's `WebSocket`.
+
+The math is simple: a Discord library brings in dozens of transitive dependencies for features Alfira doesn't use (message handling, cache management, permission resolution, REST client abstractions). The parts that _are_ used — the gateway, voice state events — are a few hundred lines of code. Maintaining those few hundred lines is less work than maintaining a dependency on a library that's orders of magnitude larger.
+
+The same logic applies to other dependency cuts the project has made:
+
+| Removed              | Replaced with                     | Lines added  |
+| -------------------- | --------------------------------- | ------------ |
+| discord.js / seyfert | Custom gateway on `Bun.WebSocket` | ~300         |
+| `axios`              | `Bun.fetch()`                     | 0 (built-in) |
+| `ws` (npm)           | `Bun.WebSocket` / `WebSocketPair` | 0 (built-in) |
+
+Every cut follows the same principle: if Bun provides it or a small amount of custom code replaces it, the dependency goes.
+
+---
+
+## API Layer: Bun Native HTTP (No Framework)
+
+The API server is `Bun.serve()` with a single `fetch` handler that routes by URL prefix. No Express, Hono, or any HTTP framework — just 11 route handlers, each a plain async function:
+
+```typescript
+(ctx: RouteContext, request: Request) => Promise<Response>;
+```
+
+Bun's native `Request`/`Response` API is fully standards-compliant. At this scale (prefix-based routing, single middleware function for security headers), a framework would add abstraction without removing complexity.
+
+### Real-Time Updates: Receive-Only WebSocket
+
+Player state changes are broadcast to the web UI via a WebSocket pipeline. The design is intentionally minimal:
+
+- **The client never sends messages.** The WebSocket is a push channel for player state. All mutations go through REST. This keeps the protocol one-directional.
+- **Auth before upgrade.** The session cookie is validated before the WebSocket connection is accepted. Failures return 401 without an upgrade. No post-upgrade auth handshake.
+- **No external state store.** Player state lives in-process. When `GuildPlayer` fires an update, it pushes directly to connected WebSocket clients. No Redis, no pub/sub, no message queue. This is a deliberate tradeoff: the scope is one guild, one process — shared memory replaces infrastructure.
+
+---
+
+## Frontend: React 19 + Tailwind CSS 4
+
+### React
+
+React was, honestly, just what the project started with. There was no deep framework evaluation — it was the most familiar option at the time. After building with it, though, a few things have become genuinely appreciated:
+
+- **TSX is remarkably powerful.** The combination of TypeScript and JSX — writing components as functions that return typed markup — creates a development flow where logic and presentation are co-located without ceremony. Component reuse feels natural and productive.
+- **99% of code lives in `.tsx` and `.ts` files.** Between React components and Tailwind utility classes, there's very little touching of `.html` or `.css` files. The entire UI surface is expressed in TypeScript.
+- **The ecosystem, while overwhelming, delivers.** When a specialized need arises — virtualized lists, drag-and-drop, masonry grids — there's a well-maintained library for it. Importing a library for these hard problems is pragmatic; writing them from scratch would be a distraction from the actual product.
+
+If starting over today, [Vue](https://vuejs.org/) (also backed by VoidZero, whose tooling ecosystem is highly regarded) or [SolidJS](https://www.solidjs.com/) (TSX without a virtual DOM) would get a serious look. React isn't the only game in town, and the virtual DOM overhead is real. But React has been more than capable, and there's no compelling reason to rewrite.
+
+### Pragmatic library imports
+
+Some frontend concerns are hard enough to justify pulling in a dependency:
+
+| Library                             | Why import it                                                                                             |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `@tanstack/react-virtual`           | Virtualizing lists of thousands of songs without DOM bloat. Not a thing you write yourself.               |
+| `masonic`                           | Masonry grid for the card view — variable-height cards in a packed layout. Deceptively hard to get right. |
+| `@atlaskit/pragmatic-drag-and-drop` | Playlist reordering via drag-and-drop. Writing custom DnD is a rabbit hole of edge cases.                 |
+| `motion` (framer-motion)            | Page transitions and micro-animations. `LazyMotion` + `m` keeps the bundle at 4.6KB.                      |
+| `@phosphor-icons/react`             | Consistent icon set, tree-shakeable, 6 styles per icon.                                                   |
+
+These are chosen carefully — each one solves a problem that would take weeks to implement correctly.
+
+### Tailwind CSS
+
+Tailwind is... fine. The project uses it and it works. The utility-first approach keeps styles colocated with markup, and combined with React it means almost everything is a `.tsx` file — that's genuinely nice. There's also value in Tailwind being a "standardized library" that anyone familiar with it can pick up immediately.
+
+If starting over today, it's not clear Tailwind would be the choice again. But it's not causing problems, and there's no reason to migrate away. Indifference is the operative emotion here.
+
+### Build: Bun, not Vite
+
+The web build uses `bun build` directly rather than Vite (which would be the conventional choice for a React project). Vite is an excellent tool but `bun build` handles TypeScript, JSX, and tree-shaking out of the box without additional configuration. Tailwind CSS 4 is compiled separately via `@tailwindcss/cli` before the JS bundle. Two build steps, no framework.
+
+### Why not Next.js?
+
+Next.js wasn't seriously evaluated — the project started as a React SPA because that's what made sense with the tools at hand, and it's never given a reason to look elsewhere.
+
+Next.js's headline value is **server-side rendering**: sending complete HTML to the browser before JavaScript loads, so users see content immediately rather than a loading spinner. Combined with Server Components, it lets you fetch data at render time on the server rather than in a client-side `useEffect`. These are real, meaningful benefits — for content that can be pre-rendered.
+
+Alfira's content can't, for the most part. Nearly all data flows through the REST API or arrives over the WebSocket. The song library, playlists, request queue — these change while you're looking at them and need client-side fetching to stay current regardless. The now-playing bar is literal real-time position updates. Even the pages where SSR _could_ pre-populate the initial state (settings, tags) would save a single API round-trip measured in single-digit milliseconds over a local network.
+
+A public-facing marketing site or documentation (possible post-1.0, but firmly out of scope for now) would change the calculus — Next.js excels at mixing static content with an app. But for a single-purpose, authenticated, real-time dashboard behind a reverse proxy on a home NAS, an SPA is the right call.
+
+---
+
+## Containerization: One Container, Down from Four
+
+The project used to run as three or four separate Docker containers: one for the API, one for the bot, one for frontend, and one for PostgreSQL. It has since been consolidated to **one container** containing:
+
+- The Bun API server + Discord bot (single process)
+- NodeLink (child process)
+- SQLite (file on a mounted volume)
+- Static web assets (served by Bun)
+
+This consolidation was a big deal. Multi-container setups add networking, health check orchestration, `depends_on` chains, and separate configuration per service. One container means one `docker compose up`, one health check, one set of environment variables. The Dockerfile uses multi-stage builds (build → builder → runtime) to keep the final image lean, and the runtime runs as a non-root `nodejs` user.
+
+---
+
+## Design Principles
+
+These are the principles that drive every tool choice and architectural decision in this project:
+
+1. **Self-hosting without operational burden.** One container, one process, one config file, one database file. If a choice adds operational burden, it needs a very strong justification.
+2. **Fewer, better dependencies.** Bun's built-ins over npm packages. A few hundred lines of custom code over importing an entire library for 10% of its features. Every dependency must pull its weight and justify its existence.
+3. **Single-process by design.** Bot, API, and WebSocket share memory in one Bun process. Real-time updates reach the web UI without Redis, message queues, or inter-container networking. This is a deliberate tradeoff: the scope is a single self-hosted community, not multi-tenant SaaS.
+4. **Web UI as primary interface.** The Discord bot is the playback engine; the web app is the control plane. This avoids Discord's rate limits and UX constraints while enabling features that wouldn't be possible through chat commands alone.
+5. **Audio is audio — no assumptions about content.** Works equally as a music bot or tabletop audio player. The data model (songs, playlists, tags) is content-type-agnostic: a pop song and an hour-long dungeon ambience are the same shape.
+6. **Type safety end-to-end.** TypeScript from database schema to frontend components. Type-aware linting on every file. Shared types between packages. Runtime validation with Valibot. The type system is the first line of defense against bugs.
+7. **Quality ratchet.** Lint rules only get stricter. Warnings are errors. Stale suppressions fail the build. The bar never goes down.
+
+Here's how each principle maps to specific decisions in this document:
+
+| Principle                               | Drove                                                                                                         |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Self-hosting without operational burden | SQLite over PostgreSQL, single Docker container, NodeLink as child process                                    |
+| Fewer, better dependencies              | Custom Discord gateway over discord.js, Bun over Node.js + Express + ws + better-sqlite3, Drizzle over Prisma |
+| Single-process by design                | One Bun process for bot + API + WebSocket, shared memory for player state, no Redis                           |
+| Web UI as primary interface             | React SPA as the control plane, receive-only WebSocket, Discord bot as pure playback engine                   |
+| Audio is audio                          | Content-type-agnostic data model, source resolution delegated to NodeLink                                     |
+| Type safety end-to-end                  | oxlint with tsgo, Valibot, `@alfira/server/shared` cross-package type contracts                               |
+| Quality ratchet                         | `--deny-warnings`, `reportUnusedDisableDirectives: 'error'`, ~120 lint rules                                  |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,6 +5,7 @@ This guide covers everything you need to set up Alfira for both development and 
 ## Table of Contents
 
 - [Prerequisites](#prerequisites)
+- [Networking & Access](#networking--access)
 - [Discord Application Setup](#discord-application-setup)
 - [Configuration](#configuration)
 - [Development Setup](#development-setup)
@@ -18,11 +19,10 @@ This guide covers everything you need to set up Alfira for both development and 
 
 ### For Production
 
-| Requirement       | Version | Notes                                     |
-| ----------------- | ------- | ----------------------------------------- |
-| Docker            | 20.10+  | With Docker Compose plugin                |
-| Reverse Proxy     | Any     | Caddy (recommended), Nginx, Traefik, etc. |
-| Domain (optional) | —       | For HTTPS/TLS termination                 |
+| Requirement            | Version | Notes                                    |
+| ---------------------- | ------- | ---------------------------------------- |
+| Docker                 | 20.10+  | With Docker Compose plugin               |
+| Reverse proxy + domain | Any     | Only needed for remote multi-user access |
 
 ### For Development
 
@@ -31,6 +31,49 @@ This guide covers everything you need to set up Alfira for both development and 
 | Bun         | 1.3+    | For local development                 |
 | Docker      | 20.10+  | With Docker Compose plugin (optional) |
 | Git         | Any     | For cloning the repository            |
+
+---
+
+## Networking & Access
+
+Alfira's web UI is how you browse your library, manage playlists, and control playback. The bot itself is outbound-only — it connects to Discord's gateway, no incoming ports needed. The networking requirements are purely about who can reach the web UI.
+
+| Who uses the web UI                    | What you need                                                                 |
+| -------------------------------------- | ----------------------------------------------------------------------------- |
+| Just you, same machine                 | Nothing extra — `localhost` works out of the box                              |
+| You, from other devices on your LAN    | Use your machine's LAN IP as the redirect URI                                 |
+| Multiple people, from outside your LAN | A domain, reverse proxy, and TLS (or a tunnel service like Cloudflare Tunnel) |
+
+### Local & LAN Access
+
+If you're the only one using the web UI — or accessing it from other devices on your home network — no reverse proxy or domain is needed.
+
+- **Same machine:** Set `DISCORD_REDIRECT_URI` to `http://localhost:3001/auth/callback`
+- **LAN access:** Set it to `http://<your-lan-ip>:3001/auth/callback` (e.g., `http://192.168.1.100:3001/auth/callback`)
+
+Add the matching URL to your Discord application's redirect URIs in the Developer Portal. Discord allows `localhost` and LAN IPs without TLS.
+
+### Remote Access (for sharing the web UI with others)
+
+If you want other people to use the web UI from outside your network, you'll need a public-facing HTTPS URL. The standard approach is a reverse proxy with automatic TLS:
+
+**Caddy** (recommended) — handles TLS certificates via Let's Encrypt with minimal configuration:
+
+```
+your-domain.com {
+    reverse_proxy localhost:3001
+}
+```
+
+**Cloudflare Tunnel** — if you don't have a domain, Cloudflare Tunnel (`cloudflared`) gives you a public HTTPS URL without DNS or TLS configuration:
+
+```bash
+cloudflared tunnel create alfira
+cloudflared tunnel route dns alfira alfira.example.com  # or skip for a *.cfargotunnel.com URL
+cloudflared tunnel run --url localhost:3001 alfira
+```
+
+Use the resulting URL as your `DISCORD_REDIRECT_URI`.
 
 ---
 
@@ -98,13 +141,13 @@ docker compose up -d
 
 #### Required
 
-| Variable                | Description                       | Example                                 |
-| ----------------------- | --------------------------------- | --------------------------------------- |
-| `DISCORD_CLIENT_ID`     | Discord application client ID     | `123456789012345678`                    |
-| `DISCORD_CLIENT_SECRET` | Discord application client secret | `abc123...`                             |
-| `DISCORD_BOT_TOKEN`     | Discord bot token                 | `MTAwMC4...`                            |
-| `DISCORD_REDIRECT_URI`  | OAuth2 redirect URI               | `https://your-domain.com/auth/callback` |
-| `JWT_SECRET`            | Secret for signing JWT tokens     | `your-secure-random-string`             |
+| Variable                | Description                       | Example                               |
+| ----------------------- | --------------------------------- | ------------------------------------- |
+| `DISCORD_CLIENT_ID`     | Discord application client ID     | `123456789012345678`                  |
+| `DISCORD_CLIENT_SECRET` | Discord application client secret | `abc123...`                           |
+| `DISCORD_BOT_TOKEN`     | Discord bot token                 | `MTAwMC4...`                          |
+| `DISCORD_REDIRECT_URI`  | OAuth2 redirect URI               | `http://localhost:3001/auth/callback` |
+| `JWT_SECRET`            | Secret for signing JWT tokens     | `your-secure-random-string`           |
 
 > **Security:** Use a strong, random `JWT_SECRET`. Generate one with: `openssl rand -hex 32`
 
@@ -131,15 +174,18 @@ docker compose up -d
 
 > **Music sources:** Spotify, Apple Music, and Tidal require credentials to work. Without them, these sources cannot be enabled — their checkboxes will show a warning in the setup wizard and admin settings. YouTube, SoundCloud, and Google Drive work out of the box.
 
-### Reverse Proxy
+### Configuring Your Redirect URI
 
-For use with a reverse proxy, change `DISCORD_REDIRECT_URI` to point to your custom domain:
+Set `DISCORD_REDIRECT_URI` based on how you'll access the web UI:
 
-| Variable               | Local (Docker)                        | Reverse Proxy                           |
-| ---------------------- | ------------------------------------- | --------------------------------------- |
-| `DISCORD_REDIRECT_URI` | `http://localhost:3001/auth/callback` | `https://your-domain.com/auth/callback` |
+| Access                 | Redirect URI                                             |
+| ---------------------- | -------------------------------------------------------- |
+| Same machine           | `http://localhost:3001/auth/callback`                    |
+| LAN                    | `http://192.168.1.100:3001/auth/callback`                |
+| Remote (reverse proxy) | `https://your-domain.com/auth/callback`                  |
+| Remote (tunnel)        | `https://your-tunnel-url.cfargotunnel.com/auth/callback` |
 
-> **Important:** Ensure your redirect URL in the Discord Developer Portal matches exactly. If you changed the exposed port in docker-compose.yml, use that port here.
+> **Important:** The redirect URI you set here must match exactly what you add in the Discord Developer Portal under OAuth2 → Redirects. If you changed the exposed port in docker-compose.yml, use that port.
 
 ### Discord Application Setup
 
@@ -165,9 +211,10 @@ For use with a reverse proxy, change `DISCORD_REDIRECT_URI` to point to your cus
 
 1. Navigate to **OAuth2** → **General**.
 2. Copy the **Client secret** — this is your `DISCORD_CLIENT_SECRET`.
-3. Add your redirect URL:
-   - Local (Docker): `http://localhost:3001/auth/callback`
-   - Reverse Proxy: `https://your-domain.com/auth/callback`
+3. Add your redirect URL (see [Configuring Your Redirect URI](#configuring-your-redirect-uri) above):
+   - Same machine: `http://localhost:3001/auth/callback`
+   - LAN: `http://<your-lan-ip>:3001/auth/callback`
+   - Remote: `https://your-domain.com/auth/callback`
 4. Click **"Save Changes"**.
 
 #### 4. Invite the Bot to Your Server

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,16 +26,59 @@ This guide covers everything you need to set up Alfira for both development and 
 
 ### For Development
 
-| Requirement | Version | Notes                      |
-| ----------- | ------- | -------------------------- |
-| Docker      | 20.10+  | With Docker Compose plugin |
-| Git         | Any     | For cloning the repository |
-
-No local Node.js installation needed — Docker handles everything.
+| Requirement | Version | Notes                                 |
+| ----------- | ------- | ------------------------------------- |
+| Bun         | 1.3+    | For local development                 |
+| Docker      | 20.10+  | With Docker Compose plugin (optional) |
+| Git         | Any     | For cloning the repository            |
 
 ---
 
-## Setup
+## Development Setup
+
+Two options — local development (fast, recommended for active development) or Docker (full production-like stack).
+
+### Option 1: Local Development (recommended)
+
+Runs the server directly with hot reload via `bun --watch`. No Docker needed for the server.
+
+```bash
+# 1. Clone and install dependencies
+git clone https://github.com/ebears/alfira.git
+cd alfira
+bun install
+
+# 2. Configure environment
+cp .env.example .env
+nano .env  # fill in required values (see table below)
+
+# 3. One-time NodeLink setup
+bun setup:nodelink
+
+# 4. Start the dev server — web UI at http://localhost:3001
+bun dev
+```
+
+The server auto-restarts on file changes. For web/frontend changes during a session, run `bun web:build` in another terminal and refresh.
+
+### Option 2: Docker Development
+
+Builds and runs the full stack in Docker — identical to production.
+
+```bash
+# 1. Clone and configure (same as above)
+git clone https://github.com/ebears/alfira.git
+cd alfira
+cp .env.example .env
+nano .env
+
+# 2. Start the full Docker stack
+bun dev:docker
+```
+
+---
+
+## Production Setup
 
 Alfira uses pre-built Docker images from the GitHub Container Registry.
 
@@ -67,22 +110,22 @@ docker compose up -d
 
 #### Optional
 
-| Variable                      | Description                                                                                         | Default                     |
-| ----------------------------- | --------------------------------------------------------------------------------------------------- | --------------------------- |
-| `DATABASE_URL`                | SQLite database path                                                                                | Set automatically in Docker |
-| `GUILD_ID`                    | Pre-seed Discord server ID (for existing deployments)                                               | —                           |
-| `ADMIN_ROLE_IDS`              | Pre-seed admin role IDs (for existing deployments)                                                  | —                           |
-| `VOICE_IDLE_TIMEOUT_MINUTES`  | Override idle timeout (can also be set via wizard/settings)                                         | `5`                         |
-| `LOG_LEVEL`                   | Log verbosity: `debug`, `info`, `warn`, `error`, `fatal`                                            | `info`                      |
-| `LOG_FORMAT`                  | Set to `json` for machine-readable structured logging                                               | —                           |
-| `NO_COLOR`                    | Set to any value to disable colored log output                                                      | —                           |
-| `JWT_EXPIRES_IN`              | JWT refresh token expiration (e.g., `30d`, `7d`, `24h`)                                             | `30d`                       |
-| `ENABLED_SOURCES`             | Comma-separated list of music sources to enable by default                                          | `youtube,soundcloud`        |
-| `SPOTIFY_CLIENT_ID`           | Spotify API client ID (from [Spotify Developer Dashboard](https://developer.spotify.com/dashboard)) | —                           |
-| `SPOTIFY_CLIENT_SECRET`       | Spotify API client secret                                                                           | —                           |
-| `APPLE_MUSIC_MEDIA_API_TOKEN` | Apple Music developer token (set to `token_here` for auto-fetch, or provide a JWT)                  | —                           |
-| `TIDAL_TOKEN`                 | Tidal authentication token                                                                          | —                           |
-| `GOOGLE_DRIVE_COOKIES`        | Cookie header for accessing private Google Drive files                                              | —                           |
+| Variable                      | Description                                                                                         | Default                                              |
+| ----------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `DATABASE_URL`                | SQLite database path                                                                                | `data/alfira.db` (local), `/data/alfira.db` (Docker) |
+| `GUILD_ID`                    | Pre-seed Discord server ID (for existing deployments)                                               | —                                                    |
+| `ADMIN_ROLE_IDS`              | Pre-seed admin role IDs (for existing deployments)                                                  | —                                                    |
+| `VOICE_IDLE_TIMEOUT_MINUTES`  | Override idle timeout (can also be set via wizard/settings)                                         | `5`                                                  |
+| `LOG_LEVEL`                   | Log verbosity: `debug`, `info`, `warn`, `error`, `fatal`                                            | `info`                                               |
+| `LOG_FORMAT`                  | Set to `json` for machine-readable structured logging                                               | —                                                    |
+| `NO_COLOR`                    | Set to any value to disable colored log output                                                      | —                                                    |
+| `JWT_EXPIRES_IN`              | JWT refresh token expiration (e.g., `30d`, `7d`, `24h`)                                             | `30d`                                                |
+| `ENABLED_SOURCES`             | Comma-separated list of music sources to enable by default                                          | `youtube,soundcloud`                                 |
+| `SPOTIFY_CLIENT_ID`           | Spotify API client ID (from [Spotify Developer Dashboard](https://developer.spotify.com/dashboard)) | —                                                    |
+| `SPOTIFY_CLIENT_SECRET`       | Spotify API client secret                                                                           | —                                                    |
+| `APPLE_MUSIC_MEDIA_API_TOKEN` | Apple Music developer token (set to `token_here` for auto-fetch, or provide a JWT)                  | —                                                    |
+| `TIDAL_TOKEN`                 | Tidal authentication token                                                                          | —                                                    |
+| `GOOGLE_DRIVE_COOKIES`        | Cookie header for accessing private Google Drive files                                              | —                                                    |
 
 > **Note:** `GUILD_ID` and `ADMIN_ROLE_IDS` are **not required** for new installs — these are configured through the in-app setup wizard. They're only needed for existing deployments migrating from an earlier version.
 

--- a/docs/oxlint-setup.md
+++ b/docs/oxlint-setup.md
@@ -85,6 +85,24 @@ bun run format
 - `oxlint.config.ts` — linter rules, plugins, overrides, globals
 - `oxfmt.config.ts` — formatter options (print width, quotes, semicolons, etc.)
 
+## Design Philosophy
+
+### Explicit rules over categories
+
+Every rule in the config is individually listed rather than using Oxlint's category-based defaults (correctness, suspicious, pedantic, etc.). This trades verbosity for full control:
+
+- **Every rule is a deliberate choice.** The config serves as documentation of what we enforce and why.
+- **No surprises from upstream.** New rules added to categories won't silently start flagging code.
+- **Overrides are surgical.** File-level exceptions have clear justifications in comments.
+
+### Warnings are errors
+
+The `check` script runs with `--deny-warnings`, so `warn` and `error` are equivalent in CI. The distinction is for editor experience: errors are red squiggles (must fix now), warnings are yellow (should fix, but the build won't break locally until you run `check`).
+
+### Type-aware by default
+
+Type-aware rules (`--type-aware --type-check`) run everywhere. This catches a class of bugs that purely syntactic linting misses — type assertions that don't hold, unreachable conditions, unsafe coercions. Some files suppress specific type-aware rules (e.g., `no-unnecessary-condition` on Drizzle query results) where the rule has known false positives for defensive runtime guards.
+
 ## Resources
 
 - [oxlint Documentation](https://oxc.rs/docs/guide/usage/linter.html)

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
   arrowParens: 'always',
   quoteProps: 'as-needed',
   insertFinalNewline: true,
+  sortTailwindcss: true,
   sortImports: {
     groups: [
       'type-import',

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
   quoteProps: 'as-needed',
   insertFinalNewline: true,
   sortTailwindcss: true,
+  sortPackageJson: true,
   sortImports: {
     groups: [
       'type-import',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -257,8 +257,7 @@ export default defineConfig({
     // type-aware safety — tsgolint rules that catch runtime bugs
     // -----------------------------------------------------------------------
     // `x as Type` assertion that contradicts known types — silent type lie
-    // TODO: fix 148 violations, then change to 'warn'
-    '@typescript-eslint/no-unsafe-type-assertion': 'off',
+    '@typescript-eslint/no-unsafe-type-assertion': 'warn',
     // String coercion of an object without .toString() — produces "[object Object]"
     '@typescript-eslint/no-base-to-string': 'warn',
     // `for (const k in arr)` — iterates string indices, a classic footgun
@@ -397,6 +396,14 @@ export default defineConfig({
         'unicorn/prefer-dom-node-dataset': 'off',
         'unicorn/prefer-keyboard-event-key': 'off',
         'unicorn/prefer-modern-dom-apis': 'off',
+      },
+    },
+
+    // Web: no-unsafe-type-assertion deferred to a follow-up PR
+    {
+      files: ['packages/web/**'],
+      rules: {
+        '@typescript-eslint/no-unsafe-type-assertion': 'off',
       },
     },
 

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -34,6 +34,18 @@ export default defineConfig({
     '@typescript-eslint/no-unnecessary-type-constraint': 'error',
 
     // -----------------------------------------------------------------------
+    // oxc — Oxc-specific correctness rules that catch subtle bugs
+    // -----------------------------------------------------------------------
+    // Math.min(Math.max(x, min), max) — wrong clamping direction
+    'oxc/bad-min-max-func': 'error',
+    // a < b < c evaluates as (a < b) < c — a boolean-number comparison
+    'oxc/bad-comparison-sequence': 'error',
+    // 3.14159 instead of Math.PI, 2.718 instead of Math.E, etc.
+    'oxc/approx-constant': 'error',
+    // new Error('msg') as a statement without throw — silently does nothing
+    'oxc/missing-throw': 'error',
+
+    // -----------------------------------------------------------------------
     // correctness
     // -----------------------------------------------------------------------
     'no-const-assign': 'error',
@@ -176,6 +188,8 @@ export default defineConfig({
     // style
     // -----------------------------------------------------------------------
     curly: 'error',
+    // a ? b : c ? d : e — unreadable; use if/else or extract
+    'unicorn/no-nested-ternary': 'warn',
     'no-useless-concat': 'warn',
     'object-shorthand': 'warn',
     '@typescript-eslint/array-type': 'warn',
@@ -349,6 +363,8 @@ export default defineConfig({
     'unicorn/prefer-array-flat-map': 'warn',
     // Date.now() over new Date().getTime()
     'unicorn/prefer-date-now': 'warn',
+    // str.slice() over str.substr() / str.substring() — consistent, modern
+    'unicorn/prefer-string-slice': 'warn',
     // arr.at(-1) over arr[arr.length - 1]
     'unicorn/prefer-negative-index': 'warn',
     // throw new TypeError(...) for type errors

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -81,7 +81,7 @@ export default defineConfig({
     'unicorn/throw-new-error': 'error',
     'unicorn/error-message': 'error',
     // Reassigning parameters is confusing — mutate properties instead
-    'no-param-reassign': 'warn',
+    'no-param-reassign': 'error',
     // Comma operator outside for-loops is almost always a mistake
     'no-sequences': 'error',
     // Assignment in return (e.g. return x = 5) is never intentional
@@ -110,6 +110,20 @@ export default defineConfig({
     'react/jsx-no-script-url': 'error',
     'react/no-danger': 'error',
     'react/jsx-no-target-blank': 'error',
+
+    // -----------------------------------------------------------------------
+    // type safety — catch TypeScript type-level mistakes
+    // -----------------------------------------------------------------------
+    // {} means "any non-nullish value", not "empty object" — use Record<string, never>
+    '@typescript-eslint/no-empty-object-type': 'error',
+    // Function type is unsafe — use (...args: unknown[]) => unknown
+    '@typescript-eslint/no-unsafe-function-type': 'error',
+    // String / Number / Boolean as types (uppercase wrappers) — use primitives
+    '@typescript-eslint/no-wrapper-object-types': 'error',
+    // Duplicate enum members are ambiguous and confusing
+    '@typescript-eslint/no-duplicate-enum-values': 'error',
+    // void in unions or intersections is a type-level mistake
+    '@typescript-eslint/no-invalid-void-type': 'error',
 
     // -----------------------------------------------------------------------
     // suspicious
@@ -172,7 +186,8 @@ export default defineConfig({
     // imports
     // -----------------------------------------------------------------------
     'import/first': 'warn',
-    'import/no-cycle': 'warn',
+    // Circular imports cause subtle ordering bugs — always a problem
+    'import/no-cycle': 'error',
     'unicorn/prefer-node-protocol': 'warn',
     // export let can cause cross-module side-channel bugs
     'import/no-mutable-exports': 'warn',
@@ -193,6 +208,8 @@ export default defineConfig({
     'promise/always-return': 'warn',
     // Enforce resolve/reject naming in new Promise() callbacks
     'promise/param-names': 'warn',
+    // Promise created in a callback but never returned or awaited — dangling promise
+    'promise/no-promise-in-callback': 'error',
 
     // -----------------------------------------------------------------------
     // style
@@ -313,6 +330,8 @@ export default defineConfig({
     '@typescript-eslint/no-meaningless-void-operator': 'warn',
     // Unnecessary namespace qualifier on a type that's already in scope
     '@typescript-eslint/no-unnecessary-qualifier': 'warn',
+    // Type parameters that can be inferred — dead weight
+    '@typescript-eslint/no-unnecessary-type-parameters': 'warn',
     // `Promise.reject(nonError)` — loses stack trace info
     '@typescript-eslint/prefer-promise-reject-errors': 'warn',
     // `arr.filter(fn)[0]` → `arr.find(fn)` — O(n) vs early-exit
@@ -393,6 +412,10 @@ export default defineConfig({
     'unicorn/prefer-modern-dom-apis': 'warn',
     // Number.isNaN() over isNaN(), Number.isFinite() over isFinite(), etc.
     'unicorn/prefer-number-properties': 'warn',
+    // structuredClone(x) over JSON.parse(JSON.stringify(x))
+    'unicorn/prefer-structured-clone': 'warn',
+    // String.raw over escaping backslashes in regex / path strings
+    'unicorn/prefer-string-raw': 'warn',
     // Enforce kebab-case, PascalCase, or camelCase filenames
     'unicorn/filename-case': [
       'warn',
@@ -615,6 +638,22 @@ export default defineConfig({
       ],
       rules: {
         '@typescript-eslint/no-unnecessary-condition': 'off',
+      },
+    },
+
+    // API wrappers + generic utilities: T used only in return type is necessary
+    // for caller-side type inference. no-unnecessary-type-parameters fires on
+    // single-use type params even when they're essential (e.g. get<T>(url): Promise<T>).
+    {
+      files: [
+        'packages/server/src/shared/api.ts',
+        'packages/server/src/shared/shuffle.ts',
+        'packages/server/src/lib/jwt.ts',
+        'packages/web/src/api/client.ts',
+        'packages/web/src/hooks/useSocket.ts',
+      ],
+      rules: {
+        '@typescript-eslint/no-unnecessary-type-parameters': 'off',
       },
     },
 

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -9,7 +9,17 @@ export default defineConfig({
 
   ignorePatterns: ['.pi/**', '.zed/**'],
 
-  plugins: ['react', 'react-perf', 'jsx-a11y', 'typescript', 'promise', 'import'],
+  plugins: [
+    'react',
+    'react-perf',
+    'jsx-a11y',
+    'typescript',
+    'promise',
+    'import',
+    'unicorn',
+    'oxc',
+    'eslint',
+  ],
 
   rules: {
     // -----------------------------------------------------------------------
@@ -61,7 +71,7 @@ export default defineConfig({
     'no-unsafe-finally': 'error',
     'no-unsafe-optional-chaining': 'error',
     'no-unused-labels': 'error',
-    'no-unused-vars': 'warn',
+    '@typescript-eslint/no-unused-vars': 'warn',
     'use-isnan': 'error',
     'for-direction': 'error',
     'require-yield': 'error',
@@ -114,7 +124,7 @@ export default defineConfig({
     'no-dupe-class-members': 'error',
     'no-dupe-keys': 'error',
     'no-empty': 'warn',
-    '@typescript-eslint/no-explicit-any': 'warn',
+    '@typescript-eslint/no-explicit-any': 'error',
     'no-fallthrough': 'error',
     'no-func-assign': 'error',
     'no-global-assign': 'error',
@@ -188,8 +198,9 @@ export default defineConfig({
     // style
     // -----------------------------------------------------------------------
     curly: 'error',
-    // a ? b : c ? d : e — unreadable; use if/else or extract
-    'unicorn/no-nested-ternary': 'warn',
+    // a ? b : c ? d : e — unreadable; use if/else or extract.
+    // NOTE: oxfmt strips parens from nested ternaries, so this rule is off.
+    'unicorn/no-nested-ternary': 'off',
     'no-useless-concat': 'warn',
     'object-shorthand': 'warn',
     '@typescript-eslint/array-type': 'warn',
@@ -252,6 +263,8 @@ export default defineConfig({
     '@typescript-eslint/no-unsafe-return': 'warn',
     // Conditions that are always truthy/falsy — dead code detector
     '@typescript-eslint/no-unnecessary-condition': 'warn',
+    // void expressions (arr.push, el.remove) used where a value is expected
+    '@typescript-eslint/no-confusing-void-expression': 'warn',
 
     // -----------------------------------------------------------------------
     // type-aware safety — tsgolint rules that catch runtime bugs
@@ -340,6 +353,8 @@ export default defineConfig({
     'no-console': 'warn',
     // Set.has(x) over arr.includes(x) — O(1) vs O(n), better signaling
     'unicorn/prefer-set-has': 'warn',
+    // Set.size / Map.size over .length — correctness
+    'unicorn/prefer-set-size': 'warn',
 
     // -----------------------------------------------------------------------
     // modern JS/TS — prefer modern, idiomatic APIs
@@ -376,6 +391,13 @@ export default defineConfig({
     'unicorn/prefer-keyboard-event-key': 'warn',
     // DOM: el.replaceWith() over parent.replaceChild()
     'unicorn/prefer-modern-dom-apis': 'warn',
+    // Number.isNaN() over isNaN(), Number.isFinite() over isFinite(), etc.
+    'unicorn/prefer-number-properties': 'warn',
+    // Enforce kebab-case, PascalCase, or camelCase filenames
+    'unicorn/filename-case': [
+      'warn',
+      { cases: { kebabCase: true, pascalCase: true, camelCase: true } },
+    ],
   },
 
   overrides: [
@@ -617,6 +639,24 @@ export default defineConfig({
       files: ['packages/web/src/hooks/useSocket.ts'],
       rules: {
         'non-nullable-type-assertion-style': 'off',
+      },
+    },
+
+    // React useEffect callbacks legitimately return cleanup functions.
+    // consistent-return can't distinguish React's void | Destructor contract.
+    {
+      files: ['packages/web/**'],
+      rules: {
+        '@typescript-eslint/consistent-return': 'off',
+      },
+    },
+
+    // Bun WebSocket upgrade: return; after server.upgrade() exits the fetch handler
+    // without producing a Response — correct Bun pattern, not a missing return.
+    {
+      files: ['packages/server/src/index.ts'],
+      rules: {
+        '@typescript-eslint/consistent-return': 'off',
       },
     },
   ],

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
     "lint:fix": "oxlint --fix .",
     "format": "oxfmt --write .",
     "format:check": "oxfmt --check .",
-    "check": "oxlint --type-aware --type-check --deny-warnings . && oxfmt --check .",
-    "typecheck": "oxlint --type-aware --type-check --deny-warnings ."
+    "check": "oxlint --type-aware --type-check --deny-warnings . && oxfmt --check . && bun test",
+    "typecheck": "oxlint --type-aware --type-check --deny-warnings .",
+    "test": "bun test"
   },
   "devDependencies": {
     "@types/bun": "^1.3.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alfira",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
   ],
   "type": "module",
   "scripts": {
-    "dev": "bun run check && bun run --filter @alfira/server build && docker compose -f docker-compose.dev.yml up --build",
+    "dev": "bun run check && bun run web:build && NODELINK_HOME=.nodelink bun --watch --env-file=.env packages/server/src/index.ts",
+    "dev:docker": "bun run check && bun run --filter @alfira/server build && docker compose -f docker-compose.dev.yml up --build",
     "web:build": "bun run --filter @alfira/web build",
     "discord:unregister-commands": "bun run packages/server/src/utils/unregisterCommands.ts",
+    "setup:nodelink": "bash scripts/setup-nodelink.sh",
     "lint": "oxlint .",
     "lint:fix": "oxlint --fix .",
     "format": "oxfmt --write .",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alfira/server",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "main": "./src/index.ts",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "dev": "bun run src/index.ts",
-    "build": "bun build ./src/index.ts --outdir=./dist --target bun --format esm"
+    "build": "bun build ./src/index.ts --outdir=./dist --target bun --format esm",
+    "test": "bun test"
   },
   "dependencies": {
     "drizzle-valibot": "^0.4.2",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,7 +12,10 @@
     "dev": "bun run src/index.ts",
     "build": "bun build ./src/index.ts --outdir=./dist --target bun --format esm"
   },
-  "dependencies": {},
+  "dependencies": {
+    "drizzle-valibot": "^0.4.2",
+    "valibot": "^1.4.2"
+  },
   "devDependencies": {
     "drizzle-orm": "0.45.2"
   }

--- a/packages/server/src/GuildPlayer.ts
+++ b/packages/server/src/GuildPlayer.ts
@@ -723,11 +723,13 @@ export class GuildPlayer {
 
     if (this.queue.isAtEnd) {
       if (this.loopMode === 'queue' && !this.queue.isEmpty) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         return this.queue.current() as QueuedSong | null;
       }
       return null;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     return this.queue.current() as QueuedSong | null;
   }
 
@@ -847,6 +849,7 @@ export class GuildPlayer {
       if (settings?.enabled) {
         try {
           const compressorFilter = buildCompressorFilter(settings);
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
           patch.filters = { ...(patch.filters as Record<string, unknown>), ...compressorFilter };
         } catch (err) {
           logger.error({ err, guildId: this.guildId }, 'Failed to build compressor filter');
@@ -858,6 +861,7 @@ export class GuildPlayer {
         try {
           const equalizerFilter = buildEqualizerFilter(eqBands);
           patch.filters = {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
             ...(patch.filters as Record<string, unknown>),
             equalizer: equalizerFilter,
           };
@@ -946,6 +950,7 @@ export class GuildPlayer {
     if (settings?.enabled) {
       try {
         const compressorFilter = buildCompressorFilter(settings);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         patch.filters = { ...(patch.filters as Record<string, unknown>), ...compressorFilter };
       } catch (err) {
         logger.error({ err, guildId: this.guildId }, 'Failed to build compressor filter');
@@ -957,6 +962,7 @@ export class GuildPlayer {
       try {
         const equalizerFilter = buildEqualizerFilter(eqBands);
         patch.filters = {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
           ...(patch.filters as Record<string, unknown>),
           equalizer: equalizerFilter,
         };

--- a/packages/server/src/GuildPlayer.ts
+++ b/packages/server/src/GuildPlayer.ts
@@ -144,8 +144,8 @@ export class GuildPlayer {
           });
         }
       }
-    } catch (err) {
-      logger.warn({ err, guildId: this.guildId }, 'Failed to send idle-leave notification');
+    } catch (error) {
+      logger.warn({ error, guildId: this.guildId }, 'Failed to send idle-leave notification');
     }
 
     this.stop();
@@ -851,8 +851,8 @@ export class GuildPlayer {
           const compressorFilter = buildCompressorFilter(settings);
           // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
           patch.filters = { ...(patch.filters as Record<string, unknown>), ...compressorFilter };
-        } catch (err) {
-          logger.error({ err, guildId: this.guildId }, 'Failed to build compressor filter');
+        } catch (error) {
+          logger.error({ error, guildId: this.guildId }, 'Failed to build compressor filter');
         }
       }
 
@@ -865,8 +865,8 @@ export class GuildPlayer {
             ...(patch.filters as Record<string, unknown>),
             equalizer: equalizerFilter,
           };
-        } catch (err) {
-          logger.error({ err, guildId: this.guildId }, 'Failed to build equalizer filter');
+        } catch (error) {
+          logger.error({ error, guildId: this.guildId }, 'Failed to build equalizer filter');
         }
       }
 
@@ -952,8 +952,8 @@ export class GuildPlayer {
         const compressorFilter = buildCompressorFilter(settings);
         // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         patch.filters = { ...(patch.filters as Record<string, unknown>), ...compressorFilter };
-      } catch (err) {
-        logger.error({ err, guildId: this.guildId }, 'Failed to build compressor filter');
+      } catch (error) {
+        logger.error({ error, guildId: this.guildId }, 'Failed to build compressor filter');
       }
     }
 
@@ -966,8 +966,8 @@ export class GuildPlayer {
           ...(patch.filters as Record<string, unknown>),
           equalizer: equalizerFilter,
         };
-      } catch (err) {
-        logger.error({ err, guildId: this.guildId }, 'Failed to build equalizer filter');
+      } catch (error) {
+        logger.error({ error, guildId: this.guildId }, 'Failed to build equalizer filter');
       }
     }
 
@@ -1012,16 +1012,16 @@ export class GuildPlayer {
     const attempt = async () => {
       try {
         await preloadTrack(this.guildId, sessionId, nextTrack.sourceUrl);
-      } catch (err) {
+      } catch (error) {
         logger.warn(
-          { guildId: this.guildId, track: nextTrack.title, err },
+          { guildId: this.guildId, track: nextTrack.title, error },
           'Gapless preload failed — retrying once'
         );
         try {
           await preloadTrack(this.guildId, sessionId, nextTrack.sourceUrl);
-        } catch (err2) {
+        } catch (error) {
           logger.warn(
-            { guildId: this.guildId, track: nextTrack.title, err: err2 },
+            { guildId: this.guildId, track: nextTrack.title, err: error },
             'Gapless preload retry also failed'
           );
         }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -157,7 +157,9 @@ async function handleHealth(): Promise<Response> {
   // NodeLink
   try {
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 500);
+    const timeout = setTimeout(() => {
+      controller.abort();
+    }, 500);
     const res = await fetch('http://127.0.0.1:2333/v4/info', {
       headers: { Authorization: 'nodelink-internal' },
       signal: controller.signal,
@@ -258,7 +260,7 @@ function startServer(): void {
         }
         const success = server.upgrade(request, { data: { user } });
         if (success) {
-          return undefined;
+          return;
         }
         return new Response('WebSocket upgrade failed', { status: 500 });
       }
@@ -356,22 +358,19 @@ function runMigrations(): void {
       }
       try {
         $client.run(trimmed);
-      } catch (err) {
+      } catch (error) {
         // Skip errors that indicate the schema change was already applied
         // in a previous partial run (RENAME, ADD COLUMN, CREATE TABLE retries).
         const isKnownError =
-          err instanceof Error &&
-          (err.message.includes('already exists') ||
-            err.message.includes('no such column') ||
-            err.message.includes('duplicate column name'));
+          error instanceof Error &&
+          (error.message.includes('already exists') ||
+            error.message.includes('no such column') ||
+            error.message.includes('duplicate column name'));
         if (isKnownError) {
-          logger.info(
-            { file, stmt: trimmed.substring(0, 50) },
-            'Skipping already-applied statement'
-          );
+          logger.info({ file, stmt: trimmed.slice(0, 50) }, 'Skipping already-applied statement');
           continue;
         }
-        throw err;
+        throw error;
       }
     }
 
@@ -512,8 +511,8 @@ async function main(): Promise<void> {
 void (async () => {
   try {
     await main();
-  } catch (err) {
-    logger.fatal(err, 'Fatal startup error');
+  } catch (error) {
+    logger.fatal(error, 'Fatal startup error');
     process.exit(1);
   }
 })();
@@ -553,5 +552,9 @@ function shutdown(signal: string): void {
   process.exit(0);
 }
 
-process.on('SIGTERM', () => shutdown('SIGTERM'));
-process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => {
+  shutdown('SIGTERM');
+});
+process.on('SIGINT', () => {
+  shutdown('SIGINT');
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -61,7 +61,6 @@ const requiredVars = [
   'DISCORD_CLIENT_ID',
   'DISCORD_CLIENT_SECRET',
   'DISCORD_REDIRECT_URI',
-  'DATABASE_URL',
   'JWT_SECRET',
 ];
 const missing = requiredVars.filter((v) => !process.env[v]);
@@ -73,6 +72,8 @@ if (missing.length > 0) {
 }
 
 const PORT = 3001;
+const NODELINK_HOME = process.env.NODELINK_HOME ?? '/usr/local/nodelink';
+const WEB_DIST = join(import.meta.dir, '../../web/dist');
 
 // Re-export RouteContext for consumers that import from '../index'
 export type { RouteContext } from './lib/context';
@@ -277,7 +278,7 @@ function startServer(): void {
         url.pathname === '/registerSW.js';
 
       if (isAsset || url.pathname === '/') {
-        const filePath = `/app/packages/web/dist${url.pathname === '/' ? '/index.html' : url.pathname}`;
+        const filePath = `${WEB_DIST}${url.pathname === '/' ? '/index.html' : url.pathname}`;
         const response = serveStatic(filePath, url.pathname);
         if (response) {
           return response;
@@ -285,7 +286,7 @@ function startServer(): void {
       }
 
       return (
-        serveStatic('/app/packages/web/dist/index.html', '/index.html') ??
+        serveStatic(join(WEB_DIST, 'index.html'), '/index.html') ??
         setSecurityHeaders(json({ error: 'Not Found' }, 404))
       );
     },
@@ -387,8 +388,8 @@ function runMigrations(): void {
 // ---------------------------------------------------------------------------
 function startNodeLink(): Promise<void> {
   return new Promise((resolve) => {
-    nodelinkProcess = Bun.spawn(['/usr/local/bin/bun', 'src/index.ts'], {
-      cwd: '/usr/local/nodelink',
+    nodelinkProcess = Bun.spawn(['bun', 'src/index.ts'], {
+      cwd: NODELINK_HOME,
       stdout: 'pipe',
       stderr: 'pipe',
       env: { ...process.env, NODELINK_AUTHORIZATION: 'nodelink-internal' },

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -288,18 +288,22 @@ function startServer(): void {
       );
     },
     websocket: {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       data: {} as { user: NonNullable<ReturnType<typeof verifySessionToken>> },
       open(ws) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         const wsc = ws as unknown as WsClient;
         logger.debug({ socketId: wsc.id }, 'WebSocket opened');
         registerClient(wsc, ws.data.user);
       },
       message(ws, message) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         const wsc = ws as unknown as WsClient;
         // No-op: client does not send messages
         logger.debug({ socketId: wsc.id, message }, 'Unexpected WebSocket message received');
       },
       close(ws, code, reason) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         const wsc = ws as unknown as WsClient;
         unregisterClient(wsc);
         logger.info({ socketId: wsc.id, code, reason }, 'WebSocket closed');
@@ -334,6 +338,7 @@ function runMigrations(): void {
     const hash = createHash('sha256').update(readFileSync(filePath)).digest('hex');
 
     // Check if already applied
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     const existing = $client
       .query('SELECT hash FROM "__drizzle_migrations" WHERE hash = ?')
       .get(hash) as { hash: string } | undefined;
@@ -354,11 +359,12 @@ function runMigrations(): void {
       } catch (err) {
         // Skip errors that indicate the schema change was already applied
         // in a previous partial run (RENAME, ADD COLUMN, CREATE TABLE retries).
-        if (
-          (err as Error).message.includes('already exists') ||
-          (err as Error).message.includes('no such column') ||
-          (err as Error).message.includes('duplicate column name')
-        ) {
+        const isKnownError =
+          err instanceof Error &&
+          (err.message.includes('already exists') ||
+            err.message.includes('no such column') ||
+            err.message.includes('duplicate column name'));
+        if (isKnownError) {
           logger.info(
             { file, stmt: trimmed.substring(0, 50) },
             'Skipping already-applied statement'
@@ -394,6 +400,7 @@ function startNodeLink(): Promise<void> {
     // entries, which matches the Node.js EventEmitter behavior this replaces.
     void (async () => {
       const decoder = new TextDecoder();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       for await (const chunk of nodelinkProcess.stdout as ReadableStream<Uint8Array>) {
         for (const line of decoder.decode(chunk).split('\n')) {
           const trimmed = line.trimEnd();
@@ -407,6 +414,7 @@ function startNodeLink(): Promise<void> {
     // Fire-and-forget: consume stderr, suppressing git "fatal:" noise.
     void (async () => {
       const decoder = new TextDecoder();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       for await (const chunk of nodelinkProcess.stderr as ReadableStream<Uint8Array>) {
         for (const line of decoder.decode(chunk).split('\n')) {
           const trimmed = line.trimEnd();

--- a/packages/server/src/lib/applyNodeLinkFilter.test.ts
+++ b/packages/server/src/lib/applyNodeLinkFilter.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+// The filter builders are pure, but the module also imports heavy runtime
+// dependencies for the applyNodeLinkFilter function. Mock them out.
+void mock.module('../shared/logger', () => ({
+  logger: { warn: mock(() => {}), error: mock(() => {}) },
+}));
+void mock.module('../utils/nodelink', () => ({
+  updateNodeLinkPlayer: mock(() => Promise.resolve()),
+}));
+void mock.module('./config', () => ({
+  getGuildId: mock(() => null),
+}));
+void mock.module('./lavalink', () => ({
+  lavalink: { isGuildConnected: mock(() => false), getSessionId: mock(() => null) },
+}));
+
+const {
+  buildCompressorFilter,
+  buildKaraokeFilter,
+  buildTimescaleFilter,
+  buildTremoloFilter,
+  buildVibratoFilter,
+  buildRotationFilter,
+  buildDistortionFilter,
+  buildChannelMixFilter,
+  buildLowPassFilter,
+} = await import('./applyNodeLinkFilter');
+
+describe('buildCompressorFilter', () => {
+  test('passes through all params under "compressor" key', () => {
+    const result = buildCompressorFilter({
+      threshold: -20,
+      ratio: 4,
+      attack: 10,
+      release: 100,
+      gain: 5,
+    });
+    expect(result).toEqual({
+      compressor: { threshold: -20, ratio: 4, attack: 10, release: 100, gain: 5 },
+    });
+  });
+
+  test('handles zero values', () => {
+    const result = buildCompressorFilter({
+      threshold: 0,
+      ratio: 0,
+      attack: 0,
+      release: 0,
+      gain: 0,
+    });
+    expect(result.compressor.gain).toBe(0);
+  });
+});
+
+describe('buildKaraokeFilter', () => {
+  test('passes through all params under "karaoke" key', () => {
+    const result = buildKaraokeFilter({
+      level: 0.8,
+      monoLevel: 0.5,
+      filterBand: 220,
+      filterWidth: 100,
+    });
+    expect(result).toEqual({
+      karaoke: { level: 0.8, monoLevel: 0.5, filterBand: 220, filterWidth: 100 },
+    });
+  });
+});
+
+describe('buildTimescaleFilter', () => {
+  test('passes through all params under "timescale" key', () => {
+    const result = buildTimescaleFilter({ speed: 1.5, pitch: 1.2, rate: 1 });
+    expect(result).toEqual({
+      timescale: { speed: 1.5, pitch: 1.2, rate: 1 },
+    });
+  });
+
+  test('normal speed is identity', () => {
+    const result = buildTimescaleFilter({ speed: 1, pitch: 1, rate: 1 });
+    expect(result.timescale.speed).toBe(1);
+  });
+});
+
+describe('buildTremoloFilter', () => {
+  test('passes through frequency and depth under "tremolo" key', () => {
+    const result = buildTremoloFilter({ frequency: 5, depth: 0.7 });
+    expect(result).toEqual({ tremolo: { frequency: 5, depth: 0.7 } });
+  });
+});
+
+describe('buildVibratoFilter', () => {
+  test('passes through frequency and depth under "vibrato" key', () => {
+    const result = buildVibratoFilter({ frequency: 6, depth: 0.4 });
+    expect(result).toEqual({ vibrato: { frequency: 6, depth: 0.4 } });
+  });
+});
+
+describe('buildRotationFilter', () => {
+  test('passes through rotationHz under "rotation" key', () => {
+    const result = buildRotationFilter({ rotationHz: 0.2 });
+    expect(result).toEqual({ rotation: { rotationHz: 0.2 } });
+  });
+});
+
+describe('buildDistortionFilter', () => {
+  test('passes through all 8 params under "distortion" key', () => {
+    const result = buildDistortionFilter({
+      sinOffset: 0,
+      sinScale: 1,
+      cosOffset: 0,
+      cosScale: 1,
+      tanOffset: 0,
+      tanScale: 1,
+      offset: 0,
+      scale: 1,
+    });
+    expect(result).toEqual({
+      distortion: {
+        sinOffset: 0,
+        sinScale: 1,
+        cosOffset: 0,
+        cosScale: 1,
+        tanOffset: 0,
+        tanScale: 1,
+        offset: 0,
+        scale: 1,
+      },
+    });
+  });
+});
+
+describe('buildChannelMixFilter', () => {
+  test('passes through all 4 params under "channelMix" key', () => {
+    const result = buildChannelMixFilter({
+      leftToLeft: 1,
+      leftToRight: 0,
+      rightToLeft: 0,
+      rightToRight: 1,
+    });
+    expect(result).toEqual({
+      channelMix: { leftToLeft: 1, leftToRight: 0, rightToLeft: 0, rightToRight: 1 },
+    });
+  });
+
+  test('mono mix sets equal left and right', () => {
+    const result = buildChannelMixFilter({
+      leftToLeft: 0.5,
+      leftToRight: 0.5,
+      rightToLeft: 0.5,
+      rightToRight: 0.5,
+    });
+    expect(result.channelMix.leftToLeft).toBe(0.5);
+    expect(result.channelMix.rightToRight).toBe(0.5);
+  });
+});
+
+describe('buildLowPassFilter', () => {
+  test('passes through smoothing under "lowPass" key', () => {
+    const result = buildLowPassFilter({ smoothing: 20 });
+    expect(result).toEqual({ lowPass: { smoothing: 20 } });
+  });
+
+  test('zero smoothing is allowed', () => {
+    const result = buildLowPassFilter({ smoothing: 0 });
+    expect(result.lowPass.smoothing).toBe(0);
+  });
+});

--- a/packages/server/src/lib/applyNodeLinkFilter.ts
+++ b/packages/server/src/lib/applyNodeLinkFilter.ts
@@ -189,7 +189,7 @@ export async function applyNodeLinkFilter(
 
   try {
     await updateNodeLinkPlayer(guildId, sessionId, { filters });
-  } catch (err) {
-    logger.error({ err }, `Failed to update NodeLink ${label} filter`);
+  } catch (error) {
+    logger.error({ error }, `Failed to update NodeLink ${label} filter`);
   }
 }

--- a/packages/server/src/lib/discordGateway.ts
+++ b/packages/server/src/lib/discordGateway.ts
@@ -187,6 +187,7 @@ export class DiscordGateway {
     ws.onmessage = (event: MessageEvent): void => {
       let msg: { op: number; d: unknown; s: number | null; t: string | null };
       try {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         msg = JSON.parse(event.data as string) as typeof msg;
       } catch {
         return;
@@ -214,10 +215,12 @@ export class DiscordGateway {
         }
 
         case OP_DISPATCH: {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
           const dispatch = msg as GatewayDispatch;
 
           // Handle READY for session init.
           if (dispatch.t === 'READY') {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
             const ready = dispatch.d as {
               session_id: string;
               user: { id: string; username: string };
@@ -270,6 +273,7 @@ export class DiscordGateway {
 
           // Track voice states from VOICE_STATE_UPDATE for REST-free lookups.
           if (dispatch.t === 'VOICE_STATE_UPDATE') {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
             const d = dispatch.d as {
               user_id: string;
               channel_id: string | null;
@@ -303,6 +307,7 @@ export class DiscordGateway {
           break;
 
         case OP_INVALID_SESSION: {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
           const invalid = msg as GatewayInvalidSession;
           logger.warn({ resumable: invalid.d }, 'Invalid session');
           this.sessionId = null;
@@ -450,6 +455,7 @@ export class DiscordGateway {
    * source of truth.
    */
   private seedVoiceStatesFromReady(ready: Record<string, unknown>): void {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     const guilds = ready.guilds as
       | {
           id: string;
@@ -477,6 +483,7 @@ export class DiscordGateway {
    * state after a fresh connection.
    */
   private seedVoiceStatesFromGuildCreate(data: unknown): void {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     const guild = data as {
       id: string;
       voice_states?: VoiceStateData[];

--- a/packages/server/src/lib/discordGateway.ts
+++ b/packages/server/src/lib/discordGateway.ts
@@ -154,9 +154,9 @@ export class DiscordGateway {
     let ws: WebSocket;
     try {
       ws = new WebSocket(GATEWAY_URL);
-    } catch (err) {
+    } catch (error) {
       logger.error(
-        { err: err instanceof Error ? err.message : String(err) },
+        { err: error instanceof Error ? error.message : String(error) },
         'WebSocket constructor failed'
       );
       this.scheduleReconnect();

--- a/packages/server/src/lib/discordRest.ts
+++ b/packages/server/src/lib/discordRest.ts
@@ -164,6 +164,7 @@ async function doFetchGuildMember(
       return null;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     const member = (await res.json()) as DiscordGuildMember;
     memberCache.set(cacheKey, { data: member, expiresAt: Date.now() + MEMBER_CACHE_TTL_MS });
     return member;

--- a/packages/server/src/lib/discordRest.ts
+++ b/packages/server/src/lib/discordRest.ts
@@ -168,9 +168,9 @@ async function doFetchGuildMember(
     const member = (await res.json()) as DiscordGuildMember;
     memberCache.set(cacheKey, { data: member, expiresAt: Date.now() + MEMBER_CACHE_TTL_MS });
     return member;
-  } catch (err) {
+  } catch (error) {
     logger.error(
-      { err: err instanceof Error ? err.message : String(err) },
+      { err: error instanceof Error ? error.message : String(error) },
       'fetchGuildMember error'
     );
     return null;

--- a/packages/server/src/lib/discordRoles.ts
+++ b/packages/server/src/lib/discordRoles.ts
@@ -67,8 +67,8 @@ export async function fetchGuildRoles(guildId: string): Promise<SetupRole[]> {
 
     rolesCache.set(guildId, { data: result, expiresAt: Date.now() + CACHE_TTL_MS });
     return result;
-  } catch (err) {
-    logger.error({ err }, 'Error fetching guild roles');
+  } catch (error) {
+    logger.error({ error }, 'Error fetching guild roles');
     return [];
   }
 }

--- a/packages/server/src/lib/discordRoles.ts
+++ b/packages/server/src/lib/discordRoles.ts
@@ -49,6 +49,7 @@ export async function fetchGuildRoles(guildId: string): Promise<SetupRole[]> {
       return [];
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     const roles = (await res.json()) as {
       id: string;
       name: string;

--- a/packages/server/src/lib/eqBands.test.ts
+++ b/packages/server/src/lib/eqBands.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+// eqBands imports from ../shared/db which requires DATABASE_URL at module
+// level. Mock it before the module is loaded (static imports are hoisted,
+// so we must use dynamic import after the mock call).
+// NOTE: search.test.ts also mocks ../shared/db (with $client). Bun shares
+// mock.module registrations across test files, so all mocks must export a
+// superset of keys to avoid "export not found" errors.
+void mock.module('../shared/db', () => ({
+  tables: {
+    guildSettings: {
+      eqBand0: {},
+      eqBand1: {},
+      eqBand2: {},
+      eqBand3: {},
+      eqBand4: {},
+      eqBand5: {},
+      eqBand6: {},
+      eqBand7: {},
+      eqBand8: {},
+      eqBand9: {},
+      eqBand10: {},
+      eqBand11: {},
+      eqBand12: {},
+      eqBand13: {},
+      eqBand14: {},
+    },
+  },
+  $client: { query: mock(() => ({ all: mock(() => []) })) },
+  db: {},
+}));
+
+const { buildEqualizerFilter, eqBandsFromRow, eqBandValues } = await import('./eqBands');
+
+describe('eqBandsFromRow', () => {
+  test('returns defaults (all 50) for null or undefined', () => {
+    const fromNull = eqBandsFromRow(null);
+    expect(fromNull).toHaveLength(15);
+    expect(fromNull.every((v) => v === 50)).toBe(true);
+
+    // eslint-disable-next-line unicorn/no-useless-undefined
+    const fromUndefined = eqBandsFromRow(undefined);
+    expect(fromUndefined).toHaveLength(15);
+    expect(fromUndefined.every((v) => v === 50)).toBe(true);
+  });
+
+  test('extracts band values from a row', () => {
+    const row = {
+      eqBand0: 60,
+      eqBand1: 45,
+      eqBand2: 50,
+      eqBand3: 50,
+      eqBand4: 50,
+      eqBand5: 50,
+      eqBand6: 50,
+      eqBand7: 50,
+      eqBand8: 50,
+      eqBand9: 50,
+      eqBand10: 50,
+      eqBand11: 50,
+      eqBand12: 50,
+      eqBand13: 50,
+      eqBand14: 50,
+    };
+    const result = eqBandsFromRow(row);
+    expect(result[0]).toBe(60);
+    expect(result[1]).toBe(45);
+    expect(result[2]).toBe(50);
+    expect(result).toHaveLength(15);
+  });
+});
+
+describe('eqBandValues', () => {
+  test('converts a 15-element array to a record', () => {
+    const bands = Array.from({ length: 15 }, (_, i) => i * 10);
+    const result = eqBandValues(bands);
+    expect(result.eqBand0).toBe(0);
+    expect(result.eqBand7).toBe(70);
+    expect(result.eqBand14).toBe(140);
+  });
+});
+
+describe('buildEqualizerFilter', () => {
+  const flat: number[] = Array.from({ length: 15 }, () => 50);
+
+  test('neutral band (50) maps to gain 0', () => {
+    const result = buildEqualizerFilter(flat);
+    expect(result).toHaveLength(15);
+    expect(result.every((f) => f.gain === 0)).toBe(true);
+  });
+
+  test('minimum band (0) maps to gain -0.5', () => {
+    const bands: number[] = [0, ...flat.slice(1)];
+    const result = buildEqualizerFilter(bands);
+    expect(result[0]?.gain).toBe(-0.5);
+  });
+
+  test('maximum band (100) maps to gain 0.5', () => {
+    const bands: number[] = [100, ...flat.slice(1)];
+    const result = buildEqualizerFilter(bands);
+    expect(result[0]?.gain).toBe(0.5);
+  });
+
+  test('bands are zero-indexed', () => {
+    const result = buildEqualizerFilter(flat);
+    for (const [i, f] of result.entries()) {
+      expect(f.band).toBe(i);
+    }
+  });
+
+  test('mid-scale value maps correctly', () => {
+    const bands: number[] = [75, ...flat.slice(1)];
+    const result = buildEqualizerFilter(bands);
+    expect(result[0]?.gain).toBe(0.25);
+  });
+});

--- a/packages/server/src/lib/gatewayState.ts
+++ b/packages/server/src/lib/gatewayState.ts
@@ -79,8 +79,8 @@ async function tryCompleteVoiceConnection(guildId: string): Promise<void> {
     });
     lavalink.markConnected(guildId, true);
     pending.resolve();
-  } catch (err) {
-    pending.reject(err instanceof Error ? err : new Error(String(err)));
+  } catch (error) {
+    pending.reject(error instanceof Error ? error : new Error(String(error)));
   }
 }
 

--- a/packages/server/src/lib/gatewayState.ts
+++ b/packages/server/src/lib/gatewayState.ts
@@ -80,7 +80,7 @@ async function tryCompleteVoiceConnection(guildId: string): Promise<void> {
     lavalink.markConnected(guildId, true);
     pending.resolve();
   } catch (err) {
-    pending.reject(err as Error);
+    pending.reject(err instanceof Error ? err : new Error(String(err)));
   }
 }
 

--- a/packages/server/src/lib/jwt.ts
+++ b/packages/server/src/lib/jwt.ts
@@ -30,7 +30,7 @@ function parseExpiresIn(expiresIn: string): number {
   if (!match?.[1] || !match[2]) {
     throw new Error(`Invalid expiresIn format: ${expiresIn}`);
   }
-  const num = parseInt(match[1], 10);
+  const num = Number.parseInt(match[1], 10);
   const unit = match[2];
   const multipliers: Record<string, number> = { s: 1, m: 60, h: 3600, d: 86400 };
   return num * (multipliers[unit] ?? 1);

--- a/packages/server/src/lib/jwt.ts
+++ b/packages/server/src/lib/jwt.ts
@@ -96,7 +96,12 @@ export function verify<T = Record<string, unknown>>(token: string, secret: strin
   // Decode and parse the payload
   let payload: Record<string, unknown>;
   try {
-    payload = JSON.parse(base64urlDecode(payloadB64)) as Record<string, unknown>;
+    const raw: unknown = JSON.parse(base64urlDecode(payloadB64));
+    if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+      return null;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    payload = raw as Record<string, unknown>;
   } catch {
     return null;
   }
@@ -106,5 +111,6 @@ export function verify<T = Record<string, unknown>>(token: string, secret: strin
     return null;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
   return payload as T;
 }

--- a/packages/server/src/lib/lavalink.ts
+++ b/packages/server/src/lib/lavalink.ts
@@ -145,6 +145,7 @@ class LavalinkSocket extends EventEmitter<LavalinkEvents> {
     headers['Client-Name'] = 'Alfira';
 
     // Bun extends WebSocket constructor with { headers } option
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     const ws = new WebSocket(this.url, { headers } as never);
     this.ws = ws;
 
@@ -156,6 +157,7 @@ class LavalinkSocket extends EventEmitter<LavalinkEvents> {
     ws.addEventListener('message', (event: MessageEvent) => {
       let msg: LavalinkMessage;
       try {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         msg = JSON.parse(event.data as string) as LavalinkMessage;
       } catch {
         logger.warn({ raw: String(event.data).slice(0, 200) }, 'Lavalink: unparseable message');

--- a/packages/server/src/lib/migrateExistingTags.ts
+++ b/packages/server/src/lib/migrateExistingTags.ts
@@ -49,8 +49,8 @@ export async function runTagMigration(): Promise<{ normalized: number; errors: n
           .where(sql`id = ${song.id}`);
         normalized++;
       }
-    } catch (err) {
-      logger.error({ songId: song.id, err }, 'Error normalizing tags');
+    } catch (error) {
+      logger.error({ songId: song.id, error }, 'Error normalizing tags');
       errors++;
     }
   }
@@ -64,8 +64,8 @@ if (import.meta.filename.includes('migrateExistingTags')) {
   void (async () => {
     try {
       await runTagMigration();
-    } catch (err) {
-      logger.fatal(err, 'Tag migration failed');
+    } catch (error) {
+      logger.fatal(error, 'Tag migration failed');
       process.exit(1);
     }
   })();

--- a/packages/server/src/lib/notifications.ts
+++ b/packages/server/src/lib/notifications.ts
@@ -63,8 +63,8 @@ export async function sendRequestNotification(
       },
       body: JSON.stringify({ content }),
     });
-  } catch (err) {
-    logger.warn({ err }, 'Failed to send request notification');
+  } catch (error) {
+    logger.warn({ error }, 'Failed to send request notification');
   }
 }
 
@@ -107,7 +107,7 @@ export async function sendRequestDm(
       },
       body: JSON.stringify({ content: messages[status] }),
     });
-  } catch (err) {
-    logger.warn({ err, discordId }, 'Failed to send request DM');
+  } catch (error) {
+    logger.warn({ error, discordId }, 'Failed to send request DM');
   }
 }

--- a/packages/server/src/lib/notifications.ts
+++ b/packages/server/src/lib/notifications.ts
@@ -92,6 +92,7 @@ export async function sendRequestDm(
       return;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     const dmChannel = (await dmRes.json()) as { id: string };
     const messages: Record<string, string> = {
       approved: `✅ Your song request for **${title}** has been approved and added to the library!`,

--- a/packages/server/src/lib/pagination.test.ts
+++ b/packages/server/src/lib/pagination.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test';
+
+import { parsePagination } from './pagination';
+
+describe('parsePagination', () => {
+  test('returns defaults when no params provided', () => {
+    const url = new URL('http://localhost/');
+    const result = parsePagination(url);
+    expect(result).toEqual({ page: 1, limit: 30, skip: 0 });
+  });
+
+  test('returns custom default limit', () => {
+    const url = new URL('http://localhost/');
+    const result = parsePagination(url, 50);
+    expect(result).toEqual({ page: 1, limit: 50, skip: 0 });
+  });
+
+  test('parses page and limit from query params', () => {
+    const url = new URL('http://localhost/?page=3&limit=10');
+    const result = parsePagination(url);
+    expect(result).toEqual({ page: 3, limit: 10, skip: 20 });
+  });
+
+  test('clamps negative page to 1', () => {
+    const url = new URL('http://localhost/?page=-5');
+    expect(parsePagination(url).page).toBe(1);
+  });
+
+  test('clamps page of 0 to 1', () => {
+    const url = new URL('http://localhost/?page=0');
+    expect(parsePagination(url).page).toBe(1);
+  });
+
+  test('clamps limit above 100', () => {
+    const url = new URL('http://localhost/?limit=200');
+    expect(parsePagination(url).limit).toBe(100);
+  });
+
+  test('limit of 0 falls back to default (falsy)', () => {
+    const url = new URL('http://localhost/?limit=0');
+    expect(parsePagination(url).limit).toBe(30);
+  });
+
+  test('clamps negative limit', () => {
+    const url = new URL('http://localhost/?limit=-10');
+    expect(parsePagination(url).limit).toBe(1);
+  });
+
+  test('handles non-numeric values gracefully', () => {
+    const url = new URL('http://localhost/?page=abc&limit=xyz');
+    const result = parsePagination(url);
+    // NaN || fallback → falls back to defaults
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(30);
+  });
+
+  test('skip is computed correctly', () => {
+    const url = new URL('http://localhost/?page=4&limit=25');
+    expect(parsePagination(url).skip).toBe(75);
+  });
+});

--- a/packages/server/src/lib/pagination.ts
+++ b/packages/server/src/lib/pagination.ts
@@ -1,8 +1,11 @@
 export function parsePagination(url: URL, defaultLimit = 30) {
-  const page = Math.max(1, parseInt(url.searchParams.get('page') ?? '1', 10) || 1);
+  const page = Math.max(1, Number.parseInt(url.searchParams.get('page') ?? '1', 10) || 1);
   const limit = Math.min(
     100,
-    Math.max(1, parseInt(url.searchParams.get('limit') ?? String(defaultLimit), 10) || defaultLimit)
+    Math.max(
+      1,
+      Number.parseInt(url.searchParams.get('limit') ?? String(defaultLimit), 10) || defaultLimit
+    )
   );
   const skip = (page - 1) * limit;
   return { page, limit, skip };

--- a/packages/server/src/lib/search.test.ts
+++ b/packages/server/src/lib/search.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+// search.ts imports drizzle-orm's `sql` tagged-template and the DB client.
+// Full fidelity mocking of sql.raw() / nested sql chunks is brittle without
+// the real drizzle-orm.  Test pure functions exhaustively; query builders
+// get structural assertions (shape, null/undefined guards, sort direction).
+
+interface SqlFragment {
+  strings: string[];
+  values: unknown[];
+}
+
+function makeSqlResult(strings: string[], values: unknown[]): SqlFragment {
+  return { strings: [...strings], values };
+}
+
+const sqlMock = (strings: TemplateStringsArray, ...values: unknown[]): SqlFragment =>
+  makeSqlResult([...strings], values);
+sqlMock.raw = (value: string) => value;
+// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+(sqlMock as unknown as Record<string, unknown>).join = (
+  items: unknown[],
+  sep: unknown
+): SqlFragment => makeSqlResult(['(', ')'], [items, sep]);
+
+// NOTE: eqBands.test.ts also mocks ../shared/db (with tables). Bun shares
+// mock.module registrations across test files, so both mocks must export a
+// superset of keys to avoid "export not found" errors in either file.
+void mock.module('drizzle-orm', () => ({
+  sql: sqlMock,
+}));
+void mock.module('../shared/db', () => ({
+  $client: { query: mock(() => ({ all: mock(() => []) })) },
+  tables: {},
+}));
+
+const { parseSongSortField, buildSongOrderBy, buildSongFilterClause, SONG_SORT_FIELDS } =
+  await import('./search');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Cast a drizzle SQL result to our mock shape so we can inspect fragments. */
+function asSqlFragment(s: unknown): SqlFragment {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  return s as SqlFragment;
+}
+
+// ---------------------------------------------------------------------------
+// SONG_SORT_FIELDS
+// ---------------------------------------------------------------------------
+
+describe('SONG_SORT_FIELDS', () => {
+  test('contains expected fields', () => {
+    expect(SONG_SORT_FIELDS).toContain('createdAt');
+    expect(SONG_SORT_FIELDS).toContain('title');
+    expect(SONG_SORT_FIELDS).toContain('artist');
+    expect(SONG_SORT_FIELDS).toContain('album');
+    expect(SONG_SORT_FIELDS).toContain('duration');
+  });
+
+  test('has exactly 5 fields', () => {
+    expect(SONG_SORT_FIELDS).toHaveLength(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseSongSortField
+// ---------------------------------------------------------------------------
+
+describe('parseSongSortField', () => {
+  test('returns the field for every valid input', () => {
+    for (const field of SONG_SORT_FIELDS) {
+      expect(parseSongSortField(field)).toBe(field);
+    }
+  });
+
+  test('returns null for unrecognized strings', () => {
+    expect(parseSongSortField('bpm')).toBeNull();
+    expect(parseSongSortField('')).toBeNull();
+    expect(parseSongSortField('genre')).toBeNull();
+  });
+
+  test('returns null for injection-looking strings', () => {
+    expect(parseSongSortField('DROP TABLE songs')).toBeNull();
+    expect(parseSongSortField('1; SELECT *')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSongOrderBy  (structural — full SQL content requires real drizzle-orm)
+// ---------------------------------------------------------------------------
+
+describe('buildSongOrderBy', () => {
+  test('returns an object with strings and values arrays', () => {
+    const result = asSqlFragment(buildSongOrderBy('title', 'ASC'));
+    expect(result).toHaveProperty('strings');
+    expect(result).toHaveProperty('values');
+    expect(Array.isArray(result.strings)).toBe(true);
+    expect(Array.isArray(result.values)).toBe(true);
+  });
+
+  test('every sort field produces a non-empty result', () => {
+    for (const field of SONG_SORT_FIELDS) {
+      const asc = asSqlFragment(buildSongOrderBy(field, 'ASC'));
+      const desc = asSqlFragment(buildSongOrderBy(field, 'DESC'));
+      expect(asc.strings.length).toBeGreaterThan(0);
+      expect(desc.strings.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('accepts custom column references', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cols: any = {
+      title: 't.custom_title',
+      nickname: 't.nickname',
+      artist: 't.artist',
+      album: 't.album',
+      duration: 't.duration',
+      createdAt: 't.created_at',
+    };
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    const result = asSqlFragment(buildSongOrderBy('title', 'ASC', cols));
+    expect(result).toHaveProperty('strings');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSongFilterClause  (structural)
+// ---------------------------------------------------------------------------
+
+describe('buildSongFilterClause', () => {
+  test('returns undefined when no tags or sources are provided', () => {
+    expect(buildSongFilterClause([], [])).toBeUndefined();
+  });
+
+  test('returns a clause object when tags are provided', () => {
+    const result = asSqlFragment(buildSongFilterClause(['rock'], []));
+    expect(result).toHaveProperty('strings');
+    expect(result).toHaveProperty('values');
+  });
+
+  test('returns a clause object when sources are provided', () => {
+    const result = asSqlFragment(buildSongFilterClause([], ['youtube']));
+    expect(result).toHaveProperty('strings');
+  });
+
+  test('returns a clause object when both tags and sources are provided', () => {
+    const result = buildSongFilterClause(['rock', 'jazz'], ['youtube', 'soundcloud']);
+    expect(result).not.toBeUndefined();
+  });
+
+  test('unknown source produces undefined (no matching patterns)', () => {
+    const result = buildSongFilterClause([], ['nonexistent']);
+    expect(result).toBeUndefined();
+  });
+
+  test('accepts custom column references', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cols: any = {
+      tags: 't.tags',
+      sourceUrl: 't.url',
+    };
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    const result = asSqlFragment(buildSongFilterClause(['rock'], [], cols));
+    expect(result).toHaveProperty('strings');
+  });
+});

--- a/packages/server/src/lib/search.ts
+++ b/packages/server/src/lib/search.ts
@@ -10,6 +10,7 @@ export type SongSortField = (typeof SONG_SORT_FIELDS)[number];
 
 /** Parse a raw sort query param into a SongSortField, or null if unrecognized. */
 export function parseSongSortField(raw: string): SongSortField | null {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
   return (SONG_SORT_FIELDS as readonly string[]).includes(raw) ? (raw as SongSortField) : null;
 }
 
@@ -130,11 +131,11 @@ export function buildSongSearchClause(
     return undefined;
   }
 
-  const tagMatchingIds = (
-    $client.query(`SELECT id FROM "Song" WHERE lower(tags) LIKE lower(?)`).all(`%${search}%`) as {
-      id: string;
-    }[]
-  ).map((r) => r.id);
+  const rows = $client
+    .query(`SELECT id FROM "Song" WHERE lower(tags) LIKE lower(?)`)
+    .all(`%${search}%`);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  const tagMatchingIds = (rows as { id: string }[]).map((r) => r.id);
 
   const base = sql`(lower(title) LIKE lower(${`%${search}%`}) OR lower(nickname) LIKE lower(${`%${search}%`}) OR lower(artist) LIKE lower(${`%${search}%`}) OR lower(album) LIKE lower(${`%${search}%`}))`;
 

--- a/packages/server/src/lib/serialization.test.ts
+++ b/packages/server/src/lib/serialization.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+
+import { formatSong, type SerializedSong } from './serialization';
+
+describe('formatSong', () => {
+  test('converts Date createdAt to ISO string', () => {
+    const date = new Date('2024-06-15T12:00:00.000Z');
+    const result = formatSong({ createdAt: date });
+    expect(result.createdAt).toBe('2024-06-15T12:00:00.000Z');
+  });
+
+  test('passes through string createdAt unchanged', () => {
+    const result = formatSong({ createdAt: '2024-01-01T00:00:00.000Z' });
+    expect(result.createdAt).toBe('2024-01-01T00:00:00.000Z');
+  });
+
+  test('defaults tags to empty array when null', () => {
+    const result = formatSong({ createdAt: '2024-01-01T00:00:00.000Z', tags: null });
+    expect(result.tags).toEqual([]);
+  });
+
+  test('defaults tags to empty array when undefined', () => {
+    const result = formatSong({ createdAt: '2024-01-01T00:00:00.000Z' });
+    expect(result.tags).toEqual([]);
+  });
+
+  test('preserves existing tags', () => {
+    const result = formatSong({
+      createdAt: '2024-01-01T00:00:00.000Z',
+      tags: ['rock', 'jazz'],
+    });
+    expect(result.tags).toEqual(['rock', 'jazz']);
+  });
+
+  test('output satisfies SerializedSong type', () => {
+    const result: SerializedSong = formatSong({
+      createdAt: new Date(),
+    });
+    expect(result).toHaveProperty('createdAt');
+    expect(result).toHaveProperty('tags');
+  });
+});

--- a/packages/server/src/lib/serialization.ts
+++ b/packages/server/src/lib/serialization.ts
@@ -12,6 +12,7 @@ export function formatSong(s: {
   createdAt: Date | string;
   tags?: string[] | null;
 }): SerializedSong {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
   return {
     ...s,
     createdAt: s.createdAt instanceof Date ? s.createdAt.toISOString() : s.createdAt,

--- a/packages/server/src/lib/syncAllFilters.ts
+++ b/packages/server/src/lib/syncAllFilters.ts
@@ -148,7 +148,7 @@ export async function syncAllFilters(): Promise<void> {
 
   try {
     await updateNodeLinkPlayer(guildId, sessionId, { filters });
-  } catch (err) {
-    logger.error({ err }, 'Failed to sync audio filters to NodeLink');
+  } catch (error) {
+    logger.error({ error }, 'Failed to sync audio filters to NodeLink');
   }
 }

--- a/packages/server/src/lib/syncAllFilters.ts
+++ b/packages/server/src/lib/syncAllFilters.ts
@@ -65,7 +65,9 @@ export async function syncAllFilters(): Promise<void> {
   // When the UI toggle is off, send flat bands (all 50 → gain 0.0).
   {
     const bands = Array.from({ length: 15 }, (_, i) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       const key = `eqBand${i}` as keyof typeof row;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       return row.eqEnabled ? (row[key] as number) : 50;
     });
     filters.equalizer = buildEqualizerFilter(bands);

--- a/packages/server/src/lib/validation.test.ts
+++ b/packages/server/src/lib/validation.test.ts
@@ -1,0 +1,383 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+// validation.ts imports heavy runtime modules. The functions we test are pure
+// validation logic, so mock the side-effect-heavy imports.
+void mock.module('../shared/logger', () => ({
+  logger: { error: mock(() => {}), warn: mock(() => {}) },
+}));
+void mock.module('../startDiscord', () => ({
+  isValidSourceUrl: mock((url: string) => url.startsWith('https://')),
+  isPlaylistUrl: mock((url: string) => url.includes('playlist')),
+  getEnabledSourceDisplayNames: mock(() => ['YouTube', 'SoundCloud']),
+  getMetadata: mock(() => Promise.resolve({})),
+  getPlaylistMetadataWithVideos: mock(() => Promise.resolve({})),
+}));
+void mock.module('./json', () => ({
+  json: mock((data: unknown, status: number) => new Response(JSON.stringify(data), { status })),
+}));
+
+const {
+  clampMaxVideos,
+  youTubeUrl,
+  validateArtworkUrl,
+  validateNickname,
+  validateOptionalString,
+  validatePlaylistName,
+  validatePlaylistUrl,
+  validateSourceUrl,
+  validateTags,
+  validateVolumeBoost,
+} = await import('./validation');
+
+describe('clampMaxVideos', () => {
+  test('returns undefined when input is undefined', () => {
+    // eslint-disable-next-line unicorn/no-useless-undefined
+    expect(clampMaxVideos(undefined)).toBeUndefined();
+  });
+
+  test('clamps below 1', () => {
+    expect(clampMaxVideos(0)).toBe(1);
+    expect(clampMaxVideos(-5)).toBe(1);
+  });
+
+  test('clamps above 100', () => {
+    expect(clampMaxVideos(101)).toBe(100);
+    expect(clampMaxVideos(500)).toBe(100);
+  });
+
+  test('passes through values in range', () => {
+    expect(clampMaxVideos(1)).toBe(1);
+    expect(clampMaxVideos(50)).toBe(50);
+    expect(clampMaxVideos(100)).toBe(100);
+  });
+});
+
+describe('youTubeUrl', () => {
+  test('builds a canonical YouTube watch URL', () => {
+    expect(youTubeUrl('dQw4w9WgXcQ')).toBe('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+  });
+
+  test('handles empty string', () => {
+    expect(youTubeUrl('')).toBe('https://www.youtube.com/watch?v=');
+  });
+});
+
+describe('validateSourceUrl', () => {
+  test('rejects non-strings', () => {
+    const result = validateSourceUrl(123);
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects empty string', () => {
+    const result = validateSourceUrl('');
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects null', () => {
+    const result = validateSourceUrl(null);
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects sourceUrl that isValidSourceUrl rejects', () => {
+    const result = validateSourceUrl('ftp://not-https.com/video');
+    expect(result.ok).toBe(false);
+  });
+
+  test('accepts valid HTTPS URL', () => {
+    const result = validateSourceUrl('https://youtube.com/watch?v=abc');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe('https://youtube.com/watch?v=abc');
+    }
+  });
+
+  test('trims whitespace', () => {
+    const result = validateSourceUrl('  https://youtube.com/watch?v=abc  ');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe('https://youtube.com/watch?v=abc');
+    }
+  });
+});
+
+describe('validatePlaylistUrl', () => {
+  test('rejects non-strings', () => {
+    const result = validatePlaylistUrl(456);
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects URL that isPlaylistUrl rejects', () => {
+    const result = validatePlaylistUrl('https://youtube.com/watch?v=abc');
+    expect(result.ok).toBe(false);
+  });
+
+  test('accepts URL containing "playlist"', () => {
+    const result = validatePlaylistUrl('https://youtube.com/playlist?list=abc');
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('validatePlaylistName', () => {
+  test('rejects non-strings', () => {
+    const result = validatePlaylistName(123);
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects empty string', () => {
+    const result = validatePlaylistName('');
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects whitespace-only string', () => {
+    const result = validatePlaylistName('   ');
+    expect(result.ok).toBe(false);
+  });
+
+  test('accepts valid name and trims', () => {
+    const result = validatePlaylistName('  My Playlist  ');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe('My Playlist');
+    }
+  });
+
+  test('rejects null', () => {
+    const result = validatePlaylistName(null);
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('validateNickname', () => {
+  test('returns null for undefined', () => {
+    // eslint-disable-next-line unicorn/no-useless-undefined
+    const result = validateNickname(undefined);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBeNull();
+    }
+  });
+
+  test('returns null for null', () => {
+    const result = validateNickname(null);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBeNull();
+    }
+  });
+
+  test('returns null for empty string', () => {
+    const result = validateNickname('');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBeNull();
+    }
+  });
+
+  test('returns null for whitespace-only', () => {
+    const result = validateNickname('   ');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBeNull();
+    }
+  });
+
+  test('trims and returns valid nickname', () => {
+    const result = validateNickname('  Cool Song  ');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe('Cool Song');
+    }
+  });
+
+  test('rejects non-string values', () => {
+    const result = validateNickname(42);
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('validateOptionalString', () => {
+  test('returns null for undefined', () => {
+    // eslint-disable-next-line unicorn/no-useless-undefined
+    expect(validateOptionalString(undefined)).toBeNull();
+  });
+
+  test('returns null for null', () => {
+    expect(validateOptionalString(null)).toBeNull();
+  });
+
+  test('returns null for non-string', () => {
+    expect(validateOptionalString(42)).toBeNull();
+  });
+
+  test('trims and returns string', () => {
+    expect(validateOptionalString('  hello  ')).toBe('hello');
+  });
+
+  test('returns null for whitespace-only', () => {
+    expect(validateOptionalString('   ')).toBeNull();
+  });
+});
+
+describe('validateArtworkUrl', () => {
+  test('returns null for undefined', () => {
+    // eslint-disable-next-line unicorn/no-useless-undefined
+    const result = validateArtworkUrl(undefined);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBeNull();
+    }
+  });
+
+  test('returns null for null', () => {
+    const result = validateArtworkUrl(null);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBeNull();
+    }
+  });
+
+  test('returns null for empty string', () => {
+    const result = validateArtworkUrl('');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBeNull();
+    }
+  });
+
+  test('rejects non-string values', () => {
+    const result = validateArtworkUrl(123);
+    expect(result.ok).toBe(false);
+  });
+
+  test('accepts and trims valid URL', () => {
+    const result = validateArtworkUrl('  https://example.com/art.jpg  ');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe('https://example.com/art.jpg');
+    }
+  });
+
+  test('rejects invalid URL', () => {
+    const result = validateArtworkUrl('not-a-url');
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('validateTags', () => {
+  test('returns empty array for undefined', () => {
+    // eslint-disable-next-line unicorn/no-useless-undefined
+    const result = validateTags(undefined);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual([]);
+    }
+  });
+
+  test('returns empty array for null', () => {
+    const result = validateTags(null);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual([]);
+    }
+  });
+
+  test('rejects non-array values', () => {
+    const result = validateTags('not-an-array');
+    expect(result.ok).toBe(false);
+  });
+
+  test('filters non-strings and empty strings', () => {
+    const result = validateTags(['rock', '', 123, '  ', 'jazz']);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual(['rock', 'jazz']);
+    }
+  });
+
+  test('deduplicates tags', () => {
+    const result = validateTags(['rock', 'rock', 'jazz']);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual(['rock', 'jazz']);
+    }
+  });
+
+  test('replaces spaces with hyphens', () => {
+    const result = validateTags(['alt rock', 'drum and bass']);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual(['alt-rock', 'drum-and-bass']);
+    }
+  });
+
+  test('empty array returns empty', () => {
+    const result = validateTags([]);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual([]);
+    }
+  });
+});
+
+describe('validateVolumeBoost', () => {
+  test('returns undefined for undefined (PATCH skips)', () => {
+    // eslint-disable-next-line unicorn/no-useless-undefined
+    const result = validateVolumeBoost(undefined);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBeUndefined();
+    }
+  });
+
+  test('returns null for null (explicitly cleared)', () => {
+    const result = validateVolumeBoost(null);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBeNull();
+    }
+  });
+
+  test('rejects non-integer numbers', () => {
+    const result = validateVolumeBoost(1.5);
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects non-numbers', () => {
+    const result = validateVolumeBoost('loud');
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects below -100', () => {
+    const result = validateVolumeBoost(-101);
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects above 200', () => {
+    const result = validateVolumeBoost(201);
+    expect(result.ok).toBe(false);
+  });
+
+  test('accepts -100', () => {
+    const result = validateVolumeBoost(-100);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe(-100);
+    }
+  });
+
+  test('accepts 0', () => {
+    const result = validateVolumeBoost(0);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe(0);
+    }
+  });
+
+  test('accepts 200', () => {
+    const result = validateVolumeBoost(200);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe(200);
+    }
+  });
+});

--- a/packages/server/src/lib/validation.ts
+++ b/packages/server/src/lib/validation.ts
@@ -91,7 +91,7 @@ async function wrapBotCall<T>(
   try {
     return { ok: true, value: await fn() };
   } catch (error) {
-    logger.error({ err: error as Error }, 'NodeLink call failed');
+    logger.error({ err: error instanceof Error ? error : String(error) }, 'NodeLink call failed');
 
     // If it's a fetch error with response status, propagate the actual status
     if (error instanceof Error && error.message.startsWith('NodeLink REST')) {

--- a/packages/server/src/lib/validation.ts
+++ b/packages/server/src/lib/validation.ts
@@ -97,7 +97,7 @@ async function wrapBotCall<T>(
     if (error instanceof Error && error.message.startsWith('NodeLink REST')) {
       const match = /NodeLink REST (\d+):/.exec(error.message);
       if (match?.[1]) {
-        const status = parseInt(match[1], 10);
+        const status = Number.parseInt(match[1], 10);
         return { ok: false, response: json({ error: error.message }, status) };
       }
       // If regex didn't match but it's a NodeLink REST error, use 502

--- a/packages/server/src/lib/voice.ts
+++ b/packages/server/src/lib/voice.ts
@@ -77,7 +77,10 @@ export async function resolveOrAutoJoinPlayer(
 
     return { ok: true, player: createPlayer(guildId, voiceChannelId) };
   } catch (error) {
-    logger.error({ err: error as Error }, 'Failed to auto-join voice channel');
+    logger.error(
+      { err: error instanceof Error ? error : String(error) },
+      'Failed to auto-join voice channel'
+    );
     return {
       ok: false,
       response: json(

--- a/packages/server/src/lib/voice.ts
+++ b/packages/server/src/lib/voice.ts
@@ -40,10 +40,8 @@ export async function resolveOrAutoJoinPlayer(
 > {
   const guildId = getGuildId();
   const existingPlayer = getPlayer(guildId);
-  if (existingPlayer) {
-    if (lavalink.isGuildConnected(guildId)) {
-      return { ok: true, player: existingPlayer };
-    }
+  if (existingPlayer && lavalink.isGuildConnected(guildId)) {
+    return { ok: true, player: existingPlayer };
   }
 
   const gateway = getClient();

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -1,5 +1,6 @@
 import { and, eq, lt } from 'drizzle-orm';
 import crypto from 'node:crypto';
+import * as v from 'valibot';
 
 import { getGuildId, refreshGuildId } from '../lib/config';
 import { type RouteContext } from '../lib/context';
@@ -171,6 +172,21 @@ function authRateLimit(ip: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Discord API response schemas
+// ---------------------------------------------------------------------------
+const DiscordMemberSchema = v.object({ roles: v.optional(v.array(v.string())) });
+const DiscordUserSchema = v.object({
+  username: v.string(),
+  avatar: v.nullable(v.string()),
+});
+const DiscordTokenSchema = v.object({ access_token: v.optional(v.string()) });
+const DiscordIdentitySchema = v.object({
+  id: v.string(),
+  username: v.string(),
+  avatar: v.nullable(v.string()),
+});
+
+// ---------------------------------------------------------------------------
 // Helper functions
 // ---------------------------------------------------------------------------
 
@@ -192,8 +208,9 @@ async function fetchGuildMemberRoles(discordId: string): Promise<string[] | null
     if (!memberRes.ok) {
       throw new Error(`Discord API error: ${memberRes.status}`);
     }
-    const data = (await memberRes.json()) as { roles?: string[] };
-    return data.roles ?? [];
+    const raw: unknown = await memberRes.json();
+    const parsed = v.parse(DiscordMemberSchema, raw);
+    return parsed.roles ?? [];
   } catch (err: unknown) {
     logger.error(
       { err: err instanceof Error ? err.message : String(err) },
@@ -217,11 +234,12 @@ async function fetchDiscordUserProfile(
     if (!res.ok) {
       return null;
     }
-    const data = (await res.json()) as { username: string; avatar: string | null };
+    const raw: unknown = await res.json();
+    const parsed = v.parse(DiscordUserSchema, raw);
     return {
-      username: data.username,
-      avatar: data.avatar
-        ? `https://cdn.discordapp.com/avatars/${discordId}/${data.avatar}.png`
+      username: parsed.username,
+      avatar: parsed.avatar
+        ? `https://cdn.discordapp.com/avatars/${discordId}/${parsed.avatar}.png`
         : null,
     };
   } catch {
@@ -240,7 +258,8 @@ async function fetchUserAdminStatus(
     if (!userRes.ok) {
       throw new Error(`Discord API error: ${userRes.status}`);
     }
-    const userData = (await userRes.json()) as { username: string; avatar: string | null };
+    const raw: unknown = await userRes.json();
+    const userData = v.parse(DiscordUserSchema, raw);
     const { username, avatar } = userData;
 
     const roles = await fetchGuildMemberRoles(discordId);
@@ -283,7 +302,8 @@ async function exchangeAuthorizationCode(code: string): Promise<string | null> {
     if (!tokenRes.ok) {
       return null;
     }
-    const data = (await tokenRes.json()) as { access_token?: string };
+    const raw: unknown = await tokenRes.json();
+    const data = v.parse(DiscordTokenSchema, raw);
     return data.access_token ?? null;
   } catch {
     return null;
@@ -304,7 +324,8 @@ async function fetchDiscordIdentity(
     if (!userRes.ok) {
       return null;
     }
-    return (await userRes.json()) as { id: string; username: string; avatar: string | null };
+    const raw: unknown = await userRes.json();
+    return v.parse(DiscordIdentitySchema, raw);
   } catch {
     return null;
   }
@@ -598,7 +619,7 @@ async function handleRefresh(
       isSetupAdmin = true;
     } catch (err) {
       logger.warn(
-        { discordId: decoded.discordId, err: (err as Error).message },
+        { discordId: decoded.discordId, err: err instanceof Error ? err.message : String(err) },
         'Auth refresh failed: Discord unreachable (setup mode)'
       );
       return json({ error: 'Discord is temporarily unreachable. Please try again.' }, 503);
@@ -620,7 +641,7 @@ async function handleRefresh(
       roles = userInfo.roles;
     } catch (err) {
       logger.warn(
-        { discordId: decoded.discordId, err: (err as Error).message },
+        { discordId: decoded.discordId, err: err instanceof Error ? err.message : String(err) },
         'Auth refresh failed: Discord unreachable'
       );
       return json({ error: 'Discord is temporarily unreachable. Please try again.' }, 503);

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -98,7 +98,7 @@ const REFRESH_TOKEN_MAX_AGE = (() => {
   }
   const multipliers: Record<string, number> = { d: 86400000, h: 3600000, m: 60000, s: 1000 };
   const unit = match[2] ?? 'd';
-  const num = match[1] ? parseInt(match[1], 10) : 30;
+  const num = match[1] ? Number.parseInt(match[1], 10) : 30;
   return num * (multipliers[unit] ?? 86400000);
 })();
 
@@ -211,9 +211,9 @@ async function fetchGuildMemberRoles(discordId: string): Promise<string[] | null
     const raw: unknown = await memberRes.json();
     const parsed = v.parse(DiscordMemberSchema, raw);
     return parsed.roles ?? [];
-  } catch (err: unknown) {
+  } catch (error: unknown) {
     logger.error(
-      { err: err instanceof Error ? err.message : String(err) },
+      { err: error instanceof Error ? error.message : String(error) },
       'Failed to fetch guild member roles'
     );
     return null;
@@ -273,9 +273,9 @@ async function fetchUserAdminStatus(
       avatar: avatar ? `https://cdn.discordapp.com/avatars/${discordId}/${avatar}.png` : null,
       roles,
     };
-  } catch (err: unknown) {
+  } catch (error: unknown) {
     logger.error(
-      { err: err instanceof Error ? err.message : String(err) },
+      { err: error instanceof Error ? error.message : String(error) },
       'Failed to fetch user info from Discord'
     );
     return null;
@@ -524,8 +524,8 @@ async function withRetry<T>(fn: () => Promise<T>, attempts = 3, baseDelayMs = 50
   for (let i = 0; i < attempts; i++) {
     try {
       return await fn();
-    } catch (err) {
-      lastErr = err;
+    } catch (error) {
+      lastErr = error;
       if (i < attempts - 1) {
         await new Promise((resolve) => setTimeout(resolve, baseDelayMs * 2 ** i));
       }
@@ -617,9 +617,12 @@ async function handleRefresh(
       avatar = profile.avatar;
       isAdmin = true;
       isSetupAdmin = true;
-    } catch (err) {
+    } catch (error) {
       logger.warn(
-        { discordId: decoded.discordId, err: err instanceof Error ? err.message : String(err) },
+        {
+          discordId: decoded.discordId,
+          err: error instanceof Error ? error.message : String(error),
+        },
         'Auth refresh failed: Discord unreachable (setup mode)'
       );
       return json({ error: 'Discord is temporarily unreachable. Please try again.' }, 503);
@@ -639,9 +642,12 @@ async function handleRefresh(
       avatar = userInfo.avatar;
       isAdmin = userInfo.isAdmin;
       roles = userInfo.roles;
-    } catch (err) {
+    } catch (error) {
       logger.warn(
-        { discordId: decoded.discordId, err: err instanceof Error ? err.message : String(err) },
+        {
+          discordId: decoded.discordId,
+          err: error instanceof Error ? error.message : String(error),
+        },
         'Auth refresh failed: Discord unreachable'
       );
       return json({ error: 'Discord is temporarily unreachable. Please try again.' }, 503);

--- a/packages/server/src/routes/channelMix.ts
+++ b/packages/server/src/routes/channelMix.ts
@@ -30,10 +30,10 @@ function handleChannelMixGet(
 
   return json({
     enabled: row?.channelMixEnabled ?? false,
-    leftToLeft: row?.channelMixLeftToLeft ?? 1.0,
-    leftToRight: row?.channelMixLeftToRight ?? 0.0,
-    rightToLeft: row?.channelMixRightToLeft ?? 0.0,
-    rightToRight: row?.channelMixRightToRight ?? 1.0,
+    leftToLeft: row?.channelMixLeftToLeft ?? 1,
+    leftToRight: row?.channelMixLeftToRight ?? 0,
+    rightToLeft: row?.channelMixRightToLeft ?? 0,
+    rightToRight: row?.channelMixRightToRight ?? 1,
   });
 }
 

--- a/packages/server/src/routes/channelMix.ts
+++ b/packages/server/src/routes/channelMix.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { type RouteContext } from '../lib/context';
 import { json } from '../lib/json';
@@ -7,13 +8,13 @@ import { routeTable } from '../lib/routeTable';
 import { syncAllFilters } from '../lib/syncAllFilters';
 import { db, tables } from '../shared/db';
 
-interface ChannelMixPayload {
-  enabled: boolean;
-  leftToLeft: number;
-  leftToRight: number;
-  rightToLeft: number;
-  rightToRight: number;
-}
+const ChannelMixSchema = v.object({
+  enabled: v.boolean(),
+  leftToLeft: v.pipe(v.number(), v.minValue(0), v.maxValue(1)),
+  leftToRight: v.pipe(v.number(), v.minValue(0), v.maxValue(1)),
+  rightToLeft: v.pipe(v.number(), v.minValue(0), v.maxValue(1)),
+  rightToRight: v.pipe(v.number(), v.minValue(0), v.maxValue(1)),
+});
 
 function handleChannelMixGet(
   ctx: RouteContext,
@@ -46,30 +47,19 @@ async function handleChannelMixPatch(
     return guards;
   }
 
-  let body: ChannelMixPayload;
+  let raw: unknown;
   try {
-    body = (await request.json()) as ChannelMixPayload;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON' }, 400);
   }
 
-  const { enabled, leftToLeft, leftToRight, rightToLeft, rightToRight } = body;
+  const parsed = v.safeParse(ChannelMixSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
 
-  if (typeof enabled !== 'boolean') {
-    return json({ error: 'enabled must be boolean' }, 400);
-  }
-  if (typeof leftToLeft !== 'number' || leftToLeft < 0 || leftToLeft > 1) {
-    return json({ error: 'leftToLeft must be number 0.0 to 1.0' }, 400);
-  }
-  if (typeof leftToRight !== 'number' || leftToRight < 0 || leftToRight > 1) {
-    return json({ error: 'leftToRight must be number 0.0 to 1.0' }, 400);
-  }
-  if (typeof rightToLeft !== 'number' || rightToLeft < 0 || rightToLeft > 1) {
-    return json({ error: 'rightToLeft must be number 0.0 to 1.0' }, 400);
-  }
-  if (typeof rightToRight !== 'number' || rightToRight < 0 || rightToRight > 1) {
-    return json({ error: 'rightToRight must be number 0.0 to 1.0' }, 400);
-  }
+  const { enabled, leftToLeft, leftToRight, rightToLeft, rightToRight } = parsed.output;
 
   db.insert(tables.guildSettings)
     .values({

--- a/packages/server/src/routes/compressor.ts
+++ b/packages/server/src/routes/compressor.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { type RouteContext } from '../lib/context';
 import { json } from '../lib/json';
@@ -7,14 +8,14 @@ import { routeTable } from '../lib/routeTable';
 import { syncAllFilters } from '../lib/syncAllFilters';
 import { db, tables } from '../shared/db';
 
-interface CompressorPayload {
-  enabled: boolean;
-  threshold: number;
-  ratio: number;
-  attack: number;
-  release: number;
-  gain: number;
-}
+const CompressorSchema = v.object({
+  enabled: v.boolean(),
+  threshold: v.pipe(v.number(), v.integer(), v.minValue(-60), v.maxValue(0)),
+  ratio: v.pipe(v.number(), v.minValue(1), v.maxValue(20)),
+  attack: v.pipe(v.number(), v.integer(), v.minValue(0), v.maxValue(100)),
+  release: v.pipe(v.number(), v.integer(), v.minValue(10), v.maxValue(1000)),
+  gain: v.pipe(v.number(), v.integer(), v.minValue(0), v.maxValue(24)),
+});
 
 function handleCompressorGet(
   ctx: RouteContext,
@@ -48,34 +49,19 @@ async function handleCompressorPatch(
     return guards;
   }
 
-  let body: CompressorPayload;
+  let raw: unknown;
   try {
-    body = (await request.json()) as CompressorPayload;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON' }, 400);
   }
 
-  const { enabled, threshold, ratio, attack, release, gain } = body;
+  const parsed = v.safeParse(CompressorSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
 
-  // Validate ranges
-  if (typeof enabled !== 'boolean') {
-    return json({ error: 'enabled must be boolean' }, 400);
-  }
-  if (!Number.isInteger(threshold) || threshold < -60 || threshold > 0) {
-    return json({ error: 'threshold must be integer -60 to 0' }, 400);
-  }
-  if (typeof ratio !== 'number' || ratio < 1 || ratio > 20) {
-    return json({ error: 'ratio must be number 1 to 20' }, 400);
-  }
-  if (!Number.isInteger(attack) || attack < 0 || attack > 100) {
-    return json({ error: 'attack must be integer 0 to 100' }, 400);
-  }
-  if (!Number.isInteger(release) || release < 10 || release > 1000) {
-    return json({ error: 'release must be integer 10 to 1000' }, 400);
-  }
-  if (!Number.isInteger(gain) || gain < 0 || gain > 24) {
-    return json({ error: 'gain must be integer 0 to 24' }, 400);
-  }
+  const { enabled, threshold, ratio, attack, release, gain } = parsed.output;
 
   // Upsert into DB
   db.insert(tables.guildSettings)

--- a/packages/server/src/routes/compressor.ts
+++ b/packages/server/src/routes/compressor.ts
@@ -32,7 +32,7 @@ function handleCompressorGet(
   return json({
     enabled: row?.compressorEnabled ?? false,
     threshold: row?.compressorThreshold ?? -6,
-    ratio: row?.compressorRatio ?? 4.0,
+    ratio: row?.compressorRatio ?? 4,
     attack: row?.compressorAttack ?? 5,
     release: row?.compressorRelease ?? 50,
     gain: row?.compressorGain ?? 3,

--- a/packages/server/src/routes/distortion.ts
+++ b/packages/server/src/routes/distortion.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { type RouteContext } from '../lib/context';
 import { json } from '../lib/json';
@@ -7,17 +8,17 @@ import { routeTable } from '../lib/routeTable';
 import { syncAllFilters } from '../lib/syncAllFilters';
 import { db, tables } from '../shared/db';
 
-interface DistortionPayload {
-  enabled: boolean;
-  sinOffset: number;
-  sinScale: number;
-  cosOffset: number;
-  cosScale: number;
-  tanOffset: number;
-  tanScale: number;
-  offset: number;
-  scale: number;
-}
+const DistortionSchema = v.object({
+  enabled: v.boolean(),
+  sinOffset: v.pipe(v.number(), v.minValue(-1), v.maxValue(1)),
+  sinScale: v.pipe(v.number(), v.minValue(0), v.maxValue(5)),
+  cosOffset: v.pipe(v.number(), v.minValue(-1), v.maxValue(1)),
+  cosScale: v.pipe(v.number(), v.minValue(0), v.maxValue(5)),
+  tanOffset: v.pipe(v.number(), v.minValue(-1), v.maxValue(1)),
+  tanScale: v.pipe(v.number(), v.minValue(0), v.maxValue(5)),
+  offset: v.pipe(v.number(), v.minValue(-1), v.maxValue(1)),
+  scale: v.pipe(v.number(), v.minValue(0), v.maxValue(5)),
+});
 
 function handleDistortionGet(
   ctx: RouteContext,
@@ -54,43 +55,20 @@ async function handleDistortionPatch(
     return guards;
   }
 
-  let body: DistortionPayload;
+  let raw: unknown;
   try {
-    body = (await request.json()) as DistortionPayload;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON' }, 400);
   }
 
-  const { enabled, sinOffset, sinScale, cosOffset, cosScale, tanOffset, tanScale, offset, scale } =
-    body;
+  const parsed = v.safeParse(DistortionSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
 
-  if (typeof enabled !== 'boolean') {
-    return json({ error: 'enabled must be boolean' }, 400);
-  }
-  if (typeof sinOffset !== 'number' || sinOffset < -1 || sinOffset > 1) {
-    return json({ error: 'sinOffset must be number -1.0 to 1.0' }, 400);
-  }
-  if (typeof sinScale !== 'number' || sinScale < 0 || sinScale > 5) {
-    return json({ error: 'sinScale must be number 0.0 to 5.0' }, 400);
-  }
-  if (typeof cosOffset !== 'number' || cosOffset < -1 || cosOffset > 1) {
-    return json({ error: 'cosOffset must be number -1.0 to 1.0' }, 400);
-  }
-  if (typeof cosScale !== 'number' || cosScale < 0 || cosScale > 5) {
-    return json({ error: 'cosScale must be number 0.0 to 5.0' }, 400);
-  }
-  if (typeof tanOffset !== 'number' || tanOffset < -1 || tanOffset > 1) {
-    return json({ error: 'tanOffset must be number -1.0 to 1.0' }, 400);
-  }
-  if (typeof tanScale !== 'number' || tanScale < 0 || tanScale > 5) {
-    return json({ error: 'tanScale must be number 0.0 to 5.0' }, 400);
-  }
-  if (typeof offset !== 'number' || offset < -1 || offset > 1) {
-    return json({ error: 'offset must be number -1.0 to 1.0' }, 400);
-  }
-  if (typeof scale !== 'number' || scale < 0 || scale > 5) {
-    return json({ error: 'scale must be number 0.0 to 5.0' }, 400);
-  }
+  const { enabled, sinOffset, sinScale, cosOffset, cosScale, tanOffset, tanScale, offset, scale } =
+    parsed.output;
 
   db.insert(tables.guildSettings)
     .values({

--- a/packages/server/src/routes/distortion.ts
+++ b/packages/server/src/routes/distortion.ts
@@ -34,14 +34,14 @@ function handleDistortionGet(
 
   return json({
     enabled: row?.distortionEnabled ?? false,
-    sinOffset: row?.distortionSinOffset ?? 0.0,
-    sinScale: row?.distortionSinScale ?? 1.0,
-    cosOffset: row?.distortionCosOffset ?? 0.0,
-    cosScale: row?.distortionCosScale ?? 1.0,
-    tanOffset: row?.distortionTanOffset ?? 0.0,
-    tanScale: row?.distortionTanScale ?? 1.0,
-    offset: row?.distortionOffset ?? 0.0,
-    scale: row?.distortionScale ?? 1.0,
+    sinOffset: row?.distortionSinOffset ?? 0,
+    sinScale: row?.distortionSinScale ?? 1,
+    cosOffset: row?.distortionCosOffset ?? 0,
+    cosScale: row?.distortionCosScale ?? 1,
+    tanOffset: row?.distortionTanOffset ?? 0,
+    tanScale: row?.distortionTanScale ?? 1,
+    offset: row?.distortionOffset ?? 0,
+    scale: row?.distortionScale ?? 1,
   });
 }
 

--- a/packages/server/src/routes/equalizer.ts
+++ b/packages/server/src/routes/equalizer.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { type RouteContext } from '../lib/context';
 import { EQ_BAND_COLUMNS, eqBandsFromRow, eqBandValues } from '../lib/eqBands';
@@ -8,10 +9,13 @@ import { routeTable } from '../lib/routeTable';
 import { syncAllFilters } from '../lib/syncAllFilters';
 import { db, tables } from '../shared/db';
 
-interface EqualizerPayload {
-  bands: number[]; // length 15, each 0-100
-  enabled: boolean;
-}
+const EqualizerSchema = v.object({
+  bands: v.pipe(
+    v.array(v.pipe(v.number(), v.integer(), v.minValue(0), v.maxValue(100))),
+    v.length(15)
+  ),
+  enabled: v.boolean(),
+});
 
 function handleEqualizerGet(
   ctx: RouteContext,
@@ -48,30 +52,19 @@ async function handleEqualizerPatch(
     return guards;
   }
 
-  let body: EqualizerPayload;
+  let raw: unknown;
   try {
-    body = (await request.json()) as EqualizerPayload;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON' }, 400);
   }
 
-  const { bands, enabled } = body;
-
-  // Validate: enabled must be boolean
-  if (typeof enabled !== 'boolean') {
-    return json({ error: 'enabled must be boolean' }, 400);
+  const parsed = v.safeParse(EqualizerSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
   }
 
-  // Validate: must be array of 15 integers, each 0-100
-  if (!Array.isArray(bands) || bands.length !== 15) {
-    return json({ error: 'bands must be array of 15 integers' }, 400);
-  }
-  for (let i = 0; i < 15; i++) {
-    const v = bands[i];
-    if (v === undefined || !Number.isInteger(v) || v < 0 || v > 100) {
-      return json({ error: `band[${i}] must be integer 0-100` }, 400);
-    }
-  }
+  const { bands, enabled } = parsed.output;
 
   // Upsert into DB
   db.insert(tables.guildSettings)

--- a/packages/server/src/routes/generalSettings.ts
+++ b/packages/server/src/routes/generalSettings.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { type RouteContext } from '../lib/context';
 import { json } from '../lib/json';
@@ -71,20 +72,22 @@ function handleGetGeneral(
   return json(attachAvailableSources(row));
 }
 
+const GeneralSettingsPatchSchema = v.partial(
+  v.object({
+    adminRoleIds: v.pipe(v.string(), v.minLength(1)),
+    voiceIdleTimeoutMinutes: v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(120)),
+    afkNotificationChannelId: v.nullable(v.string()),
+    requestNotificationChannelId: v.nullable(v.string()),
+    notifyOnApproved: v.boolean(),
+    notifyOnDenied: v.boolean(),
+    publicUrl: v.nullable(v.string()),
+    enabledSources: v.pipe(v.string(), v.minLength(1)),
+  })
+);
+
 // ---------------------------------------------------------------------------
 // PATCH /api/settings/general
 // ---------------------------------------------------------------------------
-interface GeneralSettingsPatch {
-  adminRoleIds?: string;
-  voiceIdleTimeoutMinutes?: number;
-  afkNotificationChannelId?: string | null;
-  requestNotificationChannelId?: string | null;
-  notifyOnApproved?: boolean;
-  notifyOnDenied?: boolean;
-  publicUrl?: string | null;
-  enabledSources?: string;
-}
-
 async function handlePatchGeneral(
   ctx: RouteContext,
   request: Request,
@@ -95,78 +98,51 @@ async function handlePatchGeneral(
     return guards;
   }
 
-  let body: GeneralSettingsPatch;
+  let raw: unknown;
   try {
-    body = (await request.json()) as GeneralSettingsPatch;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON' }, 400);
   }
 
+  const parsed = v.safeParse(GeneralSettingsPatchSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
+
+  const body = parsed.output;
+
   const updates: Record<string, unknown> = {};
 
   if (body.adminRoleIds !== undefined) {
-    if (typeof body.adminRoleIds !== 'string') {
-      return json({ error: 'adminRoleIds must be a string' }, 400);
-    }
-    if (body.adminRoleIds.trim().length === 0) {
-      return json({ error: 'adminRoleIds must not be empty' }, 400);
-    }
     updates.adminRoleIds = body.adminRoleIds;
   }
 
   if (body.voiceIdleTimeoutMinutes !== undefined) {
-    const v = body.voiceIdleTimeoutMinutes;
-    if (!Number.isInteger(v) || v < 1 || v > 120) {
-      return json({ error: 'voiceIdleTimeoutMinutes must be an integer between 1 and 120' }, 400);
-    }
-    updates.voiceIdleTimeoutMinutes = v;
+    updates.voiceIdleTimeoutMinutes = body.voiceIdleTimeoutMinutes;
   }
 
   if (body.afkNotificationChannelId !== undefined) {
-    if (
-      body.afkNotificationChannelId !== null &&
-      typeof body.afkNotificationChannelId !== 'string'
-    ) {
-      return json({ error: 'afkNotificationChannelId must be a string or null' }, 400);
-    }
     updates.afkNotificationChannelId = body.afkNotificationChannelId;
   }
 
   if (body.requestNotificationChannelId !== undefined) {
-    if (
-      body.requestNotificationChannelId !== null &&
-      typeof body.requestNotificationChannelId !== 'string'
-    ) {
-      return json({ error: 'requestNotificationChannelId must be a string or null' }, 400);
-    }
     updates.requestNotificationChannelId = body.requestNotificationChannelId;
   }
 
   if (body.notifyOnApproved !== undefined) {
-    if (typeof body.notifyOnApproved !== 'boolean') {
-      return json({ error: 'notifyOnApproved must be a boolean' }, 400);
-    }
     updates.notifyOnApproved = body.notifyOnApproved;
   }
 
   if (body.notifyOnDenied !== undefined) {
-    if (typeof body.notifyOnDenied !== 'boolean') {
-      return json({ error: 'notifyOnDenied must be a boolean' }, 400);
-    }
     updates.notifyOnDenied = body.notifyOnDenied;
   }
 
   if (body.publicUrl !== undefined) {
-    if (body.publicUrl !== null && typeof body.publicUrl !== 'string') {
-      return json({ error: 'publicUrl must be a string or null' }, 400);
-    }
     updates.publicUrl = body.publicUrl;
   }
 
   if (body.enabledSources !== undefined) {
-    if (typeof body.enabledSources !== 'string' || body.enabledSources.trim().length === 0) {
-      return json({ error: 'enabledSources must be a non-empty comma-separated string' }, 400);
-    }
     updates.enabledSources = body.enabledSources.trim();
   }
 
@@ -183,8 +159,8 @@ async function handlePatchGeneral(
     .run();
 
   // Refresh the enabled sources cache if sources were updated.
-  if (updates.enabledSources) {
-    refreshEnabledSources(updates.enabledSources as string);
+  if (body.enabledSources) {
+    refreshEnabledSources(body.enabledSources.trim());
   }
 
   // Return the full updated row.
@@ -194,7 +170,11 @@ async function handlePatchGeneral(
     .where(eq(tables.guildSettings.id, 1))
     .get();
 
-  return json(attachAvailableSources(row as Omit<GeneralSettings, 'availableSources'>));
+  if (!row) {
+    return json({ error: 'Settings not found after update.' }, 500);
+  }
+
+  return json(attachAvailableSources(row));
 }
 
 export const handleGeneralSettings = routeTable('/api/settings/general', {

--- a/packages/server/src/routes/karaoke.ts
+++ b/packages/server/src/routes/karaoke.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { type RouteContext } from '../lib/context';
 import { json } from '../lib/json';
@@ -7,13 +8,13 @@ import { routeTable } from '../lib/routeTable';
 import { syncAllFilters } from '../lib/syncAllFilters';
 import { db, tables } from '../shared/db';
 
-interface KaraokePayload {
-  enabled: boolean;
-  level: number;
-  monoLevel: number;
-  filterBand: number;
-  filterWidth: number;
-}
+const KaraokeSchema = v.object({
+  enabled: v.boolean(),
+  level: v.pipe(v.number(), v.minValue(0), v.maxValue(1)),
+  monoLevel: v.pipe(v.number(), v.minValue(0), v.maxValue(1)),
+  filterBand: v.pipe(v.number(), v.minValue(50), v.maxValue(10000)),
+  filterWidth: v.pipe(v.number(), v.minValue(10), v.maxValue(10000)),
+});
 
 function handleKaraokeGet(
   ctx: RouteContext,
@@ -46,30 +47,19 @@ async function handleKaraokePatch(
     return guards;
   }
 
-  let body: KaraokePayload;
+  let raw: unknown;
   try {
-    body = (await request.json()) as KaraokePayload;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON' }, 400);
   }
 
-  const { enabled, level, monoLevel, filterBand, filterWidth } = body;
+  const parsed = v.safeParse(KaraokeSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
 
-  if (typeof enabled !== 'boolean') {
-    return json({ error: 'enabled must be boolean' }, 400);
-  }
-  if (typeof level !== 'number' || level < 0 || level > 1) {
-    return json({ error: 'level must be number 0.0 to 1.0' }, 400);
-  }
-  if (typeof monoLevel !== 'number' || monoLevel < 0 || monoLevel > 1) {
-    return json({ error: 'monoLevel must be number 0.0 to 1.0' }, 400);
-  }
-  if (typeof filterBand !== 'number' || filterBand < 50 || filterBand > 10000) {
-    return json({ error: 'filterBand must be number 50 to 10000' }, 400);
-  }
-  if (typeof filterWidth !== 'number' || filterWidth < 10 || filterWidth > 10000) {
-    return json({ error: 'filterWidth must be number 10 to 10000' }, 400);
-  }
+  const { enabled, level, monoLevel, filterBand, filterWidth } = parsed.output;
 
   db.insert(tables.guildSettings)
     .values({

--- a/packages/server/src/routes/karaoke.ts
+++ b/packages/server/src/routes/karaoke.ts
@@ -30,10 +30,10 @@ function handleKaraokeGet(
 
   return json({
     enabled: row?.karaokeEnabled ?? false,
-    level: row?.karaokeLevel ?? 1.0,
-    monoLevel: row?.karaokeMonoLevel ?? 1.0,
-    filterBand: row?.karaokeFilterBand ?? 220.0,
-    filterWidth: row?.karaokeFilterWidth ?? 100.0,
+    level: row?.karaokeLevel ?? 1,
+    monoLevel: row?.karaokeMonoLevel ?? 1,
+    filterBand: row?.karaokeFilterBand ?? 220,
+    filterWidth: row?.karaokeFilterWidth ?? 100,
   });
 }
 

--- a/packages/server/src/routes/lowPass.ts
+++ b/packages/server/src/routes/lowPass.ts
@@ -27,7 +27,7 @@ function handleLowPassGet(
 
   return json({
     enabled: row?.lowPassEnabled ?? false,
-    smoothing: row?.lowPassSmoothing ?? 20.0,
+    smoothing: row?.lowPassSmoothing ?? 20,
   });
 }
 

--- a/packages/server/src/routes/lowPass.ts
+++ b/packages/server/src/routes/lowPass.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { type RouteContext } from '../lib/context';
 import { json } from '../lib/json';
@@ -7,10 +8,10 @@ import { routeTable } from '../lib/routeTable';
 import { syncAllFilters } from '../lib/syncAllFilters';
 import { db, tables } from '../shared/db';
 
-interface LowPassPayload {
-  enabled: boolean;
-  smoothing: number;
-}
+const LowPassSchema = v.object({
+  enabled: v.boolean(),
+  smoothing: v.pipe(v.number(), v.minValue(0), v.maxValue(60)),
+});
 
 function handleLowPassGet(
   ctx: RouteContext,
@@ -40,21 +41,19 @@ async function handleLowPassPatch(
     return guards;
   }
 
-  let body: LowPassPayload;
+  let raw: unknown;
   try {
-    body = (await request.json()) as LowPassPayload;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON' }, 400);
   }
 
-  const { enabled, smoothing } = body;
+  const parsed = v.safeParse(LowPassSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
 
-  if (typeof enabled !== 'boolean') {
-    return json({ error: 'enabled must be boolean' }, 400);
-  }
-  if (typeof smoothing !== 'number' || smoothing < 0 || smoothing > 60) {
-    return json({ error: 'smoothing must be number 0.0 to 60.0' }, 400);
-  }
+  const { enabled, smoothing } = parsed.output;
 
   db.insert(tables.guildSettings)
     .values({

--- a/packages/server/src/routes/permissions.ts
+++ b/packages/server/src/routes/permissions.ts
@@ -1,4 +1,5 @@
 import { eq, inArray } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { getGuildId } from '../lib/config';
 import { type RouteContext } from '../lib/context';
@@ -58,6 +59,15 @@ async function handleGetPermissions(
   });
 }
 
+const PermissionsPatchSchema = v.object({
+  action: v.string(),
+  roleIds: v.array(v.string()),
+});
+
+function isPermissionAction(value: string): value is PermissionAction {
+  return value in PERMISSION_LABELS;
+}
+
 // ---------------------------------------------------------------------------
 // PATCH /api/permissions
 // Body: { action: PermissionAction; roleIds: string[] }
@@ -72,26 +82,22 @@ async function handlePatchPermissions(
     return guards;
   }
 
-  let body: { action?: unknown; roleIds?: unknown };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  if (typeof body.action !== 'string') {
-    return json({ error: 'action (string) is required.' }, 400);
+  const parsed = v.safeParse(PermissionsPatchSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
   }
 
-  if (!Array.isArray(body.roleIds) || body.roleIds.some((id) => typeof id !== 'string')) {
-    return json({ error: 'roleIds must be an array of strings.' }, 400);
-  }
-
-  const action = body.action;
-  const roleIds = body.roleIds as string[];
+  const { action, roleIds } = parsed.output;
 
   // Validate the action is a known permission.
-  if (!PERMISSION_LABELS[action as PermissionAction]) {
+  if (!isPermissionAction(action)) {
     return json({ error: `Unknown permission action: ${action}` }, 400);
   }
 

--- a/packages/server/src/routes/player.ts
+++ b/packages/server/src/routes/player.ts
@@ -55,7 +55,7 @@ function handleGetQueue(
       queue: [],
       trackStartedAt: null,
       nextTrack: null,
-      timescaleSpeed: 1.0,
+      timescaleSpeed: 1,
       nodeLinkPosition: null,
       nodeLinkTime: null,
     });
@@ -110,7 +110,7 @@ async function handlePlay(ctx: RouteContext, request: Request): Promise<Response
       return json({ error: 'Playlist not found.' }, 404);
     }
 
-    const accessResult = canAccessPlaylist(playlist, user, undefined);
+    const accessResult = canAccessPlaylist(playlist, user);
     if (!accessResult.ok) {
       return json({ error: accessResult.error }, 403);
     }
@@ -720,8 +720,8 @@ async function handleReorderQueue(ctx: RouteContext, request: Request): Promise<
     } else {
       playerResult.player.reorderQueue(songIds);
     }
-  } catch (err) {
-    return json({ error: err instanceof Error ? err.message : 'Invalid reorder.' }, 422);
+  } catch (error) {
+    return json({ error: error instanceof Error ? error.message : 'Invalid reorder.' }, 422);
   }
 
   return json({ message: 'Queue reordered.' });

--- a/packages/server/src/routes/player.ts
+++ b/packages/server/src/routes/player.ts
@@ -1,3 +1,5 @@
+import * as v from 'valibot';
+
 import { type GuildPlayer } from '../GuildPlayer';
 import { getGuildId } from '../lib/config';
 import { type RouteContext } from '../lib/context';
@@ -18,7 +20,6 @@ import {
 import { resolveOrAutoJoinPlayer } from '../lib/voice';
 import {
   fisherYatesShuffle as fisherYatesShuffleImpl,
-  type LoopMode,
   type QueuedSong,
   toQueuedSong,
 } from '../shared';
@@ -63,6 +64,13 @@ function handleGetQueue(
   return json(player.getQueueState());
 }
 
+const PlaySchema = v.object({
+  playlistId: v.optional(v.string()),
+  mode: v.optional(v.picklist(['sequential', 'random'])),
+  loop: v.optional(v.picklist(['off', 'song', 'queue'])),
+  startFromSongId: v.optional(v.string()),
+});
+
 // ---------------------------------------------------------------------------
 // POST /api/player/play — load songs and start playback
 // ---------------------------------------------------------------------------
@@ -73,19 +81,19 @@ async function handlePlay(ctx: RouteContext, request: Request): Promise<Response
   }
   const { user } = guards;
 
-  let body: {
-    playlistId?: string;
-    mode?: 'sequential' | 'random';
-    loop?: LoopMode;
-    startFromSongId?: string;
-  };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  const { playlistId, mode, loop, startFromSongId } = body;
+  const parsed = v.safeParse(PlaySchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
+
+  const { playlistId, mode, loop, startFromSongId } = parsed.output;
 
   const playerResult = await resolveOrAutoJoinPlayer(user.discordId);
   if (!playerResult.ok) {
@@ -195,6 +203,10 @@ function handleLeave(
   return json({ message: 'Left the voice channel.' });
 }
 
+const LoopSchema = v.object({
+  mode: v.picklist(['off', 'song', 'queue']),
+});
+
 // ---------------------------------------------------------------------------
 // POST /api/player/loop — set loop mode
 // ---------------------------------------------------------------------------
@@ -204,18 +216,19 @@ async function handleLoop(ctx: RouteContext, request: Request): Promise<Response
     return guards;
   }
 
-  let body: { mode?: LoopMode };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  const { mode } = body;
-
-  if (!mode || !['off', 'song', 'queue'].includes(mode)) {
+  const parsed = v.safeParse(LoopSchema, raw);
+  if (!parsed.success) {
     return json({ error: 'mode must be "off", "song", or "queue".' }, 400);
   }
+
+  const { mode } = parsed.output;
 
   const playerResult = requirePlayer();
   if (!playerResult.ok) {
@@ -271,6 +284,10 @@ function handleUnshuffle(
   return json({ message: 'Queue order restored.' });
 }
 
+const UrlSchema = v.object({
+  url: v.optional(v.string()),
+});
+
 // ---------------------------------------------------------------------------
 // Shared: resolve a source URL into a temp QueuedSong with player ready
 // ---------------------------------------------------------------------------
@@ -290,14 +307,19 @@ async function resolveUrlTempSong(
   }
   const { user } = guards;
 
-  let body: { url?: unknown };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return { ok: false, response: json({ error: 'Invalid JSON body.' }, 400) };
   }
 
-  const urlResult = validateSourceUrl(body.url);
+  const parsed = v.safeParse(UrlSchema, raw);
+  if (!parsed.success) {
+    return { ok: false, response: json({ error: 'url is required.' }, 400) };
+  }
+
+  const urlResult = validateSourceUrl(parsed.output.url);
   if (!urlResult.ok) {
     return { ok: false, response: urlResult.response };
   }
@@ -345,6 +367,11 @@ async function handleQuickAdd(ctx: RouteContext, request: Request): Promise<Resp
   });
 }
 
+const QuickAddPlaylistSchema = v.object({
+  url: v.optional(v.string()),
+  maxVideos: v.optional(v.number()),
+});
+
 // ---------------------------------------------------------------------------
 // POST /api/player/quick-add-playlist — add playlist to queue (admin only)
 // ---------------------------------------------------------------------------
@@ -355,15 +382,20 @@ async function handleQuickAddPlaylist(ctx: RouteContext, request: Request): Prom
   }
   const { user } = guards;
 
-  let body: { url?: unknown; maxVideos?: number };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  const maxVideos = clampMaxVideos(body.maxVideos);
-  const urlResult = validatePlaylistUrl(body.url);
+  const parsed = v.safeParse(QuickAddPlaylistSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
+
+  const maxVideos = clampMaxVideos(parsed.output.maxVideos);
+  const urlResult = validatePlaylistUrl(parsed.output.url);
   if (!urlResult.ok) {
     return urlResult.response;
   }
@@ -428,6 +460,10 @@ function handlePauseToggle(
   return json({ isPaused });
 }
 
+const SeekSchema = v.object({
+  position: v.number(),
+});
+
 // ---------------------------------------------------------------------------
 // POST /api/player/seek — seek to position in current track
 // ---------------------------------------------------------------------------
@@ -437,18 +473,19 @@ async function handleSeek(ctx: RouteContext, request: Request): Promise<Response
     return guards;
   }
 
-  let body: { position?: unknown };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  const { position } = body;
-
-  if (typeof position !== 'number' || !Number.isFinite(position) || position < 0) {
+  const parsed = v.safeParse(SeekSchema, raw);
+  if (!parsed.success || parsed.output.position < 0 || !Number.isFinite(parsed.output.position)) {
     return json({ error: 'position must be a non-negative number (milliseconds).' }, 400);
   }
+
+  const { position } = parsed.output;
 
   const playingResult = requirePlaying();
   if (!playingResult.ok) {
@@ -481,6 +518,10 @@ function handleClear(
   return json({ message: 'Queue cleared.' });
 }
 
+const SongIdSchema = v.object({
+  songId: v.string(),
+});
+
 // ---------------------------------------------------------------------------
 // POST /api/player/add-to-priority — add library song to Up Next (admin only)
 // ---------------------------------------------------------------------------
@@ -491,18 +532,19 @@ async function handleAddToPriority(ctx: RouteContext, request: Request): Promise
   }
   const { user } = guards;
 
-  let body: { songId?: unknown };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  const { songId } = body;
-
-  if (!songId || typeof songId !== 'string') {
+  const parsed = v.safeParse(SongIdSchema, raw);
+  if (!parsed.success) {
     return json({ error: 'songId is required.' }, 400);
   }
+
+  const { songId } = parsed.output;
 
   const [song] = await db.select().from(songTable).where(eq(songTable.id, songId)).limit(1);
 
@@ -633,6 +675,11 @@ function handleDemoteSong(
   return json({ message: 'Song moved to queue.' });
 }
 
+const ReorderSchema = v.object({
+  songIds: v.array(v.string()),
+  target: v.optional(v.picklist(['queue', 'priority'])),
+});
+
 // ---------------------------------------------------------------------------
 // PATCH /api/player/queue/reorder — reorder remaining queue or priority items
 // ---------------------------------------------------------------------------
@@ -642,22 +689,25 @@ async function handleReorderQueue(ctx: RouteContext, request: Request): Promise<
     return guards;
   }
 
-  let body: { songIds?: unknown; target?: unknown };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  const { songIds, target } = body;
-
-  if (!Array.isArray(songIds) || !songIds.every((id): id is string => typeof id === 'string')) {
+  const parsed = v.safeParse(ReorderSchema, raw);
+  if (!parsed.success) {
     return json({ error: 'songIds must be an array of strings.' }, 400);
   }
 
-  if (target !== undefined && target !== 'queue' && target !== 'priority') {
-    return json({ error: 'target must be "queue" or "priority".' }, 400);
+  const { songIds, target } = parsed.output;
+
+  if (songIds.length === 0) {
+    return json({ error: 'songIds must not be empty.' }, 400);
   }
+
+  // target already validated by picklist — no additional check needed
 
   const playerResult = requirePlayer();
   if (!playerResult.ok) {

--- a/packages/server/src/routes/playlists.ts
+++ b/packages/server/src/routes/playlists.ts
@@ -1,4 +1,5 @@
 import { and, count, desc, eq, inArray, sql } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { type RouteContext } from '../lib/context';
 import { getUserDisplayName, resolveDisplayNames } from '../lib/displayName';
@@ -43,6 +44,27 @@ function formatPlaylistSongWithSong(
     },
   };
 }
+
+// ---------------------------------------------------------------------------
+// Request body schemas
+// ---------------------------------------------------------------------------
+const PlaylistCreateSchema = v.object({
+  name: v.optional(v.string()),
+  tagNameLower: v.optional(v.string()),
+});
+
+const PlaylistVisibilitySchema = v.object({
+  isPrivate: v.optional(v.boolean()),
+  adminView: v.optional(v.boolean()),
+});
+
+const PlaylistAddSongSchema = v.object({
+  songId: v.string(),
+});
+
+const PlaylistRemoveSongsSchema = v.object({
+  songIds: v.pipe(v.array(v.string()), v.minLength(1), v.maxLength(5000)),
+});
 
 // ---------------------------------------------------------------------------
 // GET /api/playlists — paginated list of playlists
@@ -132,12 +154,19 @@ async function handlePostPlaylist(ctx: RouteContext, request: Request): Promise<
   }
   const { user } = guards;
 
-  let body: { name?: unknown; tagNameLower?: unknown };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
+
+  const parsed = v.safeParse(PlaylistCreateSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
+
+  const body = parsed.output;
 
   const nameResult = validatePlaylistName(body.name);
   if (!nameResult.ok) {
@@ -398,18 +427,25 @@ async function handlePatchVisibility(
   }
   const { user } = guards;
 
-  let body: { isPrivate?: unknown; adminView?: unknown };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  if (typeof body.isPrivate !== 'boolean') {
+  const parsed = v.safeParse(PlaylistVisibilitySchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
+
+  const { isPrivate, adminView: rawAdminView } = parsed.output;
+
+  if (isPrivate === undefined) {
     return json({ error: 'isPrivate (boolean) is required.' }, 400);
   }
 
-  const adminView = body.adminView === true;
+  const adminView = rawAdminView === true;
   const existing = await requirePlaylist(id, user, adminView);
   if (existing instanceof Response) {
     return existing;
@@ -417,7 +453,7 @@ async function handlePatchVisibility(
 
   const [updatedPlaylist] = await db
     .update(playlistTable)
-    .set({ isPrivate: body.isPrivate })
+    .set({ isPrivate })
     .where(eq(playlistTable.id, id))
     .returning();
 
@@ -446,12 +482,19 @@ async function handlePatchPlaylist(
   }
   const { user } = guards;
 
-  let body: { name?: unknown; tagNameLower?: unknown };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
+
+  const parsed = v.safeParse(PlaylistCreateSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
+
+  const body = parsed.output;
 
   const existing = await requirePlaylist(id, user);
   if (existing instanceof Response) {
@@ -541,16 +584,19 @@ async function handleAddSong(
   }
   const { user } = guards;
 
-  let body: { songId?: unknown };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  if (!body.songId) {
+  const parsed = v.safeParse(PlaylistAddSongSchema, raw);
+  if (!parsed.success) {
     return json({ error: 'songId is required.' }, 400);
   }
+
+  const { songId } = parsed.output;
 
   const playlist = await requirePlaylist(id, user);
   if (playlist instanceof Response) {
@@ -567,11 +613,7 @@ async function handleAddSong(
     );
   }
 
-  const [song] = await db
-    .select()
-    .from(tables.song)
-    .where(eq(tables.song.id, body.songId as string))
-    .limit(1);
+  const [song] = await db.select().from(tables.song).where(eq(tables.song.id, songId)).limit(1);
   if (!song) {
     return json({ error: 'Song not found.' }, 404);
   }
@@ -702,18 +744,19 @@ async function handleBulkRemoveSongs(
     return playlist;
   }
 
-  let body: { songIds?: unknown };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  if (!Array.isArray(body.songIds) || body.songIds.length === 0) {
+  const parsed = v.safeParse(PlaylistRemoveSongsSchema, raw);
+  if (!parsed.success) {
     return json({ error: 'songIds must be a non-empty array.' }, 400);
   }
 
-  const songIds = (body.songIds as string[]).slice(0, 5000);
+  const { songIds } = parsed.output;
 
   // Delete and re-index in a transaction
   await db.transaction(async (tx) => {

--- a/packages/server/src/routes/playlists.ts
+++ b/packages/server/src/routes/playlists.ts
@@ -66,6 +66,10 @@ const PlaylistRemoveSongsSchema = v.object({
   songIds: v.pipe(v.array(v.string()), v.minLength(1), v.maxLength(5000)),
 });
 
+const PlaylistReorderSchema = v.object({
+  songIds: v.pipe(v.array(v.string()), v.minLength(1), v.maxLength(5000)),
+});
+
 // ---------------------------------------------------------------------------
 // GET /api/playlists — paginated list of playlists
 // ---------------------------------------------------------------------------
@@ -790,6 +794,87 @@ async function handleBulkRemoveSongs(
 }
 
 // ---------------------------------------------------------------------------
+// PATCH /api/playlists/:id/reorder — reorder songs in a playlist
+// ---------------------------------------------------------------------------
+async function handleReorderSongs(
+  ctx: RouteContext,
+  request: Request,
+  params: Record<string, string>
+): Promise<Response> {
+  const { id: playlistId } = params;
+  const guards = checkGuards(ctx);
+  if (guards instanceof Response) {
+    return guards;
+  }
+  const { user } = guards;
+
+  const playlist = await requirePlaylist(playlistId, user);
+  if (playlist instanceof Response) {
+    return playlist;
+  }
+
+  // Smart playlists are auto-managed — reject manual reorder
+  if (playlist.tagNameLower) {
+    return json({ error: 'Cannot reorder a smart playlist. It is managed by its tag.' }, 409);
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return json({ error: 'Invalid JSON body.' }, 400);
+  }
+
+  const parsed = v.safeParse(PlaylistReorderSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'songIds must be a non-empty array.' }, 400);
+  }
+
+  const { songIds } = parsed.output;
+
+  // Verify all songIds belong to this playlist and the count matches
+  const existing = await db
+    .select({ songId: playlistSongTable.songId })
+    .from(playlistSongTable)
+    .where(eq(playlistSongTable.playlistId, playlistId));
+
+  const existingIds = new Set(existing.map((e) => e.songId));
+
+  if (songIds.length !== existingIds.size) {
+    return json(
+      {
+        error: `songIds count (${songIds.length}) does not match playlist song count (${existingIds.size}).`,
+      },
+      400
+    );
+  }
+
+  for (const id of songIds) {
+    if (!existingIds.has(id)) {
+      return json({ error: `Song ${id} is not in this playlist.` }, 400);
+    }
+  }
+
+  // Delete all and re-insert with new positions in a transaction
+  await db.transaction(async (tx) => {
+    await tx.delete(playlistSongTable).where(eq(playlistSongTable.playlistId, playlistId));
+
+    const rows = songIds.map((songId, index) => ({
+      playlistId,
+      songId,
+      position: index,
+    }));
+
+    await tx.insert(playlistSongTable).values(rows);
+  });
+
+  const value = await getPlaylistSongCount(playlistId);
+  emitPlaylistUpdated(formatPlaylist(playlist, value));
+
+  return json({ message: 'Playlist reordered.' });
+}
+
+// ---------------------------------------------------------------------------
 export const handlePlaylists = routeTable('/api/playlists', {
   rateLimit: { windowMs: 60_000, maxRequests: 20, bucket: 'playlists-mutations' },
   routes: [
@@ -801,6 +886,7 @@ export const handlePlaylists = routeTable('/api/playlists', {
     ['PATCH', '/:id/visibility', handlePatchVisibility],
     ['GET', '/:id', handleGetPlaylist],
     ['PATCH', '/:id', handlePatchPlaylist],
+    ['PATCH', '/:id/reorder', handleReorderSongs],
     ['DELETE', '/:id', handleDeletePlaylist],
   ],
 });

--- a/packages/server/src/routes/requests.ts
+++ b/packages/server/src/routes/requests.ts
@@ -1,4 +1,5 @@
 import { and, eq, inArray, or, sql } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { type RouteContext } from '../lib/context';
 import { getUserDisplayName, resolveDisplayNames } from '../lib/displayName';
@@ -33,14 +34,14 @@ const { song: songTable, songRequest: requestTable } = tables;
 // ---------------------------------------------------------------------------
 
 function formatRequest(row: typeof requestTable.$inferSelect): SongRequest {
-  const base = {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  return {
     ...row,
     createdAt: new Date(row.createdAt).toISOString(),
     closedAt: row.closedAt ? new Date(row.closedAt).toISOString() : null,
     playlistData: row.playlistData,
-    type: row.type as 'track' | 'playlist',
-  };
-  return base as SongRequest;
+    type: row.type === 'playlist' ? 'playlist' : 'track',
+  } as SongRequest;
 }
 
 async function userCanAutoApprove(ctx: RouteContext): Promise<boolean> {
@@ -70,20 +71,29 @@ async function userCanAutoApprove(ctx: RouteContext): Promise<boolean> {
 // ---------------------------------------------------------------------------
 // POST /api/requests/preview — resolve URL metadata without creating.
 // ---------------------------------------------------------------------------
+const PreviewRequestSchema = v.object({
+  url: v.string(),
+});
+
 async function handlePreviewRequest(ctx: RouteContext, request: Request): Promise<Response> {
   const guards = checkGuards(ctx);
   if (guards instanceof Response) {
     return guards;
   }
 
-  let body: { url?: unknown };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  const urlResult = validateSourceUrl(body.url);
+  const parsed = v.safeParse(PreviewRequestSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
+
+  const urlResult = validateSourceUrl(parsed.output.url);
   if (!urlResult.ok) {
     return urlResult.response;
   }
@@ -160,6 +170,20 @@ async function handlePreviewRequest(ctx: RouteContext, request: Request): Promis
   });
 }
 
+const CreateRequestSchema = v.partial(
+  v.object({
+    sourceUrl: v.unknown(),
+    notifyDm: v.unknown(),
+    nickname: v.unknown(),
+    artist: v.unknown(),
+    album: v.unknown(),
+    artwork: v.unknown(),
+    tags: v.unknown(),
+    volumeBoost: v.unknown(),
+    type: v.optional(v.union([v.literal('track'), v.literal('playlist')])),
+  })
+);
+
 // ---------------------------------------------------------------------------
 // POST /api/requests — create a song or playlist request.
 // ---------------------------------------------------------------------------
@@ -170,21 +194,19 @@ async function handleCreateRequest(ctx: RouteContext, request: Request): Promise
   }
   const { user } = guards;
 
-  let body: {
-    sourceUrl?: unknown;
-    notifyDm?: unknown;
-    nickname?: unknown;
-    artist?: unknown;
-    album?: unknown;
-    artwork?: unknown;
-    tags?: unknown;
-    volumeBoost?: unknown;
-  };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
+
+  const parsed = v.safeParse(CreateRequestSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
+
+  const body = parsed.output;
 
   const notifyDm = body.notifyDm === true;
 
@@ -610,6 +632,10 @@ async function handleGetRequests(ctx: RouteContext, request: Request): Promise<R
   });
 }
 
+const PatchRequestSchema = v.object({
+  status: v.union([v.literal('approved'), v.literal('denied')]),
+});
+
 // ---------------------------------------------------------------------------
 // PATCH /api/requests/:id — approve or deny a request. Admin only.
 // ---------------------------------------------------------------------------
@@ -625,15 +651,16 @@ async function handlePatchRequest(
   }
   const { user } = guards;
 
-  let body: { status?: unknown };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  if (body.status !== 'approved' && body.status !== 'denied') {
-    return json({ error: 'status must be "approved" or "denied".' }, 400);
+  const parsed = v.safeParse(PatchRequestSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
   }
 
   const [existing] = await db.select().from(requestTable).where(eq(requestTable.id, id)).limit(1);
@@ -646,7 +673,7 @@ async function handlePatchRequest(
     return json({ error: 'This request has already been processed.' }, 409);
   }
 
-  const newStatus = body.status;
+  const newStatus = parsed.output.status;
   const closedAt = new Date();
 
   if (newStatus === 'denied') {

--- a/packages/server/src/routes/requests.ts
+++ b/packages/server/src/routes/requests.ts
@@ -363,8 +363,8 @@ async function handleCreateRequest(ctx: RouteContext, request: Request): Promise
         void (async () => {
           try {
             await sendRequestNotification('approved', formatRequest(reqRow), user, ctx);
-          } catch (err) {
-            logger.warn({ err }, 'Failed to send playlist auto-approve notification');
+          } catch (error) {
+            logger.warn({ error }, 'Failed to send playlist auto-approve notification');
           }
         })();
       }
@@ -518,8 +518,8 @@ async function handleCreateRequest(ctx: RouteContext, request: Request): Promise
       void (async () => {
         try {
           await sendRequestNotification('approved', formatRequest(reqRow), user, ctx);
-        } catch (err) {
-          logger.warn({ err }, 'Failed to send auto-approve notification');
+        } catch (error) {
+          logger.warn({ error }, 'Failed to send auto-approve notification');
         }
       })();
     }
@@ -528,8 +528,8 @@ async function handleCreateRequest(ctx: RouteContext, request: Request): Promise
     if (notifyDm) {
       try {
         await sendRequestDm(user.discordId, 'approved', metadata.title);
-      } catch (err) {
-        logger.warn({ err }, 'Failed to send auto-approve DM');
+      } catch (error) {
+        logger.warn({ error }, 'Failed to send auto-approve DM');
       }
     }
 
@@ -611,7 +611,7 @@ async function handleGetRequests(ctx: RouteContext, request: Request): Promise<R
       .where(where),
   ]);
 
-  const total = parseInt(String(countResult[0]?.count ?? 0), 10);
+  const total = Number.parseInt(String(countResult[0]?.count ?? 0), 10);
 
   // Resolve display names for requesters
   const nameMap = await resolveDisplayNames(requests.map((r) => ({ addedBy: r.requestedBy })));
@@ -694,8 +694,8 @@ async function handlePatchRequest(
     void (async () => {
       try {
         await sendRequestNotification('denied', formatted, user, ctx);
-      } catch (err) {
-        logger.warn({ err }, 'Failed to send denied notification');
+      } catch (error) {
+        logger.warn({ error }, 'Failed to send denied notification');
       }
     })();
 
@@ -703,8 +703,8 @@ async function handlePatchRequest(
     if (existing.notifyDm) {
       try {
         await sendRequestDm(existing.requestedBy, 'denied', existing.title);
-      } catch (err) {
-        logger.warn({ err }, 'Failed to send denied DM');
+      } catch (error) {
+        logger.warn({ error }, 'Failed to send denied DM');
       }
     }
 
@@ -770,8 +770,8 @@ async function handlePatchRequest(
     if (existing.notifyDm) {
       try {
         await sendRequestDm(existing.requestedBy, 'approved', existing.title);
-      } catch (err) {
-        logger.warn({ err }, 'Failed to send approved DM');
+      } catch (error) {
+        logger.warn({ error }, 'Failed to send approved DM');
       }
     }
 
@@ -786,8 +786,8 @@ async function handlePatchRequest(
     void (async () => {
       try {
         await sendRequestNotification('approved', formatted, user, ctx);
-      } catch (err) {
-        logger.warn({ err }, 'Failed to send playlist approved notification');
+      } catch (error) {
+        logger.warn({ error }, 'Failed to send playlist approved notification');
       }
     })();
 
@@ -835,8 +835,8 @@ async function handlePatchRequest(
   if (existing.notifyDm) {
     try {
       await sendRequestDm(existing.requestedBy, 'approved', existing.title);
-    } catch (err) {
-      logger.warn({ err }, 'Failed to send approved DM');
+    } catch (error) {
+      logger.warn({ error }, 'Failed to send approved DM');
     }
   }
 
@@ -851,8 +851,8 @@ async function handlePatchRequest(
   void (async () => {
     try {
       await sendRequestNotification('approved', formatted, user, ctx);
-    } catch (err) {
-      logger.warn({ err }, 'Failed to send approved notification');
+    } catch (error) {
+      logger.warn({ error }, 'Failed to send approved notification');
     }
   })();
 

--- a/packages/server/src/routes/rotation.ts
+++ b/packages/server/src/routes/rotation.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { type RouteContext } from '../lib/context';
 import { json } from '../lib/json';
@@ -7,10 +8,10 @@ import { routeTable } from '../lib/routeTable';
 import { syncAllFilters } from '../lib/syncAllFilters';
 import { db, tables } from '../shared/db';
 
-interface RotationPayload {
-  enabled: boolean;
-  rotationHz: number;
-}
+const RotationSchema = v.object({
+  enabled: v.boolean(),
+  rotationHz: v.pipe(v.number(), v.minValue(0), v.maxValue(1)),
+});
 
 function handleRotationGet(
   ctx: RouteContext,
@@ -40,21 +41,19 @@ async function handleRotationPatch(
     return guards;
   }
 
-  let body: RotationPayload;
+  let raw: unknown;
   try {
-    body = (await request.json()) as RotationPayload;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON' }, 400);
   }
 
-  const { enabled, rotationHz } = body;
+  const parsed = v.safeParse(RotationSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
 
-  if (typeof enabled !== 'boolean') {
-    return json({ error: 'enabled must be boolean' }, 400);
-  }
-  if (typeof rotationHz !== 'number' || rotationHz < 0 || rotationHz > 1) {
-    return json({ error: 'rotationHz must be number 0.0 to 1.0' }, 400);
-  }
+  const { enabled, rotationHz } = parsed.output;
 
   db.insert(tables.guildSettings)
     .values({

--- a/packages/server/src/routes/rotation.ts
+++ b/packages/server/src/routes/rotation.ts
@@ -27,7 +27,7 @@ function handleRotationGet(
 
   return json({
     enabled: row?.rotationEnabled ?? false,
-    rotationHz: row?.rotationHz ?? 0.0,
+    rotationHz: row?.rotationHz ?? 0,
   });
 }
 

--- a/packages/server/src/routes/setup.ts
+++ b/packages/server/src/routes/setup.ts
@@ -122,8 +122,8 @@ async function handleGetGuilds(
     }));
 
     return json({ guilds: result });
-  } catch (err) {
-    logger.error({ err }, 'Error fetching bot guilds');
+  } catch (error) {
+    logger.error({ error }, 'Error fetching bot guilds');
     return json({ error: 'Could not fetch guild list.' }, 502);
   }
 }
@@ -205,8 +205,8 @@ async function handleGetChannels(
 
     channelsCache.set(guildId, { data: result, expiresAt: Date.now() + CACHE_TTL_MS });
     return json({ channels: result });
-  } catch (err) {
-    logger.error({ err }, 'Error fetching guild channels');
+  } catch (error) {
+    logger.error({ error }, 'Error fetching guild channels');
     return json({ error: 'Could not fetch channels.' }, 502);
   }
 }
@@ -320,8 +320,8 @@ async function handlePostComplete(
     refreshEnabledSources(enabledSources);
 
     return json({ success: true });
-  } catch (err) {
-    logger.error({ err }, 'Failed to save setup configuration');
+  } catch (error) {
+    logger.error({ error }, 'Failed to save setup configuration');
     return json({ error: 'Could not save configuration.' }, 500);
   }
 }

--- a/packages/server/src/routes/setup.ts
+++ b/packages/server/src/routes/setup.ts
@@ -61,6 +61,7 @@ async function handleGetStatus(
           headers: botHeaders(),
         });
         if (res.ok) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
           const guild = (await res.json()) as { name: string };
           guildName = guild.name;
         }
@@ -107,6 +108,7 @@ async function handleGetGuilds(
       return json({ error: 'Could not fetch guild list from Discord.' }, 502);
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     const guilds = (await res.json()) as {
       id: string;
       name: string;
@@ -186,6 +188,7 @@ async function handleGetChannels(
       return json({ error: 'Could not fetch channels from Discord.' }, 502);
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     const channels = (await res.json()) as {
       id: string;
       name: string;
@@ -233,6 +236,7 @@ async function handlePostComplete(
   };
 
   try {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     body = (await request.json()) as typeof body;
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);

--- a/packages/server/src/routes/songs.ts
+++ b/packages/server/src/routes/songs.ts
@@ -3,7 +3,7 @@ import * as v from 'valibot';
 
 import { getGuildId } from '../lib/config';
 import { type RouteContext } from '../lib/context';
-import { resolveDisplayNames } from '../lib/displayName';
+import { getUserDisplayName, resolveDisplayNames } from '../lib/displayName';
 import { json } from '../lib/json';
 import { parsePagination } from '../lib/pagination';
 import { checkGuards } from '../lib/routeGuards';
@@ -127,8 +127,13 @@ async function handleBulkTag(ctx: RouteContext, request: Request): Promise<Respo
   // Re-fetch updated songs and emit events
   const updatedSongs = await db.select().from(songTable).where(inArray(songTable.id, updatedIds));
 
+  // Resolve display names before emitting so the frontend doesn't lose them
+  const bulkTagNameMap = await resolveDisplayNames(updatedSongs);
   for (const s of updatedSongs) {
-    emitSongUpdated(formatSong(s));
+    emitSongUpdated({
+      ...formatSong(s),
+      addedByDisplayName: bulkTagNameMap.get(s.addedBy) ?? s.addedBy,
+    });
   }
 
   // If tags changed, re-sync any smart playlists tracking affected tags
@@ -248,8 +253,13 @@ async function handleBulkEdit(ctx: RouteContext, request: Request): Promise<Resp
   // Re-fetch updated songs and emit events
   const updatedSongs = await db.select().from(songTable).where(inArray(songTable.id, ids));
 
+  // Resolve display names before emitting so the frontend doesn't lose them
+  const bulkEditNameMap = await resolveDisplayNames(updatedSongs);
   for (const s of updatedSongs) {
-    emitSongUpdated(formatSong(s));
+    emitSongUpdated({
+      ...formatSong(s),
+      addedByDisplayName: bulkEditNameMap.get(s.addedBy) ?? s.addedBy,
+    });
   }
 
   // If tags changed, re-sync any smart playlists tracking affected tags
@@ -261,10 +271,12 @@ async function handleBulkEdit(ctx: RouteContext, request: Request): Promise<Resp
   // in the queue / now playing.
   const bulkPlayer = getPlayer(getGuildId());
   if (bulkPlayer) {
-    if (processedVolumeBoost != null) {
+    // Use !== undefined so we handle explicit null (clear boost → 0)
+    // as well as explicit 0.
+    if (processedVolumeBoost !== undefined) {
       const currentSong = bulkPlayer.getCurrentSong();
       if (currentSong && ids.includes(currentSong.id)) {
-        bulkPlayer.updateVolumeBoost(processedVolumeBoost);
+        bulkPlayer.updateVolumeBoost(processedVolumeBoost ?? 0);
       }
     }
     const bulkFields: Record<string, unknown> = {};
@@ -505,7 +517,11 @@ async function handlePatchSong(
     return json({ error: 'Failed to update song.' }, 500);
   }
 
-  emitSongUpdated(formatSong(updatedSong));
+  const patchedDisplayName = await getUserDisplayName(updatedSong.addedBy);
+  emitSongUpdated({
+    ...formatSong(updatedSong),
+    addedByDisplayName: patchedDisplayName,
+  });
 
   // If tags changed, re-sync any smart playlists tracking affected tags
   if (processedTags) {
@@ -518,11 +534,13 @@ async function handlePatchSong(
   // regular queue) so the UI reflects metadata changes immediately.
   const player = getPlayer(getGuildId());
   if (player) {
-    // Volume boost also needs live audio update
-    if (processedVolumeBoost != null) {
+    // Volume boost also needs live audio update.
+    // Use !== undefined so we handle explicit null (clear boost → 0)
+    // as well as explicit 0.
+    if (processedVolumeBoost !== undefined) {
       const currentSong = player.getCurrentSong();
       if (currentSong?.id === id) {
-        player.updateVolumeBoost(processedVolumeBoost);
+        player.updateVolumeBoost(processedVolumeBoost ?? 0);
       }
     }
 

--- a/packages/server/src/routes/songs.ts
+++ b/packages/server/src/routes/songs.ts
@@ -1,4 +1,5 @@
 import { eq, inArray, sql } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { getGuildId } from '../lib/config';
 import { type RouteContext } from '../lib/context';
@@ -29,6 +30,10 @@ import { getPlayer } from '../startDiscord';
 
 const { song: songTable } = tables;
 
+const BulkDeleteSchema = v.object({
+  ids: v.pipe(v.array(v.string()), v.minLength(1), v.maxLength(5000)),
+});
+
 // ---------------------------------------------------------------------------
 // POST /api/songs/bulk-delete — delete multiple songs at once.
 // ---------------------------------------------------------------------------
@@ -38,18 +43,19 @@ async function handleBulkDelete(ctx: RouteContext, request: Request): Promise<Re
     return guards;
   }
 
-  let body: { ids?: unknown };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  if (!Array.isArray(body.ids) || body.ids.length === 0) {
-    return json({ error: 'ids must be a non-empty array of song IDs.' }, 400);
+  const parsed = v.safeParse(BulkDeleteSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
   }
 
-  const ids = body.ids.slice(0, 5000) as string[];
+  const { ids } = parsed.output;
 
   // Delete songs from DB
   await db.delete(songTable).where(inArray(songTable.id, ids));
@@ -62,6 +68,12 @@ async function handleBulkDelete(ctx: RouteContext, request: Request): Promise<Re
   return json({ deleted: ids.length });
 }
 
+const BulkTagSchema = v.object({
+  ids: v.pipe(v.array(v.string()), v.minLength(1), v.maxLength(5000)),
+  tags: v.optional(v.array(v.string())),
+  mode: v.optional(v.pipe(v.string(), v.picklist(['add', 'set']))),
+});
+
 // ---------------------------------------------------------------------------
 // POST /api/songs/bulk-tag — add or set tags on multiple songs at once.
 // ---------------------------------------------------------------------------
@@ -71,25 +83,27 @@ async function handleBulkTag(ctx: RouteContext, request: Request): Promise<Respo
     return guards;
   }
 
-  let body: { ids?: unknown; tags?: unknown; mode?: unknown };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  if (!Array.isArray(body.ids) || body.ids.length === 0) {
-    return json({ error: 'ids must be a non-empty array of song IDs.' }, 400);
+  const parsed = v.safeParse(BulkTagSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
   }
 
-  const tagsResult = validateTags(body.tags);
+  const { ids } = parsed.output;
+
+  const tagsResult = validateTags(parsed.output.tags);
   if (!tagsResult.ok) {
     return tagsResult.response;
   }
 
-  const ids = (body.ids as string[]).slice(0, 5000);
   const newTags = await canonicalizeTags(tagsResult.value);
-  const mode = body.mode === 'set' ? 'set' : 'add'; // "add" is default (merge with existing)
+  const mode = parsed.output.mode ?? 'add';
 
   // Fetch existing songs
   const existingSongs = await db.select().from(songTable).where(inArray(songTable.id, ids));
@@ -135,35 +149,36 @@ async function handleBulkEdit(ctx: RouteContext, request: Request): Promise<Resp
     return guards;
   }
 
-  let body: {
-    ids?: unknown;
-    nickname?: unknown;
-    artist?: unknown;
-    album?: unknown;
-    artwork?: unknown;
-    tags?: unknown;
-    volumeBoost?: unknown;
-    clearFields?: unknown;
-  };
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  if (!Array.isArray(body.ids) || body.ids.length === 0) {
-    return json({ error: 'ids must be a non-empty array of song IDs.' }, 400);
+  const BulkEditBaseSchema = v.object({
+    ids: v.pipe(v.array(v.string()), v.minLength(1), v.maxLength(5000)),
+    nickname: v.optional(v.string()),
+    artist: v.optional(v.string()),
+    album: v.optional(v.string()),
+    artwork: v.optional(v.string()),
+    tags: v.optional(v.array(v.string())),
+    volumeBoost: v.optional(v.number()),
+    clearFields: v.optional(v.array(v.string())),
+  });
+
+  const parsed = v.safeParse(BulkEditBaseSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
   }
 
-  const ids = (body.ids as string[]).slice(0, 5000);
-  const clearFields: string[] = Array.isArray(body.clearFields)
-    ? (body.clearFields as string[])
-    : [];
+  const { ids, clearFields = [] } = parsed.output;
+  const body = parsed.output;
 
   const data: Record<string, unknown> = {};
 
   // Nickname
-  if ('nickname' in body && body.nickname !== undefined) {
+  if (body.nickname !== undefined) {
     const result = validateNickname(body.nickname);
     if (!result.ok) {
       return result.response;
@@ -174,21 +189,21 @@ async function handleBulkEdit(ctx: RouteContext, request: Request): Promise<Resp
   }
 
   // Artist
-  if ('artist' in body && body.artist !== undefined) {
+  if (body.artist !== undefined) {
     data.artist = validateOptionalString(body.artist);
   } else if (clearFields.includes('artist')) {
     data.artist = null;
   }
 
   // Album
-  if ('album' in body && body.album !== undefined) {
+  if (body.album !== undefined) {
     data.album = validateOptionalString(body.album);
   } else if (clearFields.includes('album')) {
     data.album = null;
   }
 
   // Artwork
-  if ('artwork' in body && body.artwork !== undefined) {
+  if (body.artwork !== undefined) {
     const artworkResult = validateArtworkUrl(body.artwork);
     if (!artworkResult.ok) {
       return artworkResult.response;
@@ -199,23 +214,27 @@ async function handleBulkEdit(ctx: RouteContext, request: Request): Promise<Resp
   }
 
   // Tags
-  if ('tags' in body && body.tags !== undefined) {
+  let processedTags: string[] | undefined;
+  if (body.tags !== undefined) {
     const tagsResult = validateTags(body.tags);
     if (!tagsResult.ok) {
       return tagsResult.response;
     }
-    data.tags = await canonicalizeTags(tagsResult.value);
+    processedTags = await canonicalizeTags(tagsResult.value);
+    data.tags = processedTags;
   } else if (clearFields.includes('tags')) {
     data.tags = [];
   }
 
   // Volume boost
-  if ('volumeBoost' in body && body.volumeBoost !== undefined) {
+  let processedVolumeBoost: number | null | undefined;
+  if (body.volumeBoost !== undefined) {
     const volumeResult = validateVolumeBoost(body.volumeBoost);
     if (!volumeResult.ok) {
       return volumeResult.response;
     }
-    data.volumeBoost = volumeResult.value;
+    processedVolumeBoost = volumeResult.value;
+    data.volumeBoost = processedVolumeBoost;
   } else if (clearFields.includes('volumeBoost')) {
     data.volumeBoost = null;
   }
@@ -234,18 +253,18 @@ async function handleBulkEdit(ctx: RouteContext, request: Request): Promise<Resp
   }
 
   // If tags changed, re-sync any smart playlists tracking affected tags
-  if ('tags' in data) {
-    await reSyncPlaylistsForTags(((data.tags as string[]) ?? []).map((t) => t.toLowerCase()));
+  if (processedTags) {
+    await reSyncPlaylistsForTags(processedTags.map((t) => t.toLowerCase()));
   }
 
   // Update the player cache for any of the edited songs that are currently
   // in the queue / now playing.
   const bulkPlayer = getPlayer(getGuildId());
   if (bulkPlayer) {
-    if ('volumeBoost' in data) {
+    if (processedVolumeBoost != null) {
       const currentSong = bulkPlayer.getCurrentSong();
       if (currentSong && ids.includes(currentSong.id)) {
-        bulkPlayer.updateVolumeBoost(data.volumeBoost as number);
+        bulkPlayer.updateVolumeBoost(processedVolumeBoost);
       }
     }
     const bulkFields: Record<string, unknown> = {};
@@ -391,12 +410,14 @@ async function handlePatchSong(
     return guards;
   }
 
-  let body: Record<string, unknown>;
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
+
+  const body = raw as Record<string, unknown>;
 
   const [existing] = await db.select().from(songTable).where(eq(songTable.id, id)).limit(1);
   if (!existing) {
@@ -436,22 +457,26 @@ async function handlePatchSong(
   // Tags
   // Track old tags for smart playlist re-sync
   const oldTagsLower = new Set((existing.tags ?? []).map((t: string) => t.toLowerCase()));
+  let processedTags: string[] | undefined;
 
   if ('tags' in body) {
     const tagsResult = validateTags(body.tags);
     if (!tagsResult.ok) {
       return tagsResult.response;
     }
-    data.tags = await canonicalizeTags(tagsResult.value);
+    processedTags = await canonicalizeTags(tagsResult.value);
+    data.tags = processedTags;
   }
 
   // Volume boost
+  let processedVolumeBoost: number | null | undefined;
   if ('volumeBoost' in body) {
     const volumeResult = validateVolumeBoost(body.volumeBoost);
     if (!volumeResult.ok) {
       return volumeResult.response;
     }
-    data.volumeBoost = volumeResult.value;
+    processedVolumeBoost = volumeResult.value;
+    data.volumeBoost = processedVolumeBoost;
   }
 
   const [updatedSong] = await db
@@ -467,10 +492,8 @@ async function handlePatchSong(
   emitSongUpdated(formatSong(updatedSong));
 
   // If tags changed, re-sync any smart playlists tracking affected tags
-  if ('tags' in data) {
-    const newTagsLower = new Set(
-      ((data.tags as string[]) ?? []).map((t: string) => t.toLowerCase())
-    );
+  if (processedTags) {
+    const newTagsLower = new Set(processedTags.map((t) => t.toLowerCase()));
     const affectedTags = [...new Set([...oldTagsLower, ...newTagsLower])];
     await reSyncPlaylistsForTags(affectedTags);
   }
@@ -480,10 +503,10 @@ async function handlePatchSong(
   const player = getPlayer(getGuildId());
   if (player) {
     // Volume boost also needs live audio update
-    if (data.volumeBoost !== undefined) {
+    if (processedVolumeBoost != null) {
       const currentSong = player.getCurrentSong();
       if (currentSong?.id === id) {
-        player.updateVolumeBoost(data.volumeBoost as number);
+        player.updateVolumeBoost(processedVolumeBoost);
       }
     }
 

--- a/packages/server/src/routes/songs.ts
+++ b/packages/server/src/routes/songs.ts
@@ -396,6 +396,17 @@ async function handleDeleteSong(
   return new Response(null, { status: 204 });
 }
 
+const SongPatchSchema = v.partial(
+  v.object({
+    nickname: v.unknown(),
+    artist: v.unknown(),
+    album: v.unknown(),
+    artwork: v.unknown(),
+    tags: v.unknown(),
+    volumeBoost: v.unknown(),
+  })
+);
+
 // ---------------------------------------------------------------------------
 // PATCH /api/songs/:id — update song fields. Admin only.
 // ---------------------------------------------------------------------------
@@ -417,7 +428,12 @@ async function handlePatchSong(
     return json({ error: 'Invalid JSON body.' }, 400);
   }
 
-  const body = raw as Record<string, unknown>;
+  const parsed = v.safeParse(SongPatchSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
+
+  const body = parsed.output;
 
   const [existing] = await db.select().from(songTable).where(eq(songTable.id, id)).limit(1);
   if (!existing) {
@@ -427,7 +443,7 @@ async function handlePatchSong(
   const data: Record<string, unknown> = {};
 
   // Nickname
-  if ('nickname' in body) {
+  if (body.nickname !== undefined) {
     const result = validateNickname(body.nickname);
     if (!result.ok) {
       return result.response;
@@ -436,17 +452,17 @@ async function handlePatchSong(
   }
 
   // Artist
-  if ('artist' in body) {
+  if (body.artist !== undefined) {
     data.artist = validateOptionalString(body.artist);
   }
 
   // Album
-  if ('album' in body) {
+  if (body.album !== undefined) {
     data.album = validateOptionalString(body.album);
   }
 
   // Artwork
-  if ('artwork' in body) {
+  if (body.artwork !== undefined) {
     const artworkResult = validateArtworkUrl(body.artwork);
     if (!artworkResult.ok) {
       return artworkResult.response;
@@ -459,7 +475,7 @@ async function handlePatchSong(
   const oldTagsLower = new Set((existing.tags ?? []).map((t: string) => t.toLowerCase()));
   let processedTags: string[] | undefined;
 
-  if ('tags' in body) {
+  if (body.tags !== undefined) {
     const tagsResult = validateTags(body.tags);
     if (!tagsResult.ok) {
       return tagsResult.response;
@@ -470,7 +486,7 @@ async function handlePatchSong(
 
   // Volume boost
   let processedVolumeBoost: number | null | undefined;
-  if ('volumeBoost' in body) {
+  if (body.volumeBoost !== undefined) {
     const volumeResult = validateVolumeBoost(body.volumeBoost);
     if (!volumeResult.ok) {
       return volumeResult.response;

--- a/packages/server/src/routes/songs.ts
+++ b/packages/server/src/routes/songs.ts
@@ -348,7 +348,7 @@ async function handleGetSongs(ctx: RouteContext, request: Request): Promise<Resp
       .from(songTable)
       .where(where),
   ]);
-  const total = parseInt(String(countResult[0]?.count ?? 0), 10);
+  const total = Number.parseInt(String(countResult[0]?.count ?? 0), 10);
 
   // Resolve Discord display names for unique addedBy IDs
   const nameMap = await resolveDisplayNames(songs);

--- a/packages/server/src/routes/tags.ts
+++ b/packages/server/src/routes/tags.ts
@@ -1,4 +1,5 @@
 import { eq, sql } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { type RouteContext } from '../lib/context';
 import { json } from '../lib/json';
@@ -10,7 +11,6 @@ import { db, tables } from '../shared/db';
 const { tag: tagTable, song: songTable, playlist: playlistTable } = tables;
 
 const TAG_COLORS = ['orange', 'sky', 'emerald', 'amber', 'violet'] as const;
-type TagColor = (typeof TAG_COLORS)[number];
 
 // ---------------------------------------------------------------------------
 // GET /api/tags — list all tags
@@ -80,6 +80,13 @@ function handleGetTagSongs(
   return json({ songs });
 }
 
+const TagPatchSchema = v.partial(
+  v.object({
+    canonicalName: v.pipe(v.string(), v.minLength(1)),
+    color: v.nullable(v.picklist(TAG_COLORS)),
+  })
+);
+
 async function handlePatchTag(
   ctx: RouteContext,
   request: Request,
@@ -87,12 +94,20 @@ async function handlePatchTag(
 ): Promise<Response> {
   const { nameLower } = params;
 
-  let body: Record<string, unknown>;
+  let raw: unknown;
   try {
-    body = (await request.json()) as typeof body;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON body.' }, 400);
   }
+
+  const parsed = v.safeParse(TagPatchSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
+
+  const body = parsed.output;
+
   const guards = checkGuards(ctx, { admin: true, permission: 'tags.manage' });
   if (guards instanceof Response) {
     return guards;
@@ -109,20 +124,11 @@ async function handlePatchTag(
 
   const data: Record<string, unknown> = {};
 
-  if ('canonicalName' in body) {
-    if (typeof body.canonicalName !== 'string' || body.canonicalName.trim().length === 0) {
-      return json({ error: 'canonicalName must be a non-empty string.' }, 400);
-    }
+  if (body.canonicalName !== undefined) {
     data.canonicalName = body.canonicalName.replace(/\s+/g, '-').trim();
   }
 
-  if ('color' in body) {
-    if (body.color !== null && typeof body.color !== 'string') {
-      return json({ error: 'color must be a string or null.' }, 400);
-    }
-    if (body.color !== null && !TAG_COLORS.includes(body.color as TagColor)) {
-      return json({ error: `color must be one of: ${TAG_COLORS.join(', ')}.` }, 400);
-    }
+  if (body.color !== undefined) {
     data.color = body.color;
   }
 

--- a/packages/server/src/routes/timescale.ts
+++ b/packages/server/src/routes/timescale.ts
@@ -13,9 +13,9 @@ import { getPlayer } from '../startDiscord';
 
 const TimescaleSchema = v.object({
   enabled: v.boolean(),
-  speed: v.pipe(v.number(), v.minValue(0.5), v.maxValue(2.0)),
-  pitch: v.pipe(v.number(), v.minValue(0.5), v.maxValue(2.0)),
-  rate: v.pipe(v.number(), v.minValue(0.5), v.maxValue(2.0)),
+  speed: v.pipe(v.number(), v.minValue(0.5), v.maxValue(2)),
+  pitch: v.pipe(v.number(), v.minValue(0.5), v.maxValue(2)),
+  rate: v.pipe(v.number(), v.minValue(0.5), v.maxValue(2)),
 });
 
 function handleTimescaleGet(
@@ -32,9 +32,9 @@ function handleTimescaleGet(
 
   return json({
     enabled: row?.timescaleEnabled ?? false,
-    speed: row?.timescaleSpeed ?? 1.0,
-    pitch: row?.timescalePitch ?? 1.0,
-    rate: row?.timescaleRate ?? 1.0,
+    speed: row?.timescaleSpeed ?? 1,
+    pitch: row?.timescalePitch ?? 1,
+    rate: row?.timescaleRate ?? 1,
   });
 }
 

--- a/packages/server/src/routes/timescale.ts
+++ b/packages/server/src/routes/timescale.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { getGuildId } from '../lib/config';
 import { type RouteContext } from '../lib/context';
@@ -10,12 +11,12 @@ import { syncAllFilters } from '../lib/syncAllFilters';
 import { db, tables } from '../shared/db';
 import { getPlayer } from '../startDiscord';
 
-interface TimescalePayload {
-  enabled: boolean;
-  speed: number;
-  pitch: number;
-  rate: number;
-}
+const TimescaleSchema = v.object({
+  enabled: v.boolean(),
+  speed: v.pipe(v.number(), v.minValue(0.5), v.maxValue(2.0)),
+  pitch: v.pipe(v.number(), v.minValue(0.5), v.maxValue(2.0)),
+  rate: v.pipe(v.number(), v.minValue(0.5), v.maxValue(2.0)),
+});
 
 function handleTimescaleGet(
   ctx: RouteContext,
@@ -47,27 +48,19 @@ async function handleTimescalePatch(
     return guards;
   }
 
-  let body: TimescalePayload;
+  let raw: unknown;
   try {
-    body = (await request.json()) as TimescalePayload;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON' }, 400);
   }
 
-  const { enabled, speed, pitch, rate } = body;
+  const parsed = v.safeParse(TimescaleSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
 
-  if (typeof enabled !== 'boolean') {
-    return json({ error: 'enabled must be boolean' }, 400);
-  }
-  if (typeof speed !== 'number' || speed < 0.5 || speed > 2.0) {
-    return json({ error: 'speed must be number 0.5 to 2.0' }, 400);
-  }
-  if (typeof pitch !== 'number' || pitch < 0.5 || pitch > 2.0) {
-    return json({ error: 'pitch must be number 0.5 to 2.0' }, 400);
-  }
-  if (typeof rate !== 'number' || rate < 0.5 || rate > 2.0) {
-    return json({ error: 'rate must be number 0.5 to 2.0' }, 400);
-  }
+  const { enabled, speed, pitch, rate } = parsed.output;
 
   db.insert(tables.guildSettings)
     .values({

--- a/packages/server/src/routes/tremolo.ts
+++ b/packages/server/src/routes/tremolo.ts
@@ -10,7 +10,7 @@ import { db, tables } from '../shared/db';
 
 const TremoloSchema = v.object({
   enabled: v.boolean(),
-  frequency: v.pipe(v.number(), v.minValue(0.1), v.maxValue(14.0)),
+  frequency: v.pipe(v.number(), v.minValue(0.1), v.maxValue(14)),
   depth: v.pipe(v.number(), v.minValue(0), v.maxValue(1)),
 });
 
@@ -28,7 +28,7 @@ function handleTremoloGet(
 
   return json({
     enabled: row?.tremoloEnabled ?? false,
-    frequency: row?.tremoloFrequency ?? 2.0,
+    frequency: row?.tremoloFrequency ?? 2,
     depth: row?.tremoloDepth ?? 0.5,
   });
 }

--- a/packages/server/src/routes/tremolo.ts
+++ b/packages/server/src/routes/tremolo.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { type RouteContext } from '../lib/context';
 import { json } from '../lib/json';
@@ -7,11 +8,11 @@ import { routeTable } from '../lib/routeTable';
 import { syncAllFilters } from '../lib/syncAllFilters';
 import { db, tables } from '../shared/db';
 
-interface TremoloPayload {
-  enabled: boolean;
-  frequency: number;
-  depth: number;
-}
+const TremoloSchema = v.object({
+  enabled: v.boolean(),
+  frequency: v.pipe(v.number(), v.minValue(0.1), v.maxValue(14.0)),
+  depth: v.pipe(v.number(), v.minValue(0), v.maxValue(1)),
+});
 
 function handleTremoloGet(
   ctx: RouteContext,
@@ -42,24 +43,19 @@ async function handleTremoloPatch(
     return guards;
   }
 
-  let body: TremoloPayload;
+  let raw: unknown;
   try {
-    body = (await request.json()) as TremoloPayload;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON' }, 400);
   }
 
-  const { enabled, frequency, depth } = body;
+  const parsed = v.safeParse(TremoloSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
 
-  if (typeof enabled !== 'boolean') {
-    return json({ error: 'enabled must be boolean' }, 400);
-  }
-  if (typeof frequency !== 'number' || frequency < 0.1 || frequency > 14.0) {
-    return json({ error: 'frequency must be number 0.1 to 14.0' }, 400);
-  }
-  if (typeof depth !== 'number' || depth < 0 || depth > 1) {
-    return json({ error: 'depth must be number 0.0 to 1.0' }, 400);
-  }
+  const { enabled, frequency, depth } = parsed.output;
 
   db.insert(tables.guildSettings)
     .values({

--- a/packages/server/src/routes/vibrato.ts
+++ b/packages/server/src/routes/vibrato.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import * as v from 'valibot';
 
 import { type RouteContext } from '../lib/context';
 import { json } from '../lib/json';
@@ -7,11 +8,11 @@ import { routeTable } from '../lib/routeTable';
 import { syncAllFilters } from '../lib/syncAllFilters';
 import { db, tables } from '../shared/db';
 
-interface VibratoPayload {
-  enabled: boolean;
-  frequency: number;
-  depth: number;
-}
+const VibratoSchema = v.object({
+  enabled: v.boolean(),
+  frequency: v.pipe(v.number(), v.minValue(0.1), v.maxValue(14.0)),
+  depth: v.pipe(v.number(), v.minValue(0), v.maxValue(1)),
+});
 
 function handleVibratoGet(
   ctx: RouteContext,
@@ -42,24 +43,19 @@ async function handleVibratoPatch(
     return guards;
   }
 
-  let body: VibratoPayload;
+  let raw: unknown;
   try {
-    body = (await request.json()) as VibratoPayload;
+    raw = await request.json();
   } catch {
     return json({ error: 'Invalid JSON' }, 400);
   }
 
-  const { enabled, frequency, depth } = body;
+  const parsed = v.safeParse(VibratoSchema, raw);
+  if (!parsed.success) {
+    return json({ error: 'Invalid request body.', details: v.flatten(parsed.issues) }, 400);
+  }
 
-  if (typeof enabled !== 'boolean') {
-    return json({ error: 'enabled must be boolean' }, 400);
-  }
-  if (typeof frequency !== 'number' || frequency < 0.1 || frequency > 14.0) {
-    return json({ error: 'frequency must be number 0.1 to 14.0' }, 400);
-  }
-  if (typeof depth !== 'number' || depth < 0 || depth > 1) {
-    return json({ error: 'depth must be number 0.0 to 1.0' }, 400);
-  }
+  const { enabled, frequency, depth } = parsed.output;
 
   db.insert(tables.guildSettings)
     .values({

--- a/packages/server/src/routes/vibrato.ts
+++ b/packages/server/src/routes/vibrato.ts
@@ -10,7 +10,7 @@ import { db, tables } from '../shared/db';
 
 const VibratoSchema = v.object({
   enabled: v.boolean(),
-  frequency: v.pipe(v.number(), v.minValue(0.1), v.maxValue(14.0)),
+  frequency: v.pipe(v.number(), v.minValue(0.1), v.maxValue(14)),
   depth: v.pipe(v.number(), v.minValue(0), v.maxValue(1)),
 });
 
@@ -28,7 +28,7 @@ function handleVibratoGet(
 
   return json({
     enabled: row?.vibratoEnabled ?? false,
-    frequency: row?.vibratoFrequency ?? 2.0,
+    frequency: row?.vibratoFrequency ?? 2,
     depth: row?.vibratoDepth ?? 0.5,
   });
 }

--- a/packages/server/src/shared/api.ts
+++ b/packages/server/src/shared/api.ts
@@ -381,6 +381,10 @@ export function togglePlaylistVisibility(
   return patch(`/api/playlists/${playlistId}/visibility${params}`, { isPrivate });
 }
 
+export function reorderPlaylistSongs(playlistId: string, songIds: string[]): Promise<void> {
+  return patch(`/api/playlists/${playlistId}/reorder`, { songIds });
+}
+
 // ---------------------------------------------------------------------------
 // Player API Functions
 // ---------------------------------------------------------------------------

--- a/packages/server/src/shared/db/index.ts
+++ b/packages/server/src/shared/db/index.ts
@@ -1,6 +1,8 @@
 import { Database } from 'bun:sqlite';
 import { eq, sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/bun-sqlite';
+import { mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
 
 import * as schema from './schema';
 
@@ -11,10 +13,10 @@ import * as schema from './schema';
 // process, so this does not open a second physical socket.
 // ---------------------------------------------------------------------------
 
-const DATABASE_URL = process.env.DATABASE_URL;
-if (!DATABASE_URL) {
-  throw new Error('DATABASE_URL environment variable is not set');
-}
+const DATABASE_URL = process.env.DATABASE_URL ?? 'data/alfira.db';
+
+// Ensure the parent directory exists (e.g., data/ for local dev).
+mkdirSync(dirname(DATABASE_URL), { recursive: true });
 
 const sqliteDb = new Database(DATABASE_URL, { create: true, strict: true });
 sqliteDb.run('PRAGMA journal_mode=WAL;');

--- a/packages/server/src/shared/db/index.ts
+++ b/packages/server/src/shared/db/index.ts
@@ -60,6 +60,7 @@ export async function findPlaylistWithSongs(playlistId: string) {
     .sort((a, b) => (a.PlaylistSong?.position ?? 0) - (b.PlaylistSong?.position ?? 0))
     .map(
       (r) =>
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         ({
           ...r.PlaylistSong,
           song: r.Song,

--- a/packages/server/src/shared/db/schema.ts
+++ b/packages/server/src/shared/db/schema.ts
@@ -90,7 +90,7 @@ export const guildSettings = sqliteTable('guildSettings', {
   id: integer('id').primaryKey(), // always 1 — single guild row
   compressorEnabled: integer('compressorEnabled', { mode: 'boolean' }).notNull().default(false),
   compressorThreshold: integer('compressorThreshold').notNull().default(-6), // dB, -60 to 0
-  compressorRatio: real('compressorRatio').notNull().default(4.0), // 1.0 to 20.0
+  compressorRatio: real('compressorRatio').notNull().default(4), // 1.0 to 20.0
   compressorAttack: integer('compressorAttack').notNull().default(5), // ms, 0 to 100
   compressorRelease: integer('compressorRelease').notNull().default(50), // ms, 10 to 1000
   compressorGain: integer('compressorGain').notNull().default(3), // dB, 0 to 24
@@ -113,52 +113,52 @@ export const guildSettings = sqliteTable('guildSettings', {
 
   // Karaoke filter
   karaokeEnabled: integer('karaokeEnabled', { mode: 'boolean' }).notNull().default(false),
-  karaokeLevel: real('karaokeLevel').notNull().default(1.0),
-  karaokeMonoLevel: real('karaokeMonoLevel').notNull().default(1.0),
-  karaokeFilterBand: real('karaokeFilterBand').notNull().default(220.0),
-  karaokeFilterWidth: real('karaokeFilterWidth').notNull().default(100.0),
+  karaokeLevel: real('karaokeLevel').notNull().default(1),
+  karaokeMonoLevel: real('karaokeMonoLevel').notNull().default(1),
+  karaokeFilterBand: real('karaokeFilterBand').notNull().default(220),
+  karaokeFilterWidth: real('karaokeFilterWidth').notNull().default(100),
 
   // Timescale filter
   timescaleEnabled: integer('timescaleEnabled', { mode: 'boolean' }).notNull().default(false),
-  timescaleSpeed: real('timescaleSpeed').notNull().default(1.0),
-  timescalePitch: real('timescalePitch').notNull().default(1.0),
-  timescaleRate: real('timescaleRate').notNull().default(1.0),
+  timescaleSpeed: real('timescaleSpeed').notNull().default(1),
+  timescalePitch: real('timescalePitch').notNull().default(1),
+  timescaleRate: real('timescaleRate').notNull().default(1),
 
   // Tremolo filter
   tremoloEnabled: integer('tremoloEnabled', { mode: 'boolean' }).notNull().default(false),
-  tremoloFrequency: real('tremoloFrequency').notNull().default(2.0),
+  tremoloFrequency: real('tremoloFrequency').notNull().default(2),
   tremoloDepth: real('tremoloDepth').notNull().default(0.5),
 
   // Vibrato filter
   vibratoEnabled: integer('vibratoEnabled', { mode: 'boolean' }).notNull().default(false),
-  vibratoFrequency: real('vibratoFrequency').notNull().default(2.0),
+  vibratoFrequency: real('vibratoFrequency').notNull().default(2),
   vibratoDepth: real('vibratoDepth').notNull().default(0.5),
 
   // Rotation filter
   rotationEnabled: integer('rotationEnabled', { mode: 'boolean' }).notNull().default(false),
-  rotationHz: real('rotationHz').notNull().default(0.0),
+  rotationHz: real('rotationHz').notNull().default(0),
 
   // Distortion filter
   distortionEnabled: integer('distortionEnabled', { mode: 'boolean' }).notNull().default(false),
-  distortionSinOffset: real('distortionSinOffset').notNull().default(0.0),
-  distortionSinScale: real('distortionSinScale').notNull().default(1.0),
-  distortionCosOffset: real('distortionCosOffset').notNull().default(0.0),
-  distortionCosScale: real('distortionCosScale').notNull().default(1.0),
-  distortionTanOffset: real('distortionTanOffset').notNull().default(0.0),
-  distortionTanScale: real('distortionTanScale').notNull().default(1.0),
-  distortionOffset: real('distortionOffset').notNull().default(0.0),
-  distortionScale: real('distortionScale').notNull().default(1.0),
+  distortionSinOffset: real('distortionSinOffset').notNull().default(0),
+  distortionSinScale: real('distortionSinScale').notNull().default(1),
+  distortionCosOffset: real('distortionCosOffset').notNull().default(0),
+  distortionCosScale: real('distortionCosScale').notNull().default(1),
+  distortionTanOffset: real('distortionTanOffset').notNull().default(0),
+  distortionTanScale: real('distortionTanScale').notNull().default(1),
+  distortionOffset: real('distortionOffset').notNull().default(0),
+  distortionScale: real('distortionScale').notNull().default(1),
 
   // Channel mix filter
   channelMixEnabled: integer('channelMixEnabled', { mode: 'boolean' }).notNull().default(false),
-  channelMixLeftToLeft: real('channelMixLeftToLeft').notNull().default(1.0),
-  channelMixLeftToRight: real('channelMixLeftToRight').notNull().default(0.0),
-  channelMixRightToLeft: real('channelMixRightToLeft').notNull().default(0.0),
-  channelMixRightToRight: real('channelMixRightToRight').notNull().default(1.0),
+  channelMixLeftToLeft: real('channelMixLeftToLeft').notNull().default(1),
+  channelMixLeftToRight: real('channelMixLeftToRight').notNull().default(0),
+  channelMixRightToLeft: real('channelMixRightToLeft').notNull().default(0),
+  channelMixRightToRight: real('channelMixRightToRight').notNull().default(1),
 
   // Low pass filter
   lowPassEnabled: integer('lowPassEnabled', { mode: 'boolean' }).notNull().default(false),
-  lowPassSmoothing: real('lowPassSmoothing').notNull().default(20.0),
+  lowPassSmoothing: real('lowPassSmoothing').notNull().default(20),
 
   // General setup / admin settings
   guildId: text('guildId'),

--- a/packages/server/src/shared/format.test.ts
+++ b/packages/server/src/shared/format.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test';
+
+import { formatDuration } from './format';
+
+describe('formatDuration', () => {
+  test('formats whole minutes', () => {
+    expect(formatDuration(60)).toBe('1:00');
+    expect(formatDuration(120)).toBe('2:00');
+    expect(formatDuration(600)).toBe('10:00');
+  });
+
+  test('formats seconds under a minute', () => {
+    expect(formatDuration(0)).toBe('0:00');
+    expect(formatDuration(1)).toBe('0:01');
+    expect(formatDuration(30)).toBe('0:30');
+    expect(formatDuration(59)).toBe('0:59');
+  });
+
+  test('formats mixed minutes and seconds', () => {
+    expect(formatDuration(65)).toBe('1:05');
+    expect(formatDuration(125)).toBe('2:05');
+    expect(formatDuration(3661)).toBe('61:01');
+  });
+
+  test('pads seconds to two digits', () => {
+    expect(formatDuration(5)).toBe('0:05');
+    expect(formatDuration(65)).toBe('1:05');
+  });
+
+  test('rounds fractional seconds', () => {
+    expect(formatDuration(0.4)).toBe('0:00');
+    expect(formatDuration(0.5)).toBe('0:01');
+    expect(formatDuration(59.9)).toBe('1:00');
+  });
+
+  test('negative values produce negative output', () => {
+    // formatDuration doesn't guard against negative input — it applies
+    // Math.floor and % to the negative number directly
+    expect(formatDuration(-5)).toBe('-1:-5');
+    expect(formatDuration(-60)).toBe('-1:00');
+  });
+
+  test('handles NaN and Infinity', () => {
+    expect(formatDuration(Number.NaN)).toBe('NaN:NaN');
+    expect(formatDuration(Number.POSITIVE_INFINITY)).toBe('Infinity:NaN');
+  });
+});

--- a/packages/server/src/shared/logger.ts
+++ b/packages/server/src/shared/logger.ts
@@ -16,7 +16,12 @@ const LABELS: Record<LogLevel, string> = {
   fatal: 'FATAL',
 };
 
-const currentLevel: number = LEVELS[(process.env.LOG_LEVEL as LogLevel | undefined) ?? 'info'];
+function isLogLevel(value: string | undefined): value is LogLevel {
+  return value !== undefined && value in LEVELS;
+}
+
+const currentLevel: number =
+  LEVELS[isLogLevel(process.env.LOG_LEVEL) ? process.env.LOG_LEVEL : 'info'];
 
 const useJson = process.env.LOG_FORMAT === 'json';
 const noColor = process.env.NO_COLOR !== undefined || process.env.NODE_ENV === 'production';
@@ -51,12 +56,14 @@ function log(level: LogLevel, first: LogArg, second?: string): void {
   }
 
   const msg: string = typeof first === 'string' ? first : (second ?? '');
-  const meta: Record<string, unknown> | undefined =
-    typeof first === 'object' && first !== null && !(first instanceof Error)
-      ? (first as Record<string, unknown>)
-      : first instanceof Error
-        ? { err: first.message, stack: first.stack }
-        : undefined;
+
+  let meta: Record<string, unknown> | undefined;
+  if (first instanceof Error) {
+    meta = { err: first.message, stack: first.stack };
+  } else if (typeof first === 'object' && first !== null) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    meta = first as Record<string, unknown>;
+  }
 
   if (useJson) {
     const entry = JSON.stringify({

--- a/packages/server/src/shared/logger.ts
+++ b/packages/server/src/shared/logger.ts
@@ -97,9 +97,19 @@ function log(level: LogLevel, first: LogArg, second?: string): void {
 }
 
 export const logger = {
-  debug: (obj: LogArg, msg?: string) => log('debug', obj, msg),
-  info: (obj: LogArg, msg?: string) => log('info', obj, msg),
-  warn: (obj: LogArg, msg?: string) => log('warn', obj, msg),
-  error: (obj: LogArg, msg?: string) => log('error', obj, msg),
-  fatal: (obj: LogArg, msg?: string) => log('fatal', obj, msg),
+  debug: (obj: LogArg, msg?: string) => {
+    log('debug', obj, msg);
+  },
+  info: (obj: LogArg, msg?: string) => {
+    log('info', obj, msg);
+  },
+  warn: (obj: LogArg, msg?: string) => {
+    log('warn', obj, msg);
+  },
+  error: (obj: LogArg, msg?: string) => {
+    log('error', obj, msg);
+  },
+  fatal: (obj: LogArg, msg?: string) => {
+    log('fatal', obj, msg);
+  },
 };

--- a/packages/server/src/shared/queue.test.ts
+++ b/packages/server/src/shared/queue.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+
+import { toQueuedSong } from './queue';
+import { type Song } from './types';
+
+const baseSong: Song = {
+  id: 'abc-123',
+  title: 'Test Song',
+  sourceUrl: 'https://example.com/video',
+  sourceId: 'video-1',
+  duration: 180,
+  thumbnailUrl: 'https://example.com/thumb.jpg',
+  addedBy: 'user-1',
+  createdAt: '2024-01-01T00:00:00.000Z',
+};
+
+describe('toQueuedSong', () => {
+  test('preserves all song properties', () => {
+    const result = toQueuedSong(baseSong, 'TestUser');
+    expect(result.id).toBe(baseSong.id);
+    expect(result.title).toBe(baseSong.title);
+    expect(result.sourceUrl).toBe(baseSong.sourceUrl);
+    expect(result.sourceId).toBe(baseSong.sourceId);
+    expect(result.duration).toBe(baseSong.duration);
+    expect(result.thumbnailUrl).toBe(baseSong.thumbnailUrl);
+    expect(result.addedBy).toBe(baseSong.addedBy);
+    expect(result.createdAt).toBe(baseSong.createdAt);
+  });
+
+  test('attaches requestedBy', () => {
+    const result = toQueuedSong(baseSong, 'DJ Foobar');
+    expect(result.requestedBy).toBe('DJ Foobar');
+  });
+
+  test('preserves optional fields', () => {
+    const songWithOptionals: Song = {
+      ...baseSong,
+      nickname: 'Custom Name',
+      artist: 'Some Artist',
+      album: 'Some Album',
+      tags: ['rock', 'chill'],
+      volumeBoost: 1.5,
+    };
+    const result = toQueuedSong(songWithOptionals, 'User');
+    expect(result.nickname).toBe('Custom Name');
+    expect(result.artist).toBe('Some Artist');
+    expect(result.album).toBe('Some Album');
+    expect(result.tags).toEqual(['rock', 'chill']);
+    expect(result.volumeBoost).toBe(1.5);
+  });
+});

--- a/packages/server/src/shared/shuffle.test.ts
+++ b/packages/server/src/shared/shuffle.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+import { fisherYatesShuffle } from './shuffle';
+
+describe('fisherYatesShuffle', () => {
+  test('preserves array length', () => {
+    const arr = [1, 2, 3, 4, 5];
+    fisherYatesShuffle(arr);
+    expect(arr).toHaveLength(5);
+  });
+
+  test('preserves all original elements', () => {
+    const arr = [1, 2, 3, 4, 5];
+    fisherYatesShuffle(arr);
+    const sorted = [...arr].sort((a, b) => a - b);
+    expect(sorted).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  test('handles empty array', () => {
+    const arr: number[] = [];
+    fisherYatesShuffle(arr);
+    expect(arr).toEqual([]);
+  });
+
+  test('handles single-element array', () => {
+    const arr = [42];
+    fisherYatesShuffle(arr);
+    expect(arr).toEqual([42]);
+  });
+
+  test('mutates the array in place (returns void)', () => {
+    const arr = [1, 2, 3];
+    fisherYatesShuffle(arr);
+    // fisherYatesShuffle returns void — if it returned a value,
+    // we'd have a confusing void expression. We verify it doesn't throw.
+    expect(arr).toHaveLength(3);
+  });
+
+  test('produces a deterministic shuffle with mocked random', () => {
+    const originalRandom = Math.random;
+    Math.random = mock(() => 0);
+
+    const arr = [1, 2, 3, 4, 5];
+    fisherYatesShuffle(arr);
+
+    Math.random = originalRandom;
+
+    // With Math.random always 0, each iteration swaps with index 0,
+    // resulting in a specific deterministic order
+    expect(arr).toHaveLength(5);
+    expect(arr.sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5]);
+  });
+});

--- a/packages/server/src/startDiscord.ts
+++ b/packages/server/src/startDiscord.ts
@@ -45,6 +45,7 @@ const prevVoiceChannel = new Map<string, string | null>();
 // ---------------------------------------------------------------------------
 
 function handleVoiceStateUpdate(data: unknown): void {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
   const d = data as {
     guild_id: string;
     user_id: string;
@@ -124,11 +125,13 @@ function handleVoiceStateUpdate(data: unknown): void {
 }
 
 function handleVoiceServerUpdate(data: unknown): void {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
   const d = data as { guild_id: string; token: string; endpoint: string };
   setPendingConnectionDetails(d.guild_id, d.token, d.endpoint);
 }
 
 function handleReady(data: unknown): void {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
   const ready = data as { user: { id: string; username: string } };
   setBotUserId(ready.user.id);
   logger.info(`Bot logged in as ${ready.user.username}`);

--- a/packages/server/src/startDiscord.ts
+++ b/packages/server/src/startDiscord.ts
@@ -145,8 +145,8 @@ function handleReady(data: unknown): void {
     try {
       await lavalink.connect(wsUrl, NODELINK_AUTH, ready.user.id);
       logger.info('Lavalink WebSocket connected');
-    } catch (err) {
-      logger.error({ err }, 'Lavalink WebSocket connection failed — audio will be unavailable');
+    } catch (error) {
+      logger.error({ error }, 'Lavalink WebSocket connection failed — audio will be unavailable');
     }
   })();
 }

--- a/packages/server/src/utils/nodelink.ts
+++ b/packages/server/src/utils/nodelink.ts
@@ -309,6 +309,7 @@ async function loadTrack(url: string): Promise<LoadTrackResponse> {
   if (!response.ok) {
     throw new Error(`NodeLink REST ${response.status}: ${await response.text()}`);
   }
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
   const data = (await response.json()) as LoadTrackResponse;
   if (data.loadType === 'error' || data.exception) {
     throw new Error(`NodeLink failed to load: ${data.exception?.message ?? 'unknown error'}`);

--- a/packages/server/src/utils/unregisterCommands.ts
+++ b/packages/server/src/utils/unregisterCommands.ts
@@ -38,7 +38,9 @@ async function deleteCommand(
       const errText = await res.text();
       let retryAfter = 1000; // default 1s
       try {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         const err = JSON.parse(errText) as Record<string, unknown>;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         retryAfter = Math.ceil(((err.retry_after as number | undefined) ?? 1) * 1000) + 100; // add buffer
       } catch {
         // ignore parse errors
@@ -81,6 +83,7 @@ export async function unregisterStaleCommands(): Promise<void> {
     return;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
   const commands = (await res.json()) as { id: string; name: string }[];
 
   if (commands.length === 0) {
@@ -104,6 +107,7 @@ export async function unregisterStaleCommands(): Promise<void> {
   );
 
   if (globalRes.ok) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     const globalCommands = (await globalRes.json()) as { id: string; name: string }[];
     for (const cmd of globalCommands) {
       await deleteCommand(

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alfira/web",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -10,6 +10,9 @@
   },
   "dependencies": {
     "@alfira/server": "workspace:*",
+    "@atlaskit/pragmatic-drag-and-drop": "^2.0.1",
+    "@atlaskit/pragmatic-drag-and-drop-auto-scroll": "^3.0.0",
+    "@atlaskit/pragmatic-drag-and-drop-hitbox": "^2.0.0",
     "@phosphor-icons/react": "2.1.10",
     "@tanstack/react-virtual": "3.14.6",
     "masonic": "^4.1.0",

--- a/packages/web/src/api/api.ts
+++ b/packages/web/src/api/api.ts
@@ -60,6 +60,7 @@ export {
   type RequestCreateData,
   removeSongFromPlaylist,
   renamePlaylist,
+  reorderPlaylistSongs,
   startPlayback,
   togglePlaylistVisibility,
   updateGeneralSettings,

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -38,7 +38,9 @@ function extractRateLimit(url: string, headers: Headers): void {
 
 async function fetchWithTimeout(url: string, init?: RequestInit): Promise<Response> {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  const timeout = setTimeout(() => {
+    controller.abort();
+  }, TIMEOUT_MS);
   try {
     return await fetch(url, { ...init, signal: controller.signal });
   } finally {
@@ -63,19 +65,19 @@ let failedQueue: {
 let isSilentRefreshing = false;
 
 function processQueue(error: Error | null): void {
-  failedQueue.forEach((prom) => {
+  for (const prom of failedQueue) {
     if (error) {
       prom.reject(error);
     } else {
       prom.resolve();
     }
-  });
+  }
   failedQueue = [];
 }
 
 function redirectToLogin(reason: string): void {
   if (window.location.pathname !== '/login') {
-    console.warn(`[auth] redirectToLogin: ${reason}`, new Error().stack);
+    console.warn(`[auth] redirectToLogin: ${reason}`, new Error('redirect to login').stack);
     window.location.href = '/login';
   }
 }
@@ -106,8 +108,12 @@ export async function trySilentRefresh(): Promise<boolean> {
     console.warn('[auth] trySilentRefresh: already refreshing, queuing');
     return new Promise<boolean>((resolve, _reject) => {
       failedQueue.push({
-        resolve: () => resolve(true),
-        reject: () => resolve(false),
+        resolve: () => {
+          resolve(true);
+        },
+        reject: () => {
+          resolve(false);
+        },
       });
     });
   }

--- a/packages/web/src/components/AddFilterPopover.tsx
+++ b/packages/web/src/components/AddFilterPopover.tsx
@@ -39,14 +39,16 @@ const FilterTagButton = memo(function FilterTagButton({
 }: FilterTagButtonProps) {
   const explicitColor = tag.color ?? null;
   const colors = getTagColorClasses(tag.canonicalName, explicitColor);
-  const handleClick = useCallback(() => onClick(tag), [onClick, tag]);
+  const handleClick = useCallback(() => {
+    onClick(tag);
+  }, [onClick, tag]);
 
   return (
     <button
       type='button'
-      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium whitespace-nowrap cursor-pointer transition-opacity hover:opacity-80 active:opacity-70 ${
+      className={`inline-flex cursor-pointer items-center gap-1 rounded px-2 py-0.5 text-[11px] font-medium whitespace-nowrap transition-opacity hover:opacity-80 active:opacity-70 ${
         isActive
-          ? `${colors.bg} ${colors.text} ring-1 ring-inset ring-current/30`
+          ? `${colors.bg} ${colors.text} ring-1 ring-current/30 ring-inset`
           : `${colors.bg} ${colors.text} opacity-60 hover:opacity-90`
       }`}
       onClick={handleClick}
@@ -68,20 +70,22 @@ const FilterSourceRow = memo(function FilterSourceRow({
   isActive,
   onToggle,
 }: FilterSourceRowProps) {
-  const handleChange = useCallback(() => onToggle(source.key), [onToggle, source.key]);
+  const handleChange = useCallback(() => {
+    onToggle(source.key);
+  }, [onToggle, source.key]);
 
   return (
     <label
-      className={`flex items-center gap-3 px-3 py-2 rounded-lg cursor-pointer transition-colors select-none ${
+      className={`flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2 transition-colors select-none ${
         isActive ? 'bg-accent/5 text-accent' : 'hover:bg-elevated active:bg-elevated/80 text-muted'
       }`}
     >
       <input type='checkbox' checked={isActive} onChange={handleChange} className='sr-only' />
-      <span className='flex items-center gap-2 flex-1'>
+      <span className='flex flex-1 items-center gap-2'>
         <SourceIcon sourceKey={source.key} />
         <span className='font-body text-sm'>{source.label}</span>
       </span>
-      {isActive && <span className='text-[11px] font-mono text-accent'>active</span>}
+      {isActive && <span className='text-accent font-mono text-[11px]'>active</span>}
     </label>
   );
 });
@@ -163,12 +167,12 @@ export default function AddFilterPopover({
 
   return (
     <Backdrop onClose={onClose}>
-      <SpringUp className='w-full max-w-sm glass-modal flex flex-col max-h-[70vh]'>
-        <div className='p-4 border-b border-border flex items-center justify-between'>
-          <h3 className='font-body font-semibold text-sm text-fg'>Filters</h3>
+      <SpringUp className='glass-modal flex max-h-[70vh] w-full max-w-sm flex-col'>
+        <div className='border-border flex items-center justify-between border-b p-4'>
+          <h3 className='font-body text-fg text-sm font-semibold'>Filters</h3>
           <button
             type='button'
-            className='p-1 rounded hover:bg-elevated transition-colors cursor-pointer'
+            className='hover:bg-elevated cursor-pointer rounded p-1 transition-colors'
             onClick={onClose}
             aria-label='Close'
           >
@@ -178,17 +182,17 @@ export default function AddFilterPopover({
 
         <div className='flex-1 overflow-y-auto'>
           {/* ── Tags section ─────────────────────────────────── */}
-          <div className='p-4 border-b border-border'>
-            <p className='font-mono text-[11px] text-muted uppercase tracking-wider mb-2.5'>Tags</p>
+          <div className='border-border border-b p-4'>
+            <p className='text-muted mb-2.5 font-mono text-[11px] tracking-wider uppercase'>Tags</p>
 
             <div className='relative mb-2.5'>
               <MagnifyingGlassIcon
-                className='absolute left-2.5 top-1/2 -translate-y-1/2 text-faint w-3.5 h-3.5'
+                className='text-faint absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2'
                 weight='duotone'
               />
               <input
                 ref={inputRef}
-                className='input pl-8 py-1.5 text-xs'
+                className='input py-1.5 pl-8 text-xs'
                 placeholder='Search tags...'
                 value={tagSearch}
                 onChange={handleSearchChange}
@@ -196,11 +200,11 @@ export default function AddFilterPopover({
             </div>
 
             {filteredTags.length === 0 ? (
-              <p className='font-mono text-xs text-muted py-2 text-center'>
+              <p className='text-muted py-2 text-center font-mono text-xs'>
                 {tagSearch ? 'no matching tags' : 'no tags available'}
               </p>
             ) : (
-              <div className='flex flex-wrap gap-1.5 max-h-40 overflow-y-auto'>
+              <div className='flex max-h-40 flex-wrap gap-1.5 overflow-y-auto'>
                 {filteredTags.map((tag) => {
                   const isActive = activeTags.includes(tag.nameLower);
                   return (
@@ -218,7 +222,7 @@ export default function AddFilterPopover({
 
           {/* ── Sources section ──────────────────────────────── */}
           <div className='p-4'>
-            <p className='font-mono text-[11px] text-muted uppercase tracking-wider mb-2.5'>
+            <p className='text-muted mb-2.5 font-mono text-[11px] tracking-wider uppercase'>
               Source
             </p>
 

--- a/packages/web/src/components/AddSongModal.tsx
+++ b/packages/web/src/components/AddSongModal.tsx
@@ -56,10 +56,14 @@ export default function AddSongModal({
   // Auto-close after successful submission
   useEffect(() => {
     if (successMsg) {
-      const id = setTimeout(() => onClose(), 1500);
-      return () => clearTimeout(id);
+      const id = setTimeout(() => {
+        onClose();
+      }, 1500);
+      return () => {
+        clearTimeout(id);
+      };
     }
-    return undefined;
+    return;
   }, [successMsg, onClose]);
 
   const handleFetch = useCallback(async () => {
@@ -87,8 +91,8 @@ export default function AddSongModal({
       }
 
       setStep('metadata');
-    } catch (err: unknown) {
-      setError(apiErrorMessage(err, 'Could not fetch track info. Try again.'));
+    } catch (error: unknown) {
+      setError(apiErrorMessage(error, 'Could not fetch track info. Try again.'));
     } finally {
       setLoading(false);
     }
@@ -116,8 +120,8 @@ export default function AddSongModal({
       } else {
         setSuccessMsg('Playlist request submitted! An admin will review it.');
       }
-    } catch (err: unknown) {
-      setError(apiErrorMessage(err, 'Could not import playlist. Try again.'));
+    } catch (error: unknown) {
+      setError(apiErrorMessage(error, 'Could not import playlist. Try again.'));
     } finally {
       setLoading(false);
     }
@@ -132,7 +136,8 @@ export default function AddSongModal({
     setSuccessMsg('');
 
     try {
-      const parsedBoost = volumeBoost.trim() === '' ? null : parseInt(volumeBoost.trim(), 10);
+      const parsedBoost =
+        volumeBoost.trim() === '' ? null : Number.parseInt(volumeBoost.trim(), 10);
 
       const result = await createRequest({
         sourceUrl: url.trim(),
@@ -156,8 +161,8 @@ export default function AddSongModal({
       } else {
         setSuccessMsg('Request submitted! An admin will review it.');
       }
-    } catch (err: unknown) {
-      setError(apiErrorMessage(err, 'Something went wrong. Try again.'));
+    } catch (error: unknown) {
+      setError(apiErrorMessage(error, 'Something went wrong. Try again.'));
     } finally {
       setLoading(false);
     }
@@ -234,7 +239,7 @@ export default function AddSongModal({
   const handleTagPillRemove = useCallback(
     (e: React.MouseEvent<HTMLButtonElement>) => {
       e.stopPropagation();
-      const tag = e.currentTarget.closest('[data-tag]')?.getAttribute('data-tag');
+      const tag = e.currentTarget.closest<HTMLElement>('[data-tag]')?.dataset.tag;
       if (tag) {
         removeTag(tag);
       }
@@ -242,10 +247,9 @@ export default function AddSongModal({
     [removeTag]
   );
 
-  const handleTagInputChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => setTagInput(e.target.value),
-    []
-  );
+  const handleTagInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setTagInput(e.target.value);
+  }, []);
 
   const handleVolumeTextChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const v = e.target.value;
@@ -258,30 +262,29 @@ export default function AddSongModal({
     if (volumeBoost.trim() === '' || volumeBoost === '-') {
       setVolumeBoost('0');
     } else {
-      const n = parseInt(volumeBoost, 10);
+      const n = Number.parseInt(volumeBoost, 10);
       if (!Number.isNaN(n)) {
         setVolumeBoost(String(Math.min(200, Math.max(-100, n))));
       }
     }
   }, [volumeBoost]);
 
-  const handleVolumeRangeChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => setVolumeBoost(e.target.value),
-    []
-  );
+  const handleVolumeRangeChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setVolumeBoost(e.target.value);
+  }, []);
 
   const volumeSliderValue = useMemo(
     () =>
       volumeBoost.trim() === '' || volumeBoost === '-'
         ? 0
-        : Math.min(200, Math.max(-100, parseInt(volumeBoost, 10) || 0)),
+        : Math.min(200, Math.max(-100, Number.parseInt(volumeBoost, 10) || 0)),
     [volumeBoost]
   );
 
   const volumeRangeStyle = useMemo(
     () =>
       ({
-        '--volume-pct': `${((Math.min(200, Math.max(-100, parseInt(volumeBoost, 10) || 0)) + 100) / 300) * 100}%`,
+        '--volume-pct': `${((Math.min(200, Math.max(-100, Number.parseInt(volumeBoost, 10) || 0)) + 100) / 300) * 100}%`,
       }) as React.CSSProperties,
     [volumeBoost]
   );
@@ -290,11 +293,11 @@ export default function AddSongModal({
 
   return (
     <Backdrop onClose={onClose}>
-      <SpringUp className='p-5 md:p-6 w-full max-w-md mx-4 glass-modal'>
-        <h2 className='font-display text-2xl md:text-3xl text-fg tracking-wider mb-1'>
+      <SpringUp className='glass-modal mx-4 w-full max-w-md p-5 md:p-6'>
+        <h2 className='font-display text-fg mb-1 text-2xl tracking-wider md:text-3xl'>
           Request Song
         </h2>
-        <p className='font-mono text-xs text-muted mb-4 md:mb-6'>
+        <p className='text-muted mb-4 font-mono text-xs md:mb-6'>
           {step === 'url' ? 'paste a url' : (preview?.title ?? 'review details')}
         </p>
 
@@ -312,21 +315,21 @@ export default function AddSongModal({
             />
 
             {isPlaylist && (
-              <p className='font-mono text-[10px] text-muted mb-3'>
+              <p className='text-muted mb-3 font-mono text-[10px]'>
                 Playlist detected — Fetch to add a single track, or import the full playlist.
               </p>
             )}
 
-            {error && <p className='font-mono text-xs text-danger mb-3'>{error}</p>}
+            {error && <p className='text-danger mb-3 font-mono text-xs'>{error}</p>}
 
             {loading && (
-              <p className='font-mono text-xs text-muted mb-3 flex items-center gap-2'>
+              <p className='text-muted mb-3 flex items-center gap-2 font-mono text-xs'>
                 <Spinner />
                 loading...
               </p>
             )}
 
-            <div className='flex gap-2 justify-end'>
+            <div className='flex justify-end gap-2'>
               <Button variant='inherit' onClick={onClose} disabled={loading} surface='surface'>
                 Cancel
               </Button>
@@ -351,29 +354,29 @@ export default function AddSongModal({
         {step === 'metadata' && preview && (
           <div className='flex flex-col gap-3'>
             {/* Thumbnail + title + duration + source */}
-            <div className='flex items-center gap-3 -mb-1'>
+            <div className='-mb-1 flex items-center gap-3'>
               {(preview.artworkUrl ?? preview.thumbnailUrl) && (
-                <div className='w-12 h-12 rounded border border-border shrink-0 overflow-hidden bg-elevated'>
+                <div className='border-border bg-elevated h-12 w-12 shrink-0 overflow-hidden rounded border'>
                   <ArtworkImage
                     src={preview.artworkUrl ?? preview.thumbnailUrl}
                     alt='Album art'
-                    className='w-full h-full'
+                    className='h-full w-full'
                   />
                 </div>
               )}
-              <div className='flex flex-col gap-0.5 min-w-0'>
-                <span className='font-body text-sm text-fg truncate'>{preview.title}</span>
+              <div className='flex min-w-0 flex-col gap-0.5'>
+                <span className='font-body text-fg truncate text-sm'>{preview.title}</span>
                 <div className='flex items-center gap-2'>
-                  <span className='font-mono text-xs text-fg'>
+                  <span className='text-fg font-mono text-xs'>
                     {formatSeconds(preview.duration)}
                   </span>
                   {preview.sourceName && (
-                    <span className='font-mono text-[10px] text-faint uppercase'>
+                    <span className='text-faint font-mono text-[10px] uppercase'>
                       {preview.sourceName}
                     </span>
                   )}
                   {preview.isPlaylist && (
-                    <span className='font-mono text-[10px] text-accent uppercase'>
+                    <span className='text-accent font-mono text-[10px] uppercase'>
                       Playlist ({preview.playlistMeta?.videoCount ?? '?'} tracks)
                     </span>
                   )}
@@ -418,13 +421,13 @@ export default function AddSongModal({
             <div>
               <label
                 htmlFor='add-tag-input'
-                className='block font-mono text-[10px] text-muted uppercase mb-1'
+                className='text-muted mb-1 block font-mono text-[10px] uppercase'
               >
                 Tags
               </label>
               {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- container click focuses inner input; keyboard handled by input */}
               <div
-                className='input text-sm flex flex-wrap gap-1.5 items-center min-h-9.5 cursor-text'
+                className='input flex min-h-9.5 cursor-text flex-wrap items-center gap-1.5 text-sm'
                 onClick={handleFocusTagInput}
               >
                 {tags.map((tag) => {
@@ -432,7 +435,7 @@ export default function AddSongModal({
                   return (
                     <span
                       key={tag}
-                      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-mono ${c.bg} ${c.text} border ${c.border}`}
+                      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-mono text-xs ${c.bg} ${c.text} border ${c.border}`}
                     >
                       {tag}
                       <button
@@ -448,7 +451,7 @@ export default function AddSongModal({
                 })}
                 <input
                   id='add-tag-input'
-                  className='flex-1 min-w-20 bg-transparent outline-none text-sm text-fg placeholder:text-faint'
+                  className='text-fg placeholder:text-faint min-w-20 flex-1 bg-transparent text-sm outline-none'
                   placeholder={tags.length === 0 ? 'Custom grouping (enter to confirm)' : ''}
                   value={tagInput}
                   onChange={handleTagInputChange}
@@ -459,19 +462,19 @@ export default function AddSongModal({
 
             {/* Volume Boost */}
             <div>
-              <span className='block font-mono text-[10px] text-muted uppercase mb-1'>
+              <span className='text-muted mb-1 block font-mono text-[10px] uppercase'>
                 Volume Boost
               </span>
               <div className='flex items-center gap-3'>
                 <input
                   id='add-volume-boost'
-                  className='input text-sm w-16 text-center'
+                  className='input w-16 text-center text-sm'
                   type='text'
                   value={volumeBoost}
                   onChange={handleVolumeTextChange}
                   onBlur={handleVolumeBlur}
                 />
-                <span className='text-xs text-muted font-mono w-8 text-left'>%</span>
+                <span className='text-muted w-8 text-left font-mono text-xs'>%</span>
                 <input
                   type='range'
                   min={-100}
@@ -485,21 +488,21 @@ export default function AddSongModal({
             </div>
 
             {/* Notify DM */}
-            <label className='flex items-center gap-2 cursor-pointer'>
+            <label className='flex cursor-pointer items-center gap-2'>
               <Checkbox checked={notifyDm} onChange={setNotifyDm} />
-              <span className='font-mono text-xs text-fg'>DM me when this request is reviewed</span>
+              <span className='text-fg font-mono text-xs'>DM me when this request is reviewed</span>
             </label>
 
-            {error && <p className='font-mono text-xs text-danger'>{error}</p>}
+            {error && <p className='text-danger font-mono text-xs'>{error}</p>}
 
             {loading && (
-              <p className='font-mono text-xs text-muted flex items-center gap-2'>
+              <p className='text-muted flex items-center gap-2 font-mono text-xs'>
                 <Spinner />
                 submitting request...
               </p>
             )}
 
-            <div className='flex gap-2 justify-end mt-1'>
+            <div className='mt-1 flex justify-end gap-2'>
               <Button
                 variant='inherit'
                 onClick={handleBackToUrl}
@@ -515,7 +518,7 @@ export default function AddSongModal({
           </div>
         )}
 
-        {successMsg && <p className='font-mono text-xs text-success mt-3'>{successMsg}</p>}
+        {successMsg && <p className='text-success mt-3 font-mono text-xs'>{successMsg}</p>}
       </SpringUp>
     </Backdrop>
   );
@@ -535,12 +538,14 @@ function Field({
   placeholder?: string;
 }) {
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.value),
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange(e.target.value);
+    },
     [onChange]
   );
   return (
     <div>
-      <label htmlFor={id} className='block font-mono text-[10px] text-muted uppercase mb-1'>
+      <label htmlFor={id} className='text-muted mb-1 block font-mono text-[10px] uppercase'>
         {label}
       </label>
       <input

--- a/packages/web/src/components/AddSongsModal.tsx
+++ b/packages/web/src/components/AddSongsModal.tsx
@@ -1,6 +1,5 @@
 import { type PlaylistDetail, type Song } from '@alfira/server/shared';
 import { formatDuration } from '@alfira/server/shared';
-import { useVirtualizer } from '@tanstack/react-virtual';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { addSongToPlaylist, getSongsPage } from '../api/api';
@@ -9,6 +8,7 @@ import { ArtworkImage } from './ui/ArtworkImage';
 import { Button } from './ui/Button';
 import { Skeleton } from './ui/Skeleton';
 import { SpringUp } from './ui/SpringUp';
+import { VirtualList } from './VirtualList';
 
 const PAGE_SIZE = 30;
 
@@ -24,44 +24,70 @@ export default function AddSongsModal({
   const [songs, setSongs] = useState<Song[]>([]);
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(true);
-  const [loading, setLoading] = useState(true);
-  const [loadingMore, setLoadingMore] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const [isFetching, setIsFetching] = useState(false);
+  const [isError, setIsError] = useState(false);
   const [adding, setAdding] = useState<Set<string>>(new Set());
   const [added, setAdded] = useState<Set<string>>(new Set(playlist.songs.map((ps) => ps.songId)));
   const [search, setSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
   // eslint-disable-next-line unicorn/no-useless-undefined
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const scrollRef = useRef<HTMLDivElement>(null);
 
-  // Stable refs to avoid recreating callbacks on every render
+  // Stable refs so callbacks don't trigger virtualizer re-indexing.
   const hasMoreRef = useRef(true);
-  const loadingMoreRef = useRef(false);
-  const debouncedSearchRef = useRef('');
+  const isFetchingRef = useRef(false);
   const pageRef = useRef(1);
+  const debouncedSearchRef = useRef('');
+  const mountedRef = useRef(true);
   hasMoreRef.current = hasMore;
-  loadingMoreRef.current = loadingMore;
-  debouncedSearchRef.current = debouncedSearch;
+  isFetchingRef.current = isFetching;
   pageRef.current = page;
+  debouncedSearchRef.current = debouncedSearch;
 
-  // Reset and fetch page 1 on search change
+  // Reset and fetch page 1 when debounced search changes.
   useEffect(() => {
+    mountedRef.current = true;
     setSongs([]);
     setPage(1);
     pageRef.current = 1;
     setHasMore(true);
-    setLoading(true);
-    debouncedSearchRef.current = debouncedSearch;
+    hasMoreRef.current = true;
+    setIsLoading(true);
+    setHasLoaded(false);
+    setIsError(false);
+
     void (async () => {
-      const result = await getSongsPage(1, PAGE_SIZE, { search: debouncedSearch || undefined });
-      setSongs(result.items);
-      setHasMore(result.items.length >= PAGE_SIZE);
-      hasMoreRef.current = result.items.length >= PAGE_SIZE;
-      setLoading(false);
+      try {
+        const result = await getSongsPage(1, PAGE_SIZE, {
+          search: debouncedSearch || undefined,
+        });
+        if (!mountedRef.current) {
+          return;
+        }
+        setSongs(result.items);
+        setHasMore(result.items.length >= PAGE_SIZE);
+        hasMoreRef.current = result.items.length >= PAGE_SIZE;
+      } catch {
+        if (!mountedRef.current) {
+          return;
+        }
+        setIsError(true);
+      } finally {
+        if (mountedRef.current) {
+          setIsLoading(false);
+          setHasLoaded(true);
+        }
+      }
     })();
+
+    return () => {
+      mountedRef.current = false;
+    };
   }, [debouncedSearch]);
 
-  // Debounce search input
+  // Debounce search input.
   useEffect(() => {
     if (timerRef.current) {
       clearTimeout(timerRef.current);
@@ -76,50 +102,44 @@ export default function AddSongsModal({
     };
   }, [search]);
 
-  const loadMore = useCallback(() => {
-    if (!hasMoreRef.current || loadingMoreRef.current) {
+  const fetchMore = useCallback(() => {
+    if (!hasMoreRef.current || isFetchingRef.current) {
       return;
     }
-    loadingMoreRef.current = true;
-    setLoadingMore(true);
+    isFetchingRef.current = true;
+    setIsFetching(true);
     const nextPage = pageRef.current + 1;
     void (async () => {
-      const result = await getSongsPage(nextPage, PAGE_SIZE, {
-        search: debouncedSearchRef.current || undefined,
-      });
-      setSongs((prev) => [...prev, ...result.items]);
-      setPage(nextPage);
-      pageRef.current = nextPage;
-      setHasMore(result.items.length >= PAGE_SIZE);
-      hasMoreRef.current = result.items.length >= PAGE_SIZE;
-      loadingMoreRef.current = false;
-      setLoadingMore(false);
+      try {
+        const result = await getSongsPage(nextPage, PAGE_SIZE, {
+          search: debouncedSearchRef.current || undefined,
+        });
+        if (!mountedRef.current) {
+          return;
+        }
+        setSongs((prev) => [...prev, ...result.items]);
+        setPage(nextPage);
+        pageRef.current = nextPage;
+        setHasMore(result.items.length >= PAGE_SIZE);
+        hasMoreRef.current = result.items.length >= PAGE_SIZE;
+      } catch {
+        if (!mountedRef.current) {
+          return;
+        }
+        setIsError(true);
+      } finally {
+        if (mountedRef.current) {
+          setIsFetching(false);
+          isFetchingRef.current = false;
+        }
+      }
     })();
   }, []);
 
-  // Check near-bottom on scroll
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) {
-      return;
-    }
-    const check = () => {
-      if (el.scrollHeight - el.scrollTop - el.clientHeight < 300) {
-        loadMore();
-      }
-    };
-    el.addEventListener('scroll', check, { passive: true });
-    return () => {
-      el.removeEventListener('scroll', check);
-    };
-  }, [loadMore]);
-
-  const virtualizer = useVirtualizer({
-    count: songs.length,
-    getScrollElement: () => scrollRef.current,
-    estimateSize: () => 60,
-    overscan: 5,
-  });
+  const retry = useCallback(() => {
+    setIsError(false);
+    fetchMore();
+  }, [fetchMore]);
 
   const handleAdd = useCallback(
     async (song: Song) => {
@@ -128,7 +148,7 @@ export default function AddSongsModal({
         await addSongToPlaylist(playlist.id, song.id);
         setAdded((prev) => new Set([...prev, song.id]));
       } catch {
-        /* already added — mark as added */
+        // Already in playlist — mark as added regardless.
         setAdded((prev) => new Set([...prev, song.id]));
       } finally {
         setAdding((prev) => {
@@ -147,12 +167,34 @@ export default function AddSongsModal({
     setSearch(e.target.value);
   }, []);
 
-  const virtualContainerStyle = useMemo(
-    () => ({
-      height: `${virtualizer.getTotalSize()}px`,
-      position: 'relative' as const,
-    }),
-    [virtualizer]
+  // Stable callbacks for VirtualList.
+  const estimateSize = useCallback(() => 60, []);
+  const getItemKey = useCallback((song: Song) => song.id, []);
+
+  const renderItem = useCallback(
+    (song: Song) => (
+      <SongRow
+        song={song}
+        isAdded={added.has(song.id)}
+        isAdding={adding.has(song.id)}
+        onAdd={handleAdd}
+      />
+    ),
+    [added, adding, handleAdd]
+  );
+
+  const skeleton = useMemo(
+    () => (
+      <div className='space-y-2 p-4 md:p-6'>
+        {[1, 2, 3, 4, 5].map((n) => (
+          <div key={`skeleton-${n}`} className='flex items-center gap-3'>
+            <Skeleton className='h-8 w-12 rounded md:h-7 md:w-10' />
+            <Skeleton className='h-3 flex-1' />
+          </div>
+        ))}
+      </div>
+    ),
+    []
   );
 
   return (
@@ -160,7 +202,7 @@ export default function AddSongsModal({
       <SpringUp className='glass-modal flex max-h-[80vh] w-full max-w-lg flex-col'>
         <div className='border-border border-b p-4 md:p-5'>
           <h2 className='font-display text-fg text-2xl tracking-wider md:text-3xl'>Add Songs</h2>
-          <p className='text-muted mt-0.5 font-mono text-xs'>to "{playlist.name}"</p>
+          <p className='text-muted mt-0.5 font-mono text-xs'>to &quot;{playlist.name}&quot;</p>
           <input
             className='input mt-3 md:mt-4'
             placeholder='Search...'
@@ -168,51 +210,23 @@ export default function AddSongsModal({
             onChange={handleSearchChange}
           />
         </div>
-        <div ref={scrollRef} className='flex-1 overflow-y-auto'>
-          {loading ? (
-            <div className='space-y-2 p-4 md:p-6'>
-              {[1, 2, 3, 4, 5].map((n) => (
-                <div key={`skeleton-${n}`} className='flex items-center gap-3'>
-                  <Skeleton className='h-8 w-12 rounded md:h-7 md:w-10' />
-                  <Skeleton className='h-3 flex-1' />
-                </div>
-              ))}
-            </div>
-          ) : songs.length === 0 ? (
-            <p className='text-muted p-4 text-center font-mono text-xs md:p-6'>no songs found</p>
-          ) : (
-            <div style={virtualContainerStyle}>
-              {virtualizer.getVirtualItems().map((virtualRow) => {
-                const song = songs[virtualRow.index];
-                if (song == null) {
-                  return null;
-                }
-                const isAdded = added.has(song.id);
-                const isAdding = adding.has(song.id);
-                return (
-                  <div
-                    key={song.id}
-                    data-index={virtualRow.index}
-                    ref={virtualizer.measureElement}
-                    /* eslint-disable-next-line react-perf/jsx-no-new-object-as-prop -- per-row dynamic transform from virtualizer */
-                    style={{
-                      position: 'absolute',
-                      top: 0,
-                      left: 0,
-                      width: '100%',
-                      transform: `translateY(${virtualRow.start}px)`,
-                    }}
-                  >
-                    <SongRow song={song} isAdded={isAdded} isAdding={isAdding} onAdd={handleAdd} />
-                  </div>
-                );
-              })}
-            </div>
-          )}
-          {loadingMore && (
-            <p className='text-muted p-3 text-center font-mono text-xs'>loading...</p>
-          )}
-        </div>
+
+        <VirtualList
+          items={songs}
+          getItemKey={getItemKey}
+          renderItem={renderItem}
+          estimateSize={estimateSize}
+          isLoading={isLoading}
+          hasLoaded={hasLoaded}
+          isFetching={isFetching}
+          isError={isError}
+          hasMore={hasMore}
+          onRetry={retry}
+          onFetchMore={fetchMore}
+          skeleton={skeleton}
+          emptyTitle='No Songs'
+          emptyMessage='No songs found matching your search.'
+        />
 
         <div className='border-border flex justify-end border-t p-4'>
           <Button variant='primary' onClick={hasAddedNew ? onAdded : onClose}>
@@ -223,6 +237,10 @@ export default function AddSongsModal({
     </Backdrop>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Row
+// ---------------------------------------------------------------------------
 
 const SongRow = memo(function SongRow({
   song,

--- a/packages/web/src/components/AddSongsModal.tsx
+++ b/packages/web/src/components/AddSongsModal.tsx
@@ -30,6 +30,7 @@ export default function AddSongsModal({
   const [added, setAdded] = useState<Set<string>>(new Set(playlist.songs.map((ps) => ps.songId)));
   const [search, setSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
+  // eslint-disable-next-line unicorn/no-useless-undefined
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -65,7 +66,9 @@ export default function AddSongsModal({
     if (timerRef.current) {
       clearTimeout(timerRef.current);
     }
-    timerRef.current = setTimeout(() => setDebouncedSearch(search), 200);
+    timerRef.current = setTimeout(() => {
+      setDebouncedSearch(search);
+    }, 200);
     return () => {
       if (timerRef.current) {
         clearTimeout(timerRef.current);
@@ -98,7 +101,7 @@ export default function AddSongsModal({
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) {
-      return undefined;
+      return;
     }
     const check = () => {
       if (el.scrollHeight - el.scrollTop - el.clientHeight < 300) {
@@ -106,7 +109,9 @@ export default function AddSongsModal({
       }
     };
     el.addEventListener('scroll', check, { passive: true });
-    return () => el.removeEventListener('scroll', check);
+    return () => {
+      el.removeEventListener('scroll', check);
+    };
   }, [loadMore]);
 
   const virtualizer = useVirtualizer({
@@ -152,10 +157,10 @@ export default function AddSongsModal({
 
   return (
     <Backdrop onClose={onClose}>
-      <SpringUp className='w-full max-w-lg glass-modal flex flex-col max-h-[80vh]'>
-        <div className='p-4 md:p-5 border-b border-border'>
-          <h2 className='font-display text-2xl md:text-3xl text-fg tracking-wider'>Add Songs</h2>
-          <p className='font-mono text-xs text-muted mt-0.5'>to "{playlist.name}"</p>
+      <SpringUp className='glass-modal flex max-h-[80vh] w-full max-w-lg flex-col'>
+        <div className='border-border border-b p-4 md:p-5'>
+          <h2 className='font-display text-fg text-2xl tracking-wider md:text-3xl'>Add Songs</h2>
+          <p className='text-muted mt-0.5 font-mono text-xs'>to "{playlist.name}"</p>
           <input
             className='input mt-3 md:mt-4'
             placeholder='Search...'
@@ -165,16 +170,16 @@ export default function AddSongsModal({
         </div>
         <div ref={scrollRef} className='flex-1 overflow-y-auto'>
           {loading ? (
-            <div className='p-4 md:p-6 space-y-2'>
+            <div className='space-y-2 p-4 md:p-6'>
               {[1, 2, 3, 4, 5].map((n) => (
                 <div key={`skeleton-${n}`} className='flex items-center gap-3'>
-                  <Skeleton className='w-12 h-8 md:w-10 md:h-7 rounded' />
+                  <Skeleton className='h-8 w-12 rounded md:h-7 md:w-10' />
                   <Skeleton className='h-3 flex-1' />
                 </div>
               ))}
             </div>
           ) : songs.length === 0 ? (
-            <p className='p-4 md:p-6 font-mono text-xs text-muted text-center'>no songs found</p>
+            <p className='text-muted p-4 text-center font-mono text-xs md:p-6'>no songs found</p>
           ) : (
             <div style={virtualContainerStyle}>
               {virtualizer.getVirtualItems().map((virtualRow) => {
@@ -205,11 +210,11 @@ export default function AddSongsModal({
             </div>
           )}
           {loadingMore && (
-            <p className='p-3 font-mono text-xs text-muted text-center'>loading...</p>
+            <p className='text-muted p-3 text-center font-mono text-xs'>loading...</p>
           )}
         </div>
 
-        <div className='p-4 border-t border-border flex justify-end'>
+        <div className='border-border flex justify-end border-t p-4'>
           <Button variant='primary' onClick={hasAddedNew ? onAdded : onClose}>
             {hasAddedNew ? 'Done' : 'Close'}
           </Button>
@@ -235,19 +240,19 @@ const SongRow = memo(function SongRow({
   }, [onAdd, song]);
 
   return (
-    <div className='flex items-center gap-2 md:gap-3 px-4 md:px-5 py-3 hover:bg-elevated active:bg-elevated/80 transition-colors duration-100'>
-      <div className='overflow-hidden w-10 h-10 md:w-8 md:h-8 rounded border border-border shrink-0 bg-elevated'>
+    <div className='hover:bg-elevated active:bg-elevated/80 flex items-center gap-2 px-4 py-3 transition-colors duration-100 md:gap-3 md:px-5'>
+      <div className='border-border bg-elevated h-10 w-10 shrink-0 overflow-hidden rounded border md:h-8 md:w-8'>
         <ArtworkImage
           src={song.artwork ?? song.thumbnailUrl}
           alt={song.nickname ?? song.title}
-          className='w-full h-full'
+          className='h-full w-full'
           imageClassName='scale-[1.33]'
         />
       </div>
-      <span className='flex-1 font-body text-sm text-fg truncate'>
+      <span className='font-body text-fg flex-1 truncate text-sm'>
         {song.nickname ?? song.title}
       </span>
-      <span className='font-mono text-xs text-muted hidden sm:block'>
+      <span className='text-muted hidden font-mono text-xs sm:block'>
         {formatDuration(song.duration)}
       </span>
       <Button
@@ -255,7 +260,7 @@ const SongRow = memo(function SongRow({
         surface='surface'
         disabled={isAdded || isAdding}
         onClick={handleClick}
-        className={`font-mono text-xs px-3 py-2 md:py-1 min-h-11 md:min-h-0 ${
+        className={`min-h-11 px-3 py-2 font-mono text-xs md:min-h-0 md:py-1 ${
           isAdded ? 'border-accent/30 text-accent bg-accent/5 cursor-default' : ''
         }`}
       >

--- a/packages/web/src/components/AnimatedOutlet.tsx
+++ b/packages/web/src/components/AnimatedOutlet.tsx
@@ -22,7 +22,7 @@ export function AnimatedOutlet() {
   return (
     <AnimatePresence mode='wait'>
       <m.div
-        className='flex-1 min-h-0'
+        className='min-h-0 flex-1'
         key={location.pathname}
         variants={pageVariants}
         initial='initial'

--- a/packages/web/src/components/Backdrop.tsx
+++ b/packages/web/src/components/Backdrop.tsx
@@ -29,7 +29,7 @@ export function Backdrop({
 
   return (
     <div
-      className='fixed inset-0 z-50 bg-black/70 flex items-center justify-center p-4 cursor-default'
+      className='fixed inset-0 z-50 flex cursor-default items-center justify-center bg-black/70 p-4'
       onMouseDown={handleMouseDown}
       onKeyDown={handleKeyDown}
       role='presentation'

--- a/packages/web/src/components/BarButton.tsx
+++ b/packages/web/src/components/BarButton.tsx
@@ -38,10 +38,10 @@ export function BarButton({
         busy
           ? 'text-black/50 dark:text-white/50'
           : `${pulse ? 'pressed text-accent' : 'text-black dark:text-white'} ${hoverColor} cursor-pointer`
-      } disabled:cursor-not-allowed disabled:opacity-50 md:w-12 md:h-12 ${className}`}
+      } disabled:cursor-not-allowed disabled:opacity-50 md:h-12 md:w-12 ${className}`}
     >
       {busy ? (
-        <CircleNotchIcon size={22} weight='bold' className='animate-spin md:w-5 md:h-5' />
+        <CircleNotchIcon size={22} weight='bold' className='animate-spin md:h-5 md:w-5' />
       ) : (
         children
       )}

--- a/packages/web/src/components/BulkActionBar.tsx
+++ b/packages/web/src/components/BulkActionBar.tsx
@@ -35,26 +35,26 @@ export default function BulkActionBar({
     loadedCount < totalCount ? `Select all ${loadedCount}` : `Select all ${totalCount}`;
 
   return (
-    <div className='fixed bottom-20 md:bottom-18 left-0 right-0 z-50 flex justify-center pb-4 md:pb-6 pointer-events-none'>
-      <SpringUp className='pointer-events-auto flex items-center gap-3 px-4 py-3 bg-elevated border border-border rounded-xl shadow-2xl'>
-        <span className='text-sm font-mono text-fg tabular-nums'>
+    <div className='pointer-events-none fixed right-0 bottom-20 left-0 z-50 flex justify-center pb-4 md:bottom-18 md:pb-6'>
+      <SpringUp className='bg-elevated border-border pointer-events-auto flex items-center gap-3 rounded-xl border px-4 py-3 shadow-2xl'>
+        <span className='text-fg font-mono text-sm tabular-nums'>
           {count} / {totalCount} selected
         </span>
 
         <button
           type='button'
-          className='text-xs text-muted hover:text-accent transition-colors cursor-pointer'
+          className='text-muted hover:text-accent cursor-pointer text-xs transition-colors'
           onClick={allLoadedSelected ? onDeselectAll : onSelectAll}
         >
           {allLoadedSelected ? 'Deselect all' : selectLabel}
         </button>
 
-        <div className='w-px h-5 bg-border' />
+        <div className='bg-border h-5 w-px' />
 
         {canDelete && (
           <Button
             variant='danger'
-            className='text-xs flex items-center gap-1.5'
+            className='flex items-center gap-1.5 text-xs'
             onClick={onDelete}
             disabled={isDeleting}
           >
@@ -67,7 +67,7 @@ export default function BulkActionBar({
           <Button
             variant='inherit'
             surface='surface'
-            className='text-xs flex items-center gap-1.5'
+            className='flex items-center gap-1.5 text-xs'
             onClick={onTag}
           >
             <TagIcon size={14} weight='duotone' />
@@ -77,7 +77,7 @@ export default function BulkActionBar({
 
         <button
           type='button'
-          className='ml-1 p-1 text-muted hover:text-fg transition-colors cursor-pointer'
+          className='text-muted hover:text-fg ml-1 cursor-pointer p-1 transition-colors'
           onClick={onDeselectAll}
           title='Clear selection'
         >

--- a/packages/web/src/components/BulkEditModal.tsx
+++ b/packages/web/src/components/BulkEditModal.tsx
@@ -46,7 +46,7 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
   // Close tag dropdown when clicking outside
   useEffect(() => {
     if (!showDropdown) {
-      return undefined;
+      return;
     }
     const handler = (e: MouseEvent) => {
       const target = e.target as Node;
@@ -60,7 +60,9 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
       }
     };
     document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
+    return () => {
+      document.removeEventListener('mousedown', handler);
+    };
   }, [showDropdown]);
 
   // Volume boost
@@ -182,7 +184,9 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
     [toggleClear]
   );
 
-  const handleBackdropClick = useCallback((e: React.MouseEvent) => e.stopPropagation(), []);
+  const handleBackdropClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+  }, []);
 
   const handleFocusTagInput = useCallback(() => {
     tagInputRef.current?.focus();
@@ -192,7 +196,7 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
   const handleTagPillRemove = useCallback(
     (e: React.MouseEvent<HTMLButtonElement>) => {
       e.stopPropagation();
-      const tag = e.currentTarget.closest('[data-tag]')?.getAttribute('data-tag');
+      const tag = e.currentTarget.closest<HTMLElement>('[data-tag]')?.dataset.tag;
       if (tag) {
         removeTag(tag);
       }
@@ -206,9 +210,13 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
     setHighlightedIdx(0);
   }, []);
 
-  const handleTagInputFocus = useCallback(() => setShowDropdown(true), []);
+  const handleTagInputFocus = useCallback(() => {
+    setShowDropdown(true);
+  }, []);
 
-  const handleClearTags = useCallback(() => toggleClear('tags'), [toggleClear]);
+  const handleClearTags = useCallback(() => {
+    toggleClear('tags');
+  }, [toggleClear]);
 
   const handleDropdownSelect = useCallback(
     (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -243,12 +251,13 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
     }
   }, [volumeBoost]);
 
-  const handleVolumeRangeChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => setVolumeBoost(e.target.value),
-    []
-  );
+  const handleVolumeRangeChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setVolumeBoost(e.target.value);
+  }, []);
 
-  const handleClearVolumeBoost = useCallback(() => toggleClear('volumeBoost'), [toggleClear]);
+  const handleClearVolumeBoost = useCallback(() => {
+    toggleClear('volumeBoost');
+  }, [toggleClear]);
 
   const volumeRangeStyle = useMemo(
     () => ({ '--volume-pct': volumePct }) as React.CSSProperties,
@@ -313,11 +322,11 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
   return (
     <Backdrop onClose={onClose}>
       <SpringUp
-        className='w-full max-w-md mx-4 p-6 glass-modal max-h-[85vh] overflow-y-auto'
+        className='glass-modal mx-4 max-h-[85vh] w-full max-w-md overflow-y-auto p-6'
         onClick={handleBackdropClick}
       >
-        <h2 className='font-display text-lg text-fg mb-1'>Edit {count} songs</h2>
-        <p className='text-xs text-muted font-mono mb-4'>
+        <h2 className='font-display text-fg mb-1 text-lg'>Edit {count} songs</h2>
+        <p className='text-muted mb-4 font-mono text-xs'>
           Fill in fields you want to change. Blank fields are left unchanged. Use clear to reset a
           field.
         </p>
@@ -328,13 +337,13 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
               <div className='flex-1'>
                 <label
                   htmlFor={`bulk-edit-${key}`}
-                  className='block font-mono text-[10px] text-muted uppercase mb-1'
+                  className='text-muted mb-1 block font-mono text-[10px] uppercase'
                 >
                   {label}
                 </label>
                 <input
                   id={`bulk-edit-${key}`}
-                  className={`input text-sm w-full${clearFields.has(key) ? ' opacity-30 pointer-events-none' : ''}`}
+                  className={`input text-sm w-full${clearFields.has(key) ? ' pointer-events-none opacity-30' : ''}`}
                   placeholder={placeholder}
                   value={fieldValues[key]}
                   onChange={handleFieldChange}
@@ -342,15 +351,15 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
                   disabled={clearFields.has(key)}
                 />
               </div>
-              <label className='flex flex-col items-center gap-0.5 shrink-0 pt-5 cursor-pointer'>
+              <label className='flex shrink-0 cursor-pointer flex-col items-center gap-0.5 pt-5'>
                 <input
                   type='checkbox'
-                  className='sr-only peer'
+                  className='peer sr-only'
                   checked={clearFields.has(key)}
                   onChange={handleClearField}
                   data-field={key}
                 />
-                <span className='text-[9px] font-mono uppercase text-muted peer-checked:text-danger transition-colors'>
+                <span className='text-muted peer-checked:text-danger font-mono text-[9px] uppercase transition-colors'>
                   Clear
                 </span>
                 <EraserIcon
@@ -368,14 +377,14 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
               <div className='flex-1'>
                 <label
                   htmlFor='bulk-edit-tags'
-                  className='block font-mono text-[10px] text-muted uppercase mb-1'
+                  className='text-muted mb-1 block font-mono text-[10px] uppercase'
                 >
                   Tags
                 </label>
                 {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- container click focuses inner input */}
                 <div
                   ref={tagAreaRef}
-                  className={`input text-sm flex flex-wrap gap-1.5 items-center min-h-9.5 cursor-text relative${clearFields.has('tags') ? ' opacity-30 pointer-events-none' : ''}`}
+                  className={`input flex min-h-9.5 cursor-text flex-wrap items-center gap-1.5 text-sm relative${clearFields.has('tags') ? ' pointer-events-none opacity-30' : ''}`}
                   onClick={handleFocusTagInput}
                 >
                   {tags.map((tag) => {
@@ -383,7 +392,7 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
                     return (
                       <span
                         key={tag}
-                        className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium ${c.bg} ${c.text} ${c.border} border`}
+                        className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium ${c.bg} ${c.text} ${c.border} border`}
                       >
                         {tag}
                         <button
@@ -400,7 +409,7 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
                   <input
                     ref={tagInputRef}
                     id='bulk-edit-tags'
-                    className='bg-transparent outline-none flex-1 min-w-30 text-sm placeholder:text-faint py-0.5'
+                    className='placeholder:text-faint min-w-30 flex-1 bg-transparent py-0.5 text-sm outline-none'
                     placeholder={
                       tags.length === 0 ? 'Type a tag and press Enter...' : 'Add another...'
                     }
@@ -412,14 +421,14 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
                   />
                 </div>
               </div>
-              <label className='flex flex-col items-center gap-0.5 shrink-0 pt-5 cursor-pointer'>
+              <label className='flex shrink-0 cursor-pointer flex-col items-center gap-0.5 pt-5'>
                 <input
                   type='checkbox'
-                  className='sr-only peer'
+                  className='peer sr-only'
                   checked={clearFields.has('tags')}
                   onChange={handleClearTags}
                 />
-                <span className='text-[9px] font-mono uppercase text-muted peer-checked:text-danger transition-colors'>
+                <span className='text-muted peer-checked:text-danger font-mono text-[9px] uppercase transition-colors'>
                   Clear
                 </span>
                 <EraserIcon
@@ -435,7 +444,7 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
               <div className='relative'>
                 <div
                   ref={tagDropdownRef}
-                  className='absolute top-1 left-0 right-0 glass-popover z-30 max-h-40'
+                  className='glass-popover absolute top-1 right-0 left-0 z-30 max-h-40'
                 >
                   {filtered.map((t, i) => {
                     const c = getTagColorClasses(t.canonicalName, t.color);
@@ -443,7 +452,7 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
                       <button
                         key={t.nameLower}
                         type='button'
-                        className={`w-full text-left px-3 py-1.5 text-sm transition-colors cursor-pointer ${
+                        className={`w-full cursor-pointer px-3 py-1.5 text-left text-sm transition-colors ${
                           i === highlightedIdx
                             ? 'bg-accent/10 text-accent'
                             : 'text-fg hover:bg-surface'
@@ -452,7 +461,7 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
                         data-tag={t.nameLower}
                       >
                         <span
-                          className={`inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium ${c.bg} ${c.text}`}
+                          className={`inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium ${c.bg} ${c.text}`}
                         >
                           {t.canonicalName}
                         </span>
@@ -469,14 +478,14 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
             <div className='flex-1'>
               <label
                 htmlFor='bulk-edit-volumeboost'
-                className='block font-mono text-[10px] text-muted uppercase mb-1'
+                className='text-muted mb-1 block font-mono text-[10px] uppercase'
               >
                 Volume Boost (dB)
               </label>
               <div className='flex items-center gap-3'>
                 <input
                   id='bulk-edit-volumeboost'
-                  className='input text-sm w-16 text-center disabled:opacity-30 disabled:cursor-not-allowed'
+                  className='input w-16 text-center text-sm disabled:cursor-not-allowed disabled:opacity-30'
                   placeholder='0'
                   type='text'
                   value={volumeBoost}
@@ -484,27 +493,27 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
                   onBlur={handleVolumeBlur}
                   disabled={clearFields.has('volumeBoost')}
                 />
-                <span className='text-xs text-muted font-mono w-8 text-left'>dB</span>
+                <span className='text-muted w-8 text-left font-mono text-xs'>dB</span>
                 <input
                   type='range'
                   min={-100}
                   max={200}
                   value={volumeNumeric}
                   onChange={handleVolumeRangeChange}
-                  className={`volume-range-input${clearFields.has('volumeBoost') ? ' opacity-30 pointer-events-none' : ''}`}
+                  className={`volume-range-input${clearFields.has('volumeBoost') ? ' pointer-events-none opacity-30' : ''}`}
                   disabled={clearFields.has('volumeBoost')}
                   style={volumeRangeStyle}
                 />
               </div>
             </div>
-            <label className='flex flex-col items-center gap-0.5 shrink-0 pt-5 cursor-pointer'>
+            <label className='flex shrink-0 cursor-pointer flex-col items-center gap-0.5 pt-5'>
               <input
                 type='checkbox'
-                className='sr-only peer'
+                className='peer sr-only'
                 checked={clearFields.has('volumeBoost')}
                 onChange={handleClearVolumeBoost}
               />
-              <span className='text-[9px] font-mono uppercase text-muted peer-checked:text-danger transition-colors'>
+              <span className='text-muted peer-checked:text-danger font-mono text-[9px] uppercase transition-colors'>
                 Clear
               </span>
               <EraserIcon
@@ -517,7 +526,7 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
         </div>
 
         {/* Actions */}
-        <div className='flex justify-end gap-2 mt-4'>
+        <div className='mt-4 flex justify-end gap-2'>
           <Button variant='inherit' surface='surface' onClick={onClose} className='text-xs'>
             Cancel
           </Button>

--- a/packages/web/src/components/ConfirmModal.tsx
+++ b/packages/web/src/components/ConfirmModal.tsx
@@ -21,10 +21,10 @@ export default function ConfirmModal({
 }: ConfirmModalProps) {
   return (
     <Backdrop onClose={onCancel}>
-      <SpringUp className='p-5 md:p-6 w-full max-w-sm mx-4 glass-modal'>
-        <h2 className='font-display text-2xl md:text-3xl text-fg tracking-wider mb-1'>{title}</h2>
-        <p className='font-body text-sm text-muted mb-4 md:mb-6'>{message}</p>
-        <div className='flex gap-2 justify-end'>
+      <SpringUp className='glass-modal mx-4 w-full max-w-sm p-5 md:p-6'>
+        <h2 className='font-display text-fg mb-1 text-2xl tracking-wider md:text-3xl'>{title}</h2>
+        <p className='font-body text-muted mb-4 text-sm md:mb-6'>{message}</p>
+        <div className='flex justify-end gap-2'>
           <Button variant='inherit' onClick={onCancel} surface='surface'>
             Cancel
           </Button>

--- a/packages/web/src/components/ContextMenu.tsx
+++ b/packages/web/src/components/ContextMenu.tsx
@@ -151,7 +151,7 @@ export function ContextMenu({
   // Position calculation — useLayoutEffect runs before paint, preventing a (0,0) flash.
   useLayoutEffect(() => {
     if (!isOpen || !triggerRef.current) {
-      return undefined;
+      return;
     }
 
     const lastUpdateRef = { current: 0 };
@@ -210,7 +210,7 @@ export function ContextMenu({
   // Close on outside click
   useEffect(() => {
     if (!isOpen) {
-      return undefined;
+      return;
     }
 
     const handler = (e: MouseEvent | TouchEvent) => {
@@ -232,7 +232,7 @@ export function ContextMenu({
   // Close on Escape (or go back from submenu)
   useEffect(() => {
     if (!isOpen) {
-      return undefined;
+      return;
     }
 
     const handler = (e: KeyboardEvent) => {
@@ -251,7 +251,9 @@ export function ContextMenu({
     };
 
     document.addEventListener('keydown', handler);
-    return () => document.removeEventListener('keydown', handler);
+    return () => {
+      document.removeEventListener('keydown', handler);
+    };
   }, [
     isOpen,
     onClose,
@@ -344,7 +346,7 @@ export function ContextMenu({
       onKeyDown={activeEditItemId ? undefined : handleKeyDown}
       onClick={handleStopPropagation}
     >
-      <div className='glass-popover outline-2 outline-accent/20'>
+      <div className='glass-popover outline-accent/20 outline-2'>
         {activeSubmenu ? (
           <SubmenuPanel
             config={activeSubmenu}
@@ -363,7 +365,7 @@ export function ContextMenu({
               return (
                 <div key={item.id}>
                   {(index > 0 || item.separatorBefore) && (
-                    <div className='border-b border-muted/50' />
+                    <div className='border-muted/50 border-b' />
                   )}
                   <InfoRow item={item} />
                 </div>
@@ -371,7 +373,7 @@ export function ContextMenu({
             }
             return (
               <div key={item.id}>
-                {index > 0 && <div className='border-b border-muted/50' />}
+                {index > 0 && <div className='border-muted/50 border-b' />}
                 <MenuItemRow
                   item={item}
                   focusedIndex={focusedIndex}
@@ -440,7 +442,7 @@ function InfoRow({ item }: { item: MenuItem }) {
   return (
     <div
       role='presentation'
-      className='px-3 py-1.5 text-xs font-mono text-muted flex items-center gap-2'
+      className='text-muted flex items-center gap-2 px-3 py-1.5 font-mono text-xs'
     >
       {item.icon && <span className='shrink-0'>{item.icon}</span>}
       <span className='truncate'>{item.info?.label}</span>

--- a/packages/web/src/components/ContextMenu/EditSubmenuPanel.tsx
+++ b/packages/web/src/components/ContextMenu/EditSubmenuPanel.tsx
@@ -18,11 +18,15 @@ export function EditSubmenuPanel({ config, onBack, onSave }: EditSubmenuPanelPro
   useEffect(() => {
     // Delay focus to let the spring-up animation start.
     const timer = setTimeout(() => inputRef.current?.focus(), 50);
-    return () => clearTimeout(timer);
+    return () => {
+      clearTimeout(timer);
+    };
   }, []);
 
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => config.onChange(e.target.value),
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      config.onChange(e.target.value);
+    },
     [config]
   );
 
@@ -41,32 +45,32 @@ export function EditSubmenuPanel({ config, onBack, onSave }: EditSubmenuPanelPro
 
   return (
     <SpringUp>
-      <div className='flex items-center gap-2 px-3 py-2 border-b border-border'>
+      <div className='border-border flex items-center gap-2 border-b px-3 py-2'>
         <button
           type='button'
           aria-label='Back to main menu'
           onClick={onBack}
-          className='text-muted hover:text-fg p-1 rounded transition-colors'
+          className='text-muted hover:text-fg rounded p-1 transition-colors'
         >
           <CaretLeftIcon size={14} weight='duotone' />
         </button>
-        <span className='font-mono text-xs text-muted truncate'>{config.title}</span>
+        <span className='text-muted truncate font-mono text-xs'>{config.title}</span>
       </div>
       <div className='px-2 py-2'>
         <input
           ref={inputRef}
-          className='input text-xs py-1.5 px-2 w-full mb-2'
+          className='input mb-2 w-full px-2 py-1.5 text-xs'
           value={config.value}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
           disabled={config.saving}
           placeholder={config.placeholder ?? 'Enter value...'}
         />
-        <div className='flex gap-1 justify-end'>
+        <div className='flex justify-end gap-1'>
           <button
             type='button'
             onClick={onBack}
-            className='text-xs text-muted hover:text-fg px-2 py-1 rounded transition-colors'
+            className='text-muted hover:text-fg rounded px-2 py-1 text-xs transition-colors'
           >
             Cancel
           </button>
@@ -74,7 +78,7 @@ export function EditSubmenuPanel({ config, onBack, onSave }: EditSubmenuPanelPro
             type='button'
             onClick={onSave}
             disabled={config.saving}
-            className='text-xs text-accent hover:text-accent/80 px-2 py-1 rounded transition-colors disabled:opacity-50'
+            className='text-accent hover:text-accent/80 rounded px-2 py-1 text-xs transition-colors disabled:opacity-50'
           >
             {config.saving ? '...' : 'Save'}
           </button>

--- a/packages/web/src/components/ContextMenu/MenuItemButton.tsx
+++ b/packages/web/src/components/ContextMenu/MenuItemButton.tsx
@@ -24,18 +24,12 @@ export function MenuItemButton({ item, onClick }: MenuItemButtonProps) {
       tabIndex={-1}
       disabled={item.disabled}
       onClick={onClick}
-      className={`
-				w-full text-left px-3 py-1.5 text-xs font-mono
-				flex items-center gap-2
-				transition-colors duration-100
-				disabled:opacity-50 disabled:cursor-not-allowed
-				${item.danger ? 'text-danger hover:bg-danger/10' : 'text-fg hover:bg-muted/20'}
-			`}
+      className={`flex w-full items-center gap-2 px-3 py-1.5 text-left font-mono text-xs transition-colors duration-100 disabled:cursor-not-allowed disabled:opacity-50 ${item.danger ? 'text-danger hover:bg-danger/10' : 'text-fg hover:bg-muted/20'} `}
     >
       {item.icon && <span className='shrink-0'>{item.icon}</span>}
-      <span className='truncate flex-1'>{item.label}</span>
+      <span className='flex-1 truncate'>{item.label}</span>
       {(item.submenu ?? item.editSubmenu) && (
-        <CaretRightIcon size={12} weight='duotone' className='shrink-0 ml-auto opacity-50' />
+        <CaretRightIcon size={12} weight='duotone' className='ml-auto shrink-0 opacity-50' />
       )}
     </button>
   );

--- a/packages/web/src/components/ContextMenu/SubmenuPanel.tsx
+++ b/packages/web/src/components/ContextMenu/SubmenuPanel.tsx
@@ -16,7 +16,9 @@ interface SubmenuItemProps {
 }
 
 const SubmenuItem = memo(function SubmenuItem({ item, onSelect }: SubmenuItemProps) {
-  const handleClick = useCallback(() => onSelect(item.id), [onSelect, item.id]);
+  const handleClick = useCallback(() => {
+    onSelect(item.id);
+  }, [onSelect, item.id]);
 
   return (
     <button
@@ -25,7 +27,7 @@ const SubmenuItem = memo(function SubmenuItem({ item, onSelect }: SubmenuItemPro
       tabIndex={-1}
       disabled={item.disabled}
       onClick={handleClick}
-      className='w-full text-left px-3 py-1.5 text-xs font-mono text-fg hover:bg-border/50 transition-colors duration-100 disabled:opacity-50 flex items-center gap-2'
+      className='text-fg hover:bg-border/50 flex w-full items-center gap-2 px-3 py-1.5 text-left font-mono text-xs transition-colors duration-100 disabled:opacity-50'
     >
       {item.icon && <span className='shrink-0'>{item.icon}</span>}
       <span className='truncate'>{item.label}</span>
@@ -36,26 +38,26 @@ const SubmenuItem = memo(function SubmenuItem({ item, onSelect }: SubmenuItemPro
 export function SubmenuPanel({ config, onBack, onSelect }: SubmenuPanelProps) {
   return (
     <SpringUp>
-      <div className='flex items-center gap-2 px-3 py-2 border-b border-border'>
+      <div className='border-border flex items-center gap-2 border-b px-3 py-2'>
         <button
           type='button'
           aria-label='Back to main menu'
           onClick={onBack}
-          className='text-muted hover:text-fg p-1 rounded transition-colors'
+          className='text-muted hover:text-fg rounded p-1 transition-colors'
         >
           <CaretLeftIcon size={14} weight='duotone' />
         </button>
-        <span className='font-mono text-xs text-muted truncate'>{config.title}</span>
+        <span className='text-muted truncate font-mono text-xs'>{config.title}</span>
       </div>
       <div className='max-h-48 overflow-y-auto'>
         {config.items.length === 0 ? (
-          <p className='px-3 py-2 text-xs font-mono text-muted'>
+          <p className='text-muted px-3 py-2 font-mono text-xs'>
             {config.emptyMessage ?? 'no items'}
           </p>
         ) : (
           config.items.map((item, idx) => (
             <div key={item.id}>
-              {idx > 0 && <div className='border-b border-border' />}
+              {idx > 0 && <div className='border-border border-b' />}
               <SubmenuItem item={item} onSelect={onSelect} />
             </div>
           ))

--- a/packages/web/src/components/EmptyState.tsx
+++ b/packages/web/src/components/EmptyState.tsx
@@ -68,19 +68,19 @@ export default function EmptyState({
   return (
     <div className={`text-center ${compact ? 'py-8' : 'py-24'}`}>
       <div
-        className={`rounded-full bg-elevated border border-border flex items-center justify-center mx-auto ${compact ? 'w-10 h-10 mb-2' : 'w-12 h-12 mb-3'}`}
+        className={`bg-elevated border-border mx-auto flex items-center justify-center rounded-full border ${compact ? 'mb-2 h-10 w-10' : 'mb-3 h-12 w-12'}`}
       >
         <Icon size={compact ? 16 : 20} weight='duotone' className='text-faint' />
       </div>
       <p
-        className={`font-display text-faint tracking-wider ${compact ? 'text-xl mb-1' : 'text-4xl mb-2'}`}
+        className={`font-display text-faint tracking-wider ${compact ? 'mb-1 text-xl' : 'mb-2 text-4xl'}`}
       >
         {title}
       </p>
       {message ? (
-        <p className='font-mono text-xs text-faint'>{message}</p>
+        <p className='text-faint font-mono text-xs'>{message}</p>
       ) : isAdmin ? (
-        <p className='font-mono text-xs text-faint'>
+        <p className='text-faint font-mono text-xs'>
           <button type='button' className='text-accent hover:underline' onClick={onAdd}>
             {addLabel}
           </button>{' '}

--- a/packages/web/src/components/FilterChips.tsx
+++ b/packages/web/src/components/FilterChips.tsx
@@ -37,13 +37,13 @@ const FilterTagChip = memo(function FilterTagChip({ tag, onRemove }: FilterTagCh
 
   return (
     <span
-      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium whitespace-nowrap select-none ${colors.bg} ${colors.text}`}
+      className={`inline-flex items-center gap-1 rounded px-2 py-0.5 text-[11px] font-medium whitespace-nowrap select-none ${colors.bg} ${colors.text}`}
     >
       <TagIcon size={11} weight='fill' />
       <span>{tag}</span>
       <button
         type='button'
-        className='ml-0.5 cursor-pointer rounded-full p-px hover:bg-black/10 dark:hover:bg-white/10 transition-colors'
+        className='ml-0.5 cursor-pointer rounded-full p-px transition-colors hover:bg-black/10 dark:hover:bg-white/10'
         onClick={handleRemove}
         aria-label={`Remove tag filter: ${tag}`}
       >
@@ -71,12 +71,12 @@ const FilterSourceChip = memo(function FilterSourceChip({
   );
 
   return (
-    <span className='inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium whitespace-nowrap select-none bg-elevated text-muted border border-border/50'>
+    <span className='bg-elevated text-muted border-border/50 inline-flex items-center gap-1 rounded border px-2 py-0.5 text-[11px] font-medium whitespace-nowrap select-none'>
       <SourceIcon sourceKey={source} />
       <span>{SOURCE_LABELS[source] ?? source}</span>
       <button
         type='button'
-        className='ml-0.5 cursor-pointer rounded-full p-px hover:bg-black/10 dark:hover:bg-white/10 transition-colors'
+        className='ml-0.5 cursor-pointer rounded-full p-px transition-colors hover:bg-black/10 dark:hover:bg-white/10'
         onClick={handleRemove}
         aria-label={`Remove source filter: ${SOURCE_LABELS[source] ?? source}`}
       >
@@ -104,7 +104,7 @@ export default function FilterChips({
   onRemoveSource,
 }: FilterChipsProps) {
   return (
-    <div className='flex items-center gap-2 flex-wrap'>
+    <div className='flex flex-wrap items-center gap-2'>
       {tags.map((tag) => (
         <FilterTagChip key={`tag-${tag}`} tag={tag} onRemove={onRemoveTag} />
       ))}

--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -37,7 +37,7 @@ function LayoutContent() {
 
   useEffect(() => {
     if (!user?.isAdmin) {
-      return undefined;
+      return;
     }
 
     const interval = setInterval(() => {
@@ -49,7 +49,9 @@ function LayoutContent() {
       }
     }, 20_000);
 
-    return () => clearInterval(interval);
+    return () => {
+      clearInterval(interval);
+    };
   }, [user?.isAdmin, hintControls]);
 
   const [collapsed, setCollapsed] = useState(() => {
@@ -71,7 +73,9 @@ function LayoutContent() {
     void navigate('/login');
   }, [logout, navigate]);
 
-  const handleToggleCollapse = useCallback(() => setCollapsed((c) => !c), []);
+  const handleToggleCollapse = useCallback(() => {
+    setCollapsed((c) => !c);
+  }, []);
 
   const navLinkClassName = useCallback(
     ({ isActive }: { isActive: boolean }) =>
@@ -87,7 +91,7 @@ function LayoutContent() {
     []
   );
   return (
-    <div className='flex flex-col h-full bg-surface overflow-hidden'>
+    <div className='bg-surface flex h-full flex-col overflow-hidden'>
       {/* ------------------------------------------------------------------ */}
       {/* Mobile Navigation - visible on small screens */}
       {/* ------------------------------------------------------------------ */}
@@ -96,12 +100,12 @@ function LayoutContent() {
       {/* ------------------------------------------------------------------ */}
       {/* Middle row: sidebar + content */}
       {/* ------------------------------------------------------------------ */}
-      <div className='flex-1 flex overflow-hidden'>
+      <div className='flex flex-1 overflow-hidden'>
         {/* ------------------------------------------------------------------ */}
         {/* Sidebar - visible on medium screens and up */}
         {/* ------------------------------------------------------------------ */}
         <m.aside
-          className='hidden md:flex shrink-0 flex-col bg-elevated overflow-hidden h-full'
+          className='bg-elevated hidden h-full shrink-0 flex-col overflow-hidden md:flex'
           animate={sidebarAnimate}
           initial={false}
           transition={sidebarTransition}
@@ -109,11 +113,11 @@ function LayoutContent() {
           {/* Wordmark */}
           <div
             className={`flex pt-6 pb-4 ${
-              collapsed ? 'flex-col items-center justify-start px-3 gap-2' : 'items-center px-5'
+              collapsed ? 'flex-col items-center justify-start gap-2 px-3' : 'items-center px-5'
             }`}
           >
             {!collapsed && (
-              <div className='flex items-center gap-2 min-w-0'>
+              <div className='flex min-w-0 items-center gap-2'>
                 <m.button
                   type='button'
                   onClick={toggleAdminView}
@@ -125,7 +129,7 @@ function LayoutContent() {
                         : 'Switch to Admin view'
                       : undefined
                   }
-                  className={`flex items-center justify-center w-10 h-10 shrink-0 rounded border border-accent/30 bg-accent/10 self-end transition-opacity ${
+                  className={`border-accent/30 bg-accent/10 flex h-10 w-10 shrink-0 items-center justify-center self-end rounded border transition-opacity ${
                     user?.isAdmin ? 'cursor-pointer hover:opacity-80' : 'cursor-default'
                   }`}
                 >
@@ -135,7 +139,7 @@ function LayoutContent() {
                     <GuitarIcon size={24} weight='duotone' className='text-accent' />
                   )}
                 </m.button>
-                <span className='font-display text-5xl text-accent tracking-wider'>Alfira</span>
+                <span className='font-display text-accent text-5xl tracking-wider'>Alfira</span>
               </div>
             )}
             {collapsed && (
@@ -143,7 +147,7 @@ function LayoutContent() {
                 type='button'
                 onClick={toggleAdminView}
                 animate={hintControls}
-                className={`w-10 h-10 flex items-center justify-center shrink-0 rounded border border-accent/30 bg-accent/10 transition-opacity ${
+                className={`border-accent/30 bg-accent/10 flex h-10 w-10 shrink-0 items-center justify-center rounded border transition-opacity ${
                   user?.isAdmin ? 'cursor-pointer hover:opacity-80' : 'cursor-default'
                 }`}
                 title={
@@ -166,11 +170,11 @@ function LayoutContent() {
           {/* Spacer between wordmark and nav */}
           {collapsed ? (
             <div className='flex justify-center px-2'>
-              <div className='w-full h-px bg-fg/20' />
+              <div className='bg-fg/20 h-px w-full' />
             </div>
           ) : (
             <div className='px-5'>
-              <div className='h-px bg-fg/20' />
+              <div className='bg-fg/20 h-px' />
             </div>
           )}
 
@@ -193,11 +197,11 @@ function LayoutContent() {
                 {/* Separator between user and admin nav items */}
                 {collapsed ? (
                   <div className='flex justify-center px-2 py-1'>
-                    <div className='w-6 h-px bg-fg/15' />
+                    <div className='bg-fg/15 h-px w-6' />
                   </div>
                 ) : (
                   <div className='px-2 py-1'>
-                    <div className='h-px bg-fg/15' />
+                    <div className='bg-fg/15 h-px' />
                   </div>
                 )}
                 {ADMIN_NAV_ITEMS.map(({ to, label, icon: Icon }) => (
@@ -221,12 +225,12 @@ function LayoutContent() {
             <div className={collapsed ? 'flex justify-center px-2 pb-2' : 'px-3 pb-2'}>
               <div
                 title={connectionStatus === 'reconnecting' ? 'Reconnecting...' : 'Disconnected'}
-                className={`flex items-center rounded-xl font-body w-full select-none ${
-                  collapsed ? 'justify-center px-0 py-3' : 'px-3 py-3 gap-3'
+                className={`font-body flex w-full items-center rounded-xl select-none ${
+                  collapsed ? 'justify-center px-0 py-3' : 'gap-3 px-3 py-3'
                 } ${connectionStatus === 'reconnecting' ? 'text-warning' : 'text-danger'}`}
               >
                 {!collapsed && (
-                  <span className='mr-auto text-sm text-fg/80'>
+                  <span className='text-fg/80 mr-auto text-sm'>
                     {connectionStatus === 'reconnecting' ? 'Reconnecting...' : 'Disconnected'}
                   </span>
                 )}
@@ -248,7 +252,7 @@ function LayoutContent() {
               type='button'
               onClick={handleToggleCollapse}
               title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-              className={`flex items-center rounded-xl font-body transition-all duration-150 cursor-pointer w-full ${
+              className={`font-body flex w-full cursor-pointer items-center rounded-xl transition-all duration-150 ${
                 collapsed ? 'justify-center px-0 py-2' : 'px-3 py-2'
               } btn-inherit`}
               style={elevatedSurfaceStyle}
@@ -261,11 +265,11 @@ function LayoutContent() {
           {/* Separator above user section */}
           {collapsed ? (
             <div className='flex justify-center px-2'>
-              <div className='w-full h-px bg-fg/20' />
+              <div className='bg-fg/20 h-px w-full' />
             </div>
           ) : (
             <div className='px-5'>
-              <div className='h-px bg-fg/20' />
+              <div className='bg-fg/20 h-px' />
             </div>
           )}
 
@@ -302,15 +306,15 @@ function QueueLayout() {
 
   return (
     <>
-      <div className='flex-1 flex flex-col min-w-0 pt-14 md:pt-0 overflow-hidden'>
-        <main className='flex-1 flex flex-col overflow-hidden'>
+      <div className='flex min-w-0 flex-1 flex-col overflow-hidden pt-14 md:pt-0'>
+        <main className='flex flex-1 flex-col overflow-hidden'>
           <AnimatedOutlet />
         </main>
       </div>
 
       {/* Desktop: right-side panel that pushes content */}
       <m.aside
-        className='shrink-0 flex-col bg-elevated overflow-hidden clay-floating md:flex hidden h-full'
+        className='bg-elevated clay-floating hidden h-full shrink-0 flex-col overflow-hidden md:flex'
         animate={queuePanelAnimate}
         initial={false}
         transition={queuePanelTransition}

--- a/packages/web/src/components/ListToolbar.tsx
+++ b/packages/web/src/components/ListToolbar.tsx
@@ -95,6 +95,7 @@ export default function ListToolbar({
 }: ListToolbarProps) {
   // ── Search (local mirror + debounce) ─────────────────────────────
   const [searchInput, setSearchInput] = useState(searchValue);
+  // eslint-disable-next-line unicorn/no-useless-undefined
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   // Sync local input ← external value (e.g. browser back/forward on SongsPage)
@@ -122,7 +123,7 @@ export default function ListToolbar({
   // Close dropdown on outside click
   useEffect(() => {
     if (!sortOpen) {
-      return undefined;
+      return;
     }
     const handler = (e: MouseEvent) => {
       if (sortRef.current && !sortRef.current.contains(e.target as Node)) {
@@ -130,17 +131,27 @@ export default function ListToolbar({
       }
     };
     document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
+    return () => {
+      document.removeEventListener('mousedown', handler);
+    };
   }, [sortOpen]);
 
   const hasActiveSort = sort !== defaultSort || order !== 'desc';
 
-  const handleOpenFilter = useCallback(() => setFilterOpen(true), []);
-  const handleCloseFilter = useCallback(() => setFilterOpen(false), []);
-  const handleToggleSort = useCallback(() => setSortOpen((v) => !v), []);
+  const handleOpenFilter = useCallback(() => {
+    setFilterOpen(true);
+  }, []);
+  const handleCloseFilter = useCallback(() => {
+    setFilterOpen(false);
+  }, []);
+  const handleToggleSort = useCallback(() => {
+    setSortOpen((v) => !v);
+  }, []);
 
   const handleSearchChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => handleSearchInputChange(e.target.value),
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      handleSearchInputChange(e.target.value);
+    },
     [handleSearchInputChange]
   );
 
@@ -176,11 +187,11 @@ export default function ListToolbar({
   return (
     <>
       {/* ── Toolbar ── */}
-      <div className='flex items-center gap-2 mb-1'>
+      <div className='mb-1 flex items-center gap-2'>
         {/* Search */}
         <div className='relative flex-1'>
           <MagnifyingGlassIcon
-            className='absolute left-3 top-1/2 -translate-y-1/2 text-faint w-4 h-4 md:w-3.5 md:h-3.5'
+            className='text-faint absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 md:h-3.5 md:w-3.5'
             weight='duotone'
           />
           <input
@@ -235,7 +246,7 @@ export default function ListToolbar({
           </Button>
 
           {sortOpen && (
-            <div className='absolute right-0 top-full mt-1.5 w-48 glass-popover z-20 py-1 origin-top-right'>
+            <div className='glass-popover absolute top-full right-0 z-20 mt-1.5 w-48 origin-top-right py-1'>
               {sortOptions.map((opt) => {
                 const isActive = sort === opt.value;
                 return (
@@ -316,7 +327,9 @@ const SortOptionItem = memo(function SortOptionItem({
   order: 'asc' | 'desc';
   onClick: (value: string) => void;
 }) {
-  const handleClick = useCallback(() => onClick(opt.value), [onClick, opt.value]);
+  const handleClick = useCallback(() => {
+    onClick(opt.value);
+  }, [onClick, opt.value]);
   const handleArrowClick = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
@@ -328,7 +341,7 @@ const SortOptionItem = memo(function SortOptionItem({
   return (
     <button
       type='button'
-      className={`w-full flex items-center justify-between px-3 py-2 text-sm font-body transition-colors ${
+      className={`font-body flex w-full items-center justify-between px-3 py-2 text-sm transition-colors ${
         isActive ? 'text-accent bg-accent/5' : 'text-fg hover:bg-surface active:bg-surface/80'
       }`}
       onClick={handleClick}
@@ -337,7 +350,7 @@ const SortOptionItem = memo(function SortOptionItem({
       {isActive && (
         <button
           type='button'
-          className='cursor-pointer p-0.5 rounded hover:bg-black/10 dark:hover:bg-white/10 transition-colors'
+          className='cursor-pointer rounded p-0.5 transition-colors hover:bg-black/10 dark:hover:bg-white/10'
           onClick={handleArrowClick}
           title={order === 'asc' ? 'Switch to descending' : 'Switch to ascending'}
         >

--- a/packages/web/src/components/MobileNav.tsx
+++ b/packages/web/src/components/MobileNav.tsx
@@ -31,7 +31,7 @@ export default function MobileNav() {
   // Close drawer on escape key
   useEffect(() => {
     if (!isOpen) {
-      return undefined;
+      return;
     }
 
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -41,7 +41,9 @@ export default function MobileNav() {
     };
 
     document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
   }, [isOpen]);
 
   // Prevent body scroll when drawer is open
@@ -59,7 +61,7 @@ export default function MobileNav() {
   // Close drawer when clicking outside
   useEffect(() => {
     if (!isOpen) {
-      return undefined;
+      return;
     }
 
     const handleClickOutside = (e: MouseEvent) => {
@@ -69,7 +71,9 @@ export default function MobileNav() {
     };
 
     document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
   }, [isOpen]);
 
   const handleLogout = useCallback(async () => {
@@ -77,8 +81,12 @@ export default function MobileNav() {
     void navigate('/login');
   }, [logout, navigate]);
 
-  const handleOpen = useCallback(() => setIsOpen(true), []);
-  const handleClose = useCallback(() => setIsOpen(false), []);
+  const handleOpen = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+  }, []);
 
   const backdropKeyHandler = useCallback((e: React.KeyboardEvent) => {
     if (e.key === 'Escape' || e.key === 'Enter') {
@@ -94,7 +102,7 @@ export default function MobileNav() {
   return (
     <>
       {/* Mobile header bar */}
-      <header className='md:hidden fixed top-0 left-0 right-0 z-40 h-14 flex items-center justify-between px-4 bg-elevated border-b border-border safe-area-top'>
+      <header className='bg-elevated border-border safe-area-top fixed top-0 right-0 left-0 z-40 flex h-14 items-center justify-between border-b px-4 md:hidden'>
         {/* Left: Menu button */}
         <Button
           variant='inherit'
@@ -108,26 +116,26 @@ export default function MobileNav() {
 
         {/* Center: Wordmark */}
         <div className='flex items-center gap-2'>
-          <span className='font-display text-3xl text-accent tracking-wider'>Alfira</span>
+          <span className='font-display text-accent text-3xl tracking-wider'>Alfira</span>
           {isAdminView && (
-            <span className='text-[9px] font-mono bg-accent/10 text-accent border border-accent/20 px-1.5 py-0.5 rounded uppercase tracking-widest'>
+            <span className='bg-accent/10 text-accent border-accent/20 rounded border px-1.5 py-0.5 font-mono text-[9px] tracking-widest uppercase'>
               admin
             </span>
           )}
         </div>
 
         {/* Right: User avatar */}
-        <div className='w-11 h-11 flex items-center justify-center'>
+        <div className='flex h-11 w-11 items-center justify-center'>
           {user?.avatar ? (
             <img
               src={user.avatar}
               alt={user.username}
-              className='w-8 h-8 rounded-full border border-border'
+              className='border-border h-8 w-8 rounded-full border'
               decoding='async'
             />
           ) : (
-            <div className='w-8 h-8 rounded-full bg-elevated border border-border flex items-center justify-center'>
-              <span className='font-mono text-xs text-muted'>
+            <div className='bg-elevated border-border flex h-8 w-8 items-center justify-center rounded-full border'>
+              <span className='text-muted font-mono text-xs'>
                 {user?.username?.[0]?.toUpperCase()}
               </span>
             </div>
@@ -137,11 +145,11 @@ export default function MobileNav() {
 
       {/* Backdrop overlay */}
       {isOpen && (
-        <SpringUp className='md:hidden fixed inset-0 z-50'>
+        <SpringUp className='fixed inset-0 z-50 md:hidden'>
           <button
             type='button'
             aria-label='Close navigation menu'
-            className='bg-black/60 backdrop-blur-sm absolute inset-0'
+            className='absolute inset-0 bg-black/60 backdrop-blur-sm'
             onClick={handleClose}
             onKeyDown={backdropKeyHandler}
           />
@@ -151,21 +159,21 @@ export default function MobileNav() {
       {/* Slide-out drawer */}
       <div
         ref={drawerRef}
-        className={`md:hidden fixed top-0 left-0 bottom-0 z-50 w-72 max-w-[85vw] bg-elevated border-r border-border flex flex-col transform transition-transform duration-300 ease-out safe-area-top ${
+        className={`bg-elevated border-border safe-area-top fixed top-0 bottom-0 left-0 z-50 flex w-72 max-w-[85vw] transform flex-col border-r transition-transform duration-300 ease-out md:hidden ${
           isOpen ? 'translate-x-0' : '-translate-x-full'
         }`}
       >
         {/* Drawer header */}
-        <div className='flex items-center justify-between p-4 border-b border-border'>
+        <div className='border-border flex items-center justify-between border-b p-4'>
           <div className='flex items-center gap-2'>
-            <span className='flex items-center justify-center w-10 h-10 shrink-0 rounded border border-accent/30 bg-accent/10 self-end'>
+            <span className='border-accent/30 bg-accent/10 flex h-10 w-10 shrink-0 items-center justify-center self-end rounded border'>
               {isAdminView ? (
                 <CraneTowerIcon size={24} weight='duotone' className='text-accent' />
               ) : (
                 <GuitarIcon size={24} weight='duotone' className='text-accent' />
               )}
             </span>
-            <span className='font-display text-3xl text-accent tracking-wider'>Alfira</span>
+            <span className='font-display text-accent text-3xl tracking-wider'>Alfira</span>
           </div>
           <Button
             variant='inherit'
@@ -179,7 +187,7 @@ export default function MobileNav() {
         </div>
 
         {/* Navigation links */}
-        <nav className='px-3 pt-3 pb-2 space-y-2'>
+        <nav className='space-y-2 px-3 pt-3 pb-2'>
           {NAV_ITEMS.map(({ to, label, icon: Icon }) => (
             <NavLink
               key={to}
@@ -195,7 +203,7 @@ export default function MobileNav() {
           {isAdminView && ADMIN_NAV_ITEMS.length > 0 && (
             <>
               <div className='px-2 py-1'>
-                <div className='h-px bg-fg/15' />
+                <div className='bg-fg/15 h-px' />
               </div>
               {ADMIN_NAV_ITEMS.map(({ to, label, icon: Icon }) => (
                 <NavLink
@@ -220,32 +228,32 @@ export default function MobileNav() {
 
           {/* Separator above user section */}
           <div className='px-5'>
-            <div className='h-px bg-fg/20' />
+            <div className='bg-fg/20 h-px' />
           </div>
 
           {/* User section */}
           <div className='p-3'>
-            <div className='flex items-center gap-3 px-2 py-2 mb-3'>
+            <div className='mb-3 flex items-center gap-3 px-2 py-2'>
               {user?.avatar ? (
                 <img
                   src={user.avatar}
                   alt={user.username}
-                  className='w-7 h-7 rounded-full'
+                  className='h-7 w-7 rounded-full'
                   decoding='async'
                 />
               ) : (
-                <div className='w-7 h-7 rounded-full bg-elevated flex items-center justify-center'>
-                  <span className='font-mono text-sm text-muted'>
+                <div className='bg-elevated flex h-7 w-7 items-center justify-center rounded-full'>
+                  <span className='text-muted font-mono text-sm'>
                     {user?.username?.[0]?.toUpperCase()}
                   </span>
                 </div>
               )}
-              <span className='text-fg font-body truncate flex-1'>{user?.username}</span>
+              <span className='text-fg font-body flex-1 truncate'>{user?.username}</span>
             </div>
             <Button
               variant='danger'
               onClick={handleLogout}
-              className='flex items-center rounded-xl transition-all duration-150 cursor-pointer px-3 py-2 w-full text-foreground'
+              className='text-foreground flex w-full cursor-pointer items-center rounded-xl px-3 py-2 transition-all duration-150'
             >
               <span className='mr-auto text-sm'>log out</span>
               <SignOutIcon size={18} weight='duotone' />

--- a/packages/web/src/components/NotificationToast.tsx
+++ b/packages/web/src/components/NotificationToast.tsx
@@ -9,7 +9,7 @@ interface NotificationToastProps {
 export default function NotificationToast({ notification, lift }: NotificationToastProps) {
   return (
     <SpringUp
-      className={`fixed ${lift ? 'bottom-48 md:bottom-40' : 'bottom-24'} left-1/2 -translate-x-1/2 z-50 px-4 py-3 glass-toast font-mono text-xs ${
+      className={`fixed ${lift ? 'bottom-48 md:bottom-40' : 'bottom-24'} glass-toast left-1/2 z-50 -translate-x-1/2 px-4 py-3 font-mono text-xs ${
         notification.type === 'success'
           ? 'bg-accent/15 border-accent/40 text-accent'
           : 'bg-danger/15 border-danger/40 text-danger'

--- a/packages/web/src/components/NowPlayingBar.tsx
+++ b/packages/web/src/components/NowPlayingBar.tsx
@@ -35,7 +35,7 @@ import { VolumeBoostBadge } from './ui/VolumeBoostBadge';
  * Module-level constants — stable references for memoized components
  * --------------------------------------------------------------------------- */
 
-const NOOP = () => undefined;
+const NOOP = () => {};
 
 const MOBILE_PROGRESS_BOX_STYLE = { boxShadow: 'var(--clay-shadow-flat)' } as const;
 const ZERO_WIDTH_STYLE = { width: '0%' } as const;
@@ -80,7 +80,7 @@ const PlaybackControls = memo(function PlaybackControls({
   const realDisabled = !currentSong || pauseBusy || skipBusy;
 
   return (
-    <div className='flex items-center gap-1 md:gap-1.5 shrink-0'>
+    <div className='flex shrink-0 items-center gap-1 md:gap-1.5'>
       <BarButton
         {...cooldownButtonProps(cooldown, {
           onClick: onPauseResume,
@@ -92,9 +92,9 @@ const PlaybackControls = memo(function PlaybackControls({
         pulse={isPlaying && !isPaused}
       >
         {isPaused || isStopped ? (
-          <PlayIcon size={24} weight='duotone' className='md:w-5 md:h-5' />
+          <PlayIcon size={24} weight='duotone' className='md:h-5 md:w-5' />
         ) : (
-          <PauseIcon size={24} weight='duotone' className='md:w-5 md:h-5' />
+          <PauseIcon size={24} weight='duotone' className='md:h-5 md:w-5' />
         )}
       </BarButton>
       <BarButton
@@ -107,7 +107,7 @@ const PlaybackControls = memo(function PlaybackControls({
         hoverColor='hover:text-fg'
         className='hidden md:flex'
       >
-        <SkipForwardIcon size={24} weight='duotone' className='md:w-5 md:h-5' />
+        <SkipForwardIcon size={24} weight='duotone' className='md:h-5 md:w-5' />
       </BarButton>
 
       <Button
@@ -119,9 +119,9 @@ const PlaybackControls = memo(function PlaybackControls({
           disabled: !isConnectedToVoice,
           title: 'Stop playback',
         })}
-        className='text-black dark:text-white hover:text-danger md:w-12 md:h-12'
+        className='hover:text-danger text-black md:h-12 md:w-12 dark:text-white'
       >
-        <DoorOpenIcon size={24} weight='duotone' className='md:w-5 md:h-5' />
+        <DoorOpenIcon size={24} weight='duotone' className='md:h-5 md:w-5' />
       </Button>
     </div>
   );
@@ -151,16 +151,16 @@ const LoopShuffleControls = memo(function LoopShuffleControls({
   const isLoopActive = loopMode !== 'off';
   const loopIcon = isLoopActive ? (
     loopMode === 'song' ? (
-      <RepeatOnceIcon size={22} weight='fill' className='md:w-5 md:h-5' />
+      <RepeatOnceIcon size={22} weight='fill' className='md:h-5 md:w-5' />
     ) : (
-      <RepeatIcon size={22} weight='fill' className='md:w-5 md:h-5' />
+      <RepeatIcon size={22} weight='fill' className='md:h-5 md:w-5' />
     )
   ) : (
-    <RepeatIcon size={22} weight='duotone' className='md:w-5 md:h-5' />
+    <RepeatIcon size={22} weight='duotone' className='md:h-5 md:w-5' />
   );
 
   return (
-    <div className='hidden md:flex items-center gap-1 md:gap-1.5 shrink-0'>
+    <div className='hidden shrink-0 items-center gap-1 md:flex md:gap-1.5'>
       <Button
         variant='inherit'
         surface='base'
@@ -170,14 +170,14 @@ const LoopShuffleControls = memo(function LoopShuffleControls({
           disabled: !currentSong || loopBusy,
           title: `Loop: ${loopMode}`,
         })}
-        className={`shrink-0 md:w-12 md:h-12 ${
+        className={`shrink-0 md:h-12 md:w-12 ${
           isLoopActive
             ? 'pressed text-accent hover:text-accent-muted'
-            : 'text-black dark:text-white hover:text-fg'
+            : 'hover:text-fg text-black dark:text-white'
         }`}
       >
         {loopBusy ? (
-          <CircleNotchIcon size={22} weight='bold' className='animate-spin md:w-5 md:h-5' />
+          <CircleNotchIcon size={22} weight='bold' className='animate-spin md:h-5 md:w-5' />
         ) : (
           loopIcon
         )}
@@ -191,19 +191,19 @@ const LoopShuffleControls = memo(function LoopShuffleControls({
           disabled: !currentSong || shuffleBusy,
           title: isShuffled ? 'Unshuffle queue' : 'Shuffle queue',
         })}
-        className={`shrink-0 md:w-12 md:h-12 ${
+        className={`shrink-0 md:h-12 md:w-12 ${
           isShuffled
             ? 'pressed text-accent hover:text-accent-muted'
-            : 'text-black dark:text-white hover:text-fg'
+            : 'hover:text-fg text-black dark:text-white'
         }`}
       >
         {shuffleBusy ? (
-          <CircleNotchIcon size={22} weight='bold' className='animate-spin md:w-5 md:h-5' />
+          <CircleNotchIcon size={22} weight='bold' className='animate-spin md:h-5 md:w-5' />
         ) : (
           <ShuffleIcon
             size={24}
             weight={isShuffled ? 'fill' : 'duotone'}
-            className='md:w-5 md:h-5'
+            className='md:h-5 md:w-5'
           />
         )}
       </Button>
@@ -320,8 +320,8 @@ const Scrubber = memo(function Scrubber({
 
   if (!isSeekable) {
     return (
-      <div className='w-full h-2 clay-inset rounded-full relative overflow-hidden cursor-not-allowed opacity-50'>
-        <div ref={fillRefCallback} className='absolute inset-y-0 left-0 bg-accent rounded-full' />
+      <div className='clay-inset relative h-2 w-full cursor-not-allowed overflow-hidden rounded-full opacity-50'>
+        <div ref={fillRefCallback} className='bg-accent absolute inset-y-0 left-0 rounded-full' />
       </div>
     );
   }
@@ -329,15 +329,15 @@ const Scrubber = memo(function Scrubber({
   return (
     <div
       ref={trackRef}
-      className='w-full h-2 clay-inset rounded-full relative cursor-pointer group'
+      className='clay-inset group relative h-2 w-full cursor-pointer rounded-full'
       onPointerDown={handlePointerDown}
     >
-      <div ref={fillRefCallback} className='absolute inset-y-0 left-0 bg-accent rounded-full' />
+      <div ref={fillRefCallback} className='bg-accent absolute inset-y-0 left-0 rounded-full' />
       {/* Fill & thumb — positioned entirely by useProgressBar (rAF + effect).
            No React style props. */}
       <div
         ref={thumbRefCallback}
-        className='scrubber-thumb absolute top-1/2 -translate-y-1/2 w-3.5 h-3.5 rounded-full bg-surface border-2 border-accent opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity'
+        className='scrubber-thumb bg-surface border-accent pointer-events-none absolute top-1/2 h-3.5 w-3.5 -translate-y-1/2 rounded-full border-2 opacity-0 transition-opacity group-hover:opacity-100'
       />
       {/* Invisible hit area for hovering */}
       <div className='absolute inset-0' />
@@ -367,12 +367,12 @@ const ProgressBar = memo(function ProgressBar({
   if (variant === 'mobile') {
     return (
       <div
-        className='md:hidden h-1 w-full clay-inset relative overflow-hidden'
+        className='clay-inset relative h-1 w-full overflow-hidden md:hidden'
         style={MOBILE_PROGRESS_BOX_STYLE}
       >
         <div
           ref={currentSong != null ? registerProgress : null}
-          className='absolute inset-y-0 left-0 bg-accent'
+          className='bg-accent absolute inset-y-0 left-0'
           style={ZERO_WIDTH_STYLE}
         />
       </div>
@@ -380,7 +380,7 @@ const ProgressBar = memo(function ProgressBar({
   }
 
   return (
-    <div className='hidden md:flex items-center flex-1 min-h-0'>
+    <div className='hidden min-h-0 flex-1 items-center md:flex'>
       <Scrubber
         isSeekable={currentSong?.isSeekable ?? false}
         duration={currentSong?.duration ?? 0}
@@ -404,7 +404,7 @@ const AlbumArt = memo(function AlbumArt({ currentSong }: AlbumArtProps) {
     <AnimatePresence mode='wait'>
       <m.div
         key={songKey}
-        className='w-12 h-12 md:w-14 md:h-14 rounded border border-border shrink-0 overflow-hidden relative bg-elevated'
+        className='border-border bg-elevated relative h-12 w-12 shrink-0 overflow-hidden rounded border md:h-14 md:w-14'
         initial={ALBUM_ART_INITIAL}
         animate={ALBUM_ART_ANIMATE}
         exit={ALBUM_ART_EXIT}
@@ -414,11 +414,11 @@ const AlbumArt = memo(function AlbumArt({ currentSong }: AlbumArtProps) {
           <ArtworkImage
             src={currentSong.artwork ?? currentSong.thumbnailUrl}
             alt={currentSong.title}
-            className='w-full h-full'
+            className='h-full w-full'
             imageClassName='scale-[1.33]'
           />
         ) : (
-          <div className='w-full h-full flex items-center justify-center'>
+          <div className='flex h-full w-full items-center justify-center'>
             <GuitarIcon size={18} weight='duotone' className='text-faint' />
           </div>
         )}
@@ -438,8 +438,8 @@ const MetadataSection = memo(function MetadataSection({
 }: MetadataSectionProps) {
   if (!currentSong) {
     return (
-      <div className='flex items-center h-6'>
-        <p className='font-body text-sm text-muted'>Nothing playing</p>
+      <div className='flex h-6 items-center'>
+        <p className='font-body text-muted text-sm'>Nothing playing</p>
       </div>
     );
   }
@@ -452,26 +452,26 @@ const MetadataSection = memo(function MetadataSection({
     <AnimatePresence mode='wait'>
       <m.div
         key={songKey}
-        className='flex flex-col min-w-0 gap-0.5'
+        className='flex min-w-0 flex-col gap-0.5'
         variants={metadataVariants}
         initial='initial'
         animate='animate'
         exit='exit'
         transition={metadataTransition}
       >
-        <div className='flex items-center gap-2 min-w-0'>
-          <p className='font-body text-sm font-medium text-fg truncate'>{displayName}</p>
+        <div className='flex min-w-0 items-center gap-2'>
+          <p className='font-body text-fg truncate text-sm font-medium'>{displayName}</p>
           {currentSong.artist && (
-            <p className='font-body text-xs text-muted shrink-0'>· {currentSong.artist}</p>
+            <p className='font-body text-muted shrink-0 text-xs'>· {currentSong.artist}</p>
           )}
           <TagTicker tags={currentSong.tags ?? []} />
         </div>
         <div className='flex items-center gap-2'>
-          <p className='font-mono text-xs text-muted'>
+          <p className='text-muted font-mono text-xs'>
             {formatDuration(elapsed)} / {formatDuration(currentSong.duration)}
           </p>
           {sourceKey && (
-            <span className='flex items-center shrink-0 [&_svg]:w-3 [&_svg]:h-3'>
+            <span className='flex shrink-0 items-center [&_svg]:h-3 [&_svg]:w-3'>
               <SourceIcon sourceKey={sourceKey} />
             </span>
           )}
@@ -541,8 +541,8 @@ export function NowPlayingBar() {
     void (async () => {
       try {
         await leave();
-      } catch (e) {
-        console.error(e);
+      } catch (error) {
+        console.error(error);
       }
     })();
   }, [leave]);
@@ -560,9 +560,13 @@ export function NowPlayingBar() {
     setOverrideElapsed(undefined);
   }, [setOverrideElapsed]);
 
-  const handleQueueToggle = useCallback(() => setQueueOpen(!queueOpen), [queueOpen, setQueueOpen]);
+  const handleQueueToggle = useCallback(() => {
+    setQueueOpen(!queueOpen);
+  }, [queueOpen, setQueueOpen]);
 
-  const handleQueueClose = useCallback(() => setQueueOpen(false), [setQueueOpen]);
+  const handleQueueClose = useCallback(() => {
+    setQueueOpen(false);
+  }, [setQueueOpen]);
 
   const mobileQuickControls = useMemo(
     () => ({
@@ -592,7 +596,7 @@ export function NowPlayingBar() {
   );
 
   return (
-    <div className='shrink-0 w-full bg-base'>
+    <div className='bg-base w-full shrink-0'>
       {/* Mobile: progress bar on top */}
       <ProgressBar
         currentSong={currentSong}
@@ -603,7 +607,7 @@ export function NowPlayingBar() {
         variant='mobile'
       />
 
-      <div className='h-22 md:h-20 flex flex-row items-center px-3 md:px-8 gap-1'>
+      <div className='flex h-22 flex-row items-center gap-1 px-3 md:h-20 md:px-8'>
         {/* Playback controls: Play/Pause (desktop: also Skip, Leave) */}
         <PlaybackControls
           currentSong={currentSong}
@@ -620,11 +624,11 @@ export function NowPlayingBar() {
         />
 
         {/* Desktop: spacer → art → metadata+progress → spacer → loop/shuffle+queue */}
-        <div className='hidden md:flex flex-1' />
-        <div className='hidden md:block shrink-0'>
+        <div className='hidden flex-1 md:flex' />
+        <div className='hidden shrink-0 md:block'>
           <AlbumArt currentSong={currentSong} />
         </div>
-        <div className='hidden md:flex flex-col flex-8 min-w-0 px-3 h-14 justify-between'>
+        <div className='hidden h-14 min-w-0 flex-8 flex-col justify-between px-3 md:flex'>
           <MetadataSection currentSong={currentSong} elapsed={elapsed} />
           <ProgressBar
             currentSong={currentSong}
@@ -636,8 +640,8 @@ export function NowPlayingBar() {
             variant='desktop'
           />
         </div>
-        <div className='hidden md:flex flex-1' />
-        <div className='hidden md:flex items-center gap-1.5 shrink-0'>
+        <div className='hidden flex-1 md:flex' />
+        <div className='hidden shrink-0 items-center gap-1.5 md:flex'>
           <LoopShuffleControls
             currentSong={currentSong}
             loopMode={loopMode}
@@ -654,34 +658,34 @@ export function NowPlayingBar() {
             size='icon'
             onClick={handleQueueToggle}
             title='Queue'
-            className={`shrink-0 md:w-12 md:h-12 ${
+            className={`shrink-0 md:h-12 md:w-12 ${
               queueOpen
                 ? 'pressed text-accent hover:text-accent-muted'
-                : 'text-black dark:text-white hover:text-fg'
+                : 'hover:text-fg text-black dark:text-white'
             }`}
           >
-            <QueueIcon size={24} weight='duotone' className='md:w-5 md:h-5' />
+            <QueueIcon size={24} weight='duotone' className='md:h-5 md:w-5' />
           </Button>
         </div>
 
         {/* Mobile: metadata + art + queue */}
-        <div className='md:hidden flex items-center ms-auto shrink-0'>
+        <div className='ms-auto flex shrink-0 items-center md:hidden'>
           <AnimatePresence mode='wait'>
             {currentSong ? (
               <m.div
                 key={currentSong.id}
-                className='max-w-32 min-w-0 mr-2'
+                className='mr-2 max-w-32 min-w-0'
                 variants={metadataVariants}
                 initial='initial'
                 animate='animate'
                 exit='exit'
                 transition={metadataTransition}
               >
-                <p className='font-body text-sm font-semibold text-fg truncate text-right'>
+                <p className='font-body text-fg truncate text-right text-sm font-semibold'>
                   {currentSong.nickname ?? currentSong.title}
                 </p>
                 {currentSong.artist && (
-                  <p className='font-body text-xs text-muted truncate text-right'>
+                  <p className='font-body text-muted truncate text-right text-xs'>
                     {currentSong.artist}
                   </p>
                 )}
@@ -689,46 +693,46 @@ export function NowPlayingBar() {
             ) : (
               <m.div
                 key='empty'
-                className='min-w-0 mr-2'
+                className='mr-2 min-w-0'
                 variants={metadataVariants}
                 initial='initial'
                 animate='animate'
                 exit='exit'
                 transition={metadataTransition}
               >
-                <p className='font-body text-sm text-muted text-right'>Nothing playing</p>
+                <p className='font-body text-muted text-right text-sm'>Nothing playing</p>
               </m.div>
             )}
           </AnimatePresence>
           <AlbumArt currentSong={currentSong} />
-          <div className='w-px h-8 bg-border shrink-0 mx-1' />
+          <div className='bg-border mx-1 h-8 w-px shrink-0' />
           <Button
             variant='inherit'
             surface='base'
             size='icon'
             onClick={handleQueueToggle}
             title='Queue'
-            className={`shrink-0 md:w-12 md:h-12 ${
+            className={`shrink-0 md:h-12 md:w-12 ${
               queueOpen
                 ? 'pressed text-accent hover:text-accent-muted'
-                : 'text-black dark:text-white hover:text-fg'
+                : 'hover:text-fg text-black dark:text-white'
             }`}
           >
-            <QueueIcon size={24} weight='duotone' className='md:w-5 md:h-5' />
+            <QueueIcon size={24} weight='duotone' className='md:h-5 md:w-5' />
           </Button>
         </div>
       </div>
 
       {/* Mobile: bottom sheet */}
       {queueOpen && (
-        <div className='md:hidden fixed inset-0 z-50'>
+        <div className='fixed inset-0 z-50 md:hidden'>
           <div
-            className='absolute inset-0 bg-black/60 backdrop-blur-sm cursor-pointer'
+            className='absolute inset-0 cursor-pointer bg-black/60 backdrop-blur-sm'
             onClick={handleQueueClose}
             role='presentation'
           />
           <m.div
-            className='absolute bottom-0 left-0 right-0 max-h-[85vh] bg-surface rounded-t-2xl flex flex-col clay-floating'
+            className='bg-surface clay-floating absolute right-0 bottom-0 left-0 flex max-h-[85vh] flex-col rounded-t-2xl'
             initial='initial'
             animate='animate'
             exit='exit'

--- a/packages/web/src/components/PlaylistRow.tsx
+++ b/packages/web/src/components/PlaylistRow.tsx
@@ -47,7 +47,7 @@ export const PlaylistRow = memo(
       <Card
         hoverable
         animate
-        className='rounded-xl flex items-center gap-3 md:gap-4 px-4 md:px-5 py-3.5 md:py-4 cursor-pointer group'
+        className='group flex cursor-pointer items-center gap-3 rounded-xl px-4 py-3.5 md:gap-4 md:px-5 md:py-4'
         style={cardStyle}
         data-playlist-id={dataPlaylistId}
         onClick={onClick}
@@ -56,27 +56,27 @@ export const PlaylistRow = memo(
         tabIndex={0}
       >
         {/* Cover art grid or fallback icon */}
-        <div className='w-16 h-16 md:w-20 md:h-20 rounded-xl overflow-hidden clay-flat shrink-0'>
+        <div className='clay-flat h-16 w-16 shrink-0 overflow-hidden rounded-xl md:h-20 md:w-20'>
           {hasArtwork ? (
-            <div className='grid grid-cols-2 grid-rows-2 w-full h-full'>
+            <div className='grid h-full w-full grid-cols-2 grid-rows-2'>
               {cells.map((url, i) => (
                 // eslint-disable-next-line react/no-array-index-key -- cells are always exactly 4, never reorder
-                <div key={i} className='overflow-hidden bg-elevated'>
-                  <ArtworkImage src={url ?? undefined} alt='' className='w-full h-full' />
+                <div key={i} className='bg-elevated overflow-hidden'>
+                  <ArtworkImage src={url ?? undefined} alt='' className='h-full w-full' />
                 </div>
               ))}
             </div>
           ) : (
-            <div className='w-full h-full bg-elevated flex items-center justify-center'>
+            <div className='bg-elevated flex h-full w-full items-center justify-center'>
               <PlaylistIcon size={32} weight='duotone' className='text-accent' />
             </div>
           )}
         </div>
 
         {/* Info */}
-        <div className='flex-1 min-w-0'>
+        <div className='min-w-0 flex-1'>
           <div className='flex items-center gap-2'>
-            <p className='font-body font-medium text-fg transition-colors duration-150'>
+            <p className='font-body text-fg font-medium transition-colors duration-150'>
               {playlist.name}
             </p>
             {playlist.isPrivate && (
@@ -93,7 +93,7 @@ export const PlaylistRow = memo(
               </span>
             )}
           </div>
-          <p className='font-mono text-xs text-muted mt-0.5'>
+          <p className='text-muted mt-0.5 font-mono text-xs'>
             {count} {count === 1 ? 'song' : 'songs'}
           </p>
         </div>
@@ -101,7 +101,7 @@ export const PlaylistRow = memo(
         <CaretRightIcon
           size={18}
           weight='duotone'
-          className='text-faint group-hover:text-muted transition-colors duration-150 md:w-4 md:h-4'
+          className='text-faint group-hover:text-muted transition-colors duration-150 md:h-4 md:w-4'
         />
       </Card>
     );

--- a/packages/web/src/components/ProtectedRoute.tsx
+++ b/packages/web/src/components/ProtectedRoute.tsx
@@ -11,10 +11,10 @@ export default function ProtectedRoute({ children }: { children: React.ReactNode
 
   if (loading) {
     return (
-      <div className='h-full flex items-center justify-center bg-elevated'>
+      <div className='bg-elevated flex h-full items-center justify-center'>
         <div className='flex flex-col items-center gap-3'>
           <Spinner size='lg' />
-          <span className='font-mono text-xs text-muted'>connecting</span>
+          <span className='text-muted font-mono text-xs'>connecting</span>
         </div>
       </div>
     );

--- a/packages/web/src/components/QueuePanel.tsx
+++ b/packages/web/src/components/QueuePanel.tsx
@@ -127,7 +127,7 @@ export default function QueuePanel({
     const items: VirtualQueueItem[] = [];
     if (priorityQueue.length > 0) {
       items.push({ type: 'header', variant: 'priority', key: 'header-priority' });
-      priorityQueue.forEach((song, i) => {
+      for (const [i, song] of priorityQueue.entries()) {
         items.push({
           type: 'song',
           variant: 'priority',
@@ -135,11 +135,11 @@ export default function QueuePanel({
           listIndex: i,
           key: `p-${song.id}`,
         });
-      });
+      }
     }
     if (queue.length > 0) {
       items.push({ type: 'header', variant: 'regular', key: 'header-regular' });
-      queue.forEach((song, i) => {
+      for (const [i, song] of queue.entries()) {
         items.push({
           type: 'song',
           variant: 'regular',
@@ -147,7 +147,7 @@ export default function QueuePanel({
           listIndex: i,
           key: `r-${song.id}`,
         });
-      });
+      }
     }
     return items;
   }, [priorityQueue, queue]);
@@ -272,17 +272,31 @@ export default function QueuePanel({
     [reorderQueue]
   );
 
-  const handleToggleMenu = useCallback(() => setMenuOpen(!menuOpen), [menuOpen]);
-  const handleCloseMenu = useCallback(() => setMenuOpen(false), []);
-  const handleCloseQuickAdd = useCallback(() => setShowQuickAdd(false), []);
-  const handleAddedQuickAdd = useCallback(() => setShowQuickAdd(false), []);
-  const handleCloseOverride = useCallback(() => setShowOverride(false), []);
-  const handleOverrideDone = useCallback(() => setShowOverride(false), []);
+  const handleToggleMenu = useCallback(() => {
+    setMenuOpen(!menuOpen);
+  }, [menuOpen]);
+  const handleCloseMenu = useCallback(() => {
+    setMenuOpen(false);
+  }, []);
+  const handleCloseQuickAdd = useCallback(() => {
+    setShowQuickAdd(false);
+  }, []);
+  const handleAddedQuickAdd = useCallback(() => {
+    setShowQuickAdd(false);
+  }, []);
+  const handleCloseOverride = useCallback(() => {
+    setShowOverride(false);
+  }, []);
+  const handleOverrideDone = useCallback(() => {
+    setShowOverride(false);
+  }, []);
   const handleConfirmClear = useCallback(async () => {
     setClearConfirm(false);
     await handleClear();
   }, [handleClear]);
-  const handleCancelClear = useCallback(() => setClearConfirm(false), []);
+  const handleCancelClear = useCallback(() => {
+    setClearConfirm(false);
+  }, []);
 
   const totalHeight = virtualizer.getTotalSize();
   const virtualContainerStyle = useMemo(
@@ -297,7 +311,9 @@ export default function QueuePanel({
         id: 'quick-add',
         label: 'Quick Add',
         icon: <PlusCircleIcon size={14} weight='duotone' />,
-        onClick: () => setShowQuickAdd(true),
+        onClick: () => {
+          setShowQuickAdd(true);
+        },
       });
     }
     if (isAdminView || hasPermission('queue.override')) {
@@ -306,7 +322,9 @@ export default function QueuePanel({
         label: 'Override',
         icon: <PlayIcon size={14} weight='duotone' />,
         danger: true,
-        onClick: () => setShowOverride(true),
+        onClick: () => {
+          setShowOverride(true);
+        },
       });
     }
     if (isAdminView || hasPermission('queue.manage')) {
@@ -316,7 +334,9 @@ export default function QueuePanel({
         icon: <BombIcon size={14} weight='duotone' />,
         danger: true,
         disabled: clearBusy || isQueueEmpty,
-        onClick: () => setClearConfirm(true),
+        onClick: () => {
+          setClearConfirm(true);
+        },
       });
     }
     return items;
@@ -324,7 +344,7 @@ export default function QueuePanel({
 
   if (loading) {
     return (
-      <div className='flex flex-col h-full'>
+      <div className='flex h-full flex-col'>
         <PanelHeader
           triggerRef={triggerRef}
           menuOpen={menuOpen}
@@ -332,7 +352,7 @@ export default function QueuePanel({
           mobileQuickControls={mobileQuickControls}
           showActions={false}
         />
-        <div className='flex-1 p-4 space-y-3'>
+        <div className='flex-1 space-y-3 p-4'>
           <Skeleton className='h-5 w-48 rounded' />
           <Skeleton className='h-12 w-full rounded' />
           <Skeleton className='h-12 w-full rounded' />
@@ -343,7 +363,7 @@ export default function QueuePanel({
   }
 
   return (
-    <div className='flex flex-col h-full'>
+    <div className='flex h-full flex-col'>
       <PanelHeader
         triggerRef={triggerRef}
         menuOpen={menuOpen}
@@ -353,7 +373,7 @@ export default function QueuePanel({
       />
 
       {/* Fixed content: Now Playing */}
-      <div className='p-4 space-y-4 shrink-0'>
+      <div className='shrink-0 space-y-4 p-4'>
         <AnimatePresence mode='wait'>
           {currentSong ? (
             <m.div
@@ -387,7 +407,7 @@ export default function QueuePanel({
         {/* Empty state */}
         {virtualItems.length === 0 && (
           <div className='py-8 text-center'>
-            <p className='font-mono text-[11px] text-faint'>queue is empty</p>
+            <p className='text-faint font-mono text-[11px]'>queue is empty</p>
           </div>
         )}
       </div>
@@ -396,7 +416,7 @@ export default function QueuePanel({
       {virtualItems.length > 0 && (
         <div
           ref={scrollRef}
-          className='flex-1 overflow-y-auto px-4 pb-4 min-h-0'
+          className='min-h-0 flex-1 overflow-y-auto px-4 pb-4'
           style={SCROLL_MASK_STYLE}
         >
           <div style={virtualContainerStyle}>
@@ -415,18 +435,18 @@ export default function QueuePanel({
                     style={getVirtualRowStyle(virtualRow.start)}
                   >
                     {item.variant === 'priority' ? (
-                      <h2 className='font-display text-lg text-fg tracking-wider'>
-                        <LightningIcon size={16} weight='duotone' className='inline mr-1' />
+                      <h2 className='font-display text-fg text-lg tracking-wider'>
+                        <LightningIcon size={16} weight='duotone' className='mr-1 inline' />
                         Up Next
-                        <span className='ml-2 font-mono text-xs text-accent normal-case tracking-normal'>
+                        <span className='text-accent ml-2 font-mono text-xs tracking-normal normal-case'>
                           {priorityQueue.length}
                         </span>
                       </h2>
                     ) : (
-                      <h2 className='font-display text-lg text-fg tracking-wider'>
+                      <h2 className='font-display text-fg text-lg tracking-wider'>
                         Queue
                         {queue.length > 0 && (
-                          <span className='ml-2 font-mono text-xs text-muted normal-case tracking-normal'>
+                          <span className='text-muted ml-2 font-mono text-xs tracking-normal normal-case'>
                             {queue.length}
                           </span>
                         )}
@@ -541,7 +561,9 @@ const QueueSongItem = memo(function QueueSongItem({
     e.stopPropagation();
     setMenuOpen((prev) => !prev);
   }, []);
-  const handleCloseSongMenu = useCallback(() => setMenuOpen(false), []);
+  const handleCloseSongMenu = useCallback(() => {
+    setMenuOpen(false);
+  }, []);
   const isPriority = variant === 'priority';
   const isFirst = index === 0;
   const isLast = index >= targetQueue.length - 1;
@@ -588,28 +610,36 @@ const QueueSongItem = memo(function QueueSongItem({
         label: 'Move Up',
         icon: <ArrowUpIcon size={14} weight='duotone' />,
         disabled: isFirst,
-        onClick: () => onMoveUp(targetQueue, song.id, isPriority ? 'priority' : 'queue'),
+        onClick: () => {
+          onMoveUp(targetQueue, song.id, isPriority ? 'priority' : 'queue');
+        },
       });
       items.push({
         id: 'move-down',
         label: 'Move Down',
         icon: <ArrowDownIcon size={14} weight='duotone' />,
         disabled: isLast,
-        onClick: () => onMoveDown(targetQueue, song.id, isPriority ? 'priority' : 'queue'),
+        onClick: () => {
+          onMoveDown(targetQueue, song.id, isPriority ? 'priority' : 'queue');
+        },
       });
       items.push({
         id: 'move-top',
         label: 'Move to Top',
         icon: <ArrowLineUpIcon size={14} weight='duotone' />,
         disabled: isFirst,
-        onClick: () => onMoveToTop(targetQueue, song.id, isPriority ? 'priority' : 'queue'),
+        onClick: () => {
+          onMoveToTop(targetQueue, song.id, isPriority ? 'priority' : 'queue');
+        },
       });
       items.push({
         id: 'move-bottom',
         label: 'Move to Bottom',
         icon: <ArrowLineDownIcon size={14} weight='duotone' />,
         disabled: isLast,
-        onClick: () => onMoveToBottom(targetQueue, song.id, isPriority ? 'priority' : 'queue'),
+        onClick: () => {
+          onMoveToBottom(targetQueue, song.id, isPriority ? 'priority' : 'queue');
+        },
       });
     }
 
@@ -634,47 +664,47 @@ const QueueSongItem = memo(function QueueSongItem({
   const sourceKey = useMemo(() => getSourceKey(song.sourceUrl), [song.sourceUrl]);
 
   return (
-    <div className='rounded-lg overflow-hidden' style={CARD_BG_STYLE}>
-      <div className='flex items-center gap-3 px-3 py-2 group'>
+    <div className='overflow-hidden rounded-lg' style={CARD_BG_STYLE}>
+      <div className='group flex items-center gap-3 px-3 py-2'>
         {/* Index */}
         <span
-          className={`font-mono text-[10px] w-4 text-right shrink-0 ${accent ? 'text-accent' : 'text-faint'}`}
+          className={`w-4 shrink-0 text-right font-mono text-[10px] ${accent ? 'text-accent' : 'text-faint'}`}
         >
           {index + 1}
         </span>
 
         {/* Thumbnail */}
-        <div className='overflow-hidden w-10 h-10 rounded border border-border shrink-0 bg-elevated'>
+        <div className='border-border bg-elevated h-10 w-10 shrink-0 overflow-hidden rounded border'>
           <ArtworkImage
             src={song.artwork ?? song.thumbnailUrl}
             alt={song.nickname ?? song.title}
-            className='w-full h-full'
+            className='h-full w-full'
             imageClassName='scale-[1.33]'
           />
         </div>
 
         {/* Info */}
-        <div className='flex-1 min-w-0 flex flex-col justify-center gap-0.5'>
-          <p className='text-xs font-semibold text-fg leading-tight flex items-center gap-1.5 min-w-0'>
-            <MusicNoteIcon size={13} weight='fill' className='shrink-0 text-muted' />
+        <div className='flex min-w-0 flex-1 flex-col justify-center gap-0.5'>
+          <p className='text-fg flex min-w-0 items-center gap-1.5 text-xs leading-tight font-semibold'>
+            <MusicNoteIcon size={13} weight='fill' className='text-muted shrink-0' />
             <span className='truncate'>{song.nickname ?? song.title}</span>
           </p>
-          <div className='flex items-center gap-2 text-[11px] text-muted min-w-0'>
+          <div className='text-muted flex min-w-0 items-center gap-2 text-[11px]'>
             {song.artist && (
-              <span className='max-w-[16ch] flex items-center gap-1 min-w-0'>
+              <span className='flex max-w-[16ch] min-w-0 items-center gap-1'>
                 <UserIcon size={12} weight='fill' className='shrink-0' />
                 <span className='truncate'>{song.artist}</span>
               </span>
             )}
             <DurationBadge seconds={song.duration} className='text-[11px]' />
           </div>
-          <div className='flex items-center gap-2 text-[11px] text-muted min-w-0'>
+          <div className='text-muted flex min-w-0 items-center gap-2 text-[11px]'>
             {sourceKey && (
-              <span className='flex items-center shrink-0 [&_svg]:w-3.5 [&_svg]:h-3.5'>
+              <span className='flex shrink-0 items-center [&_svg]:h-3.5 [&_svg]:w-3.5'>
                 <SourceIcon sourceKey={sourceKey} />
               </span>
             )}
-            <span className='max-w-[16ch] flex items-center gap-1 min-w-0'>
+            <span className='flex max-w-[16ch] min-w-0 items-center gap-1'>
               <UserCircleIcon size={12} weight='fill' className='shrink-0' />
               <span className='truncate'>{song.requestedBy}</span>
             </span>
@@ -682,7 +712,7 @@ const QueueSongItem = memo(function QueueSongItem({
         </div>
 
         {/* Badges */}
-        <div className='flex items-center gap-2 shrink-0'>
+        <div className='flex shrink-0 items-center gap-2'>
           <VolumeBoostBadge volumeBoost={song.volumeBoost} />
         </div>
 
@@ -696,7 +726,7 @@ const QueueSongItem = memo(function QueueSongItem({
             aria-haspopup='true'
             aria-expanded={menuOpen}
             aria-label='Song actions'
-            className={`opacity-0 group-hover:opacity-100 transition-opacity shrink-0 w-6 h-6 ${menuOpen ? 'pressed text-accent opacity-100' : 'text-muted hover:text-fg'}`}
+            className={`h-6 w-6 shrink-0 opacity-0 transition-opacity group-hover:opacity-100 ${menuOpen ? 'pressed text-accent opacity-100' : 'text-muted hover:text-fg'}`}
             onClick={handleToggleSongMenu}
           >
             <DotsThreeOutlineVerticalIcon size={14} weight='duotone' />
@@ -743,9 +773,9 @@ const PanelHeader = memo(function PanelHeader({
     );
 
   return (
-    <div className='flex items-center justify-between px-4 py-3 border-b border-border shrink-0'>
-      <h1 className='font-display text-3xl text-accent tracking-wider flex items-center gap-2'>
-        <QueueIcon size={24} weight='duotone' className='shrink-0 relative top-1' />
+    <div className='border-border flex shrink-0 items-center justify-between border-b px-4 py-3'>
+      <h1 className='font-display text-accent flex items-center gap-2 text-3xl tracking-wider'>
+        <QueueIcon size={24} weight='duotone' className='relative top-1 shrink-0' />
         Queue
       </h1>
       <div className='flex items-center gap-1'>
@@ -848,39 +878,39 @@ const NowPlayingCard = memo(function NowPlayingCard({
     <div className='card overflow-hidden' style={CARD_BG_STYLE}>
       <div className='flex gap-4 p-4'>
         {/* Artwork */}
-        <div className='relative shrink-0 overflow-hidden rounded-xl bg-elevated'>
+        <div className='bg-elevated relative shrink-0 overflow-hidden rounded-xl'>
           <ArtworkImage
             src={song.artwork ?? song.thumbnailUrl}
             alt={song.nickname ?? song.title}
-            className='w-20 h-20 rounded-xl border border-border'
+            className='border-border h-20 w-20 rounded-xl border'
             imageClassName='scale-[1.33]'
           />
         </div>
 
         {/* Info */}
-        <div className='flex-1 flex flex-col justify-center min-w-0 gap-1.5'>
+        <div className='flex min-w-0 flex-1 flex-col justify-center gap-1.5'>
           <a
             href={song.sourceUrl}
             target='_blank'
             rel='noopener noreferrer'
-            className='text-xs font-semibold text-fg hover:text-accent leading-tight flex items-center gap-1.5 min-w-0'
+            className='text-fg hover:text-accent flex min-w-0 items-center gap-1.5 text-xs leading-tight font-semibold'
           >
-            <MusicNoteIcon size={13} weight='fill' className='shrink-0 text-muted' />
+            <MusicNoteIcon size={13} weight='fill' className='text-muted shrink-0' />
             <span className='truncate'>{song.nickname ?? song.title}</span>
           </a>
-          <div className='flex items-center gap-2 text-[11px] text-muted min-w-0'>
+          <div className='text-muted flex min-w-0 items-center gap-2 text-[11px]'>
             {song.artist && (
-              <span className='max-w-[16ch] flex items-center gap-1 min-w-0'>
+              <span className='flex max-w-[16ch] min-w-0 items-center gap-1'>
                 <UserIcon size={12} weight='fill' className='shrink-0' />
                 <span className='truncate'>{song.artist}</span>
               </span>
             )}
-            <span className='max-w-[16ch] flex items-center gap-1 min-w-0'>
+            <span className='flex max-w-[16ch] min-w-0 items-center gap-1'>
               <UserCircleIcon size={12} weight='fill' className='shrink-0' />
               <span className='truncate'>{song.requestedBy}</span>
             </span>
             {sourceKey && (
-              <span className='flex items-center shrink-0 [&_svg]:w-3.5 [&_svg]:h-3.5'>
+              <span className='flex shrink-0 items-center [&_svg]:h-3.5 [&_svg]:w-3.5'>
                 <SourceIcon sourceKey={sourceKey} />
               </span>
             )}
@@ -889,16 +919,16 @@ const NowPlayingCard = memo(function NowPlayingCard({
 
           {/* Progress */}
           <div className='mt-1'>
-            <div className='relative h-1.5 w-full bg-elevated rounded-full overflow-hidden'>
+            <div className='bg-elevated relative h-1.5 w-full overflow-hidden rounded-full'>
               <div
                 ref={registerProgress}
-                className='absolute inset-y-0 left-0 bg-accent rounded-full'
+                className='bg-accent absolute inset-y-0 left-0 rounded-full'
                 style={ZERO_WIDTH_STYLE}
               />
             </div>
-            <div className='flex justify-between mt-1'>
-              <span className='font-mono text-[10px] text-muted'>{formatDuration(elapsed)}</span>
-              <span className='font-mono text-[10px] text-muted'>
+            <div className='mt-1 flex justify-between'>
+              <span className='text-muted font-mono text-[10px]'>{formatDuration(elapsed)}</span>
+              <span className='text-muted font-mono text-[10px]'>
                 {formatDuration(song.duration)}
               </span>
             </div>
@@ -914,10 +944,10 @@ const IdleCard = memo(function IdleCard() {
   return (
     <div className='card flex items-center justify-center py-8' style={CARD_BG_STYLE}>
       <div className='text-center'>
-        <div className='w-12 h-12 rounded-full bg-elevated border border-border flex items-center justify-center mx-auto mb-3'>
+        <div className='bg-elevated border-border mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full border'>
           <Icon size={20} weight='duotone' className='text-faint' />
         </div>
-        <p className='font-display text-xl text-faint tracking-wider mb-1'>Nothing Playing</p>
+        <p className='font-display text-faint mb-1 text-xl tracking-wider'>Nothing Playing</p>
       </div>
     </div>
   );

--- a/packages/web/src/components/QueuePanel.tsx
+++ b/packages/web/src/components/QueuePanel.tsx
@@ -7,6 +7,7 @@ import {
   ArrowUpIcon,
   BombIcon,
   CircleNotchIcon,
+  DotsSixVerticalIcon,
   DotsThreeOutlineVerticalIcon,
   LightningIcon,
   ListIcon,
@@ -37,6 +38,7 @@ import { useAdminView } from '../context/AdminViewContext';
 import { usePermissions } from '../context/PermissionsContext';
 import { usePlayer } from '../context/PlayerContext';
 import { type CooldownState } from '../hooks/useCooldownGuard';
+import { SortableListProvider, useSortableItem } from '../hooks/useSortableVirtualList';
 import { queueItemVariants } from '../lib/motion';
 import { getSourceKey } from '../utils/source';
 import { getRandomIdleIcon } from './EmptyState';
@@ -83,16 +85,6 @@ export interface MobileQuickControls {
   onShuffleToggle: () => void;
 }
 
-type VirtualQueueItem =
-  | {
-      type: 'song';
-      variant: 'priority' | 'regular';
-      song: QueuedSong;
-      listIndex: number;
-      key: string;
-    }
-  | { type: 'header'; variant: 'priority' | 'regular'; key: string };
-
 export default function QueuePanel({
   mobileQuickControls,
 }: {
@@ -122,6 +114,19 @@ export default function QueuePanel({
   const { currentSong, queue, priorityQueue } = state;
 
   const canManage = isAdminView || hasPermission('queue.manage');
+
+  const priorityIds = useMemo(() => priorityQueue.map((s) => s.id), [priorityQueue]);
+  const queueIds = useMemo(() => queue.map((s) => s.id), [queue]);
+
+  type VirtualQueueItem =
+    | {
+        type: 'song';
+        variant: 'priority' | 'regular';
+        song: QueuedSong;
+        listIndex: number;
+        key: string;
+      }
+    | { type: 'header'; variant: 'priority' | 'regular'; key: string };
 
   const virtualItems: VirtualQueueItem[] = useMemo(() => {
     const items: VirtualQueueItem[] = [];
@@ -159,6 +164,14 @@ export default function QueuePanel({
     estimateSize: (i) => (virtualItems[i]?.type === 'header' ? 36 : 92),
     overscan: 5,
   });
+
+  const virtualContainerStyle = useMemo(
+    () => ({
+      height: `${virtualizer.getTotalSize()}px`,
+      position: 'relative' as const,
+    }),
+    [virtualizer]
+  );
 
   const isQueueEmpty = queue.length === 0 && priorityQueue.length === 0 && !currentSong;
 
@@ -272,6 +285,20 @@ export default function QueuePanel({
     [reorderQueue]
   );
 
+  const handlePriorityReorder = useCallback(
+    async (orderedIds: string[]) => {
+      await reorderQueue(orderedIds, 'priority');
+    },
+    [reorderQueue]
+  );
+
+  const handleQueueReorder = useCallback(
+    async (orderedIds: string[]) => {
+      await reorderQueue(orderedIds, 'queue');
+    },
+    [reorderQueue]
+  );
+
   const handleToggleMenu = useCallback(() => {
     setMenuOpen(!menuOpen);
   }, [menuOpen]);
@@ -297,12 +324,6 @@ export default function QueuePanel({
   const handleCancelClear = useCallback(() => {
     setClearConfirm(false);
   }, []);
-
-  const totalHeight = virtualizer.getTotalSize();
-  const virtualContainerStyle = useMemo(
-    () => ({ height: `${totalHeight}px`, position: 'relative' as const }),
-    [totalHeight]
-  );
 
   const menuItems: MenuItem[] = useMemo(() => {
     const items: MenuItem[] = [];
@@ -405,7 +426,7 @@ export default function QueuePanel({
         </AnimatePresence>
 
         {/* Empty state */}
-        {virtualItems.length === 0 && (
+        {priorityQueue.length === 0 && queue.length === 0 && (
           <div className='py-8 text-center'>
             <p className='text-faint font-mono text-[11px]'>queue is empty</p>
           </div>
@@ -420,21 +441,26 @@ export default function QueuePanel({
           style={SCROLL_MASK_STYLE}
         >
           <div style={virtualContainerStyle}>
-            {virtualizer.getVirtualItems().map((virtualRow) => {
-              const item = virtualItems[virtualRow.index];
-              if (item == null) {
-                return null;
-              }
-
-              if (item.type === 'header') {
+            {/* Priority queue section */}
+            <SortableListProvider
+              itemIds={priorityIds}
+              onReorder={handlePriorityReorder}
+              scrollContainerRef={scrollRef}
+            >
+              {virtualizer.getVirtualItems().map((virtualRow) => {
+                const item = virtualItems[virtualRow.index];
+                if (!item || item.variant !== 'priority') {
+                  return null;
+                }
                 return (
                   <div
                     key={item.key}
                     data-index={virtualRow.index}
                     ref={virtualizer.measureElement}
+                    className={item.type === 'header' ? undefined : 'pb-1'}
                     style={getVirtualRowStyle(virtualRow.start)}
                   >
-                    {item.variant === 'priority' ? (
+                    {item.type === 'header' ? (
                       <h2 className='font-display text-fg text-lg tracking-wider'>
                         <LightningIcon size={16} weight='duotone' className='mr-1 inline' />
                         Up Next
@@ -443,6 +469,53 @@ export default function QueuePanel({
                         </span>
                       </h2>
                     ) : (
+                      <m.div
+                        initial='initial'
+                        animate='animate'
+                        variants={queueItemVariants}
+                        transition={QUEUE_TRANSITION}
+                      >
+                        <QueueSongItem
+                          song={item.song}
+                          index={item.listIndex}
+                          variant='priority'
+                          canManage={canManage}
+                          targetQueue={priorityQueue}
+                          onRemove={handleRemove}
+                          onPromote={handlePromote}
+                          onDemote={handleDemote}
+                          onMoveUp={handleMoveUp}
+                          onMoveDown={handleMoveDown}
+                          onMoveToTop={handleMoveToTop}
+                          onMoveToBottom={handleMoveToBottom}
+                        />
+                      </m.div>
+                    )}
+                  </div>
+                );
+              })}
+            </SortableListProvider>
+
+            {/* Regular queue section */}
+            <SortableListProvider
+              itemIds={queueIds}
+              onReorder={handleQueueReorder}
+              scrollContainerRef={scrollRef}
+            >
+              {virtualizer.getVirtualItems().map((virtualRow) => {
+                const item = virtualItems[virtualRow.index];
+                if (!item || item.variant !== 'regular') {
+                  return null;
+                }
+                return (
+                  <div
+                    key={item.key}
+                    data-index={virtualRow.index}
+                    ref={virtualizer.measureElement}
+                    className={item.type === 'header' ? undefined : 'pb-1'}
+                    style={getVirtualRowStyle(virtualRow.start)}
+                  >
+                    {item.type === 'header' ? (
                       <h2 className='font-display text-fg text-lg tracking-wider'>
                         Queue
                         {queue.length > 0 && (
@@ -451,43 +524,33 @@ export default function QueuePanel({
                           </span>
                         )}
                       </h2>
+                    ) : (
+                      <m.div
+                        initial='initial'
+                        animate='animate'
+                        variants={queueItemVariants}
+                        transition={QUEUE_TRANSITION}
+                      >
+                        <QueueSongItem
+                          song={item.song}
+                          index={item.listIndex}
+                          variant='regular'
+                          canManage={canManage}
+                          targetQueue={queue}
+                          onRemove={handleRemove}
+                          onPromote={handlePromote}
+                          onDemote={handleDemote}
+                          onMoveUp={handleMoveUp}
+                          onMoveDown={handleMoveDown}
+                          onMoveToTop={handleMoveToTop}
+                          onMoveToBottom={handleMoveToBottom}
+                        />
+                      </m.div>
                     )}
                   </div>
                 );
-              }
-
-              return (
-                <div
-                  key={item.key}
-                  data-index={virtualRow.index}
-                  ref={virtualizer.measureElement}
-                  className='pb-1'
-                  style={getVirtualRowStyle(virtualRow.start)}
-                >
-                  <m.div
-                    initial='initial'
-                    animate='animate'
-                    variants={queueItemVariants}
-                    transition={QUEUE_TRANSITION}
-                  >
-                    <QueueSongItem
-                      song={item.song}
-                      index={item.listIndex}
-                      variant={item.variant}
-                      canManage={canManage}
-                      targetQueue={item.variant === 'priority' ? priorityQueue : queue}
-                      onRemove={handleRemove}
-                      onPromote={handlePromote}
-                      onDemote={handleDemote}
-                      onMoveUp={handleMoveUp}
-                      onMoveDown={handleMoveDown}
-                      onMoveToTop={handleMoveToTop}
-                      onMoveToBottom={handleMoveToBottom}
-                    />
-                  </m.div>
-                </div>
-              );
-            })}
+              })}
+            </SortableListProvider>
           </div>
         </div>
       )}
@@ -555,6 +618,10 @@ const QueueSongItem = memo(function QueueSongItem({
   onMoveToTop: (targetQueue: QueuedSong[], songId: string, target: 'queue' | 'priority') => void;
   onMoveToBottom: (targetQueue: QueuedSong[], songId: string, target: 'queue' | 'priority') => void;
 }) {
+  const { itemRef, dragHandleRef, isDragging, isAnyDragging, isDropTarget } = useSortableItem(
+    song.id,
+    index
+  );
   const [menuOpen, setMenuOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const handleToggleSongMenu = useCallback((e: React.MouseEvent) => {
@@ -664,8 +731,24 @@ const QueueSongItem = memo(function QueueSongItem({
   const sourceKey = useMemo(() => getSourceKey(song.sourceUrl), [song.sourceUrl]);
 
   return (
-    <div className='overflow-hidden rounded-lg' style={CARD_BG_STYLE}>
-      <div className='group flex items-center gap-3 px-3 py-2'>
+    <div ref={itemRef} className='relative overflow-hidden rounded-lg' style={CARD_BG_STYLE}>
+      {/* Drop target highlight */}
+      {isDropTarget && (
+        <div className='bg-accent/10 pointer-events-none absolute inset-0 z-10 rounded-lg' />
+      )}
+      <div className={`group flex items-center gap-3 px-3 py-2 ${isDragging ? 'opacity-50' : ''}`}>
+        {/* Drag handle */}
+        {canManage && (
+          <button
+            ref={dragHandleRef}
+            type='button'
+            className={`text-faint hover:text-muted shrink-0 cursor-grab rounded opacity-0 transition-opacity active:cursor-grabbing ${isAnyDragging ? 'opacity-100' : 'group-hover:opacity-100'}`}
+            aria-label={`Drag to reorder "${song.nickname ?? song.title}"`}
+          >
+            <DotsSixVerticalIcon size={18} weight='bold' />
+          </button>
+        )}
+
         {/* Index */}
         <span
           className={`w-4 shrink-0 text-right font-mono text-[10px] ${accent ? 'text-accent' : 'text-faint'}`}

--- a/packages/web/src/components/RequestCard.tsx
+++ b/packages/web/src/components/RequestCard.tsx
@@ -38,45 +38,51 @@ export const RequestCard = memo(function RequestCard({
     : (req.artworkUrl ?? req.thumbnailUrl);
   const dateLabel = new Date(req.createdAt).toLocaleDateString();
 
-  const handleCancel = useCallback(() => onCancel(req.id), [onCancel, req.id]);
-  const handleApprove = useCallback(() => onApprove(req.id), [onApprove, req.id]);
-  const handleDeny = useCallback(() => onDeny(req.id), [onDeny, req.id]);
+  const handleCancel = useCallback(() => {
+    onCancel(req.id);
+  }, [onCancel, req.id]);
+  const handleApprove = useCallback(() => {
+    onApprove(req.id);
+  }, [onApprove, req.id]);
+  const handleDeny = useCallback(() => {
+    onDeny(req.id);
+  }, [onDeny, req.id]);
 
   return (
-    <Card className='rounded-xl flex items-center gap-4 p-4'>
+    <Card className='flex items-center gap-4 rounded-xl p-4'>
       {/* Thumbnail */}
       {thumbnailUrl ? (
         <ArtworkImage
           src={thumbnailUrl}
           alt=''
-          className='w-14 h-14 rounded-lg shrink-0 border border-border'
+          className='border-border h-14 w-14 shrink-0 rounded-lg border'
         />
       ) : (
-        <div className='w-14 h-14 rounded-lg bg-muted/20 shrink-0 flex items-center justify-center'>
-          <span className='text-muted text-xs font-mono'>{isPlaylist ? 'PL' : 'TR'}</span>
+        <div className='bg-muted/20 flex h-14 w-14 shrink-0 items-center justify-center rounded-lg'>
+          <span className='text-muted font-mono text-xs'>{isPlaylist ? 'PL' : 'TR'}</span>
         </div>
       )}
 
       {/* Info */}
-      <div className='flex-1 min-w-0'>
-        <p className='font-body text-sm text-fg truncate'>{req.title}</p>
-        <div className='flex items-center gap-1.5 mt-0.5'>
+      <div className='min-w-0 flex-1'>
+        <p className='font-body text-fg truncate text-sm'>{req.title}</p>
+        <div className='mt-0.5 flex items-center gap-1.5'>
           {req.sourceName && req.sourceName !== 'playlist' && (
             <SourceIcon sourceKey={req.sourceName} />
           )}
-          <span className='font-mono text-[10px] text-muted'>{formatDuration(req.duration)}</span>
+          <span className='text-muted font-mono text-[10px]'>{formatDuration(req.duration)}</span>
           {isPlaylist && req.playlistData && (
-            <span className='font-mono text-[10px] text-muted'>
+            <span className='text-muted font-mono text-[10px]'>
               · {req.playlistData.videoCount} tracks
             </span>
           )}
-          <span className='font-mono text-[10px] text-muted'>
+          <span className='text-muted font-mono text-[10px]'>
             · {req.requestedByDisplayName ?? req.requestedBy}
           </span>
-          <span className='font-mono text-[10px] text-faint'>· {dateLabel}</span>
+          <span className='text-faint font-mono text-[10px]'>· {dateLabel}</span>
         </div>
         {!isPending && req.reviewedBy && (
-          <p className='font-mono text-[10px] text-muted mt-0.5'>
+          <p className='text-muted mt-0.5 font-mono text-[10px]'>
             Reviewed {req.closedAt ? new Date(req.closedAt).toLocaleDateString() : ''}
           </p>
         )}
@@ -84,7 +90,7 @@ export const RequestCard = memo(function RequestCard({
 
       {/* Status badge */}
       <span
-        className={`px-2 py-0.5 rounded-full text-[10px] font-mono uppercase border shrink-0 ${
+        className={`shrink-0 rounded-full border px-2 py-0.5 font-mono text-[10px] uppercase ${
           statusColors[req.status] ?? 'bg-muted/10 text-muted border-muted/20'
         }`}
       >
@@ -93,7 +99,7 @@ export const RequestCard = memo(function RequestCard({
 
       {/* Actions */}
       {isPending && (
-        <div className='flex items-center gap-2 shrink-0'>
+        <div className='flex shrink-0 items-center gap-2'>
           {isOwn && (
             <Button
               variant='inherit'

--- a/packages/web/src/components/SongCard.tsx
+++ b/packages/web/src/components/SongCard.tsx
@@ -87,19 +87,29 @@ const SongCardInner = ({
   );
 
   // Stable callbacks for ContextMenu
-  const handleMenuToggle = useCallback(() => setMenuOpen((v) => !v), [setMenuOpen]);
-  const handleMenuClose = useCallback(() => setMenuOpen(false), [setMenuOpen]);
+  const handleMenuToggle = useCallback(() => {
+    setMenuOpen((v) => !v);
+  }, [setMenuOpen]);
+  const handleMenuClose = useCallback(() => {
+    setMenuOpen(false);
+  }, [setMenuOpen]);
   const handleMenuMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
   }, []);
 
   // Stable callbacks for inline edit panels
-  const handleEditClose = useCallback(() => setOpenSongId(null), [setOpenSongId]);
+  const handleEditClose = useCallback(() => {
+    setOpenSongId(null);
+  }, [setOpenSongId]);
 
   // Stable callbacks for list variant
-  const handleMouseEnter = useCallback(() => setIsRowHovered(true), []);
-  const handleMouseLeave = useCallback(() => setIsRowHovered(false), []);
+  const handleMouseEnter = useCallback(() => {
+    setIsRowHovered(true);
+  }, []);
+  const handleMouseLeave = useCallback(() => {
+    setIsRowHovered(false);
+  }, []);
   const pointerCursorStyle = useMemo(() => ({ cursor: 'pointer' }), []);
 
   const handleListKeyDown = useCallback(
@@ -146,21 +156,21 @@ const SongCardInner = ({
     return (
       <Card
         hoverable={!!isAdminView}
-        className={`rounded-lg flex flex-col relative${(isAdminView && !selectionMode) || selectionMode ? ' cursor-pointer' : ''}${selectionMode ? ` select-none${isSelected ? ' ring-2 ring-accent' : ' hover:ring-2 hover:ring-accent/50'}` : ''}${!selectionMode ? ' group' : ''}`}
+        className={`flex flex-col rounded-lg relative${(isAdminView && !selectionMode) || selectionMode ? ' cursor-pointer' : ''}${selectionMode ? ` select-none${isSelected ? ' ring-accent ring-2' : ' hover:ring-accent/50 hover:ring-2'}` : ''}${!selectionMode ? ' group' : ''}`}
         style={gridStyle}
         data-song-edit-container
         onClick={handleGridClick}
       >
         {isSelected && (
-          <div className='absolute inset-0 bg-accent/20 pointer-events-none rounded-lg z-10' />
+          <div className='bg-accent/20 pointer-events-none absolute inset-0 z-10 rounded-lg' />
         )}
 
         {/* Clean thumbnail */}
-        <div className='relative aspect-square overflow-hidden rounded-lg border border-border m-3 mb-0 bg-elevated'>
+        <div className='border-border bg-elevated relative m-3 mb-0 aspect-square overflow-hidden rounded-lg border'>
           <ArtworkImage
             src={song.artwork ?? song.thumbnailUrl}
             alt=''
-            className='w-full h-full'
+            className='h-full w-full'
             imageClassName='scale-[1.33]'
           />
           {/* Selection checkbox overlay */}
@@ -172,23 +182,23 @@ const SongCardInner = ({
         </div>
 
         {/* Info */}
-        <div className='p-4 flex-1 flex flex-col gap-1.5'>
+        <div className='flex flex-1 flex-col gap-1.5 p-4'>
           {/* Title + Source */}
           <div className='flex items-center justify-between gap-2'>
-            <p className='text-sm font-semibold text-fg leading-tight flex items-center gap-1.5 min-w-0'>
-              <MusicNoteIcon size={13} weight='fill' className='shrink-0 text-muted' />
+            <p className='text-fg flex min-w-0 items-center gap-1.5 text-sm leading-tight font-semibold'>
+              <MusicNoteIcon size={13} weight='fill' className='text-muted shrink-0' />
               <span className='line-clamp-2'>{song.nickname ?? song.title}</span>
             </p>
             {sourceKey && (
-              <span className='flex items-center shrink-0 [&_svg]:w-3.5 [&_svg]:h-3.5'>
+              <span className='flex shrink-0 items-center [&_svg]:h-3.5 [&_svg]:w-3.5'>
                 <SourceIcon sourceKey={sourceKey} />
               </span>
             )}
           </div>
           {/* Artist + Duration */}
-          <div className='flex items-center justify-between gap-2 text-xs text-muted overflow-hidden'>
+          <div className='text-muted flex items-center justify-between gap-2 overflow-hidden text-xs'>
             {song.artist ? (
-              <span className='flex items-center gap-1 min-w-0'>
+              <span className='flex min-w-0 items-center gap-1'>
                 <MicrophoneStageIcon size={12} weight='fill' className='shrink-0' />
                 <span className='truncate'>{song.artist}</span>
               </span>
@@ -199,9 +209,9 @@ const SongCardInner = ({
           </div>
 
           {/* Album + VolumeBoost */}
-          <div className='flex items-center justify-between gap-2 text-xs text-muted overflow-hidden'>
+          <div className='text-muted flex items-center justify-between gap-2 overflow-hidden text-xs'>
             {song.album ? (
-              <span className='flex items-center gap-1 min-w-0'>
+              <span className='flex min-w-0 items-center gap-1'>
                 <DiscIcon size={12} weight='fill' className='shrink-0' />
                 <span className='truncate'>{song.album}</span>
               </span>
@@ -213,8 +223,8 @@ const SongCardInner = ({
 
           {/* Requested by */}
           {song.addedBy ? (
-            <div className='flex items-center justify-between gap-2 text-xs text-muted overflow-hidden'>
-              <span className='flex items-center gap-1 min-w-0'>
+            <div className='text-muted flex items-center justify-between gap-2 overflow-hidden text-xs'>
+              <span className='flex min-w-0 items-center gap-1'>
                 <UserIcon size={12} weight='fill' className='shrink-0' />
                 <span className='truncate'>{song.addedByDisplayName ?? song.addedBy}</span>
               </span>
@@ -225,12 +235,12 @@ const SongCardInner = ({
           {/* Tags + Actions */}
           <div className='flex items-center justify-between gap-2 pt-1'>
             <div className='min-w-0'>{tags.length > 0 && <TagTicker tags={tags} />}</div>
-            <div className='flex items-center gap-1 shrink-0'>
+            <div className='flex shrink-0 items-center gap-1'>
               <div
                 className={
                   menuOpen
                     ? ''
-                    : 'opacity-0 group-hover:opacity-100 [@media(hover:none)]:opacity-100 transition-opacity duration-150'
+                    : 'opacity-0 transition-opacity duration-150 group-hover:opacity-100 [@media(hover:none)]:opacity-100'
                 }
               >
                 <ContextMenuTrigger
@@ -269,18 +279,18 @@ const SongCardInner = ({
   return (
     <Card
       hoverable={!!isAdminView}
-      className={`rounded-lg flex flex-col relative${selectionMode ? ' select-none hover:ring-2 hover:ring-accent/50' : ''}${isSelected ? ' ring-2 ring-accent' : ''}`}
+      className={`flex flex-col rounded-lg relative${selectionMode ? ' hover:ring-accent/50 select-none hover:ring-2' : ''}${isSelected ? ' ring-accent ring-2' : ''}`}
       data-song-id={song.id}
       data-song-edit-container
     >
       {isSelected && (
-        <div className='absolute inset-0 bg-accent/20 pointer-events-none rounded-lg z-10' />
+        <div className='bg-accent/20 pointer-events-none absolute inset-0 z-10 rounded-lg' />
       )}
 
       <div
         role='button'
         tabIndex={canEdit || selectionMode ? 0 : -1}
-        className='flex items-center gap-3 md:gap-4 px-4 py-4 w-full text-left bg-transparent border-0'
+        className='flex w-full items-center gap-3 border-0 bg-transparent px-4 py-4 text-left md:gap-4'
         onClick={handleListClick}
         onKeyDown={handleListKeyDown}
         style={canEdit || selectionMode ? pointerCursorStyle : undefined}
@@ -294,42 +304,42 @@ const SongCardInner = ({
           </span>
         )}
 
-        <div className='overflow-hidden w-16 h-16 rounded border border-border shrink-0 bg-elevated'>
+        <div className='border-border bg-elevated h-16 w-16 shrink-0 overflow-hidden rounded border'>
           <ArtworkImage
             src={song.artwork ?? song.thumbnailUrl}
             alt={song.nickname ?? song.title}
-            className='w-full h-full'
+            className='h-full w-full'
             imageClassName='scale-[1.33]'
           />
         </div>
-        <div className='flex-1 min-w-0 flex flex-col justify-center gap-1.5'>
-          <p className='text-sm font-semibold text-fg leading-tight flex items-center gap-1.5 min-w-0'>
-            <MusicNoteIcon size={13} weight='fill' className='shrink-0 text-muted' />
+        <div className='flex min-w-0 flex-1 flex-col justify-center gap-1.5'>
+          <p className='text-fg flex min-w-0 items-center gap-1.5 text-sm leading-tight font-semibold'>
+            <MusicNoteIcon size={13} weight='fill' className='text-muted shrink-0' />
             <span className='truncate'>{song.nickname ?? song.title}</span>
           </p>
-          <div className='flex items-center gap-2.5 flex-wrap text-xs text-muted min-w-0'>
+          <div className='text-muted flex min-w-0 flex-wrap items-center gap-2.5 text-xs'>
             {song.artist && (
-              <span className='max-w-[16ch] flex items-center gap-1 min-w-0'>
+              <span className='flex max-w-[16ch] min-w-0 items-center gap-1'>
                 <MicrophoneStageIcon size={12} weight='fill' className='shrink-0' />
                 <span className='truncate'>{song.artist}</span>
               </span>
             )}
             {song.album && (
-              <span className='max-w-[20ch] flex items-center gap-1 min-w-0'>
+              <span className='flex max-w-[20ch] min-w-0 items-center gap-1'>
                 <DiscIcon size={12} weight='fill' className='shrink-0' />
                 <span className='truncate'>{song.album}</span>
               </span>
             )}
             {tags.length > 0 && <TagTicker tags={tags} isHovered={isRowHovered} />}
           </div>
-          <div className='flex items-center gap-2.5 flex-wrap text-xs text-muted min-w-0'>
+          <div className='text-muted flex min-w-0 flex-wrap items-center gap-2.5 text-xs'>
             {sourceKey && (
-              <span className='flex items-center shrink-0 [&_svg]:w-3.5 [&_svg]:h-3.5'>
+              <span className='flex shrink-0 items-center [&_svg]:h-3.5 [&_svg]:w-3.5'>
                 <SourceIcon sourceKey={sourceKey} />
               </span>
             )}
             {song.addedBy && (
-              <span className='max-w-[16ch] flex items-center gap-1 min-w-0'>
+              <span className='flex max-w-[16ch] min-w-0 items-center gap-1'>
                 <UserIcon size={12} weight='fill' className='shrink-0' />
                 <span className='truncate'>{song.addedByDisplayName ?? song.addedBy}</span>
               </span>
@@ -342,7 +352,7 @@ const SongCardInner = ({
           className={
             menuOpen
               ? ''
-              : `opacity-0 [@media(hover:none)]:opacity-100 transition-opacity duration-150 ${isRowHovered ? 'opacity-100' : ''}`
+              : `opacity-0 transition-opacity duration-150 [@media(hover:none)]:opacity-100 ${isRowHovered ? 'opacity-100' : ''}`
           }
         >
           <ContextMenuTrigger
@@ -350,13 +360,13 @@ const SongCardInner = ({
             onToggle={handleMenuToggle}
             isOpen={menuOpen}
             onMouseDown={handleMenuMouseDown}
-            className='w-12 h-12'
+            className='h-12 w-12'
           />
         </div>
         <PlayButton
           onClick={onPlay}
           isPlaying={!!isPlaying}
-          className='w-12 h-12 disabled:opacity-50'
+          className='h-12 w-12 disabled:opacity-50'
         />
         {menuOpen && (
           <ContextMenu

--- a/packages/web/src/components/SongEditPanel.tsx
+++ b/packages/web/src/components/SongEditPanel.tsx
@@ -152,7 +152,7 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
         tags: t,
         volumeBoost: vo,
       } = fieldsRef.current();
-      const parsedRaw = vo.trim() === '' ? null : parseInt(vo.trim(), 10);
+      const parsedRaw = vo.trim() === '' ? null : Number.parseInt(vo.trim(), 10);
       const parsedBoost =
         parsedRaw != null && !Number.isNaN(parsedRaw) && parsedRaw !== 0 ? parsedRaw : null;
 
@@ -202,7 +202,7 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
         tags: t,
         volumeBoost: vo,
       } = fieldsRef.current();
-      const parsedRaw = vo.trim() === '' ? null : parseInt(vo.trim(), 10);
+      const parsedRaw = vo.trim() === '' ? null : Number.parseInt(vo.trim(), 10);
       const parsedBoost =
         parsedRaw != null && !Number.isNaN(parsedRaw) && parsedRaw !== 0 ? parsedRaw : null;
 
@@ -241,7 +241,9 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
     [doSave]
   );
 
-  const handlePanelClick = useCallback((e: React.MouseEvent) => e.stopPropagation(), []);
+  const handlePanelClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+  }, []);
 
   const panelStyle = useMemo(
     () => (closing ? ({ pointerEvents: 'none' } as const) : undefined),
@@ -262,7 +264,7 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
 
   const handleTagPillRemove = useCallback(
     (e: React.MouseEvent<HTMLButtonElement>) => {
-      const tag = e.currentTarget.closest('[data-tag]')?.getAttribute('data-tag');
+      const tag = e.currentTarget.closest<HTMLElement>('[data-tag]')?.dataset.tag;
       if (tag) {
         removeTag(tag);
       }
@@ -270,17 +272,18 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
     [removeTag]
   );
 
-  const handleTagInputChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => setTagInput(e.target.value),
-    []
-  );
+  const handleTagInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setTagInput(e.target.value);
+  }, []);
 
   const handleTagToggle = useCallback(
     (tag: string) => {
       if (tags.includes(tag)) {
         removeTag(tag);
       } else {
-        flushSync(() => setTags((prev) => [...prev, tag]));
+        flushSync(() => {
+          setTags((prev) => [...prev, tag]);
+        });
       }
     },
     [tags, removeTag]
@@ -302,7 +305,7 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
       style={panelStyle}
       onClick={handlePanelClick}
     >
-      <div className='px-3 md:px-4 pt-4 pb-4 border-t border-border'>
+      <div className='border-border border-t px-3 pt-4 pb-4 md:px-4'>
         <div className='flex flex-col gap-3'>
           <Field
             id='panel-name'
@@ -342,12 +345,12 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
           <div>
             <label
               htmlFor='panel-tag-input'
-              className='block font-mono text-[10px] text-muted uppercase mb-1'
+              className='text-muted mb-1 block font-mono text-[10px] uppercase'
             >
               Tags
             </label>
             <div
-              className='input text-sm flex flex-wrap gap-1.5 items-center min-h-9.5 cursor-text relative'
+              className='input relative flex min-h-9.5 cursor-text flex-wrap items-center gap-1.5 text-sm'
               onClick={handleFocusTagInput}
             >
               {tags.map((tag) => {
@@ -355,7 +358,7 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
                 return (
                   <span
                     key={tag}
-                    className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-mono ${c.bg} ${c.text} border ${c.border}`}
+                    className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-mono text-xs ${c.bg} ${c.text} border ${c.border}`}
                   >
                     {tag}
                     <button
@@ -372,7 +375,7 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
               <input
                 id='panel-tag-input'
                 ref={tagInputRef}
-                className='flex-1 min-w-20 bg-transparent outline-none text-sm text-fg placeholder:text-faint'
+                className='text-fg placeholder:text-faint min-w-20 flex-1 bg-transparent text-sm outline-none'
                 placeholder={tags.length === 0 ? 'Custom grouping (enter to confirm)' : ''}
                 value={tagInput}
                 onChange={handleTagInputChange}
@@ -420,7 +423,8 @@ function VolumeSlider({
   max: number;
   onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
 }) {
-  const numeric = value.trim() === '' ? 0 : Math.min(max, Math.max(min, parseInt(value, 10) || 0));
+  const numeric =
+    value.trim() === '' ? 0 : Math.min(max, Math.max(min, Number.parseInt(value, 10) || 0));
   const pct = `${((numeric - min) / (max - min)) * 100}%`;
 
   const handleChange = useCallback(
@@ -437,7 +441,7 @@ function VolumeSlider({
     if (value.trim() === '') {
       onChange('0');
     } else {
-      const n = parseInt(value, 10);
+      const n = Number.parseInt(value, 10);
       if (!Number.isNaN(n)) {
         onChange(String(Math.min(max, Math.max(min, n))));
       }
@@ -445,7 +449,9 @@ function VolumeSlider({
   }, [value, onChange, min, max]);
 
   const handleRangeChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.value),
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange(e.target.value);
+    },
     [onChange]
   );
 
@@ -459,18 +465,18 @@ function VolumeSlider({
 
   return (
     <div>
-      <span className='block font-mono text-[10px] text-muted uppercase mb-1'>Volume Boost</span>
+      <span className='text-muted mb-1 block font-mono text-[10px] uppercase'>Volume Boost</span>
       <div className='flex items-center gap-3'>
         <input
           id='panel-volume-boost'
-          className='input text-sm w-16 text-center'
+          className='input w-16 text-center text-sm'
           type='text'
           value={value}
           onChange={handleChange}
           onKeyDown={onKeyDown}
           onBlur={handleBlur}
         />
-        <span className='text-xs text-muted font-mono w-8 text-left'>%</span>
+        <span className='text-muted w-8 text-left font-mono text-xs'>%</span>
         <input
           type='range'
           min={min}
@@ -509,12 +515,14 @@ function Field({
   max?: number;
 }) {
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.value),
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange(e.target.value);
+    },
     [onChange]
   );
   return (
     <div>
-      <label htmlFor={id} className='block font-mono text-[10px] text-muted uppercase mb-1'>
+      <label htmlFor={id} className='text-muted mb-1 block font-mono text-[10px] uppercase'>
         {label}
       </label>
       <input
@@ -544,7 +552,7 @@ function CheckIcon() {
       strokeWidth='3'
       strokeLinecap='round'
       strokeLinejoin='round'
-      className='text-green-400 inline-block'
+      className='inline-block text-green-400'
       aria-label='Added'
     >
       <title>Added</title>
@@ -628,7 +636,9 @@ function TagDropdown({
       }
     };
     document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
+    return () => {
+      document.removeEventListener('mousedown', handler);
+    };
   }, [onClose]);
 
   const filtered = availableTags.filter(
@@ -654,7 +664,7 @@ function TagDropdown({
 
   const handleItemMouseEnter = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
-      const idx = parseInt(e.currentTarget.dataset.index ?? '0', 10);
+      const idx = Number.parseInt(e.currentTarget.dataset.index ?? '0', 10);
       onHighlight(idx);
     },
     [onHighlight]
@@ -663,11 +673,11 @@ function TagDropdown({
   const dropdown = (
     <div
       ref={dropdownRef}
-      className='fixed z-50 min-w-45 glass-popover max-h-48'
+      className='glass-popover fixed z-50 max-h-48 min-w-45'
       style={TAG_DROPDOWN_PLACEHOLDER_STYLE}
     >
       {filtered.length === 0 ? (
-        <div className='px-3 py-2 text-xs text-muted cursor-default'>
+        <div className='text-muted cursor-default px-3 py-2 text-xs'>
           {availableTags.length === 0 ? 'No tags yet' : 'No matches'}
         </div>
       ) : (
@@ -677,7 +687,7 @@ function TagDropdown({
           return (
             <div
               key={tag.nameLower}
-              className={`flex items-center gap-2 px-3 py-2 text-sm cursor-pointer ${
+              className={`flex cursor-pointer items-center gap-2 px-3 py-2 text-sm ${
                 i === highlightedIndex ? 'bg-elevated' : 'hover:bg-elevated/70'
               }`}
               onMouseDown={handleItemMouseDown}
@@ -686,7 +696,7 @@ function TagDropdown({
               data-index={i}
             >
               <span className={`font-mono text-xs ${c.text}`}>{tag.canonicalName}</span>
-              <span className='ml-auto text-muted text-xs'>
+              <span className='text-muted ml-auto text-xs'>
                 {isAdded ? <CheckIcon /> : <CrossIcon />}
               </span>
             </div>

--- a/packages/web/src/components/SortableVirtualSongList.tsx
+++ b/packages/web/src/components/SortableVirtualSongList.tsx
@@ -1,0 +1,267 @@
+import { type Playlist, type Song } from '@alfira/server/shared';
+import { DotsSixVerticalIcon } from '@phosphor-icons/react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { useSongEdit } from '../context/SongEditContext';
+import { SortableListProvider, useSortableItem } from '../hooks/useSortableVirtualList';
+import SongCard from './SongCard';
+import { VirtualList } from './VirtualList';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface SortableVirtualSongListProps {
+  items: Song[];
+  isAdminView: boolean;
+  playlists: Playlist[];
+  isLoading: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  hasMore: boolean;
+  hasLoaded: boolean;
+  playingId: string | null;
+  onRetry: () => void;
+  onFetchMore: () => void;
+  onDelete?: (id: string) => void;
+  onPlay: (id: string) => void;
+  onAddToQueue: (id: string) => void;
+  onReorder: (orderedIds: string[]) => Promise<void>;
+  emptyTitle: string;
+  emptyMessage?: string;
+  // Bulk selection
+  selectionMode?: boolean;
+  isSelected?: (id: string) => boolean;
+  onToggleSelect?: (id: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Item wrapper with drag handle
+// ---------------------------------------------------------------------------
+
+/** Height of an expanded row (card + edit panel + spacer). */
+const EXPANDED_ROW_HEIGHT = 540;
+/** Height of a collapsed song row (card + spacer). */
+const COLLAPSED_ROW_HEIGHT = 105;
+
+interface SortableSongItemProps {
+  song: Song;
+  index: number;
+  isAdminView: boolean;
+  playlists: Playlist[];
+  playingId: string | null;
+  selectionMode: boolean;
+  isSelected: boolean;
+  onDelete?: (id: string) => void;
+  onPlay: (id: string) => void;
+  onAddToQueue: (id: string) => void;
+  onToggleSelect?: (id: string) => void;
+}
+
+const SortableSongItem = memo(function SortableSongItem({
+  song,
+  index,
+  isAdminView,
+  playlists,
+  playingId,
+  selectionMode,
+  isSelected,
+  onDelete,
+  onPlay,
+  onAddToQueue,
+  onToggleSelect,
+}: SortableSongItemProps) {
+  const { itemRef, dragHandleRef, isDragging, isAnyDragging, isDropTarget } = useSortableItem(
+    song.id,
+    index
+  );
+
+  const handlePlay = useCallback(() => {
+    onPlay(song.id);
+  }, [onPlay, song.id]);
+  const handleAddToQueue = useCallback(() => {
+    onAddToQueue(song.id);
+  }, [onAddToQueue, song.id]);
+  const handleToggleSelect = useCallback(
+    () => onToggleSelect?.(song.id),
+    [onToggleSelect, song.id]
+  );
+
+  return (
+    <div ref={itemRef} className='group relative flex items-center'>
+      {/* Drop target highlight */}
+      {isDropTarget && (
+        <div className='bg-accent/10 pointer-events-none absolute inset-0 z-10 rounded-lg' />
+      )}
+
+      {/* Drag handle — visible on row hover, always visible during any drag */}
+      <button
+        ref={dragHandleRef}
+        type='button'
+        className={`text-faint hover:text-muted -mr-0.5 ml-0.5 shrink-0 cursor-grab rounded opacity-0 transition-opacity active:cursor-grabbing ${isAnyDragging ? 'opacity-100' : 'group-hover:opacity-100'}`}
+        aria-label={`Drag to reorder "${song.nickname ?? song.title}"`}
+      >
+        <DotsSixVerticalIcon size={18} weight='bold' />
+      </button>
+
+      <div className={`min-w-0 flex-1 transition-opacity ${isDragging ? 'opacity-50' : ''}`}>
+        <SongCard
+          song={song}
+          variant='list'
+          isAdminView={isAdminView}
+          playlists={playlists}
+          onDelete={onDelete}
+          onPlay={handlePlay}
+          isPlaying={playingId === song.id}
+          onAddToQueue={handleAddToQueue}
+          selectionMode={selectionMode}
+          isSelected={isSelected}
+          onToggleSelect={onToggleSelect ? handleToggleSelect : undefined}
+        />
+      </div>
+    </div>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Skeleton
+// ---------------------------------------------------------------------------
+
+const SKELETON_KEYS = ['sk-0', 'sk-1', 'sk-2', 'sk-3', 'sk-4', 'sk-5', 'sk-6', 'sk-7'];
+
+function SkeletonList() {
+  return (
+    <div className='flex flex-col gap-1.5'>
+      {SKELETON_KEYS.map((key) => (
+        <div
+          key={key}
+          className='bg-elevated clay-resting flex items-center gap-3 rounded-lg px-4 py-4 md:gap-4'
+        >
+          <div className='bg-surface h-16 w-16 shrink-0 animate-pulse rounded border' />
+          <div className='flex min-w-0 flex-1 flex-col gap-2'>
+            <div className='bg-surface h-3.5 w-2/5 animate-pulse rounded' />
+            <div className='bg-surface h-3 w-3/5 animate-pulse rounded' />
+          </div>
+          <div className='bg-surface h-6 w-6 shrink-0 animate-pulse rounded' />
+          <div className='bg-surface h-4 w-4 shrink-0 animate-pulse rounded' />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export const SortableVirtualSongList = memo(function SortableVirtualSongList({
+  items,
+  isAdminView,
+  playlists,
+  isLoading,
+  isFetching,
+  isError,
+  hasMore,
+  hasLoaded,
+  playingId,
+  onRetry,
+  onFetchMore,
+  onDelete,
+  onPlay,
+  onAddToQueue,
+  onReorder,
+  emptyTitle,
+  emptyMessage,
+  selectionMode = false,
+  isSelected,
+  onToggleSelect,
+}: SortableVirtualSongListProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const { openSongId } = useSongEdit();
+
+  // Track the "effective" open song for layout — same pattern as VirtualSongList.
+  const [effectiveOpenId, setEffectiveOpenId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (openSongId) {
+      setEffectiveOpenId(openSongId);
+    } else {
+      const timeout = setTimeout(() => {
+        setEffectiveOpenId(null);
+      }, 300);
+      return () => {
+        clearTimeout(timeout);
+      };
+    }
+  }, [openSongId]);
+
+  // Build the ordered ID list for the provider
+  const songIds = useMemo(() => items.map((s) => s.id), [items]);
+
+  const getItemKey = useCallback((song: Song) => song.id, []);
+
+  const renderItem = useCallback(
+    (song: Song, index: number) => (
+      <SortableSongItem
+        song={song}
+        index={index}
+        isAdminView={isAdminView}
+        playlists={playlists}
+        playingId={playingId}
+        selectionMode={selectionMode}
+        isSelected={isSelected?.(song.id) ?? false}
+        onDelete={onDelete}
+        onPlay={onPlay}
+        onAddToQueue={onAddToQueue}
+        onToggleSelect={onToggleSelect}
+      />
+    ),
+    [
+      isAdminView,
+      playlists,
+      playingId,
+      selectionMode,
+      isSelected,
+      onDelete,
+      onPlay,
+      onAddToQueue,
+      onToggleSelect,
+    ]
+  );
+
+  const estimateSize = useCallback(
+    (index: number) => {
+      return (items[index] as Song | undefined)?.id === effectiveOpenId
+        ? EXPANDED_ROW_HEIGHT
+        : COLLAPSED_ROW_HEIGHT;
+    },
+    [items, effectiveOpenId]
+  );
+
+  const skeleton = useMemo(() => <SkeletonList />, []);
+
+  return (
+    <SortableListProvider itemIds={songIds} onReorder={onReorder} scrollContainerRef={scrollRef}>
+      <VirtualList
+        items={items}
+        getItemKey={getItemKey}
+        renderItem={renderItem}
+        estimateSize={estimateSize}
+        scrollRef={scrollRef}
+        itemClassName='pb-3'
+        isLoading={isLoading}
+        hasLoaded={hasLoaded}
+        isFetching={isFetching}
+        isError={isError}
+        hasMore={hasMore}
+        onRetry={onRetry}
+        onFetchMore={onFetchMore}
+        skeleton={skeleton}
+        emptyTitle={emptyTitle}
+        emptyMessage={emptyMessage}
+      />
+    </SortableListProvider>
+  );
+});
+
+export default SortableVirtualSongList;

--- a/packages/web/src/components/TagTicker.tsx
+++ b/packages/web/src/components/TagTicker.tsx
@@ -119,7 +119,7 @@ const TagTicker = memo(({ tags, isHovered: externalHovered }: TagTickerProps) =>
         return (
           <span
             key={tag}
-            className={`inline-flex items-center px-1.5 py-0 rounded text-[11px] font-medium whitespace-nowrap ${colors.bg} ${colors.text}`}
+            className={`inline-flex items-center rounded px-1.5 py-0 text-[11px] font-medium whitespace-nowrap ${colors.bg} ${colors.text}`}
           >
             {tag}
           </span>
@@ -166,13 +166,13 @@ const TagTicker = memo(({ tags, isHovered: externalHovered }: TagTickerProps) =>
     // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- hover state controls ticker; marquee has dedicated role
     <div
       role='marquee'
-      className='overflow-hidden py-0 max-w-[60%]'
+      className='max-w-[60%] overflow-hidden py-0'
       ref={outerRef}
       style={maskStyle}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
-      <div className='flex gap-1 w-max' ref={innerRef}>
+      <div className='flex w-max gap-1' ref={innerRef}>
         {renderTags()}
       </div>
     </div>

--- a/packages/web/src/components/UserMenu.tsx
+++ b/packages/web/src/components/UserMenu.tsx
@@ -51,7 +51,7 @@ export default function UserMenu({ user, collapsed, onLogout }: UserMenuProps) {
   // Position before paint (useLayoutEffect) to avoid a (0,0) flash.
   useLayoutEffect(() => {
     if (!open) {
-      return undefined;
+      return;
     }
     updatePosition();
     window.addEventListener('resize', updatePosition);
@@ -65,7 +65,7 @@ export default function UserMenu({ user, collapsed, onLogout }: UserMenuProps) {
   // Close on click outside
   useEffect(() => {
     if (!open) {
-      return undefined;
+      return;
     }
     const handler = (e: MouseEvent | TouchEvent) => {
       const target = e.target as Node;
@@ -85,7 +85,7 @@ export default function UserMenu({ user, collapsed, onLogout }: UserMenuProps) {
   // Close on Escape
   useEffect(() => {
     if (!open) {
-      return undefined;
+      return;
     }
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -94,7 +94,9 @@ export default function UserMenu({ user, collapsed, onLogout }: UserMenuProps) {
       }
     };
     document.addEventListener('keydown', handler);
-    return () => document.removeEventListener('keydown', handler);
+    return () => {
+      document.removeEventListener('keydown', handler);
+    };
   }, [open]);
 
   const handleLogout = useCallback(() => {
@@ -102,9 +104,13 @@ export default function UserMenu({ user, collapsed, onLogout }: UserMenuProps) {
     onLogout();
   }, [onLogout]);
 
-  const handleToggle = useCallback(() => setOpen((o) => !o), []);
+  const handleToggle = useCallback(() => {
+    setOpen((o) => !o);
+  }, []);
 
-  const handleStopPropagation = useCallback((e: React.SyntheticEvent) => e.stopPropagation(), []);
+  const handleStopPropagation = useCallback((e: React.SyntheticEvent) => {
+    e.stopPropagation();
+  }, []);
 
   const portalStyle = useMemo(
     () => ({ position: 'fixed' as const, top: position.top, left: position.left }),
@@ -118,12 +124,12 @@ export default function UserMenu({ user, collapsed, onLogout }: UserMenuProps) {
     <img
       src={user.avatar}
       alt={user.username}
-      className={`${avatarSize} rounded-full object-cover shrink-0`}
+      className={`${avatarSize} shrink-0 rounded-full object-cover`}
       decoding='async'
     />
   ) : (
     <div
-      className={`${avatarSize} rounded-full bg-elevated flex items-center justify-center shrink-0`}
+      className={`${avatarSize} bg-elevated flex shrink-0 items-center justify-center rounded-full`}
     >
       <span className={`font-mono ${avatarFallbackSize} text-muted`}>
         {user.username[0]?.toUpperCase()}
@@ -144,13 +150,13 @@ export default function UserMenu({ user, collapsed, onLogout }: UserMenuProps) {
         type='button'
         onClick={handleToggle}
         title={user.username}
-        className={`flex items-center rounded-xl font-body transition-all duration-150 cursor-pointer w-full btn-inherit ${
+        className={`font-body btn-inherit flex w-full cursor-pointer items-center rounded-xl transition-all duration-150 ${
           collapsed ? 'justify-center px-0 py-3' : 'gap-3 px-3 py-2.5'
         } ${open ? 'pressed text-accent' : ''}`}
         style={triggerSurfaceVar}
       >
         {!collapsed && (
-          <span className={`truncate mr-auto ${open ? 'text-accent' : 'text-fg'}`}>
+          <span className={`mr-auto truncate ${open ? 'text-accent' : 'text-fg'}`}>
             {user.username}
           </span>
         )}
@@ -169,20 +175,20 @@ export default function UserMenu({ user, collapsed, onLogout }: UserMenuProps) {
             onKeyDown={handleStopPropagation}
             onClick={handleStopPropagation}
           >
-            <div className='glass-popover outline-2 outline-accent/20'>
+            <div className='glass-popover outline-accent/20 outline-2'>
               {/* Username header — mirrors ContextMenu InfoRow */}
-              <div className='px-3 py-1.5 text-xs font-mono text-muted flex items-center gap-2'>
+              <div className='text-muted flex items-center gap-2 px-3 py-1.5 font-mono text-xs'>
                 <UserIcon size={14} weight='duotone' className='shrink-0' />
                 <span className='truncate'>{user.username}</span>
               </div>
               {/* Separator — mirrors ContextMenu separators */}
-              <div className='border-b border-muted/50' />
+              <div className='border-muted/50 border-b' />
               {/* Logout — mirrors ContextMenu MenuItemButton danger styling */}
               <button
                 type='button'
                 role='menuitem'
                 onClick={handleLogout}
-                className='w-full text-left px-3 py-1.5 text-xs font-mono text-danger hover:bg-danger/10 flex items-center gap-2 transition-colors duration-100'
+                className='text-danger hover:bg-danger/10 flex w-full items-center gap-2 px-3 py-1.5 text-left font-mono text-xs transition-colors duration-100'
               >
                 <SignOutIcon size={14} weight='duotone' className='shrink-0' />
                 <span>Log out</span>

--- a/packages/web/src/components/VirtualList.tsx
+++ b/packages/web/src/components/VirtualList.tsx
@@ -39,6 +39,9 @@ export interface VirtualListProps<T> {
   skeleton: React.ReactNode;
   emptyTitle: string;
   emptyMessage?: string;
+  /** Optional external scroll container ref. When provided, the component
+   *  uses it instead of creating its own. Useful for DnD auto-scroll. */
+  scrollRef?: React.RefObject<HTMLDivElement | null>;
 }
 
 // ---------------------------------------------------------------------------
@@ -62,8 +65,10 @@ function VirtualListInner<T>({
   skeleton,
   emptyTitle,
   emptyMessage,
+  scrollRef: externalScrollRef,
 }: VirtualListProps<T>) {
-  const scrollRef = useRef<HTMLDivElement>(null);
+  const internalScrollRef = useRef<HTMLDivElement>(null);
+  const scrollRef = externalScrollRef ?? internalScrollRef;
   const containerRef = useRef<HTMLDivElement>(null);
 
   // Keep the user-provided getItemKey in a ref so the virtualizer's

--- a/packages/web/src/components/VirtualList.tsx
+++ b/packages/web/src/components/VirtualList.tsx
@@ -145,7 +145,7 @@ function VirtualListInner<T>({
   return (
     <div
       ref={containerRef}
-      className='relative flex-1 min-h-0 flex flex-col overflow-x-hidden'
+      className='relative flex min-h-0 flex-1 flex-col overflow-x-hidden'
       style={containerStyle}
     >
       {showSkeleton && skeleton}
@@ -155,7 +155,7 @@ function VirtualListInner<T>({
       {showContent && (
         <div
           ref={scrollRef}
-          className='overflow-y-auto overflow-x-hidden px-2 pt-3 min-h-0 flex-1 bg-surface'
+          className='bg-surface min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-2 pt-3'
           style={scrollMaskStyle}
         >
           <div
@@ -187,23 +187,23 @@ function VirtualListInner<T>({
                         <button
                           type='button'
                           onClick={onRetry}
-                          className='font-mono text-xs text-muted hover:text-fg transition-colors underline'
+                          className='text-muted hover:text-fg font-mono text-xs underline transition-colors'
                         >
                           Failed to load more. Retry
                         </button>
                       </div>
                     ) : isFetching ? (
-                      <div className='flex justify-center py-4 gap-2'>
+                      <div className='flex justify-center gap-2 py-4'>
                         {Array.from({ length: 3 }).map((_, i) => (
                           <div
                             key={`loading-dot-${i}`}
-                            className='h-3 w-3 rounded-full bg-border animate-pulse'
+                            className='bg-border h-3 w-3 animate-pulse rounded-full'
                           />
                         ))}
                       </div>
                     ) : (
                       <div className='flex justify-center py-4'>
-                        <span className='font-mono text-[11px] text-faint'>
+                        <span className='text-faint font-mono text-[11px]'>
                           Nothing more to load
                         </span>
                       </div>

--- a/packages/web/src/components/VirtualPlaylistList.tsx
+++ b/packages/web/src/components/VirtualPlaylistList.tsx
@@ -33,7 +33,7 @@ function SkeletonList() {
       {Array.from({ length: 4 }).map((_, i) => (
         // eslint-disable-next-line react/no-array-index-key -- static skeleton placeholders
         <div key={`skeleton-${i}`} className='card flex items-center gap-4 px-5 py-4'>
-          <Skeleton className='w-10 h-10 rounded' />
+          <Skeleton className='h-10 w-10 rounded' />
           <div className='flex-1 space-y-2'>
             <Skeleton className='h-3 w-48' />
             <Skeleton className='h-2.5 w-24' />

--- a/packages/web/src/components/VirtualRequestList.tsx
+++ b/packages/web/src/components/VirtualRequestList.tsx
@@ -37,14 +37,14 @@ function SkeletonList() {
       {Array.from({ length: 4 }).map((_, i) => (
         <div
           key={`skel-${i}`}
-          className='flex items-center gap-4 p-4 rounded-xl bg-elevated clay-resting'
+          className='bg-elevated clay-resting flex items-center gap-4 rounded-xl p-4'
         >
-          <Skeleton className='w-14 h-14 rounded-lg shrink-0' />
-          <div className='flex-1 min-w-0 space-y-2'>
+          <Skeleton className='h-14 w-14 shrink-0 rounded-lg' />
+          <div className='min-w-0 flex-1 space-y-2'>
             <Skeleton className='h-3 w-3/4' />
             <Skeleton className='h-2 w-1/2' />
           </div>
-          <Skeleton className='h-4 w-16 rounded-full shrink-0' />
+          <Skeleton className='h-4 w-16 shrink-0 rounded-full' />
         </div>
       ))}
     </div>

--- a/packages/web/src/components/VirtualSongGrid.tsx
+++ b/packages/web/src/components/VirtualSongGrid.tsx
@@ -56,10 +56,10 @@ function SkeletonGrid() {
         {Array.from({ length: 8 }).map((_, i) => (
           <div
             key={`skeleton-${i}`}
-            className='rounded-lg bg-elevated clay-resting overflow-hidden'
+            className='bg-elevated clay-resting overflow-hidden rounded-lg'
           >
-            <Skeleton className='aspect-square m-3 rounded-lg' />
-            <div className='p-4 flex flex-col gap-2'>
+            <Skeleton className='m-3 aspect-square rounded-lg' />
+            <div className='flex flex-col gap-2 p-4'>
               <Skeleton className='h-3.5 w-3/5' />
               <Skeleton className='h-3 w-4/5' />
               <Skeleton className='h-3 w-2/5' />
@@ -195,9 +195,13 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
             isAdminView={p.isAdminView}
             playlists={p.playlists}
             onDelete={p.onDelete}
-            onPlay={() => p.onPlay(song.id)}
+            onPlay={() => {
+              p.onPlay(song.id);
+            }}
             isPlaying={isPlaying}
-            onAddToQueue={() => p.onAddToQueue(song.id)}
+            onAddToQueue={() => {
+              p.onAddToQueue(song.id);
+            }}
             selectionMode={sel}
             isSelected={selSelected}
             onToggleSelect={p.onToggleSelect ? () => p.onToggleSelect?.(song.id) : undefined}
@@ -263,14 +267,14 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
   );
 
   return (
-    <div ref={scrollRefCallback} className='pt-3 min-h-0 flex-1' style={scrollStyle}>
+    <div ref={scrollRefCallback} className='min-h-0 flex-1 pt-3' style={scrollStyle}>
       {showSkeleton && <SkeletonGrid />}
 
       {showEmpty && (
         <div className='px-4 pt-4'>
-          <div className='text-center py-16'>
+          <div className='py-16 text-center'>
             <p className='text-fg font-semibold'>{emptyTitle}</p>
-            {emptyMessage && <p className='text-muted text-sm mt-1'>{emptyMessage}</p>}
+            {emptyMessage && <p className='text-muted mt-1 text-sm'>{emptyMessage}</p>}
           </div>
         </div>
       )}
@@ -279,11 +283,11 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
       <div style={masonryWrapperStyle}>{masonry}</div>
 
       {isContentReady && isFetching && (
-        <div className='flex justify-center py-4 gap-2'>
+        <div className='flex justify-center gap-2 py-4'>
           {Array.from({ length: 3 }).map((_, i) => (
             <div
               key={`loading-dot-${i}`}
-              className='h-3 w-3 rounded-full bg-border animate-pulse'
+              className='bg-border h-3 w-3 animate-pulse rounded-full'
             />
           ))}
         </div>
@@ -294,7 +298,7 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
           <button
             type='button'
             onClick={onRetry}
-            className='font-mono text-xs text-muted hover:text-fg transition-colors underline'
+            className='text-muted hover:text-fg font-mono text-xs underline transition-colors'
           >
             Failed to load more. Retry
           </button>

--- a/packages/web/src/components/VirtualSongGrid.tsx
+++ b/packages/web/src/components/VirtualSongGrid.tsx
@@ -1,8 +1,10 @@
 import { type Playlist, type Song } from '@alfira/server/shared';
+import { DotsSixVerticalIcon } from '@phosphor-icons/react';
 import { useMasonry, usePositioner, useResizeObserver } from 'masonic';
-import { memo, useCallback, useMemo, useRef } from 'react';
+import { memo, useCallback, useMemo, useRef, useState } from 'react';
 
 import { useScrollObserver } from '../hooks/useScrollObserver';
+import { SortableGridProvider, useSortableGridItem } from '../hooks/useSortableMasonicGrid';
 import SongCard from './SongCard';
 import { Skeleton } from './ui/Skeleton';
 
@@ -31,6 +33,9 @@ interface VirtualSongGridProps {
   selectionMode?: boolean;
   isSelected?: (id: string) => boolean;
   onToggleSelect?: (id: string) => void;
+  // Drag-and-drop reorder (masonic grid)
+  sortable?: boolean;
+  onReorder?: (orderedIds: string[]) => Promise<void>;
 }
 
 /** Composite item passed to masonic so state changes trigger re-renders. */
@@ -95,9 +100,20 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
   selectionMode = false,
   isSelected,
   onToggleSelect,
+  sortable = false,
+  onReorder,
 }: VirtualSongGridProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const masonryContainerRef = useRef<HTMLDivElement>(null);
+
+  // Refs don't trigger effect re-runs, so mirror the grid element in
+  // state. SortableGridProvider uses this state as a dep so its drop
+  // target registration fires when the masonry container mounts.
+  const [gridElement, setGridElement] = useState<HTMLElement | null>(null);
+  const gridContainerCallback = useCallback((el: HTMLElement) => {
+    masonryContainerRef.current = el as HTMLDivElement;
+    setGridElement(el);
+  }, []);
 
   // rAF-batched scroll + isScrolling + size tracking via a single
   // ResizeObserver. Width is throttled (see useScrollObserver) to avoid
@@ -122,6 +138,14 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
     columnGutter: 0, // We handle padding in the render wrapper
   });
   const resizeObserver = useResizeObserver(positioner);
+
+  // Store positioner in a ref so SortableGridProvider can access it for
+  // hit-testing during drag operations.
+  const positionerRef = useRef(positioner);
+  positionerRef.current = positioner;
+
+  // Stable ID array for the sortable provider
+  const songIds = useMemo(() => items.map((s) => s.id), [items]);
 
   // ── Infinite scroll trigger ────────────────────────────────────────
   const handleRender = useCallback(
@@ -156,9 +180,14 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
   // producing a visible flash. We store dynamic props in a ref so the
   // component type identity never changes.
   //
-  // NB: playingId / selectionMode / isSelected live in gridItems (above);
+  // DnB: playingId / selectionMode / isSelected live in gridItems (above);
   // masonic re-renders individual cards when these flip without changing
   // the render function identity. Callbacks and stable props go in the ref.
+  //
+  // Sortable drag-and-drop: useSortableGridItem is called unconditionally
+  // (hooks rules). When there is no SortableGridProvider in the tree
+  // (sortable=false), it returns no-op refs and isEnabled=false, so no
+  // drag handles are rendered and no draggable behaviour is attached.
   const cardPropsRef = useRef({
     isAdminView,
     playlists,
@@ -178,7 +207,7 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
 
   const GridCard = useMemo(() => {
     const Component = ({
-      index: _index,
+      index,
       width,
       data: { song, isPlaying, selectionMode: sel, isSelected: selSelected },
     }: {
@@ -187,25 +216,55 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
       data: GridSongItem;
     }) => {
       const p = cardPropsRef.current;
+      const {
+        itemRef,
+        dragHandleRef,
+        isDragging,
+        isAnyDragging,
+        isDropTarget,
+        isEnabled: isSortable,
+      } = useSortableGridItem(song.id, index);
+
       return (
-        <div style={{ width, padding: '0 6px 16px' }}>
-          <SongCard
-            song={song}
-            variant='grid'
-            isAdminView={p.isAdminView}
-            playlists={p.playlists}
-            onDelete={p.onDelete}
-            onPlay={() => {
-              p.onPlay(song.id);
-            }}
-            isPlaying={isPlaying}
-            onAddToQueue={() => {
-              p.onAddToQueue(song.id);
-            }}
-            selectionMode={sel}
-            isSelected={selSelected}
-            onToggleSelect={p.onToggleSelect ? () => p.onToggleSelect?.(song.id) : undefined}
-          />
+        <div ref={itemRef} style={{ width, padding: '0 6px 16px' }} className='group relative'>
+          {/* Drop target highlight */}
+          {isDropTarget && (
+            <div className='bg-accent/10 pointer-events-none absolute inset-0 z-10 rounded-lg' />
+          )}
+
+          {/* Drag handle — rendered only when sortable is enabled */}
+          {isSortable && (
+            <button
+              ref={dragHandleRef}
+              type='button'
+              style={{ position: 'absolute', bottom: 24, left: 8, zIndex: 20 }}
+              className={`text-faint hover:text-muted cursor-grab rounded p-1 opacity-0 transition-opacity active:cursor-grabbing ${isAnyDragging ? 'opacity-100' : 'group-hover:opacity-100'}`}
+              aria-label={`Drag to reorder "${song.nickname ?? song.title}"`}
+            >
+              <DotsSixVerticalIcon size={18} weight='bold' />
+            </button>
+          )}
+
+          {/* Card content — dimmed while this item is being dragged */}
+          <div className={`min-w-0 transition-opacity ${isDragging ? 'opacity-50' : ''}`}>
+            <SongCard
+              song={song}
+              variant='grid'
+              isAdminView={p.isAdminView}
+              playlists={p.playlists}
+              onDelete={p.onDelete}
+              onPlay={() => {
+                p.onPlay(song.id);
+              }}
+              isPlaying={isPlaying}
+              onAddToQueue={() => {
+                p.onAddToQueue(song.id);
+              }}
+              selectionMode={sel}
+              isSelected={selSelected}
+              onToggleSelect={p.onToggleSelect ? () => p.onToggleSelect?.(song.id) : undefined}
+            />
+          </div>
         </div>
       );
     };
@@ -239,7 +298,7 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
     scrollTop,
     isScrolling,
     height: containerHeight || 600,
-    containerRef: masonryContainerRef,
+    containerRef: gridContainerCallback,
     itemKey: (item: GridSongItem) => item.song.id,
     itemHeightEstimate: 330,
     overscanBy: 2,
@@ -266,7 +325,7 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
     [isContentReady]
   );
 
-  return (
+  const gridContent = (
     <div ref={scrollRefCallback} className='min-h-0 flex-1 pt-3' style={scrollStyle}>
       {showSkeleton && <SkeletonGrid />}
 
@@ -306,6 +365,25 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
       )}
     </div>
   );
+
+  // When sortable is enabled, wrap with the sortable context provider so
+  // grid cards can register draggable handles and the container acts as
+  // a drop target with positioner-based hit-testing.
+  if (sortable && onReorder) {
+    return (
+      <SortableGridProvider
+        itemIds={songIds}
+        onReorder={onReorder}
+        scrollContainerRef={scrollContainerRef}
+        positionerRef={positionerRef}
+        gridElement={gridElement}
+      >
+        {gridContent}
+      </SortableGridProvider>
+    );
+  }
+
+  return gridContent;
 });
 
 export default VirtualSongGrid;

--- a/packages/web/src/components/VirtualSongList.tsx
+++ b/packages/web/src/components/VirtualSongList.tsx
@@ -48,10 +48,10 @@ function SkeletonList() {
       {Array.from({ length: 8 }).map((_, i) => (
         <div
           key={`skeleton-${i}`}
-          className='flex items-center gap-3 md:gap-4 px-4 py-4 rounded-lg bg-elevated clay-resting'
+          className='bg-elevated clay-resting flex items-center gap-3 rounded-lg px-4 py-4 md:gap-4'
         >
-          <Skeleton className='w-16 h-16 rounded border border-border shrink-0' />
-          <div className='flex-1 min-w-0 flex flex-col gap-2'>
+          <Skeleton className='border-border h-16 w-16 shrink-0 rounded border' />
+          <div className='flex min-w-0 flex-1 flex-col gap-2'>
             <Skeleton className='h-3.5 w-2/5' />
             <Skeleton className='h-3 w-3/5' />
           </div>
@@ -92,8 +92,12 @@ const SongListItem = memo(function SongListItem({
   onAddToQueue,
   onToggleSelect,
 }: SongListItemProps) {
-  const handlePlay = useCallback(() => onPlay(song.id), [onPlay, song.id]);
-  const handleAddToQueue = useCallback(() => onAddToQueue(song.id), [onAddToQueue, song.id]);
+  const handlePlay = useCallback(() => {
+    onPlay(song.id);
+  }, [onPlay, song.id]);
+  const handleAddToQueue = useCallback(() => {
+    onAddToQueue(song.id);
+  }, [onAddToQueue, song.id]);
   const handleToggleSelect = useCallback(
     () => onToggleSelect?.(song.id),
     [onToggleSelect, song.id]
@@ -153,11 +157,15 @@ export const VirtualSongList = memo(function VirtualSongList({
     if (openSongId) {
       // Expand immediately — allocate space before the transition starts.
       setEffectiveOpenId(openSongId);
-      return undefined;
+      return;
     } else {
       // Collapse: wait for the CSS transition to finish before releasing space.
-      const timeout = setTimeout(() => setEffectiveOpenId(null), 300);
-      return () => clearTimeout(timeout);
+      const timeout = setTimeout(() => {
+        setEffectiveOpenId(null);
+      }, 300);
+      return () => {
+        clearTimeout(timeout);
+      };
     }
   }, [openSongId]);
 

--- a/packages/web/src/components/queue/OverrideModal.tsx
+++ b/packages/web/src/components/queue/OverrideModal.tsx
@@ -30,10 +30,10 @@ export default function OverrideModal({
     try {
       await overridePlay(sourceUrl.trim());
       onOverride();
-    } catch (err: unknown) {
-      if (!isRateLimitError(err)) {
+    } catch (error: unknown) {
+      if (!isRateLimitError(error)) {
         setError(
-          apiErrorMessage(err, 'Could not override playback. Is the bot in a voice channel?')
+          apiErrorMessage(error, 'Could not override playback. Is the bot in a voice channel?')
         );
       }
       setSubmitting(false);
@@ -56,16 +56,16 @@ export default function OverrideModal({
 
   return (
     <Backdrop onClose={onClose}>
-      <SpringUp className='p-5 md:p-6 w-full max-w-sm mx-4 glass-modal'>
-        <h2 className='font-display text-2xl md:text-3xl text-fg tracking-wider mb-1'>Override</h2>
-        <p className='font-mono text-xs text-danger mb-4 md:mb-6'>
-          <WarningIcon size={14} weight='duotone' className='inline mr-1' /> This will stop current
+      <SpringUp className='glass-modal mx-4 w-full max-w-sm p-5 md:p-6'>
+        <h2 className='font-display text-fg mb-1 text-2xl tracking-wider md:text-3xl'>Override</h2>
+        <p className='text-danger mb-4 font-mono text-xs md:mb-6'>
+          <WarningIcon size={14} weight='duotone' className='mr-1 inline' /> This will stop current
           playback, clear all queues, and play the requested song immediately.
         </p>
 
-        <div className='space-y-4 mb-6'>
+        <div className='mb-6 space-y-4'>
           <div>
-            <p className='font-mono text-xs text-muted mb-2 uppercase tracking-widest'>
+            <p className='text-muted mb-2 font-mono text-xs tracking-widest uppercase'>
               Source URL
             </p>
             <input
@@ -80,16 +80,16 @@ export default function OverrideModal({
           </div>
         </div>
 
-        {error && <p className='font-mono text-xs text-danger mb-4'>{error}</p>}
+        {error && <p className='text-danger mb-4 font-mono text-xs'>{error}</p>}
 
         {submitting && (
-          <p className='font-mono text-xs text-muted mb-4 flex items-center gap-2'>
+          <p className='text-muted mb-4 flex items-center gap-2 font-mono text-xs'>
             <Spinner />
             Overriding...
           </p>
         )}
 
-        <div className='flex gap-2 justify-end'>
+        <div className='flex justify-end gap-2'>
           <Button
             variant='inherit'
             type='button'

--- a/packages/web/src/components/queue/QuickAddModal.tsx
+++ b/packages/web/src/components/queue/QuickAddModal.tsx
@@ -42,10 +42,10 @@ export default function QuickAddModal({
         await quickAddToQueue(sourceUrl.trim());
         onAdded();
       }
-    } catch (err: unknown) {
-      if (!isRateLimitError(err)) {
+    } catch (error: unknown) {
+      if (!isRateLimitError(error)) {
         setError(
-          apiErrorMessage(err, 'Could not add song to queue. Is the bot in a voice channel?')
+          apiErrorMessage(error, 'Could not add song to queue. Is the bot in a voice channel?')
         );
       }
       setSubmitting(false);
@@ -69,15 +69,15 @@ export default function QuickAddModal({
 
   return (
     <Backdrop onClose={onClose}>
-      <SpringUp className='p-5 md:p-6 w-full max-w-sm mx-4 glass-modal'>
-        <h2 className='font-display text-2xl md:text-3xl text-fg tracking-wider mb-1'>Quick Add</h2>
-        <p className='font-mono text-xs text-muted mb-4 md:mb-6'>
+      <SpringUp className='glass-modal mx-4 w-full max-w-sm p-5 md:p-6'>
+        <h2 className='font-display text-fg mb-1 text-2xl tracking-wider md:text-3xl'>Quick Add</h2>
+        <p className='text-muted mb-4 font-mono text-xs md:mb-6'>
           add a url to Up Next without saving to library
         </p>
 
-        <div className='space-y-4 mb-6'>
+        <div className='mb-6 space-y-4'>
           <div>
-            <p className='font-mono text-xs text-muted mb-2 uppercase tracking-widest'>
+            <p className='text-muted mb-2 font-mono text-xs tracking-widest uppercase'>
               Source URL
             </p>
             <input
@@ -90,29 +90,29 @@ export default function QuickAddModal({
               onKeyDown={handleKeyDown}
             />
             {isPlaylist && (
-              <label className='flex items-center gap-2 cursor-pointer mt-2'>
+              <label className='mt-2 flex cursor-pointer items-center gap-2'>
                 <Checkbox
                   checked={importFullPlaylist}
                   onChange={setImportFullPlaylist}
                   disabled={submitting}
                 />
-                <span className='font-mono text-xs text-fg'>Add all songs from playlist</span>
+                <span className='text-fg font-mono text-xs'>Add all songs from playlist</span>
               </label>
             )}
           </div>
         </div>
 
-        {successMsg && <p className='font-mono text-xs text-success mb-4'>{successMsg}</p>}
-        {error && <p className='font-mono text-xs text-danger mb-4'>{error}</p>}
+        {successMsg && <p className='text-success mb-4 font-mono text-xs'>{successMsg}</p>}
+        {error && <p className='text-danger mb-4 font-mono text-xs'>{error}</p>}
 
         {submitting && (
-          <p className='font-mono text-xs text-muted mb-4 flex items-center gap-2'>
+          <p className='text-muted mb-4 flex items-center gap-2 font-mono text-xs'>
             <Spinner />
             {importFullPlaylist ? 'Adding playlist...' : 'Adding...'}
           </p>
         )}
 
-        <div className='flex gap-2 justify-end'>
+        <div className='flex justify-end gap-2'>
           <Button
             variant='inherit'
             type='button'

--- a/packages/web/src/components/settings/AdminSection.tsx
+++ b/packages/web/src/components/settings/AdminSection.tsx
@@ -129,9 +129,11 @@ export default function AdminSection() {
       });
       setSaved(updated);
       setSuccessMsg('Settings saved.');
-      setTimeout(() => setSuccessMsg(null), 3000);
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : 'Failed to save settings.');
+      setTimeout(() => {
+        setSuccessMsg(null);
+      }, 3000);
+    } catch (error: unknown) {
+      setError(error instanceof Error ? error.message : 'Failed to save settings.');
     } finally {
       setSaving(false);
     }
@@ -146,27 +148,21 @@ export default function AdminSection() {
     timeoutMinutes,
   ]);
 
-  const handleAfkChannelChange = useCallback(
-    (e: React.ChangeEvent<HTMLSelectElement>) =>
-      setAfkNotificationChannelId(e.target.value || null),
-    []
-  );
+  const handleAfkChannelChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    setAfkNotificationChannelId(e.target.value || null);
+  }, []);
 
-  const handleRequestChannelChange = useCallback(
-    (e: React.ChangeEvent<HTMLSelectElement>) =>
-      setRequestNotificationChannelId(e.target.value || null),
-    []
-  );
+  const handleRequestChannelChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    setRequestNotificationChannelId(e.target.value || null);
+  }, []);
 
-  const handleTimeoutChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => setTimeoutMinutes(Number(e.target.value)),
-    []
-  );
+  const handleTimeoutChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setTimeoutMinutes(Number(e.target.value));
+  }, []);
 
-  const handlePublicUrlChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => setPublicUrl(e.target.value.trim() || null),
-    []
-  );
+  const handlePublicUrlChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setPublicUrl(e.target.value.trim() || null);
+  }, []);
 
   const rangeStyle = useMemo(
     () =>
@@ -233,22 +229,22 @@ export default function AdminSection() {
       {error && <ErrorBanner message={error} />}
 
       {successMsg && (
-        <div className='p-3 rounded-lg bg-accent/10 border border-accent/20 text-accent text-sm'>
+        <div className='bg-accent/10 border-accent/20 text-accent rounded-lg border p-3 text-sm'>
           {successMsg}
         </div>
       )}
 
-      <div className='grid grid-cols-1 md:grid-cols-2 gap-6'>
+      <div className='grid grid-cols-1 gap-6 md:grid-cols-2'>
         {/* Admin Roles */}
-        <div className='md:col-span-2 lg:col-span-1 space-y-2'>
-          <h3 className='font-mono text-[11px] text-muted uppercase tracking-wider'>Admin Roles</h3>
-          <p className='text-xs text-muted'>
+        <div className='space-y-2 md:col-span-2 lg:col-span-1'>
+          <h3 className='text-muted font-mono text-[11px] tracking-wider uppercase'>Admin Roles</h3>
+          <p className='text-muted text-xs'>
             Users with these roles can manage songs, control playback, and access admin settings.
           </p>
           {roles.length === 0 ? (
-            <p className='text-xs text-muted italic'>No roles loaded.</p>
+            <p className='text-muted text-xs italic'>No roles loaded.</p>
           ) : (
-            <div className='space-y-1.5 max-h-48 lg:max-h-72 overflow-y-auto'>
+            <div className='max-h-48 space-y-1.5 overflow-y-auto lg:max-h-72'>
               {roles.map((r) => (
                 <RoleItem
                   key={r.id}
@@ -263,18 +259,18 @@ export default function AdminSection() {
         </div>
 
         {/* Music Sources */}
-        <div className='md:col-span-2 lg:col-span-1 space-y-2 border-t border-muted/10 pt-5 lg:border-t-0 lg:pt-0'>
+        <div className='border-muted/10 space-y-2 border-t pt-5 md:col-span-2 lg:col-span-1 lg:border-t-0 lg:pt-0'>
           <div className='flex items-center gap-2'>
             <MusicNotesIcon size={14} weight='duotone' className='text-muted' />
-            <h3 className='font-mono text-[11px] text-muted uppercase tracking-wider'>
+            <h3 className='text-muted font-mono text-[11px] tracking-wider uppercase'>
               Music Sources
             </h3>
           </div>
-          <p className='text-xs text-muted'>
+          <p className='text-muted text-xs'>
             Choose which music platforms Alfira can play from. At least one must be enabled.
           </p>
           {availableSources.length === 0 ? (
-            <p className='text-xs text-muted italic'>No sources available.</p>
+            <p className='text-muted text-xs italic'>No sources available.</p>
           ) : (
             <div className='space-y-1.5'>
               {availableSources.map((source) => (
@@ -293,21 +289,21 @@ export default function AdminSection() {
         </div>
 
         {/* AFK Notification Channel */}
-        <div className='space-y-2 border-t border-muted/10 pt-5'>
+        <div className='border-muted/10 space-y-2 border-t pt-5'>
           <div className='flex items-center gap-2'>
             <MegaphoneIcon size={14} weight='duotone' className='text-muted' />
-            <h3 className='font-mono text-[11px] text-muted uppercase tracking-wider'>
+            <h3 className='text-muted font-mono text-[11px] tracking-wider uppercase'>
               AFK Notification Channel
             </h3>
           </div>
-          <p className='text-xs text-muted'>
+          <p className='text-muted text-xs'>
             Alfira posts a message here when it leaves a voice channel due to inactivity.
           </p>
           {channels.length > 0 ? (
             <select
               value={afkNotificationChannelId ?? ''}
               onChange={handleAfkChannelChange}
-              className='w-full px-3 py-2 rounded-lg bg-base border border-border text-fg text-sm focus:outline-none focus:border-accent transition-colors cursor-pointer'
+              className='bg-base border-border text-fg focus:border-accent w-full cursor-pointer rounded-lg border px-3 py-2 text-sm transition-colors focus:outline-none'
             >
               <option value=''>— Disabled —</option>
               {channels.map((c) => (
@@ -317,26 +313,26 @@ export default function AdminSection() {
               ))}
             </select>
           ) : (
-            <p className='text-xs text-muted italic'>No channels loaded.</p>
+            <p className='text-muted text-xs italic'>No channels loaded.</p>
           )}
         </div>
 
         {/* Request Notification Channel */}
-        <div className='space-y-2 border-t border-muted/10 pt-5'>
+        <div className='border-muted/10 space-y-2 border-t pt-5'>
           <div className='flex items-center gap-2'>
             <MegaphoneIcon size={14} weight='duotone' className='text-muted' />
-            <h3 className='font-mono text-[11px] text-muted uppercase tracking-wider'>
+            <h3 className='text-muted font-mono text-[11px] tracking-wider uppercase'>
               Song Request Notifications
             </h3>
           </div>
-          <p className='text-xs text-muted'>
+          <p className='text-muted text-xs'>
             Alfira posts here when new song requests are submitted.
           </p>
           {channels.length > 0 ? (
             <select
               value={requestNotificationChannelId ?? ''}
               onChange={handleRequestChannelChange}
-              className='w-full px-3 py-2 rounded-lg bg-base border border-border text-fg text-sm focus:outline-none focus:border-accent transition-colors cursor-pointer'
+              className='bg-base border-border text-fg focus:border-accent w-full cursor-pointer rounded-lg border px-3 py-2 text-sm transition-colors focus:outline-none'
             >
               <option value=''>— Disabled —</option>
               {channels.map((c) => (
@@ -346,7 +342,7 @@ export default function AdminSection() {
               ))}
             </select>
           ) : (
-            <p className='text-xs text-muted italic'>No channels loaded.</p>
+            <p className='text-muted text-xs italic'>No channels loaded.</p>
           )}
 
           <div className='mt-3 space-y-3'>
@@ -366,42 +362,42 @@ export default function AdminSection() {
         </div>
 
         {/* Idle Timeout */}
-        <div className='space-y-2 border-t border-muted/10 pt-5'>
+        <div className='border-muted/10 space-y-2 border-t pt-5'>
           <div className='flex items-center gap-2'>
             <TimerIcon size={14} weight='duotone' className='text-muted' />
-            <h3 className='font-mono text-[11px] text-muted uppercase tracking-wider'>
+            <h3 className='text-muted font-mono text-[11px] tracking-wider uppercase'>
               Idle Timeout
             </h3>
           </div>
-          <p className='text-xs text-muted'>
+          <p className='text-muted text-xs'>
             Alfira leaves the voice channel after this many minutes of inactivity (no music
             playing).
           </p>
-          <div className='flex items-center gap-4 mt-4'>
+          <div className='mt-4 flex items-center gap-4'>
             <input
               type='range'
               min={1}
               max={120}
               value={timeoutMinutes}
               onChange={handleTimeoutChange}
-              className='flex-1 range-input range-input-h'
+              className='range-input range-input-h flex-1'
               style={rangeStyle}
             />
-            <span className='font-mono text-sm text-fg w-20 text-right whitespace-nowrap'>
+            <span className='text-fg w-20 text-right font-mono text-sm whitespace-nowrap'>
               {timeoutMinutes} min
             </span>
           </div>
         </div>
 
         {/* Public URL */}
-        <div className='space-y-2 border-t border-muted/10 pt-5'>
+        <div className='border-muted/10 space-y-2 border-t pt-5'>
           <div className='flex items-center gap-2'>
             <GlobeIcon size={14} weight='duotone' className='text-muted' />
-            <h3 className='font-mono text-[11px] text-muted uppercase tracking-wider'>
+            <h3 className='text-muted font-mono text-[11px] tracking-wider uppercase'>
               Public URL
             </h3>
           </div>
-          <p className='text-xs text-muted'>
+          <p className='text-muted text-xs'>
             The external URL where this Alfira instance is reachable. Used for OAuth redirects and
             other features.
           </p>
@@ -415,7 +411,7 @@ export default function AdminSection() {
         </div>
 
         {/* Save */}
-        <div className='md:col-span-2 flex gap-3 pt-5 border-t border-muted/10 justify-end'>
+        <div className='border-muted/10 flex justify-end gap-3 border-t pt-5 md:col-span-2'>
           <Button variant='primary' onClick={handleSave} disabled={!hasChanges || saving}>
             {saving ? 'Saving…' : 'Save Changes'}
           </Button>
@@ -448,19 +444,21 @@ const RoleItem = memo(function RoleItem({
     }),
     [role.color]
   );
-  const handleToggle = useCallback(() => onToggle(role.id), [onToggle, role.id]);
+  const handleToggle = useCallback(() => {
+    onToggle(role.id);
+  }, [onToggle, role.id]);
 
   return (
     <label
-      className={`flex items-center gap-3 p-2.5 rounded-lg border cursor-pointer transition-colors ${
+      className={`flex cursor-pointer items-center gap-3 rounded-lg border p-2.5 transition-colors ${
         selected ? 'border-accent bg-accent/5' : 'border-border hover:border-muted'
       }`}
     >
       <Checkbox checked={selected} onChange={handleToggle} />
-      <span className='w-2.5 h-2.5 rounded-full shrink-0' style={dotStyle} />
-      <span className='text-sm text-fg'>{role.name}</span>
+      <span className='h-2.5 w-2.5 shrink-0 rounded-full' style={dotStyle} />
+      <span className='text-fg text-sm'>{role.name}</span>
       {isLastSelected && (
-        <span className='text-xs text-muted ml-auto'>(must keep at least one)</span>
+        <span className='text-muted ml-auto text-xs'>(must keep at least one)</span>
       )}
     </label>
   );
@@ -482,32 +480,34 @@ const SourceItem = memo(function SourceItem({
   isLastSelected: boolean;
   onToggle: (key: string) => void;
 }) {
-  const handleToggle = useCallback(() => onToggle(source.key), [onToggle, source.key]);
+  const handleToggle = useCallback(() => {
+    onToggle(source.key);
+  }, [onToggle, source.key]);
 
   return (
     <>
       <label
-        className={`flex items-center gap-3 p-2.5 rounded-lg border cursor-pointer transition-colors ${
+        className={`flex cursor-pointer items-center gap-3 rounded-lg border p-2.5 transition-colors ${
           selected ? 'border-accent bg-accent/5' : 'border-border hover:border-muted'
         }`}
       >
         <Checkbox checked={selected} onChange={handleToggle} />
         <SourceIcon sourceKey={source.key} className='shrink-0' />
-        <span className='text-sm text-fg'>{source.displayName}</span>
+        <span className='text-fg text-sm'>{source.displayName}</span>
         {source.helpText && (
-          <span className='relative group'>
+          <span className='group relative'>
             <QuestionIcon size={14} weight='duotone' className='text-muted cursor-help' />
-            <span className='glass-tooltip absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-56 p-2'>
+            <span className='glass-tooltip absolute bottom-full left-1/2 mb-2 w-56 -translate-x-1/2 p-2'>
               {source.helpText}
             </span>
           </span>
         )}
         {isLastSelected && (
-          <span className='text-xs text-muted ml-auto'>(must keep at least one)</span>
+          <span className='text-muted ml-auto text-xs'>(must keep at least one)</span>
         )}
       </label>
       {source.requiresCredentials && selected && (
-        <p className='text-xs text-warning ml-9'>
+        <p className='text-warning ml-9 text-xs'>
           This source requires credentials to be configured via environment variables before it can
           play music.
         </p>

--- a/packages/web/src/components/settings/ChannelMixSection.tsx
+++ b/packages/web/src/components/settings/ChannelMixSection.tsx
@@ -9,17 +9,17 @@ import { Button } from '../ui/Button';
 
 const DEFAULTS = {
   enabled: false,
-  leftToLeft: 1.0,
-  leftToRight: 0.0,
-  rightToLeft: 0.0,
-  rightToRight: 1.0,
+  leftToLeft: 1,
+  leftToRight: 0,
+  rightToLeft: 0,
+  rightToRight: 1,
 };
 
 const SLIDERS = [
-  { key: 'leftToLeft', label: 'L → L', min: 0.0, max: 1.0, step: 0.05, unit: '' },
-  { key: 'leftToRight', label: 'L → R', min: 0.0, max: 1.0, step: 0.05, unit: '' },
-  { key: 'rightToLeft', label: 'R → L', min: 0.0, max: 1.0, step: 0.05, unit: '' },
-  { key: 'rightToRight', label: 'R → R', min: 0.0, max: 1.0, step: 0.05, unit: '' },
+  { key: 'leftToLeft', label: 'L → L', min: 0, max: 1, step: 0.05, unit: '' },
+  { key: 'leftToRight', label: 'L → R', min: 0, max: 1, step: 0.05, unit: '' },
+  { key: 'rightToLeft', label: 'R → L', min: 0, max: 1, step: 0.05, unit: '' },
+  { key: 'rightToRight', label: 'R → R', min: 0, max: 1, step: 0.05, unit: '' },
 ] as const;
 
 type SliderKey = (typeof SLIDERS)[number]['key'];
@@ -36,7 +36,9 @@ const ChannelMixSlider = memo(function ChannelMixSlider({
   onChange,
 }: ChannelMixSliderProps) {
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => onChange(key, parseFloat(e.target.value)),
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange(key, Number.parseFloat(e.target.value));
+    },
     [onChange, key]
   );
 
@@ -48,8 +50,8 @@ const ChannelMixSlider = memo(function ChannelMixSlider({
 
   return (
     <div className='flex items-center gap-3'>
-      <span className='font-mono text-[11px] text-muted w-16 shrink-0'>{label}</span>
-      <span className='font-mono text-[11px] text-fg w-12 shrink-0'>{value.toFixed(2)}</span>
+      <span className='text-muted w-16 shrink-0 font-mono text-[11px]'>{label}</span>
+      <span className='text-fg w-12 shrink-0 font-mono text-[11px]'>{value.toFixed(2)}</span>
       <input
         type='range'
         min={min}
@@ -57,7 +59,7 @@ const ChannelMixSlider = memo(function ChannelMixSlider({
         step={step}
         value={value}
         onChange={handleChange}
-        className='flex-1 range-input range-input-h'
+        className='range-input range-input-h flex-1'
         style={sliderStyle}
       />
     </div>
@@ -133,7 +135,9 @@ export default function ChannelMixSection() {
     setValues((v) => ({ ...v, [key]: value }));
   }, []);
 
-  const handleToggle = useCallback(() => setValues((v) => ({ ...v, enabled: !v.enabled })), []);
+  const handleToggle = useCallback(() => {
+    setValues((v) => ({ ...v, enabled: !v.enabled }));
+  }, []);
 
   const dimmed = !canManage;
 
@@ -142,21 +146,21 @@ export default function ChannelMixSection() {
   }
 
   return (
-    <div className={`space-y-3 ${dimmed ? 'opacity-40 pointer-events-none' : ''}`}>
+    <div className={`space-y-3 ${dimmed ? 'pointer-events-none opacity-40' : ''}`}>
       <div className='flex items-center gap-3'>
-        <span className='font-mono text-[11px] text-muted w-20 shrink-0'>Enabled</span>
+        <span className='text-muted w-20 shrink-0 font-mono text-[11px]'>Enabled</span>
         <button
           type='button'
           role='switch'
           aria-checked={values.enabled}
           aria-label='Enable channel mix'
           onClick={handleToggle}
-          className={`relative shrink-0 w-9 h-5 rounded-full transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface ${
+          className={`focus:ring-accent/50 focus:ring-offset-surface relative h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-none ${
             values.enabled ? 'bg-accent' : 'bg-border'
           }`}
         >
           <span
-            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform bg-elevated ${
+            className={`bg-elevated absolute top-0.5 left-0.5 h-4 w-4 rounded-full transition-transform ${
               values.enabled ? 'translate-x-4' : 'translate-x-0'
             }`}
           />
@@ -174,7 +178,7 @@ export default function ChannelMixSection() {
         ))}
       </div>
 
-      <div className='flex gap-2 pt-1 justify-end'>
+      <div className='flex justify-end gap-2 pt-1'>
         <Button
           variant='primary'
           size='icon'

--- a/packages/web/src/components/settings/CompressorSection.tsx
+++ b/packages/web/src/components/settings/CompressorSection.tsx
@@ -7,7 +7,7 @@ import { useAdminView } from '../../context/AdminViewContext';
 import { usePermissions } from '../../context/PermissionsContext';
 import { Button } from '../ui/Button';
 
-const DEFAULTS = { enabled: false, threshold: -6, ratio: 4.0, attack: 5, release: 50, gain: 3 };
+const DEFAULTS = { enabled: false, threshold: -6, ratio: 4, attack: 5, release: 50, gain: 3 };
 
 const SLIDERS = [
   { key: 'threshold', label: 'Threshold', min: -60, max: 0, step: 1, unit: 'dB' },
@@ -35,7 +35,9 @@ const CompressorSlider = memo(function CompressorSlider({
   onChange,
 }: CompressorSliderProps) {
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => onChange(key, parseFloat(e.target.value)),
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange(key, Number.parseFloat(e.target.value));
+    },
     [onChange, key]
   );
 
@@ -47,8 +49,8 @@ const CompressorSlider = memo(function CompressorSlider({
 
   return (
     <div className='flex items-center gap-3'>
-      <span className='font-mono text-[11px] text-muted w-20 shrink-0'>{label}</span>
-      <span className='font-mono text-[11px] text-fg w-16 shrink-0'>
+      <span className='text-muted w-20 shrink-0 font-mono text-[11px]'>{label}</span>
+      <span className='text-fg w-16 shrink-0 font-mono text-[11px]'>
         {key === 'ratio'
           ? `${value.toFixed(1)}:1`
           : key === 'gain'
@@ -62,7 +64,7 @@ const CompressorSlider = memo(function CompressorSlider({
         step={step}
         value={value}
         onChange={handleChange}
-        className='flex-1 range-input range-input-h'
+        className='range-input range-input-h flex-1'
         style={sliderStyle}
       />
     </div>
@@ -138,7 +140,9 @@ export default function CompressorSection() {
     setValues((v) => ({ ...v, [key]: value }));
   }, []);
 
-  const handleToggle = useCallback(() => setValues((v) => ({ ...v, enabled: !v.enabled })), []);
+  const handleToggle = useCallback(() => {
+    setValues((v) => ({ ...v, enabled: !v.enabled }));
+  }, []);
 
   const dimmed = !canManage;
 
@@ -147,21 +151,21 @@ export default function CompressorSection() {
   }
 
   return (
-    <div className={`space-y-3 ${dimmed ? 'opacity-40 pointer-events-none' : ''}`}>
+    <div className={`space-y-3 ${dimmed ? 'pointer-events-none opacity-40' : ''}`}>
       <div className='flex items-center gap-3'>
-        <span className='font-mono text-[11px] text-muted w-20 shrink-0'>Enabled</span>
+        <span className='text-muted w-20 shrink-0 font-mono text-[11px]'>Enabled</span>
         <button
           type='button'
           role='switch'
           aria-checked={values.enabled}
           aria-label='Enable compressor'
           onClick={handleToggle}
-          className={`relative shrink-0 w-9 h-5 rounded-full transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface ${
+          className={`focus:ring-accent/50 focus:ring-offset-surface relative h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-none ${
             values.enabled ? 'bg-accent' : 'bg-border'
           }`}
         >
           <span
-            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform bg-elevated ${
+            className={`bg-elevated absolute top-0.5 left-0.5 h-4 w-4 rounded-full transition-transform ${
               values.enabled ? 'translate-x-4' : 'translate-x-0'
             }`}
           />
@@ -179,7 +183,7 @@ export default function CompressorSection() {
         ))}
       </div>
 
-      <div className='flex gap-2 pt-1 justify-end'>
+      <div className='flex justify-end gap-2 pt-1'>
         <Button
           variant='primary'
           size='icon'

--- a/packages/web/src/components/settings/DistortionSection.tsx
+++ b/packages/web/src/components/settings/DistortionSection.tsx
@@ -9,25 +9,25 @@ import { Button } from '../ui/Button';
 
 const DEFAULTS = {
   enabled: false,
-  sinOffset: 0.0,
-  sinScale: 1.0,
-  cosOffset: 0.0,
-  cosScale: 1.0,
-  tanOffset: 0.0,
-  tanScale: 1.0,
-  offset: 0.0,
-  scale: 1.0,
+  sinOffset: 0,
+  sinScale: 1,
+  cosOffset: 0,
+  cosScale: 1,
+  tanOffset: 0,
+  tanScale: 1,
+  offset: 0,
+  scale: 1,
 };
 
 const SLIDERS = [
-  { key: 'sinOffset', label: 'Sin Offset', min: -1.0, max: 1.0, step: 0.05, unit: '' },
-  { key: 'sinScale', label: 'Sin Scale', min: 0.0, max: 5.0, step: 0.1, unit: '' },
-  { key: 'cosOffset', label: 'Cos Offset', min: -1.0, max: 1.0, step: 0.05, unit: '' },
-  { key: 'cosScale', label: 'Cos Scale', min: 0.0, max: 5.0, step: 0.1, unit: '' },
-  { key: 'tanOffset', label: 'Tan Offset', min: -1.0, max: 1.0, step: 0.05, unit: '' },
-  { key: 'tanScale', label: 'Tan Scale', min: 0.0, max: 5.0, step: 0.1, unit: '' },
-  { key: 'offset', label: 'Offset', min: -1.0, max: 1.0, step: 0.05, unit: '' },
-  { key: 'scale', label: 'Scale', min: 0.0, max: 5.0, step: 0.1, unit: '' },
+  { key: 'sinOffset', label: 'Sin Offset', min: -1, max: 1, step: 0.05, unit: '' },
+  { key: 'sinScale', label: 'Sin Scale', min: 0, max: 5, step: 0.1, unit: '' },
+  { key: 'cosOffset', label: 'Cos Offset', min: -1, max: 1, step: 0.05, unit: '' },
+  { key: 'cosScale', label: 'Cos Scale', min: 0, max: 5, step: 0.1, unit: '' },
+  { key: 'tanOffset', label: 'Tan Offset', min: -1, max: 1, step: 0.05, unit: '' },
+  { key: 'tanScale', label: 'Tan Scale', min: 0, max: 5, step: 0.1, unit: '' },
+  { key: 'offset', label: 'Offset', min: -1, max: 1, step: 0.05, unit: '' },
+  { key: 'scale', label: 'Scale', min: 0, max: 5, step: 0.1, unit: '' },
 ] as const;
 
 type SliderKey = (typeof SLIDERS)[number]['key'];
@@ -44,7 +44,9 @@ const DistortionSlider = memo(function DistortionSlider({
   onChange,
 }: DistortionSliderProps) {
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => onChange(key, parseFloat(e.target.value)),
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange(key, Number.parseFloat(e.target.value));
+    },
     [onChange, key]
   );
 
@@ -56,8 +58,8 @@ const DistortionSlider = memo(function DistortionSlider({
 
   return (
     <div className='flex items-center gap-3'>
-      <span className='font-mono text-[11px] text-muted w-20 shrink-0'>{label}</span>
-      <span className='font-mono text-[11px] text-fg w-14 shrink-0'>{value.toFixed(2)}</span>
+      <span className='text-muted w-20 shrink-0 font-mono text-[11px]'>{label}</span>
+      <span className='text-fg w-14 shrink-0 font-mono text-[11px]'>{value.toFixed(2)}</span>
       <input
         type='range'
         min={min}
@@ -65,7 +67,7 @@ const DistortionSlider = memo(function DistortionSlider({
         step={step}
         value={value}
         onChange={handleChange}
-        className='flex-1 range-input range-input-h'
+        className='range-input range-input-h flex-1'
         style={sliderStyle}
       />
     </div>
@@ -145,7 +147,9 @@ export default function DistortionSection() {
     setValues((v) => ({ ...v, [key]: value }));
   }, []);
 
-  const handleToggle = useCallback(() => setValues((v) => ({ ...v, enabled: !v.enabled })), []);
+  const handleToggle = useCallback(() => {
+    setValues((v) => ({ ...v, enabled: !v.enabled }));
+  }, []);
 
   const dimmed = !canManage;
 
@@ -154,21 +158,21 @@ export default function DistortionSection() {
   }
 
   return (
-    <div className={`space-y-3 ${dimmed ? 'opacity-40 pointer-events-none' : ''}`}>
+    <div className={`space-y-3 ${dimmed ? 'pointer-events-none opacity-40' : ''}`}>
       <div className='flex items-center gap-3'>
-        <span className='font-mono text-[11px] text-muted w-20 shrink-0'>Enabled</span>
+        <span className='text-muted w-20 shrink-0 font-mono text-[11px]'>Enabled</span>
         <button
           type='button'
           role='switch'
           aria-checked={values.enabled}
           aria-label='Enable distortion'
           onClick={handleToggle}
-          className={`relative shrink-0 w-9 h-5 rounded-full transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface ${
+          className={`focus:ring-accent/50 focus:ring-offset-surface relative h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-none ${
             values.enabled ? 'bg-accent' : 'bg-border'
           }`}
         >
           <span
-            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform bg-elevated ${
+            className={`bg-elevated absolute top-0.5 left-0.5 h-4 w-4 rounded-full transition-transform ${
               values.enabled ? 'translate-x-4' : 'translate-x-0'
             }`}
           />
@@ -186,7 +190,7 @@ export default function DistortionSection() {
         ))}
       </div>
 
-      <div className='flex gap-2 pt-1 justify-end'>
+      <div className='flex justify-end gap-2 pt-1'>
         <Button
           variant='primary'
           size='icon'

--- a/packages/web/src/components/settings/EqualizerSection.tsx
+++ b/packages/web/src/components/settings/EqualizerSection.tsx
@@ -44,7 +44,9 @@ const EqBandSlider = memo(function EqBandSlider({
   onChange,
 }: EqBandSliderProps) {
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => onChange(index, parseInt(e.target.value, 10)),
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange(index, Number.parseInt(e.target.value, 10));
+    },
     [onChange, index]
   );
 
@@ -64,8 +66,8 @@ const EqBandSlider = memo(function EqBandSlider({
   );
 
   return (
-    <div className='flex flex-col items-center gap-1 shrink-0'>
-      <span className='font-mono text-[10px] text-muted'>{label}</span>
+    <div className='flex shrink-0 flex-col items-center gap-1'>
+      <span className='text-muted font-mono text-[10px]'>{label}</span>
       <div className='relative h-[120px] w-2'>
         <input
           type='range'
@@ -77,9 +79,9 @@ const EqBandSlider = memo(function EqBandSlider({
           className='range-input'
           style={sliderStyle}
         />
-        <div className='absolute inset-x-0 top-1/2 h-px bg-border/50 pointer-events-none' />
+        <div className='bg-border/50 pointer-events-none absolute inset-x-0 top-1/2 h-px' />
       </div>
-      <span className='font-mono text-[10px] text-fg min-w-[2em] text-right'>{gainLabel}</span>
+      <span className='text-fg min-w-[2em] text-right font-mono text-[10px]'>{gainLabel}</span>
     </div>
   );
 });
@@ -157,7 +159,9 @@ export default function EqualizerSection() {
     });
   }, []);
 
-  const handleToggle = useCallback(() => setEqEnabled((v) => !v), []);
+  const handleToggle = useCallback(() => {
+    setEqEnabled((v) => !v);
+  }, []);
 
   // EQ curve SVG visualization
   const curvePath = (() => {
@@ -183,22 +187,22 @@ export default function EqualizerSection() {
   }
 
   return (
-    <div className={`space-y-4 ${dimmed ? 'opacity-40 pointer-events-none' : ''}`}>
+    <div className={`space-y-4 ${dimmed ? 'pointer-events-none opacity-40' : ''}`}>
       {/* Enabled toggle */}
       <div className='flex items-center gap-3'>
-        <span className='font-mono text-[11px] text-muted w-20 shrink-0'>Enabled</span>
+        <span className='text-muted w-20 shrink-0 font-mono text-[11px]'>Enabled</span>
         <button
           type='button'
           role='switch'
           aria-checked={eqEnabled}
           aria-label='Enable equalizer'
           onClick={handleToggle}
-          className={`relative shrink-0 w-9 h-5 rounded-full transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface ${
+          className={`focus:ring-accent/50 focus:ring-offset-surface relative h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-none ${
             eqEnabled ? 'bg-accent' : 'bg-border'
           }`}
         >
           <span
-            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform bg-elevated ${
+            className={`bg-elevated absolute top-0.5 left-0.5 h-4 w-4 rounded-full transition-transform ${
               eqEnabled ? 'translate-x-4' : 'translate-x-0'
             }`}
           />
@@ -206,7 +210,7 @@ export default function EqualizerSection() {
       </div>
 
       {/* EQ curve preview */}
-      <svg viewBox={`0 0 ${curvePath.W} ${curvePath.H}`} className='w-full h-14' aria-hidden='true'>
+      <svg viewBox={`0 0 ${curvePath.W} ${curvePath.H}`} className='h-14 w-full' aria-hidden='true'>
         <line
           x1={curvePath.pad}
           y1={curvePath.centerY}
@@ -244,7 +248,7 @@ export default function EqualizerSection() {
       </div>
 
       {/* Actions */}
-      <div className='flex gap-2 pt-1 justify-end'>
+      <div className='flex justify-end gap-2 pt-1'>
         <Button
           variant='primary'
           size='icon'

--- a/packages/web/src/components/settings/KaraokeSection.tsx
+++ b/packages/web/src/components/settings/KaraokeSection.tsx
@@ -9,10 +9,10 @@ import { Button } from '../ui/Button';
 
 const DEFAULTS = {
   enabled: false,
-  level: 1.0,
-  monoLevel: 1.0,
-  filterBand: 220.0,
-  filterWidth: 100.0,
+  level: 1,
+  monoLevel: 1,
+  filterBand: 220,
+  filterWidth: 100,
 };
 
 const SLIDERS = [
@@ -36,7 +36,9 @@ const KaraokeSlider = memo(function KaraokeSlider({
   onChange,
 }: KaraokeSliderProps) {
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => onChange(key, parseFloat(e.target.value)),
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange(key, Number.parseFloat(e.target.value));
+    },
     [onChange, key]
   );
 
@@ -48,8 +50,8 @@ const KaraokeSlider = memo(function KaraokeSlider({
 
   return (
     <div className='flex items-center gap-3'>
-      <span className='font-mono text-[11px] text-muted w-24 shrink-0'>{label}</span>
-      <span className='font-mono text-[11px] text-fg w-20 shrink-0'>
+      <span className='text-muted w-24 shrink-0 font-mono text-[11px]'>{label}</span>
+      <span className='text-fg w-20 shrink-0 font-mono text-[11px]'>
         {unit ? `${value.toFixed(2)} ${unit}` : value.toFixed(2)}
       </span>
       <input
@@ -59,7 +61,7 @@ const KaraokeSlider = memo(function KaraokeSlider({
         step={step}
         value={value}
         onChange={handleChange}
-        className='flex-1 range-input range-input-h'
+        className='range-input range-input-h flex-1'
         style={sliderStyle}
       />
     </div>
@@ -135,7 +137,9 @@ export default function KaraokeSection() {
     setValues((v) => ({ ...v, [key]: value }));
   }, []);
 
-  const handleToggle = useCallback(() => setValues((v) => ({ ...v, enabled: !v.enabled })), []);
+  const handleToggle = useCallback(() => {
+    setValues((v) => ({ ...v, enabled: !v.enabled }));
+  }, []);
 
   const dimmed = !canManage;
 
@@ -144,21 +148,21 @@ export default function KaraokeSection() {
   }
 
   return (
-    <div className={`space-y-3 ${dimmed ? 'opacity-40 pointer-events-none' : ''}`}>
+    <div className={`space-y-3 ${dimmed ? 'pointer-events-none opacity-40' : ''}`}>
       <div className='flex items-center gap-3'>
-        <span className='font-mono text-[11px] text-muted w-20 shrink-0'>Enabled</span>
+        <span className='text-muted w-20 shrink-0 font-mono text-[11px]'>Enabled</span>
         <button
           type='button'
           role='switch'
           aria-checked={values.enabled}
           aria-label='Enable karaoke'
           onClick={handleToggle}
-          className={`relative shrink-0 w-9 h-5 rounded-full transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface ${
+          className={`focus:ring-accent/50 focus:ring-offset-surface relative h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-none ${
             values.enabled ? 'bg-accent' : 'bg-border'
           }`}
         >
           <span
-            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform bg-elevated ${
+            className={`bg-elevated absolute top-0.5 left-0.5 h-4 w-4 rounded-full transition-transform ${
               values.enabled ? 'translate-x-4' : 'translate-x-0'
             }`}
           />
@@ -176,7 +180,7 @@ export default function KaraokeSection() {
         ))}
       </div>
 
-      <div className='flex gap-2 pt-1 justify-end'>
+      <div className='flex justify-end gap-2 pt-1'>
         <Button
           variant='primary'
           size='icon'

--- a/packages/web/src/components/settings/LowPassSection.tsx
+++ b/packages/web/src/components/settings/LowPassSection.tsx
@@ -7,10 +7,10 @@ import { useAdminView } from '../../context/AdminViewContext';
 import { usePermissions } from '../../context/PermissionsContext';
 import { Button } from '../ui/Button';
 
-const DEFAULTS = { enabled: false, smoothing: 20.0 };
+const DEFAULTS = { enabled: false, smoothing: 20 };
 
 const SLIDERS = [
-  { key: 'smoothing', label: 'Smoothing', min: 0.0, max: 60.0, step: 0.5, unit: '' },
+  { key: 'smoothing', label: 'Smoothing', min: 0, max: 60, step: 0.5, unit: '' },
 ] as const;
 
 type SliderKey = (typeof SLIDERS)[number]['key'];
@@ -27,7 +27,9 @@ const LowPassSlider = memo(function LowPassSlider({
   onChange,
 }: LowPassSliderProps) {
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => onChange(key, parseFloat(e.target.value)),
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange(key, Number.parseFloat(e.target.value));
+    },
     [onChange, key]
   );
 
@@ -39,8 +41,8 @@ const LowPassSlider = memo(function LowPassSlider({
 
   return (
     <div className='flex items-center gap-3'>
-      <span className='font-mono text-[11px] text-muted w-20 shrink-0'>{label}</span>
-      <span className='font-mono text-[11px] text-fg w-16 shrink-0'>{value.toFixed(1)}</span>
+      <span className='text-muted w-20 shrink-0 font-mono text-[11px]'>{label}</span>
+      <span className='text-fg w-16 shrink-0 font-mono text-[11px]'>{value.toFixed(1)}</span>
       <input
         type='range'
         min={min}
@@ -48,7 +50,7 @@ const LowPassSlider = memo(function LowPassSlider({
         step={step}
         value={value}
         onChange={handleChange}
-        className='flex-1 range-input range-input-h'
+        className='range-input range-input-h flex-1'
         style={sliderStyle}
       />
     </div>
@@ -121,7 +123,9 @@ export default function LowPassSection() {
     setValues((v) => ({ ...v, [key]: value }));
   }, []);
 
-  const handleToggle = useCallback(() => setValues((v) => ({ ...v, enabled: !v.enabled })), []);
+  const handleToggle = useCallback(() => {
+    setValues((v) => ({ ...v, enabled: !v.enabled }));
+  }, []);
 
   const dimmed = !canManage;
 
@@ -130,21 +134,21 @@ export default function LowPassSection() {
   }
 
   return (
-    <div className={`space-y-3 ${dimmed ? 'opacity-40 pointer-events-none' : ''}`}>
+    <div className={`space-y-3 ${dimmed ? 'pointer-events-none opacity-40' : ''}`}>
       <div className='flex items-center gap-3'>
-        <span className='font-mono text-[11px] text-muted w-20 shrink-0'>Enabled</span>
+        <span className='text-muted w-20 shrink-0 font-mono text-[11px]'>Enabled</span>
         <button
           type='button'
           role='switch'
           aria-checked={values.enabled}
           aria-label='Enable low pass'
           onClick={handleToggle}
-          className={`relative shrink-0 w-9 h-5 rounded-full transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface ${
+          className={`focus:ring-accent/50 focus:ring-offset-surface relative h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-none ${
             values.enabled ? 'bg-accent' : 'bg-border'
           }`}
         >
           <span
-            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform bg-elevated ${
+            className={`bg-elevated absolute top-0.5 left-0.5 h-4 w-4 rounded-full transition-transform ${
               values.enabled ? 'translate-x-4' : 'translate-x-0'
             }`}
           />
@@ -162,7 +166,7 @@ export default function LowPassSection() {
         ))}
       </div>
 
-      <div className='flex gap-2 pt-1 justify-end'>
+      <div className='flex justify-end gap-2 pt-1'>
         <Button
           variant='primary'
           size='icon'

--- a/packages/web/src/components/settings/RotationSection.tsx
+++ b/packages/web/src/components/settings/RotationSection.tsx
@@ -7,10 +7,10 @@ import { useAdminView } from '../../context/AdminViewContext';
 import { usePermissions } from '../../context/PermissionsContext';
 import { Button } from '../ui/Button';
 
-const DEFAULTS = { enabled: false, rotationHz: 0.0 };
+const DEFAULTS = { enabled: false, rotationHz: 0 };
 
 const SLIDERS = [
-  { key: 'rotationHz', label: 'Rotation Hz', min: 0.0, max: 1.0, step: 0.01, unit: 'Hz' },
+  { key: 'rotationHz', label: 'Rotation Hz', min: 0, max: 1, step: 0.01, unit: 'Hz' },
 ] as const;
 
 type SliderKey = (typeof SLIDERS)[number]['key'];
@@ -27,7 +27,9 @@ const RotationSlider = memo(function RotationSlider({
   onChange,
 }: RotationSliderProps) {
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => onChange(key, parseFloat(e.target.value)),
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange(key, Number.parseFloat(e.target.value));
+    },
     [onChange, key]
   );
 
@@ -39,8 +41,8 @@ const RotationSlider = memo(function RotationSlider({
 
   return (
     <div className='flex items-center gap-3'>
-      <span className='font-mono text-[11px] text-muted w-20 shrink-0'>{label}</span>
-      <span className='font-mono text-[11px] text-fg w-16 shrink-0'>
+      <span className='text-muted w-20 shrink-0 font-mono text-[11px]'>{label}</span>
+      <span className='text-fg w-16 shrink-0 font-mono text-[11px]'>
         {value.toFixed(2)} {unit}
       </span>
       <input
@@ -50,7 +52,7 @@ const RotationSlider = memo(function RotationSlider({
         step={step}
         value={value}
         onChange={handleChange}
-        className='flex-1 range-input range-input-h'
+        className='range-input range-input-h flex-1'
         style={sliderStyle}
       />
     </div>
@@ -123,7 +125,9 @@ export default function RotationSection() {
     setValues((v) => ({ ...v, [key]: value }));
   }, []);
 
-  const handleToggle = useCallback(() => setValues((v) => ({ ...v, enabled: !v.enabled })), []);
+  const handleToggle = useCallback(() => {
+    setValues((v) => ({ ...v, enabled: !v.enabled }));
+  }, []);
 
   const dimmed = !canManage;
 
@@ -132,21 +136,21 @@ export default function RotationSection() {
   }
 
   return (
-    <div className={`space-y-3 ${dimmed ? 'opacity-40 pointer-events-none' : ''}`}>
+    <div className={`space-y-3 ${dimmed ? 'pointer-events-none opacity-40' : ''}`}>
       <div className='flex items-center gap-3'>
-        <span className='font-mono text-[11px] text-muted w-20 shrink-0'>Enabled</span>
+        <span className='text-muted w-20 shrink-0 font-mono text-[11px]'>Enabled</span>
         <button
           type='button'
           role='switch'
           aria-checked={values.enabled}
           aria-label='Enable rotation'
           onClick={handleToggle}
-          className={`relative shrink-0 w-9 h-5 rounded-full transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface ${
+          className={`focus:ring-accent/50 focus:ring-offset-surface relative h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-none ${
             values.enabled ? 'bg-accent' : 'bg-border'
           }`}
         >
           <span
-            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform bg-elevated ${
+            className={`bg-elevated absolute top-0.5 left-0.5 h-4 w-4 rounded-full transition-transform ${
               values.enabled ? 'translate-x-4' : 'translate-x-0'
             }`}
           />
@@ -164,7 +168,7 @@ export default function RotationSection() {
         ))}
       </div>
 
-      <div className='flex gap-2 pt-1 justify-end'>
+      <div className='flex justify-end gap-2 pt-1'>
         <Button
           variant='primary'
           size='icon'

--- a/packages/web/src/components/settings/SettingsPage.tsx
+++ b/packages/web/src/components/settings/SettingsPage.tsx
@@ -22,19 +22,19 @@ export default function SettingsPage() {
   }, []);
 
   return (
-    <div className='p-4 md:p-8 h-full overflow-y-auto'>
+    <div className='h-full overflow-y-auto p-4 md:p-8'>
       {/* Page header */}
-      <div className='mb-6 md:mb-8 flex items-end justify-between'>
-        <h1 className='font-display text-3xl md:text-4xl text-accent tracking-wider flex items-center gap-2'>
-          <WrenchIcon size={28} weight='duotone' className='shrink-0 relative top-1' />
+      <div className='mb-6 flex items-end justify-between md:mb-8'>
+        <h1 className='font-display text-accent flex items-center gap-2 text-3xl tracking-wider md:text-4xl'>
+          <WrenchIcon size={28} weight='duotone' className='relative top-1 shrink-0' />
           Settings
         </h1>
-        {version !== null && <p className='font-mono text-xs text-faint pb-1'>{version}</p>}
+        {version !== null && <p className='text-faint pb-1 font-mono text-xs'>{version}</p>}
       </div>
 
       {/* User settings */}
       <section className='mb-8'>
-        <h2 className='font-mono text-xs text-muted uppercase tracking-wider mb-4'>User</h2>
+        <h2 className='text-muted mb-4 font-mono text-xs tracking-wider uppercase'>User</h2>
         <div className='bg-elevated clay-resting rounded-lg p-5'>
           <UserSection />
         </div>
@@ -43,7 +43,7 @@ export default function SettingsPage() {
       {/* Admin settings */}
       {user?.isAdmin && (
         <section>
-          <h2 className='font-mono text-xs text-muted uppercase tracking-wider mb-4'>Admin</h2>
+          <h2 className='text-muted mb-4 font-mono text-xs tracking-wider uppercase'>Admin</h2>
           <div className='bg-elevated clay-resting rounded-lg p-5'>
             <AdminSection />
           </div>

--- a/packages/web/src/components/settings/SettingsToggle.tsx
+++ b/packages/web/src/components/settings/SettingsToggle.tsx
@@ -15,16 +15,17 @@ export default function SettingsToggle({
   onChange,
   disabled = false,
 }: SettingsToggleProps) {
-  const handleClick = useCallback(
-    () => !disabled && onChange(!checked),
-    [disabled, onChange, checked]
-  );
+  const handleClick = useCallback(() => {
+    if (!disabled) {
+      onChange(!checked);
+    }
+  }, [disabled, onChange, checked]);
 
   return (
-    <div className={`flex items-start gap-4 ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}>
-      <div className='flex-1 min-w-0'>
-        <p className='font-body text-sm font-medium text-fg'>{label}</p>
-        {description && <p className='font-mono text-[11px] text-muted mt-0.5'>{description}</p>}
+    <div className={`flex items-start gap-4 ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}>
+      <div className='min-w-0 flex-1'>
+        <p className='font-body text-fg text-sm font-medium'>{label}</p>
+        {description && <p className='text-muted mt-0.5 font-mono text-[11px]'>{description}</p>}
       </div>
       <button
         type='button'
@@ -33,13 +34,13 @@ export default function SettingsToggle({
         aria-label={label}
         disabled={disabled}
         onClick={handleClick}
-        className={`relative shrink-0 w-11 h-6 rounded-full transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface mt-1.5 ${
+        className={`focus:ring-accent/50 focus:ring-offset-surface relative mt-1.5 h-6 w-11 shrink-0 rounded-full transition-colors duration-200 focus:ring-2 focus:ring-offset-2 focus:outline-none ${
           checked ? 'bg-accent' : 'bg-elevated'
         } ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'}`}
       >
         <span
-          className={`absolute top-0.5 left-0.5 w-5 h-5 rounded-full transition-transform duration-200 ${
-            checked ? 'translate-x-5 bg-elevated' : 'translate-x-0 bg-muted'
+          className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full transition-transform duration-200 ${
+            checked ? 'bg-elevated translate-x-5' : 'bg-muted translate-x-0'
           }`}
         />
       </button>

--- a/packages/web/src/components/settings/TimescaleSection.tsx
+++ b/packages/web/src/components/settings/TimescaleSection.tsx
@@ -7,12 +7,12 @@ import { useAdminView } from '../../context/AdminViewContext';
 import { usePermissions } from '../../context/PermissionsContext';
 import { Button } from '../ui/Button';
 
-const DEFAULTS = { enabled: false, speed: 1.0, pitch: 1.0, rate: 1.0 };
+const DEFAULTS = { enabled: false, speed: 1, pitch: 1, rate: 1 };
 
 const SLIDERS = [
-  { key: 'speed', label: 'Speed', min: 0.5, max: 2.0, step: 0.05, unit: '×' },
-  { key: 'pitch', label: 'Pitch', min: 0.5, max: 2.0, step: 0.05, unit: '×' },
-  { key: 'rate', label: 'Rate', min: 0.5, max: 2.0, step: 0.05, unit: '×' },
+  { key: 'speed', label: 'Speed', min: 0.5, max: 2, step: 0.05, unit: '×' },
+  { key: 'pitch', label: 'Pitch', min: 0.5, max: 2, step: 0.05, unit: '×' },
+  { key: 'rate', label: 'Rate', min: 0.5, max: 2, step: 0.05, unit: '×' },
 ] as const;
 
 type SliderKey = (typeof SLIDERS)[number]['key'];
@@ -29,7 +29,9 @@ const TimescaleSlider = memo(function TimescaleSlider({
   onChange,
 }: TimescaleSliderProps) {
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => onChange(key, parseFloat(e.target.value)),
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange(key, Number.parseFloat(e.target.value));
+    },
     [onChange, key]
   );
 
@@ -41,8 +43,8 @@ const TimescaleSlider = memo(function TimescaleSlider({
 
   return (
     <div className='flex items-center gap-3'>
-      <span className='font-mono text-[11px] text-muted w-16 shrink-0'>{label}</span>
-      <span className='font-mono text-[11px] text-fg w-16 shrink-0'>
+      <span className='text-muted w-16 shrink-0 font-mono text-[11px]'>{label}</span>
+      <span className='text-fg w-16 shrink-0 font-mono text-[11px]'>
         {value.toFixed(2)}
         {unit}
       </span>
@@ -53,7 +55,7 @@ const TimescaleSlider = memo(function TimescaleSlider({
         step={step}
         value={value}
         onChange={handleChange}
-        className='flex-1 range-input range-input-h'
+        className='range-input range-input-h flex-1'
         style={sliderStyle}
       />
     </div>
@@ -128,7 +130,9 @@ export default function TimescaleSection() {
     setValues((v) => ({ ...v, [key]: value }));
   }, []);
 
-  const handleToggle = useCallback(() => setValues((v) => ({ ...v, enabled: !v.enabled })), []);
+  const handleToggle = useCallback(() => {
+    setValues((v) => ({ ...v, enabled: !v.enabled }));
+  }, []);
 
   const dimmed = !canManage;
 
@@ -137,21 +141,21 @@ export default function TimescaleSection() {
   }
 
   return (
-    <div className={`space-y-3 ${dimmed ? 'opacity-40 pointer-events-none' : ''}`}>
+    <div className={`space-y-3 ${dimmed ? 'pointer-events-none opacity-40' : ''}`}>
       <div className='flex items-center gap-3'>
-        <span className='font-mono text-[11px] text-muted w-20 shrink-0'>Enabled</span>
+        <span className='text-muted w-20 shrink-0 font-mono text-[11px]'>Enabled</span>
         <button
           type='button'
           role='switch'
           aria-checked={values.enabled}
           aria-label='Enable timescale'
           onClick={handleToggle}
-          className={`relative shrink-0 w-9 h-5 rounded-full transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface ${
+          className={`focus:ring-accent/50 focus:ring-offset-surface relative h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-none ${
             values.enabled ? 'bg-accent' : 'bg-border'
           }`}
         >
           <span
-            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform bg-elevated ${
+            className={`bg-elevated absolute top-0.5 left-0.5 h-4 w-4 rounded-full transition-transform ${
               values.enabled ? 'translate-x-4' : 'translate-x-0'
             }`}
           />
@@ -169,7 +173,7 @@ export default function TimescaleSection() {
         ))}
       </div>
 
-      <div className='flex gap-2 pt-1 justify-end'>
+      <div className='flex justify-end gap-2 pt-1'>
         <Button
           variant='primary'
           size='icon'

--- a/packages/web/src/components/settings/TremoloSection.tsx
+++ b/packages/web/src/components/settings/TremoloSection.tsx
@@ -7,11 +7,11 @@ import { useAdminView } from '../../context/AdminViewContext';
 import { usePermissions } from '../../context/PermissionsContext';
 import { Button } from '../ui/Button';
 
-const DEFAULTS = { enabled: false, frequency: 2.0, depth: 0.5 };
+const DEFAULTS = { enabled: false, frequency: 2, depth: 0.5 };
 
 const SLIDERS = [
-  { key: 'frequency', label: 'Frequency', min: 0.1, max: 14.0, step: 0.1, unit: 'Hz' },
-  { key: 'depth', label: 'Depth', min: 0.0, max: 1.0, step: 0.05, unit: '' },
+  { key: 'frequency', label: 'Frequency', min: 0.1, max: 14, step: 0.1, unit: 'Hz' },
+  { key: 'depth', label: 'Depth', min: 0, max: 1, step: 0.05, unit: '' },
 ] as const;
 
 type SliderKey = (typeof SLIDERS)[number]['key'];
@@ -28,7 +28,9 @@ const TremoloSlider = memo(function TremoloSlider({
   onChange,
 }: TremoloSliderProps) {
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => onChange(key, parseFloat(e.target.value)),
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange(key, Number.parseFloat(e.target.value));
+    },
     [onChange, key]
   );
 
@@ -40,8 +42,8 @@ const TremoloSlider = memo(function TremoloSlider({
 
   return (
     <div className='flex items-center gap-3'>
-      <span className='font-mono text-[11px] text-muted w-20 shrink-0'>{label}</span>
-      <span className='font-mono text-[11px] text-fg w-16 shrink-0'>
+      <span className='text-muted w-20 shrink-0 font-mono text-[11px]'>{label}</span>
+      <span className='text-fg w-16 shrink-0 font-mono text-[11px]'>
         {unit ? `${value.toFixed(1)} ${unit}` : value.toFixed(2)}
       </span>
       <input
@@ -51,7 +53,7 @@ const TremoloSlider = memo(function TremoloSlider({
         step={step}
         value={value}
         onChange={handleChange}
-        className='flex-1 range-input range-input-h'
+        className='range-input range-input-h flex-1'
         style={sliderStyle}
       />
     </div>
@@ -125,7 +127,9 @@ export default function TremoloSection() {
     setValues((v) => ({ ...v, [key]: value }));
   }, []);
 
-  const handleToggle = useCallback(() => setValues((v) => ({ ...v, enabled: !v.enabled })), []);
+  const handleToggle = useCallback(() => {
+    setValues((v) => ({ ...v, enabled: !v.enabled }));
+  }, []);
 
   const dimmed = !canManage;
 
@@ -134,21 +138,21 @@ export default function TremoloSection() {
   }
 
   return (
-    <div className={`space-y-3 ${dimmed ? 'opacity-40 pointer-events-none' : ''}`}>
+    <div className={`space-y-3 ${dimmed ? 'pointer-events-none opacity-40' : ''}`}>
       <div className='flex items-center gap-3'>
-        <span className='font-mono text-[11px] text-muted w-20 shrink-0'>Enabled</span>
+        <span className='text-muted w-20 shrink-0 font-mono text-[11px]'>Enabled</span>
         <button
           type='button'
           role='switch'
           aria-checked={values.enabled}
           aria-label='Enable tremolo'
           onClick={handleToggle}
-          className={`relative shrink-0 w-9 h-5 rounded-full transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface ${
+          className={`focus:ring-accent/50 focus:ring-offset-surface relative h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-none ${
             values.enabled ? 'bg-accent' : 'bg-border'
           }`}
         >
           <span
-            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform bg-elevated ${
+            className={`bg-elevated absolute top-0.5 left-0.5 h-4 w-4 rounded-full transition-transform ${
               values.enabled ? 'translate-x-4' : 'translate-x-0'
             }`}
           />
@@ -166,7 +170,7 @@ export default function TremoloSection() {
         ))}
       </div>
 
-      <div className='flex gap-2 pt-1 justify-end'>
+      <div className='flex justify-end gap-2 pt-1'>
         <Button
           variant='primary'
           size='icon'

--- a/packages/web/src/components/settings/UserSection.tsx
+++ b/packages/web/src/components/settings/UserSection.tsx
@@ -24,26 +24,28 @@ const ThemeModeButton = memo(function ThemeModeButton({
   isSelected,
   onSelect,
 }: ThemeModeButtonProps) {
-  const handleClick = useCallback(() => onSelect(mode), [onSelect, mode]);
+  const handleClick = useCallback(() => {
+    onSelect(mode);
+  }, [onSelect, mode]);
 
   return (
     <button
       type='button'
       onClick={handleClick}
-      className={`flex flex-col items-center p-1 rounded-lg transition-all cursor-pointer group ${
+      className={`group flex cursor-pointer flex-col items-center rounded-lg p-1 transition-all ${
         isSelected ? 'opacity-100' : 'opacity-50'
       }`}
     >
       <span
-        className={`w-10 h-10 sm:w-12 sm:h-12 rounded-full flex items-center justify-center text-muted transition-all ${
+        className={`text-muted flex h-10 w-10 items-center justify-center rounded-full transition-all sm:h-12 sm:w-12 ${
           isSelected
-            ? 'bg-accent/15 text-accent ring-2 ring-offset-2 ring-offset-background ring-foreground'
-            : 'bg-muted/10 group-hover:ring-1 group-hover:ring-muted/30'
+            ? 'bg-accent/15 text-accent ring-offset-background ring-foreground ring-2 ring-offset-2'
+            : 'bg-muted/10 group-hover:ring-muted/30 group-hover:ring-1'
         }`}
       >
         <Icon size={20} weight='duotone' />
       </span>
-      <span className='text-[11px] text-muted leading-none mt-1'>{label}</span>
+      <span className='text-muted mt-1 text-[11px] leading-none'>{label}</span>
     </button>
   );
 });
@@ -63,7 +65,9 @@ const ThemeColorButton = memo(function ThemeColorButton({
   isSelected,
   onSelect,
 }: ThemeColorButtonProps) {
-  const handleClick = useCallback(() => onSelect(name), [onSelect, name]);
+  const handleClick = useCallback(() => {
+    onSelect(name);
+  }, [onSelect, name]);
 
   const dotStyle = useMemo(() => ({ backgroundColor: accentColor }), [accentColor]);
 
@@ -71,21 +75,21 @@ const ThemeColorButton = memo(function ThemeColorButton({
     <button
       type='button'
       onClick={handleClick}
-      className={`flex flex-col items-center p-1 rounded-lg transition-all cursor-pointer group ${
+      className={`group flex cursor-pointer flex-col items-center rounded-lg p-1 transition-all ${
         isSelected ? 'opacity-100' : 'opacity-80'
       }`}
     >
       <span
-        className={`w-10 h-10 sm:w-12 sm:h-12 rounded-full flex items-center justify-center transition-all border border-border/40 ${
+        className={`border-border/40 flex h-10 w-10 items-center justify-center rounded-full border transition-all sm:h-12 sm:w-12 ${
           isSelected
-            ? 'ring-2 ring-offset-2 ring-offset-background ring-foreground'
-            : 'group-hover:ring-2 group-hover:ring-muted/30'
+            ? 'ring-offset-background ring-foreground ring-2 ring-offset-2'
+            : 'group-hover:ring-muted/30 group-hover:ring-2'
         }`}
         style={dotStyle}
       >
         {isSelected ? (
           <svg
-            className='w-5 h-5 text-white'
+            className='h-5 w-5 text-white'
             fill='currentColor'
             viewBox='0 0 12 12'
             aria-hidden='true'
@@ -94,7 +98,7 @@ const ThemeColorButton = memo(function ThemeColorButton({
           </svg>
         ) : null}
       </span>
-      <span className='text-[11px] text-muted leading-none mt-1'>{displayName}</span>
+      <span className='text-muted mt-1 text-[11px] leading-none'>{displayName}</span>
     </button>
   );
 });
@@ -122,11 +126,11 @@ export default function UserSection() {
   return (
     <div className='space-y-6'>
       {/* Theme & Color — side by side on md+ */}
-      <div className='flex flex-col md:flex-row gap-6'>
+      <div className='flex flex-col gap-6 md:flex-row'>
         {/* Mode selectors */}
-        <div className='space-y-3 shrink-0'>
-          <h3 className='font-mono text-[11px] text-muted uppercase tracking-wider'>Theme</h3>
-          <div className='flex md:flex-col gap-2'>
+        <div className='shrink-0 space-y-3'>
+          <h3 className='text-muted font-mono text-[11px] tracking-wider uppercase'>Theme</h3>
+          <div className='flex gap-2 md:flex-col'>
             {[
               { key: 'auto' as const, icon: DesktopIcon, label: 'Auto' },
               { key: 'light' as const, icon: SunIcon, label: 'Light' },
@@ -145,12 +149,12 @@ export default function UserSection() {
         </div>
 
         {/* Vertical divider — only on md+ */}
-        <div className='hidden md:block w-px bg-muted/15 self-stretch shrink-0' />
+        <div className='bg-muted/15 hidden w-px shrink-0 self-stretch md:block' />
 
         {/* Color Theme Selector */}
-        <div className='space-y-3 flex-1 min-w-0'>
-          <h3 className='font-mono text-[11px] text-muted uppercase tracking-wider pl-1'>Color</h3>
-          <div className='grid grid-cols-4 sm:grid-cols-5 md:grid-cols-4 lg:grid-cols-5 gap-3 justify-items-start'>
+        <div className='min-w-0 flex-1 space-y-3'>
+          <h3 className='text-muted pl-1 font-mono text-[11px] tracking-wider uppercase'>Color</h3>
+          <div className='grid grid-cols-4 justify-items-start gap-3 sm:grid-cols-5 md:grid-cols-4 lg:grid-cols-5'>
             {colorThemes.map((t) => (
               <ThemeColorButton
                 key={t.name}
@@ -168,7 +172,7 @@ export default function UserSection() {
       {/* Admin button hint animation — only shown to admins */}
       {user?.isAdmin && (
         <>
-          <div className='h-px bg-muted/15' />
+          <div className='bg-muted/15 h-px' />
           <SettingsToggle
             label='Admin button hint animation'
             description='Occasionally spins and glows the admin/member toggle button in the sidebar to remind you it is clickable.'

--- a/packages/web/src/components/settings/VibratoSection.tsx
+++ b/packages/web/src/components/settings/VibratoSection.tsx
@@ -7,11 +7,11 @@ import { useAdminView } from '../../context/AdminViewContext';
 import { usePermissions } from '../../context/PermissionsContext';
 import { Button } from '../ui/Button';
 
-const DEFAULTS = { enabled: false, frequency: 2.0, depth: 0.5 };
+const DEFAULTS = { enabled: false, frequency: 2, depth: 0.5 };
 
 const SLIDERS = [
-  { key: 'frequency', label: 'Frequency', min: 0.1, max: 14.0, step: 0.1, unit: 'Hz' },
-  { key: 'depth', label: 'Depth', min: 0.0, max: 1.0, step: 0.05, unit: '' },
+  { key: 'frequency', label: 'Frequency', min: 0.1, max: 14, step: 0.1, unit: 'Hz' },
+  { key: 'depth', label: 'Depth', min: 0, max: 1, step: 0.05, unit: '' },
 ] as const;
 
 type SliderKey = (typeof SLIDERS)[number]['key'];
@@ -28,7 +28,9 @@ const VibratoSlider = memo(function VibratoSlider({
   onChange,
 }: VibratoSliderProps) {
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => onChange(key, parseFloat(e.target.value)),
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange(key, Number.parseFloat(e.target.value));
+    },
     [onChange, key]
   );
 
@@ -40,8 +42,8 @@ const VibratoSlider = memo(function VibratoSlider({
 
   return (
     <div className='flex items-center gap-3'>
-      <span className='font-mono text-[11px] text-muted w-20 shrink-0'>{label}</span>
-      <span className='font-mono text-[11px] text-fg w-16 shrink-0'>
+      <span className='text-muted w-20 shrink-0 font-mono text-[11px]'>{label}</span>
+      <span className='text-fg w-16 shrink-0 font-mono text-[11px]'>
         {unit ? `${value.toFixed(1)} ${unit}` : value.toFixed(2)}
       </span>
       <input
@@ -51,7 +53,7 @@ const VibratoSlider = memo(function VibratoSlider({
         step={step}
         value={value}
         onChange={handleChange}
-        className='flex-1 range-input range-input-h'
+        className='range-input range-input-h flex-1'
         style={sliderStyle}
       />
     </div>
@@ -125,7 +127,9 @@ export default function VibratoSection() {
     setValues((v) => ({ ...v, [key]: value }));
   }, []);
 
-  const handleToggle = useCallback(() => setValues((v) => ({ ...v, enabled: !v.enabled })), []);
+  const handleToggle = useCallback(() => {
+    setValues((v) => ({ ...v, enabled: !v.enabled }));
+  }, []);
 
   const dimmed = !canManage;
 
@@ -134,21 +138,21 @@ export default function VibratoSection() {
   }
 
   return (
-    <div className={`space-y-3 ${dimmed ? 'opacity-40 pointer-events-none' : ''}`}>
+    <div className={`space-y-3 ${dimmed ? 'pointer-events-none opacity-40' : ''}`}>
       <div className='flex items-center gap-3'>
-        <span className='font-mono text-[11px] text-muted w-20 shrink-0'>Enabled</span>
+        <span className='text-muted w-20 shrink-0 font-mono text-[11px]'>Enabled</span>
         <button
           type='button'
           role='switch'
           aria-checked={values.enabled}
           aria-label='Enable vibrato'
           onClick={handleToggle}
-          className={`relative shrink-0 w-9 h-5 rounded-full transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-2 focus:ring-offset-surface ${
+          className={`focus:ring-accent/50 focus:ring-offset-surface relative h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-none ${
             values.enabled ? 'bg-accent' : 'bg-border'
           }`}
         >
           <span
-            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform bg-elevated ${
+            className={`bg-elevated absolute top-0.5 left-0.5 h-4 w-4 rounded-full transition-transform ${
               values.enabled ? 'translate-x-4' : 'translate-x-0'
             }`}
           />
@@ -166,7 +170,7 @@ export default function VibratoSection() {
         ))}
       </div>
 
-      <div className='flex gap-2 pt-1 justify-end'>
+      <div className='flex justify-end gap-2 pt-1'>
         <Button
           variant='primary'
           size='icon'

--- a/packages/web/src/components/ui/ArtworkImage.tsx
+++ b/packages/web/src/components/ui/ArtworkImage.tsx
@@ -17,7 +17,9 @@ export function ArtworkImage({
 }: ArtworkImageProps) {
   const [loaded, setLoaded] = useState(false);
 
-  const handleLoad = useCallback(() => setLoaded(true), []);
+  const handleLoad = useCallback(() => {
+    setLoaded(true);
+  }, []);
 
   if (!src) {
     return null;
@@ -26,7 +28,7 @@ export function ArtworkImage({
   return (
     <div className={`relative ${className}`}>
       {!loaded && (
-        <div className='absolute inset-0 bg-elevated flex items-center justify-center'>
+        <div className='bg-elevated absolute inset-0 flex items-center justify-center'>
           <DiscIcon
             size={20}
             weight='duotone'
@@ -40,7 +42,7 @@ export function ArtworkImage({
         loading='lazy'
         decoding='async'
         onLoad={handleLoad}
-        className={`absolute inset-0 w-full h-full object-cover transition-opacity duration-200 ${loaded ? 'opacity-100' : 'opacity-0'} ${imageClassName}`}
+        className={`absolute inset-0 h-full w-full object-cover transition-opacity duration-200 ${loaded ? 'opacity-100' : 'opacity-0'} ${imageClassName}`}
       />
     </div>
   );

--- a/packages/web/src/components/ui/Checkbox.tsx
+++ b/packages/web/src/components/ui/Checkbox.tsx
@@ -38,13 +38,15 @@ export default function Checkbox({
   const s = sizeConfig[size];
 
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.checked),
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange(e.target.checked);
+    },
     [onChange]
   );
 
   return (
     <span
-      className={`group relative inline-flex shrink-0 ${disabled ? 'opacity-50 pointer-events-none' : ''}`}
+      className={`group relative inline-flex shrink-0 ${disabled ? 'pointer-events-none opacity-50' : ''}`}
     >
       {/* Hidden native input fills the entire box, capturing clicks even inside parent labels */}
       <input
@@ -52,17 +54,11 @@ export default function Checkbox({
         checked={checked}
         disabled={disabled}
         onChange={handleChange}
-        className={`opacity-0 absolute inset-0 z-10 ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'}`}
+        className={`absolute inset-0 z-10 opacity-0 ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'}`}
       />
       <span
         aria-hidden
-        className={`
-          ${s.box} ${s.rounded} ${s.border}
-          flex items-center justify-center shrink-0
-          transition-colors duration-150
-          group-focus-within:ring-2 group-focus-within:ring-accent/50 group-focus-within:ring-offset-2 group-focus-within:ring-offset-surface
-          ${checked ? variantChecked[variant] : 'border-border bg-surface'}
-        `}
+        className={` ${s.box} ${s.rounded} ${s.border} group-focus-within:ring-accent/50 group-focus-within:ring-offset-surface flex shrink-0 items-center justify-center transition-colors duration-150 group-focus-within:ring-2 group-focus-within:ring-offset-2 ${checked ? variantChecked[variant] : 'border-border bg-surface'} `}
       >
         <CheckIcon
           size={s.icon}

--- a/packages/web/src/components/ui/ClayPressable.tsx
+++ b/packages/web/src/components/ui/ClayPressable.tsx
@@ -91,7 +91,9 @@ function useColorMode(): 'dark' | 'light' {
     if (current === 'light' || current === 'dark') {
       setMode(current);
     }
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+    };
   }, []);
 
   return mode;

--- a/packages/web/src/components/ui/DurationBadge.tsx
+++ b/packages/web/src/components/ui/DurationBadge.tsx
@@ -17,7 +17,7 @@ export const DurationBadge = memo(function DurationBadge({
   if (variant === 'overlay') {
     return (
       <span
-        className={`font-mono text-[10px] text-white/80 bg-black/50 px-1.5 py-0.5 rounded ${className}`}
+        className={`rounded bg-black/50 px-1.5 py-0.5 font-mono text-[10px] text-white/80 ${className}`}
       >
         {formatDuration(seconds)}
       </span>
@@ -25,7 +25,7 @@ export const DurationBadge = memo(function DurationBadge({
   }
 
   return (
-    <span className={`flex items-center gap-1.5 font-mono text-xs text-muted ${className}`}>
+    <span className={`text-muted flex items-center gap-1.5 font-mono text-xs ${className}`}>
       <ClockIcon size={11} weight='fill' className='shrink-0' />
       {formatDuration(seconds)}
     </span>

--- a/packages/web/src/components/ui/ErrorBanner.tsx
+++ b/packages/web/src/components/ui/ErrorBanner.tsx
@@ -8,7 +8,7 @@ interface ErrorBannerProps {
 export const ErrorBanner = memo(function ErrorBanner({ message, className }: ErrorBannerProps) {
   return (
     <div
-      className={`p-3 rounded-lg bg-danger/10 border border-danger/20 text-danger text-sm${className ? ` ${className}` : ''}`}
+      className={`bg-danger/10 border-danger/20 text-danger rounded-lg border p-3 text-sm${className ? ` ${className}` : ''}`}
     >
       {message}
     </div>

--- a/packages/web/src/components/ui/PageHeader.tsx
+++ b/packages/web/src/components/ui/PageHeader.tsx
@@ -9,18 +9,18 @@ interface PageHeaderProps {
 
 export function PageHeader({ icon: Icon, title, subtitle, children }: PageHeaderProps) {
   const heading = (
-    <h1 className='font-display text-3xl md:text-4xl text-accent tracking-wider flex items-center gap-2'>
-      <Icon size={28} weight='duotone' className='shrink-0 relative top-1' />
+    <h1 className='font-display text-accent flex items-center gap-2 text-3xl tracking-wider md:text-4xl'>
+      <Icon size={28} weight='duotone' className='relative top-1 shrink-0' />
       {title}
     </h1>
   );
 
   if (children) {
     return (
-      <div className='flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-6 md:mb-8 shrink-0'>
+      <div className='mb-6 flex shrink-0 flex-col justify-between gap-3 sm:flex-row sm:items-center md:mb-8'>
         <div>
           {heading}
-          {subtitle && <p className='font-mono text-xs text-muted mt-2'>{subtitle}</p>}
+          {subtitle && <p className='text-muted mt-2 font-mono text-xs'>{subtitle}</p>}
         </div>
         {children}
       </div>
@@ -28,9 +28,9 @@ export function PageHeader({ icon: Icon, title, subtitle, children }: PageHeader
   }
 
   return (
-    <div className='mb-6 md:mb-8 shrink-0'>
+    <div className='mb-6 shrink-0 md:mb-8'>
       {heading}
-      {subtitle && <p className='font-mono text-xs text-muted mt-2'>{subtitle}</p>}
+      {subtitle && <p className='text-muted mt-2 font-mono text-xs'>{subtitle}</p>}
     </div>
   );
 }

--- a/packages/web/src/components/ui/RoleComboBox.tsx
+++ b/packages/web/src/components/ui/RoleComboBox.tsx
@@ -36,7 +36,9 @@ const RoleOptionItem = memo(function RoleOptionItem({
     [onSelect, role]
   );
 
-  const handleMouseEnter = useCallback(() => onHighlight(index), [onHighlight, index]);
+  const handleMouseEnter = useCallback(() => {
+    onHighlight(index);
+  }, [onHighlight, index]);
 
   const dotStyle = useMemo(
     () => ({
@@ -52,11 +54,9 @@ const RoleOptionItem = memo(function RoleOptionItem({
     <li
       onMouseDown={handleMouseDown}
       onMouseEnter={handleMouseEnter}
-      className={`flex items-center gap-2 px-3 py-2 cursor-pointer transition-colors
-        ${isHighlighted ? 'bg-accent/10 text-fg' : 'text-fg hover:bg-surface'}
-      `}
+      className={`flex cursor-pointer items-center gap-2 px-3 py-2 transition-colors ${isHighlighted ? 'bg-accent/10 text-fg' : 'text-fg hover:bg-surface'} `}
     >
-      <span className='w-2.5 h-2.5 rounded-full shrink-0' style={dotStyle} />
+      <span className='h-2.5 w-2.5 shrink-0 rounded-full' style={dotStyle} />
       <span className='truncate'>{role.name}</span>
     </li>
   );
@@ -105,7 +105,7 @@ export default function RoleComboBox({
   // Click outside to close
   useEffect(() => {
     if (!isOpen) {
-      return undefined;
+      return;
     }
     const handler = (e: MouseEvent) => {
       if (
@@ -118,7 +118,9 @@ export default function RoleComboBox({
       }
     };
     document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
+    return () => {
+      document.removeEventListener('mousedown', handler);
+    };
   }, [isOpen]);
 
   const selectRole = useCallback(
@@ -136,7 +138,9 @@ export default function RoleComboBox({
     setIsOpen(true);
   }, []);
 
-  const handleFocus = useCallback(() => setIsOpen(true), []);
+  const handleFocus = useCallback(() => {
+    setIsOpen(true);
+  }, []);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -192,14 +196,12 @@ export default function RoleComboBox({
           onFocus={handleFocus}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
-          className='w-full bg-surface border border-border rounded-lg px-3 py-2 pr-9 text-sm text-fg placeholder:text-muted
-                     focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-accent/30
-                     transition-colors'
+          className='bg-surface border-border text-fg placeholder:text-muted focus:border-accent/50 focus:ring-accent/30 w-full rounded-lg border px-3 py-2 pr-9 text-sm transition-colors focus:ring-1 focus:outline-none'
         />
         <CaretDownIcon
           size={16}
           weight='bold'
-          className='absolute right-3 top-1/2 -translate-y-1/2 text-muted pointer-events-none transition-transform'
+          className='text-muted pointer-events-none absolute top-1/2 right-3 -translate-y-1/2 transition-transform'
           style={caretStyle}
         />
       </div>
@@ -207,11 +209,10 @@ export default function RoleComboBox({
       {isOpen && (
         <ul
           ref={listRef}
-          className='absolute z-20 mt-1 w-full max-h-52 overflow-y-auto bg-elevated border border-border rounded-lg shadow-lg
-                     text-sm'
+          className='bg-elevated border-border absolute z-20 mt-1 max-h-52 w-full overflow-y-auto rounded-lg border text-sm shadow-lg'
         >
           {filtered.length === 0 ? (
-            <li className='px-3 py-2 text-muted italic'>No roles found</li>
+            <li className='text-muted px-3 py-2 italic'>No roles found</li>
           ) : (
             filtered.map((role, i) => (
               <RoleOptionItem

--- a/packages/web/src/components/ui/Spinner.tsx
+++ b/packages/web/src/components/ui/Spinner.tsx
@@ -13,7 +13,7 @@ const sizeClasses: Record<NonNullable<SpinnerProps['size']>, string> = {
 export const Spinner = memo(function Spinner({ size = 'sm' }: SpinnerProps) {
   return (
     <span
-      className={`${sizeClasses[size]} border-accent border-t-transparent rounded-full animate-spin inline-block`}
+      className={`${sizeClasses[size]} border-accent inline-block animate-spin rounded-full border-t-transparent`}
     />
   );
 });

--- a/packages/web/src/context/AuthContext.tsx
+++ b/packages/web/src/context/AuthContext.tsx
@@ -37,20 +37,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     try {
       const me = await getMe();
       setUser(me);
-    } catch (err) {
+    } catch (error) {
       // First attempt failed (network error, expired token, etc.).
       // trySilentRefresh refreshes the token. If it succeeds, retry getMe
       // once. wrappedFetch handles any further 401s transparently.
-      console.warn('[auth] AuthContext: initial getMe() failed, trying silent refresh', err);
+      console.warn('[auth] AuthContext: initial getMe() failed, trying silent refresh', error);
       const refreshed = await trySilentRefresh();
       if (refreshed) {
         try {
           const me = await getMe();
           setUser(me);
-        } catch (err2) {
+        } catch (error) {
           console.warn(
             '[auth] AuthContext: getMe() failed after successful refresh, setting user=null',
-            err2
+            error
           );
           setUser(null);
         }

--- a/packages/web/src/context/PermissionsContext.tsx
+++ b/packages/web/src/context/PermissionsContext.tsx
@@ -44,7 +44,9 @@ export function PermissionsProvider({ children }: { children: React.ReactNode })
       void refresh();
     };
     window.addEventListener('focus', onFocus);
-    return () => window.removeEventListener('focus', onFocus);
+    return () => {
+      window.removeEventListener('focus', onFocus);
+    };
   }, [refresh]);
 
   const hasPermission = useCallback(

--- a/packages/web/src/context/PlayerContext.tsx
+++ b/packages/web/src/context/PlayerContext.tsx
@@ -93,7 +93,7 @@ const PlayerOverrideContext = createContext<(elapsed: number | undefined) => voi
 export function PlayerProvider({ children }: { children: React.ReactNode }) {
   const [state, setState] = useState<QueueState>(EMPTY_STATE);
   const [loading, setLoading] = useState(true);
-  const [overrideElapsed, setOverrideElapsed] = useState<number | undefined>(undefined);
+  const [overrideElapsed, setOverrideElapsed] = useState<number | undefined>();
   // Initialize the WebSocket connection (singleton, safe to call on every render).
   useSocket();
 

--- a/packages/web/src/context/SongEditContext.tsx
+++ b/packages/web/src/context/SongEditContext.tsx
@@ -40,10 +40,9 @@ export function SongEditProvider({ children }: { children: ReactNode }) {
         if (openSongId != null) {
           setClosingSongId(openSongId);
           setOpenSongId(null);
-          closeTimerRef.current = window.setTimeout(
-            () => setClosingSongId(null),
-            CLOSE_DURATION_MS
-          );
+          closeTimerRef.current = window.setTimeout(() => {
+            setClosingSongId(null);
+          }, CLOSE_DURATION_MS);
         }
         return;
       }
@@ -52,7 +51,9 @@ export function SongEditProvider({ children }: { children: ReactNode }) {
         // Toggling off the same song
         setClosingSongId(id);
         setOpenSongId(null);
-        closeTimerRef.current = window.setTimeout(() => setClosingSongId(null), CLOSE_DURATION_MS);
+        closeTimerRef.current = window.setTimeout(() => {
+          setClosingSongId(null);
+        }, CLOSE_DURATION_MS);
         return;
       }
 
@@ -60,7 +61,9 @@ export function SongEditProvider({ children }: { children: ReactNode }) {
       if (openSongId != null) {
         setClosingSongId(openSongId);
         setOpenSongId(id);
-        closeTimerRef.current = window.setTimeout(() => setClosingSongId(null), CLOSE_DURATION_MS);
+        closeTimerRef.current = window.setTimeout(() => {
+          setClosingSongId(null);
+        }, CLOSE_DURATION_MS);
       } else if (closingSongId != null) {
         // Previous song is still closing; keep it closing, just open the new one
         setOpenSongId(id);
@@ -74,7 +77,7 @@ export function SongEditProvider({ children }: { children: ReactNode }) {
   // Close panel when clicking outside any song edit container
   useEffect(() => {
     if (openSongId == null) {
-      return undefined;
+      return;
     }
 
     const handleMouseDown = (e: MouseEvent) => {
@@ -85,7 +88,9 @@ export function SongEditProvider({ children }: { children: ReactNode }) {
     };
 
     document.addEventListener('mousedown', handleMouseDown);
-    return () => document.removeEventListener('mousedown', handleMouseDown);
+    return () => {
+      document.removeEventListener('mousedown', handleMouseDown);
+    };
   }, [openSongId, setOpenSongIdSequenced]);
 
   const value = useMemo(

--- a/packages/web/src/context/TagsContext.tsx
+++ b/packages/web/src/context/TagsContext.tsx
@@ -22,7 +22,7 @@ const TagsContext = createContext<{
 }>({
   tags: [],
   tagColorMap: {},
-  refreshTags: () => undefined,
+  refreshTags: () => {},
 });
 
 export function TagsProvider({ children }: { children: ReactNode }) {

--- a/packages/web/src/context/ThemeContext.tsx
+++ b/packages/web/src/context/ThemeContext.tsx
@@ -156,12 +156,14 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       }
     };
     mq.addEventListener('change', handler);
-    return () => mq.removeEventListener('change', handler);
+    return () => {
+      mq.removeEventListener('change', handler);
+    };
   }, [mode]);
 
   useEffect(() => {
-    document.documentElement.setAttribute('data-color-theme', colorTheme);
-    document.documentElement.setAttribute('data-mode', resolvedMode);
+    document.documentElement.dataset.colorTheme = colorTheme;
+    document.documentElement.dataset.mode = resolvedMode;
     localStorage.setItem(COLOR_THEME_STORAGE_KEY, colorTheme);
     localStorage.setItem(MODE_STORAGE_KEY, mode);
 
@@ -170,9 +172,9 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       .getPropertyValue('--color-elevated')
       .trim();
     if (elevated) {
-      document.querySelectorAll('meta[name="theme-color"]').forEach((el) => {
+      for (const el of document.querySelectorAll('meta[name="theme-color"]')) {
         el.setAttribute('content', elevated);
-      });
+      }
     }
   }, [colorTheme, mode, resolvedMode]);
 

--- a/packages/web/src/hooks/useAddToQueue.ts
+++ b/packages/web/src/hooks/useAddToQueue.ts
@@ -12,10 +12,10 @@ export function useAddToQueue() {
       try {
         await addToPriorityQueue(songId);
         notify('Added to Up Next', 'success');
-      } catch (err: unknown) {
-        if (!isRateLimitError(err)) {
+      } catch (error: unknown) {
+        if (!isRateLimitError(error)) {
           notify(
-            apiErrorMessage(err, 'Could not add to queue. Is the bot in a voice channel?'),
+            apiErrorMessage(error, 'Could not add to queue. Is the bot in a voice channel?'),
             'error',
             5000
           );

--- a/packages/web/src/hooks/useMutationHandler.ts
+++ b/packages/web/src/hooks/useMutationHandler.ts
@@ -29,9 +29,9 @@ export function useMutationHandler(action: () => Promise<void>, errorMessage: st
     setBusy(true);
     try {
       await action();
-    } catch (err) {
-      if (!isRateLimitError(err)) {
-        notify(apiErrorMessage(err, errorMessage), 'error', 5000);
+    } catch (error) {
+      if (!isRateLimitError(error)) {
+        notify(apiErrorMessage(error, errorMessage), 'error', 5000);
       }
     } finally {
       busyRef.current = false;

--- a/packages/web/src/hooks/usePaginatedData.ts
+++ b/packages/web/src/hooks/usePaginatedData.ts
@@ -41,7 +41,7 @@ export function usePaginatedData<T, A extends unknown[], M = undefined>({
   compareFn,
 }: UsePaginatedDataOptions<T, A, M>): UsePaginatedDataReturn<T, M> {
   const [items, setItems] = useState<T[]>([]);
-  const [metadata, setMetadata] = useState<M | undefined>(undefined);
+  const [metadata, setMetadata] = useState<M | undefined>();
   const [isLoading, setIsLoading] = useState(false);
   const [isFetching, setIsFetching] = useState(false);
   const [isError, setIsError] = useState(false);
@@ -54,7 +54,8 @@ export function usePaginatedData<T, A extends unknown[], M = undefined>({
   const isFetchingRef = useRef(false);
   const isMountedRef = useRef(true);
   const hasEverLoadedRef = useRef(false);
-  const loadingTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  // eslint-disable-next-line unicorn/no-useless-undefined
+  const loadingTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const resetInProgressRef = useRef(false);
 
   hasMoreRef.current = hasMore;

--- a/packages/web/src/hooks/useProgressBar.ts
+++ b/packages/web/src/hooks/useProgressBar.ts
@@ -37,6 +37,7 @@ export function useProgressBar(
   // Tracks the last overrideElapsed value we've already applied, so periodic
   // sync broadcasts (which re-run the effect) don't re-apply a stale override
   // and flash the time text back to the seek target.
+  // eslint-disable-next-line unicorn/no-useless-undefined
   const lastOverrideRef = useRef<number | undefined>(undefined);
 
   const registerProgress = useCallback((ref: HTMLDivElement | null) => {
@@ -60,7 +61,7 @@ export function useProgressBar(
   const isPlaying = !!state.currentSong && state.isPlaying && !state.isPaused;
   const isPaused = state.isPaused;
   const trackStartedAt = state.trackStartedAt;
-  const speed = state.timescaleSpeed ?? 1.0;
+  const speed = state.timescaleSpeed ?? 1;
   const nodeLinkPosition = state.nodeLinkPosition ?? null;
   const nodeLinkTime = state.nodeLinkTime ?? null;
 
@@ -150,7 +151,7 @@ export function useProgressBar(
         }
       }
 
-      return undefined;
+      return;
     }
 
     // ---- Starting loops ----

--- a/packages/web/src/hooks/useScrollObserver.ts
+++ b/packages/web/src/hooks/useScrollObserver.ts
@@ -46,6 +46,7 @@ export function useScrollObserver(
 
   const didMountRef = useRef(0);
   const tickingRef = useRef(false);
+  // eslint-disable-next-line unicorn/no-useless-undefined
   const timeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const scrollTopRef = useRef(0);
 
@@ -56,7 +57,7 @@ export function useScrollObserver(
   useEffect(() => {
     const el = elementRef.current;
     if (!el) {
-      return undefined;
+      return;
     }
 
     const onScroll = () => {
@@ -83,7 +84,9 @@ export function useScrollObserver(
     setScrollTop(el.scrollTop);
 
     el.addEventListener('scroll', onScroll, { passive: true });
-    return () => el.removeEventListener('scroll', onScroll);
+    return () => {
+      el.removeEventListener('scroll', onScroll);
+    };
     // elementRef is a stable ref object; the effect only needs to re-run
     // if the underlying element changes (handled via the early return).
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -128,7 +131,7 @@ export function useScrollObserver(
   useLayoutEffect(() => {
     const el = elementRef.current;
     if (!el) {
-      return undefined;
+      return;
     }
 
     setHeight(el.clientHeight);
@@ -148,7 +151,9 @@ export function useScrollObserver(
     });
     ro.observe(el);
 
-    return () => ro.disconnect();
+    return () => {
+      ro.disconnect();
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/packages/web/src/hooks/useSortableMasonicGrid.tsx
+++ b/packages/web/src/hooks/useSortableMasonicGrid.tsx
@@ -1,0 +1,346 @@
+import { autoScrollForElements } from '@atlaskit/pragmatic-drag-and-drop-auto-scroll/element';
+import { type Edge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
+import {
+  draggable,
+  dropTargetForElements,
+  monitorForElements,
+} from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import { type Positioner } from 'masonic';
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface SortableItemData {
+  id: string;
+  index: number;
+  instanceId: symbol;
+}
+
+export interface DragState {
+  isDragging: boolean;
+  draggingId: string | null;
+  dropIndicatorIndex: number | null;
+}
+
+interface SortableGridContextValue {
+  instanceId: symbol;
+  dragState: DragState;
+}
+
+interface SortableGridProviderProps {
+  itemIds: string[];
+  onReorder: (orderedIds: string[]) => Promise<void>;
+  scrollContainerRef: React.RefObject<HTMLElement | null>;
+  /** Ref to the masonic positioner — needed for hit-testing during drag. */
+  positionerRef: React.RefObject<Positioner | null>;
+  /** The grid container DOM element (masonic's containerRef target).
+   * Passed as state so the drop-target effect re-runs when the element
+   * mounts (ref identity alone doesn't trigger effect re-runs). */
+  gridElement: HTMLElement | null;
+  children: ReactNode;
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+const SortableGridContext = createContext<SortableGridContextValue | null>(null);
+
+function useSortableGridContext(): SortableGridContextValue | null {
+  return useContext(SortableGridContext);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getItemData(item: SortableItemData) {
+  return { id: item.id, index: item.index, instanceId: item.instanceId };
+}
+
+function isItemData(data: unknown): data is SortableItemData {
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
+  const record = data as unknown as Record<string, unknown>;
+  return 'id' in record && 'instanceId' in record && typeof record.instanceId === 'symbol';
+}
+
+function computeDestination(
+  startIndex: number,
+  targetIndex: number,
+  closestEdge: Edge | null
+): number {
+  // 'bottom' and 'right' mean insert after the target.
+  // 'top' and 'left' mean insert before the target.
+  if (closestEdge === 'bottom' || closestEdge === 'right') {
+    return startIndex < targetIndex ? targetIndex : targetIndex + 1;
+  }
+  return startIndex < targetIndex ? targetIndex - 1 : targetIndex;
+}
+
+/**
+ * Find the nearest item index and edge for a cursor position within the grid.
+ * Uses masonic's positioner to get item positions, then finds the item whose
+ * center is closest to the cursor.
+ */
+function hitTest(
+  cursorX: number,
+  cursorY: number,
+  positioner: Positioner
+): { index: number; edge: Edge } | null {
+  const items = positioner.all();
+  if (items.length === 0) {
+    return { index: 0, edge: 'top' };
+  }
+
+  let nearestIndex = 0;
+  let nearestDist = Infinity;
+
+  const colWidth = positioner.columnWidth;
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    const cx = item.left + colWidth / 2;
+    const cy = item.top + item.height / 2;
+    const dist = Math.sqrt((cursorX - cx) ** 2 + (cursorY - cy) ** 2);
+    if (dist < nearestDist) {
+      nearestDist = dist;
+      nearestIndex = i;
+    }
+  }
+
+  const nearestItem = items[nearestIndex];
+  // In a column-based masonry layout, left/right maps to before/after in
+  // the flat list more intuitively than top/bottom. Cursor on the left
+  // half of a card → insert before; right half → insert after.
+  const edge: Edge = cursorX > nearestItem.left + positioner.columnWidth / 2 ? 'right' : 'left';
+
+  return { index: nearestIndex, edge };
+}
+
+// ---------------------------------------------------------------------------
+// Module-level callbacks + target map
+// ---------------------------------------------------------------------------
+
+const gDropTargetCallbacks = new Map<
+  symbol,
+  {
+    setDropTarget: (index: number) => void;
+    clearDropTarget: () => void;
+  }
+>();
+const gTargetMap = new Map<symbol, { index: number; edge: Edge }>();
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export function SortableGridProvider({
+  itemIds,
+  onReorder,
+  scrollContainerRef,
+  positionerRef,
+  gridElement,
+  children,
+}: SortableGridProviderProps) {
+  const instanceId = useMemo(() => Symbol('sortable-grid'), []);
+
+  const itemIdsRef = useRef(itemIds);
+  itemIdsRef.current = itemIds;
+
+  const [dragState, setDragState] = useState<DragState>({
+    isDragging: false,
+    draggingId: null,
+    dropIndicatorIndex: null,
+  });
+
+  // ── Auto-scroll ─────────────────────────────────────────────────────
+  useEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el) {
+      return;
+    }
+    return autoScrollForElements({ element: el });
+  }, [scrollContainerRef]);
+
+  // ── Drop target callbacks ───────────────────────────────────────────
+  const handleSetDropTarget = useCallback((index: number) => {
+    setDragState((prev) =>
+      prev.dropIndicatorIndex === index ? prev : { ...prev, dropIndicatorIndex: index }
+    );
+  }, []);
+
+  const handleClearDropTarget = useCallback(() => {
+    setDragState((prev) =>
+      prev.dropIndicatorIndex === null ? prev : { ...prev, dropIndicatorIndex: null }
+    );
+  }, []);
+
+  // ── Container drop target ───────────────────────────────────────────
+  useLayoutEffect(() => {
+    if (!gridElement) {
+      return;
+    }
+
+    return dropTargetForElements({
+      element: gridElement,
+      canDrop({ source }) {
+        return isItemData(source.data) && source.data.instanceId === instanceId;
+      },
+      onDrag({ location }) {
+        const pos = positionerRef.current;
+        if (!pos) {
+          return;
+        }
+        const input = location.current.input;
+        const gridRect = gridElement.getBoundingClientRect();
+        const cursorX = input.clientX - gridRect.left;
+        const cursorY = input.clientY - gridRect.top;
+
+        const result = hitTest(cursorX, cursorY, pos);
+        if (result) {
+          gTargetMap.set(instanceId, result);
+          // The drop indicator index is the item we're hovering over
+          gDropTargetCallbacks.get(instanceId)?.setDropTarget(result.index);
+        }
+      },
+      onDragLeave() {
+        gDropTargetCallbacks.get(instanceId)?.clearDropTarget();
+        gTargetMap.delete(instanceId);
+      },
+    });
+  }, [instanceId, gridElement, positionerRef]);
+
+  // ── Global drag monitor ─────────────────────────────────────────────
+  useEffect(() => {
+    gDropTargetCallbacks.set(instanceId, {
+      setDropTarget: handleSetDropTarget,
+      clearDropTarget: handleClearDropTarget,
+    });
+
+    return monitorForElements({
+      canMonitor({ source }) {
+        return isItemData(source.data) && source.data.instanceId === instanceId;
+      },
+      onDragStart({ source }) {
+        const data = source.data as unknown as SortableItemData;
+        setDragState({
+          isDragging: true,
+          draggingId: data.id,
+          dropIndicatorIndex: null,
+        });
+      },
+      onDrop({ source }) {
+        const srcData = source.data as unknown as SortableItemData;
+        const target = gTargetMap.get(instanceId) ?? null;
+        gTargetMap.delete(instanceId);
+
+        setDragState({
+          isDragging: false,
+          draggingId: null,
+          dropIndicatorIndex: null,
+        });
+
+        if (!target) {
+          return;
+        }
+
+        const currentIds = itemIdsRef.current;
+        const dest = computeDestination(srcData.index, target.index, target.edge);
+
+        if (dest === srcData.index) {
+          return;
+        }
+
+        const newIds = [...currentIds];
+        const [removed] = newIds.splice(srcData.index, 1);
+        newIds.splice(dest, 0, removed);
+
+        void onReorder(newIds);
+      },
+    });
+  }, [instanceId, onReorder, handleSetDropTarget, handleClearDropTarget]);
+
+  // Clean up
+  useEffect(() => {
+    return () => {
+      gDropTargetCallbacks.delete(instanceId);
+    };
+  }, [instanceId]);
+
+  const value: SortableGridContextValue = useMemo(
+    () => ({ instanceId, dragState }),
+    [instanceId, dragState]
+  );
+
+  return <SortableGridContext.Provider value={value}>{children}</SortableGridContext.Provider>;
+}
+
+// ---------------------------------------------------------------------------
+// Per-item hook
+// ---------------------------------------------------------------------------
+
+export function useSortableGridItem(id: string, index: number) {
+  const ctx = useSortableGridContext();
+
+  const itemEl = useRef<HTMLElement | null>(null);
+  const handleEl = useRef<HTMLElement | null>(null);
+
+  const setItemRef = (el: HTMLElement | null) => {
+    itemEl.current = el;
+  };
+  const setHandleRef = (el: HTMLElement | null) => {
+    handleEl.current = el;
+  };
+
+  const instanceId = ctx?.instanceId ?? null;
+  const dragState = ctx?.dragState ?? null;
+  const isEnabled = ctx !== null;
+
+  // Register draggable on the drag handle
+  useLayoutEffect(() => {
+    if (!isEnabled || !instanceId) {
+      return;
+    }
+
+    const handle = handleEl.current;
+    if (!handle) {
+      return;
+    }
+
+    return draggable({
+      element: handle,
+      getInitialData: () => getItemData({ id, index, instanceId }),
+      onGenerateDragPreview({ nativeSetDragImage }) {
+        const item = itemEl.current;
+        if (item && nativeSetDragImage) {
+          nativeSetDragImage(item, 0, 0);
+        }
+      },
+    });
+  }, [id, index, instanceId, isEnabled]);
+
+  return {
+    itemRef: setItemRef,
+    dragHandleRef: setHandleRef,
+    isDragging: dragState?.draggingId === id,
+    isAnyDragging: dragState?.isDragging ?? false,
+    isDropTarget: dragState?.dropIndicatorIndex === index,
+    isEnabled,
+  };
+}
+
+export type { SortableGridContextValue, SortableGridProviderProps };

--- a/packages/web/src/hooks/useSortableVirtualList.ts
+++ b/packages/web/src/hooks/useSortableVirtualList.ts
@@ -1,0 +1,280 @@
+import { autoScrollForElements } from '@atlaskit/pragmatic-drag-and-drop-auto-scroll/element';
+import { type Edge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
+import {
+  draggable,
+  dropTargetForElements,
+  monitorForElements,
+} from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import React, {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface SortableItemData {
+  id: string;
+  index: number;
+  instanceId: symbol;
+}
+
+export interface DragState {
+  isDragging: boolean;
+  draggingId: string | null;
+  dropIndicatorIndex: number | null;
+}
+
+interface SortableListContextValue {
+  instanceId: symbol;
+  dragState: DragState;
+}
+
+interface SortableListProviderProps {
+  itemIds: string[];
+  onReorder: (orderedIds: string[]) => Promise<void>;
+  scrollContainerRef: React.RefObject<HTMLElement | null>;
+  children: ReactNode;
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+const SortableListContext = createContext<SortableListContextValue | null>(null);
+
+export function useSortableListContext(): SortableListContextValue {
+  const ctx = useContext(SortableListContext);
+  if (!ctx) {
+    throw new Error('useSortableListContext must be used within SortableListProvider');
+  }
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getItemData(item: SortableItemData) {
+  return { id: item.id, index: item.index, instanceId: item.instanceId };
+}
+
+function isItemData(data: unknown): data is SortableItemData {
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
+  const record = data as unknown as Record<string, unknown>;
+  return 'id' in record && 'instanceId' in record && typeof record.instanceId === 'symbol';
+}
+
+function computeDestination(
+  startIndex: number,
+  targetIndex: number,
+  closestEdge: Edge | null
+): number {
+  if (closestEdge === 'bottom') {
+    return startIndex < targetIndex ? targetIndex : targetIndex + 1;
+  }
+  return startIndex < targetIndex ? targetIndex - 1 : targetIndex;
+}
+
+// ---------------------------------------------------------------------------
+// Module-level callbacks + edge map
+// ---------------------------------------------------------------------------
+
+let gSetDropTarget: ((index: number) => void) | null = null;
+let gClearDropTarget: (() => void) | null = null;
+const gEdgeMap = new Map<symbol, { index: number; edge: Edge }>();
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export function SortableListProvider({
+  itemIds,
+  onReorder,
+  scrollContainerRef,
+  children,
+}: SortableListProviderProps) {
+  const instanceId = useMemo(() => Symbol('sortable-list'), []);
+
+  const itemIdsRef = useRef(itemIds);
+  itemIdsRef.current = itemIds;
+
+  const [dragState, setDragState] = useState<DragState>({
+    isDragging: false,
+    draggingId: null,
+    dropIndicatorIndex: null,
+  });
+
+  // ── Auto-scroll ─────────────────────────────────────────────────────
+  useEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el) {
+      return;
+    }
+    return autoScrollForElements({ element: el });
+  }, [scrollContainerRef]);
+
+  // ── Drop target callbacks ───────────────────────────────────────────
+  const handleSetDropTarget = useCallback((index: number) => {
+    setDragState((prev) =>
+      prev.dropIndicatorIndex === index ? prev : { ...prev, dropIndicatorIndex: index }
+    );
+  }, []);
+
+  const handleClearDropTarget = useCallback(() => {
+    setDragState((prev) =>
+      prev.dropIndicatorIndex === null ? prev : { ...prev, dropIndicatorIndex: null }
+    );
+  }, []);
+
+  // ── Global drag monitor ─────────────────────────────────────────────
+  useEffect(() => {
+    gSetDropTarget = handleSetDropTarget;
+    gClearDropTarget = handleClearDropTarget;
+
+    return monitorForElements({
+      canMonitor({ source }) {
+        return isItemData(source.data) && source.data.instanceId === instanceId;
+      },
+      onDragStart({ source }) {
+        const data = source.data as unknown as SortableItemData;
+        setDragState({
+          isDragging: true,
+          draggingId: data.id,
+          dropIndicatorIndex: null,
+        });
+      },
+      onDrop({ source }) {
+        const srcData = source.data as unknown as SortableItemData;
+        const target = gEdgeMap.get(instanceId) ?? null;
+        gEdgeMap.delete(instanceId);
+
+        setDragState({
+          isDragging: false,
+          draggingId: null,
+          dropIndicatorIndex: null,
+        });
+
+        if (!target) {
+          return;
+        }
+
+        const currentIds = itemIdsRef.current;
+        const dest = computeDestination(srcData.index, target.index, target.edge);
+
+        if (dest === srcData.index) {
+          return;
+        }
+
+        const newIds = [...currentIds];
+        const [removed] = newIds.splice(srcData.index, 1);
+        newIds.splice(dest, 0, removed);
+
+        void onReorder(newIds);
+      },
+    });
+  }, [instanceId, onReorder, handleSetDropTarget, handleClearDropTarget]);
+
+  // Clean up
+  useEffect(() => {
+    return () => {
+      gSetDropTarget = null;
+      gClearDropTarget = null;
+    };
+  }, []);
+
+  const value: SortableListContextValue = useMemo(
+    () => ({ instanceId, dragState }),
+    [instanceId, dragState]
+  );
+
+  return React.createElement(SortableListContext.Provider, { value }, children);
+}
+
+// ---------------------------------------------------------------------------
+// Per-item hook
+// ---------------------------------------------------------------------------
+
+export function useSortableItem(id: string, index: number) {
+  const { instanceId, dragState } = useSortableListContext();
+
+  const itemEl = useRef<HTMLElement | null>(null);
+  const handleEl = useRef<HTMLElement | null>(null);
+
+  const setItemRef = (el: HTMLElement | null) => {
+    itemEl.current = el;
+  };
+  const setHandleRef = (el: HTMLElement | null) => {
+    handleEl.current = el;
+  };
+
+  useLayoutEffect(() => {
+    const element = itemEl.current;
+    if (!element) {
+      return;
+    }
+
+    return dropTargetForElements({
+      element,
+      canDrop({ source }) {
+        return isItemData(source.data) && source.data.instanceId === instanceId;
+      },
+      getData({ input }) {
+        const rect = element.getBoundingClientRect();
+        const edge: Edge = input.clientY < rect.top + rect.height / 2 ? 'top' : 'bottom';
+        return { index, edge };
+      },
+      onDragEnter() {
+        gSetDropTarget?.(index);
+      },
+      onDrag({ self }) {
+        const data = self.data as Record<string, unknown>;
+        const edge = (data.edge as Edge | undefined) ?? 'bottom';
+        gEdgeMap.set(instanceId, { index, edge });
+        gSetDropTarget?.(index);
+      },
+      onDragLeave() {
+        gClearDropTarget?.();
+        gEdgeMap.delete(instanceId);
+      },
+    });
+  }, [id, index, instanceId]);
+
+  useLayoutEffect(() => {
+    const handle = handleEl.current;
+    if (!handle) {
+      return;
+    }
+
+    return draggable({
+      element: handle,
+      getInitialData: () => getItemData({ id, index, instanceId }),
+      onGenerateDragPreview({ nativeSetDragImage }) {
+        const item = itemEl.current;
+        if (item && nativeSetDragImage) {
+          nativeSetDragImage(item, 0, 0);
+        }
+      },
+    });
+  }, [id, index, instanceId]);
+
+  return {
+    itemRef: setItemRef,
+    dragHandleRef: setHandleRef,
+    isDragging: dragState.draggingId === id,
+    isAnyDragging: dragState.isDragging,
+    isDropTarget: dragState.dropIndicatorIndex === index,
+  };
+}
+
+export type { SortableListContextValue, SortableListProviderProps };

--- a/packages/web/src/hooks/useSortableVirtualList.ts
+++ b/packages/web/src/hooks/useSortableVirtualList.ts
@@ -90,8 +90,13 @@ function computeDestination(
 // Module-level callbacks + edge map
 // ---------------------------------------------------------------------------
 
-let gSetDropTarget: ((index: number) => void) | null = null;
-let gClearDropTarget: (() => void) | null = null;
+const gDropTargetCallbacks = new Map<
+  symbol,
+  {
+    setDropTarget: (index: number) => void;
+    clearDropTarget: () => void;
+  }
+>();
 const gEdgeMap = new Map<symbol, { index: number; edge: Edge }>();
 
 // ---------------------------------------------------------------------------
@@ -139,8 +144,10 @@ export function SortableListProvider({
 
   // ── Global drag monitor ─────────────────────────────────────────────
   useEffect(() => {
-    gSetDropTarget = handleSetDropTarget;
-    gClearDropTarget = handleClearDropTarget;
+    gDropTargetCallbacks.set(instanceId, {
+      setDropTarget: handleSetDropTarget,
+      clearDropTarget: handleClearDropTarget,
+    });
 
     return monitorForElements({
       canMonitor({ source }) {
@@ -188,10 +195,9 @@ export function SortableListProvider({
   // Clean up
   useEffect(() => {
     return () => {
-      gSetDropTarget = null;
-      gClearDropTarget = null;
+      gDropTargetCallbacks.delete(instanceId);
     };
-  }, []);
+  }, [instanceId]);
 
   const value: SortableListContextValue = useMemo(
     () => ({ instanceId, dragState }),
@@ -235,16 +241,16 @@ export function useSortableItem(id: string, index: number) {
         return { index, edge };
       },
       onDragEnter() {
-        gSetDropTarget?.(index);
+        gDropTargetCallbacks.get(instanceId)?.setDropTarget(index);
       },
       onDrag({ self }) {
         const data = self.data as Record<string, unknown>;
         const edge = (data.edge as Edge | undefined) ?? 'bottom';
         gEdgeMap.set(instanceId, { index, edge });
-        gSetDropTarget?.(index);
+        gDropTargetCallbacks.get(instanceId)?.setDropTarget(index);
       },
       onDragLeave() {
-        gClearDropTarget?.();
+        gDropTargetCallbacks.get(instanceId)?.clearDropTarget();
         gEdgeMap.delete(instanceId);
       },
     });

--- a/packages/web/src/hooks/useWindowSize.ts
+++ b/packages/web/src/hooks/useWindowSize.ts
@@ -7,9 +7,13 @@ export function useWindowSize() {
   ]);
 
   useEffect(() => {
-    const handle = () => setSize([window.innerWidth, window.innerHeight]);
+    const handle = () => {
+      setSize([window.innerWidth, window.innerHeight]);
+    };
     window.addEventListener('resize', handle, { passive: true });
-    return () => window.removeEventListener('resize', handle);
+    return () => {
+      window.removeEventListener('resize', handle);
+    };
   }, []);
 
   return size;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -564,9 +564,7 @@
 
 @layer components {
   .btn-primary {
-    @apply font-body text-sm px-4 py-2.5 md:py-2
-           transition-all duration-150 cursor-pointer disabled:opacity-40
-           disabled:cursor-not-allowed min-h-11 md:min-h-0;
+    @apply font-body min-h-11 cursor-pointer px-4 py-2.5 text-sm transition-all duration-150 disabled:cursor-not-allowed disabled:opacity-40 md:min-h-0 md:py-2;
     border-radius: var(--clay-radius-lg);
     color: var(--color-fg);
     background: color-mix(in srgb, var(--color-accent) 95%, white);
@@ -625,9 +623,7 @@
   }
 
   .btn-primary-secondary {
-    @apply font-body text-sm px-4 py-2.5 md:py-2
-           transition-all duration-150 cursor-pointer disabled:opacity-40
-           disabled:cursor-not-allowed min-h-11 md:min-h-0;
+    @apply font-body min-h-11 cursor-pointer px-4 py-2.5 text-sm transition-all duration-150 disabled:cursor-not-allowed disabled:opacity-40 md:min-h-0 md:py-2;
     border-radius: var(--clay-radius-lg);
     color: var(--color-fg);
     background: color-mix(in srgb, var(--color-accent-secondary) 95%, white);
@@ -685,9 +681,7 @@
   }
 
   .btn-primary-surface {
-    @apply font-body text-sm px-4 py-2.5 md:py-2
-           transition-all duration-150 cursor-pointer disabled:opacity-40
-           disabled:cursor-not-allowed min-h-11 md:min-h-0;
+    @apply font-body min-h-11 cursor-pointer px-4 py-2.5 text-sm transition-all duration-150 disabled:cursor-not-allowed disabled:opacity-40 md:min-h-0 md:py-2;
     border-radius: var(--clay-radius-lg);
     color: var(--color-fg);
     background: linear-gradient(
@@ -726,9 +720,7 @@
   }
 
   .btn-inherit {
-    @apply font-body text-sm px-4 py-2.5 md:py-2
-           transition-all duration-150 cursor-pointer disabled:opacity-40
-           disabled:cursor-not-allowed min-h-11 md:min-h-0;
+    @apply font-body min-h-11 cursor-pointer px-4 py-2.5 text-sm transition-all duration-150 disabled:cursor-not-allowed disabled:opacity-40 md:min-h-0 md:py-2;
     border-radius: var(--clay-radius-lg);
     color: var(--color-fg);
   }
@@ -795,9 +787,7 @@
   }
 
   .btn-danger {
-    @apply font-body text-sm px-4 py-2.5 md:py-2
-           transition-all duration-150 cursor-pointer disabled:opacity-40
-           disabled:cursor-not-allowed min-h-11 md:min-h-0;
+    @apply font-body min-h-11 cursor-pointer px-4 py-2.5 text-sm transition-all duration-150 disabled:cursor-not-allowed disabled:opacity-40 md:min-h-0 md:py-2;
     border-radius: var(--clay-radius-lg);
     color: #fff;
     background: color-mix(in srgb, var(--color-danger) 95%, white);
@@ -856,7 +846,7 @@
   }
 
   .btn-discord {
-    @apply font-body text-sm px-4 py-2.5 md:py-2 transition-all duration-150 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed min-h-11 md:min-h-0;
+    @apply font-body min-h-11 cursor-pointer px-4 py-2.5 text-sm transition-all duration-150 disabled:cursor-not-allowed disabled:opacity-40 md:min-h-0 md:py-2;
     border-radius: var(--clay-radius-lg);
     color: #fff;
     background: color-mix(in srgb, var(--color-discord) 95%, white);
@@ -914,7 +904,7 @@
     box-shadow: inset 0 2px 3px 0 rgba(0, 0, 0, 0.15);
   }
   .input {
-    @apply text-fg font-mono text-sm px-3 py-3 md:py-2 outline-none focus:border-accent/60 transition-all duration-200 placeholder:text-faint w-full;
+    @apply text-fg focus:border-accent/60 placeholder:text-faint w-full px-3 py-3 font-mono text-sm transition-all duration-200 outline-none md:py-2;
     border-radius: var(--clay-radius-md);
     background: linear-gradient(
       180deg,
@@ -947,9 +937,7 @@
   }
 
   .btn-icon-primary {
-    @apply w-11 h-11 md:w-10 md:h-10 flex items-center justify-center
-           transition-all duration-150 cursor-pointer disabled:opacity-40
-           disabled:cursor-not-allowed;
+    @apply flex h-11 w-11 cursor-pointer items-center justify-center transition-all duration-150 disabled:cursor-not-allowed disabled:opacity-40 md:h-10 md:w-10;
     border-radius: var(--clay-radius-md);
     color: var(--color-fg);
     background: color-mix(in srgb, var(--color-accent) 92%, white);
@@ -1003,9 +991,7 @@
   }
 
   .btn-icon-primary-secondary {
-    @apply w-11 h-11 md:w-10 md:h-10 flex items-center justify-center
-           transition-all duration-150 cursor-pointer disabled:opacity-40
-           disabled:cursor-not-allowed;
+    @apply flex h-11 w-11 cursor-pointer items-center justify-center transition-all duration-150 disabled:cursor-not-allowed disabled:opacity-40 md:h-10 md:w-10;
     border-radius: var(--clay-radius-md);
     color: var(--color-fg);
     background: color-mix(in srgb, var(--color-accent-secondary) 92%, white);
@@ -1059,9 +1045,7 @@
   }
 
   .btn-icon-primary-surface {
-    @apply w-11 h-11 md:w-10 md:h-10 flex items-center justify-center
-           transition-all duration-150 cursor-pointer disabled:opacity-40
-           disabled:cursor-not-allowed;
+    @apply flex h-11 w-11 cursor-pointer items-center justify-center transition-all duration-150 disabled:cursor-not-allowed disabled:opacity-40 md:h-10 md:w-10;
     border-radius: var(--clay-radius-md);
     background: linear-gradient(
       180deg,
@@ -1103,9 +1087,7 @@
   }
 
   .btn-icon-inherit {
-    @apply w-11 h-11 md:w-10 md:h-10 flex items-center justify-center
-           transition-all duration-150 cursor-pointer disabled:opacity-40
-           disabled:cursor-not-allowed;
+    @apply flex h-11 w-11 cursor-pointer items-center justify-center transition-all duration-150 disabled:cursor-not-allowed disabled:opacity-40 md:h-10 md:w-10;
     border-radius: var(--clay-radius-md);
     color: var(--color-fg);
   }
@@ -1165,9 +1147,7 @@
   }
 
   .btn-icon-danger {
-    @apply w-11 h-11 md:w-10 md:h-10 flex items-center justify-center
-           transition-all duration-150 cursor-pointer disabled:opacity-40
-           disabled:cursor-not-allowed;
+    @apply flex h-11 w-11 cursor-pointer items-center justify-center transition-all duration-150 disabled:cursor-not-allowed disabled:opacity-40 md:h-10 md:w-10;
     border-radius: var(--clay-radius-md);
     background: linear-gradient(
       180deg,
@@ -1252,7 +1232,7 @@
 
 /* Glass popover — unified styling for dropdowns, context menus, etc. */
 @utility glass-popover {
-  @apply glass-panel rounded-2xl border border-accent/30 clay-floating overflow-hidden;
+  @apply glass-panel border-accent/30 clay-floating overflow-hidden rounded-2xl border;
 }
 
 /* Glass hover tooltip — for .group hover-revealed help text */
@@ -1268,14 +1248,14 @@
 }
 
 @utility glass-modal {
-  @apply glass-panel rounded-2xl border border-accent/30;
+  @apply glass-panel border-accent/30 rounded-2xl border;
   box-shadow:
     0 5px 0 0 color-mix(in srgb, var(--color-surface) 60%, black),
     0 13px 30px -6px rgba(0, 0, 0, 0.4);
 }
 
 @utility glass-tooltip {
-  @apply rounded-xl glass-panel border border-accent/30 clay-floating text-xs text-muted opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity z-10;
+  @apply glass-panel border-accent/30 clay-floating text-muted pointer-events-none z-10 rounded-xl border text-xs opacity-0 transition-opacity group-hover:opacity-100;
 }
 
 @utility clay-sidebar-edge {

--- a/packages/web/src/pages/AudioPage.tsx
+++ b/packages/web/src/pages/AudioPage.tsx
@@ -45,7 +45,7 @@ export default function AudioPage() {
   const canManage = isAdminView || hasPermission('audio.manage');
 
   return (
-    <div className='p-4 md:p-8 h-full overflow-y-auto'>
+    <div className='h-full overflow-y-auto p-4 md:p-8'>
       <PageHeader
         icon={SlidersHorizontalIcon}
         title='Audio'
@@ -54,17 +54,17 @@ export default function AudioPage() {
 
       {!canManage ? (
         <div className='flex flex-col items-center justify-center py-20 text-center'>
-          <p className='text-sm text-muted mb-1'>No access to audio settings</p>
-          <p className='text-xs text-muted'>
+          <p className='text-muted mb-1 text-sm'>No access to audio settings</p>
+          <p className='text-muted text-xs'>
             You need the <span className='text-fg font-medium'>audio.manage</span> permission or an
             admin role to manage audio settings.
           </p>
         </div>
       ) : (
-        <div className='grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6'>
+        <div className='grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3'>
           {FILTER_CARDS.map(({ icon: Icon, label, component: Section, wide }) => (
             <section key={label} className={wide ? 'xl:col-span-2' : ''}>
-              <h2 className='font-mono text-xs text-muted uppercase tracking-wider mb-3 flex items-center gap-2'>
+              <h2 className='text-muted mb-3 flex items-center gap-2 font-mono text-xs tracking-wider uppercase'>
                 <Icon size={14} weight='duotone' />
                 {label}
               </h2>

--- a/packages/web/src/pages/LoginPage.tsx
+++ b/packages/web/src/pages/LoginPage.tsx
@@ -41,37 +41,37 @@ export default function LoginPage() {
   }
 
   return (
-    <div className='min-h-screen bg-elevated flex items-center justify-center relative overflow-hidden'>
+    <div className='bg-elevated relative flex min-h-screen items-center justify-center overflow-hidden'>
       {/* Background texture */}
       <div className='absolute inset-0 opacity-[0.03]' style={bgStyle} />
 
       {/* Card */}
-      <SpringUp className='relative z-10 w-full max-w-sm mx-4'>
-        <div className='p-6 md:p-8 glass-modal'>
+      <SpringUp className='relative z-10 mx-4 w-full max-w-sm'>
+        <div className='glass-modal p-6 md:p-8'>
           {/* Logo */}
-          <div className='mb-6 md:mb-8 text-center'>
-            <h1 className='font-display text-5xl md:text-6xl text-accent tracking-widest'>
+          <div className='mb-6 text-center md:mb-8'>
+            <h1 className='font-display text-accent text-5xl tracking-widest md:text-6xl'>
               alfira
             </h1>
-            <p className='font-mono text-xs text-muted mt-2 tracking-widest uppercase'>music bot</p>
+            <p className='text-muted mt-2 font-mono text-xs tracking-widest uppercase'>music bot</p>
           </div>
 
           {/* Description */}
-          <p className='font-body text-sm text-muted text-center mb-6 md:mb-8 leading-relaxed'>
+          <p className='font-body text-muted mb-6 text-center text-sm leading-relaxed md:mb-8'>
             Log in with your Discord account to access the music library and controls.
           </p>
 
           {/* Login button */}
           <a
             href='/auth/login'
-            className='btn-discord flex items-center justify-center gap-3 w-full'
+            className='btn-discord flex w-full items-center justify-center gap-3'
           >
             <DiscordLogoIcon size={18} weight='duotone' />
             Login with Discord
           </a>
         </div>
 
-        <p className='text-center font-mono text-[10px] text-faint mt-6 tracking-widest uppercase'>
+        <p className='text-faint mt-6 text-center font-mono text-[10px] tracking-widest uppercase'>
           access is restricted to server members
         </p>
       </SpringUp>

--- a/packages/web/src/pages/PermissionsPage.tsx
+++ b/packages/web/src/pages/PermissionsPage.tsx
@@ -189,7 +189,9 @@ export default function PermissionsPage() {
     });
   }, []);
 
-  const handleCancelRemove = useCallback(() => setRoleToRemove(null), []);
+  const handleCancelRemove = useCallback(() => {
+    setRoleToRemove(null);
+  }, []);
 
   const handleSave = useCallback(async () => {
     if (!data) {
@@ -205,9 +207,11 @@ export default function PermissionsPage() {
       );
       setSavedMapping({ ...mapping });
       setSuccessMsg('Permissions saved.');
-      setTimeout(() => setSuccessMsg(null), 3000);
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : 'Failed to save permissions.');
+      setTimeout(() => {
+        setSuccessMsg(null);
+      }, 3000);
+    } catch (error: unknown) {
+      setError(error instanceof Error ? error.message : 'Failed to save permissions.');
     } finally {
       setSaving(false);
     }
@@ -217,18 +221,22 @@ export default function PermissionsPage() {
   // Loading state — deferred 200ms to avoid flash on fast loads
   const [showLoading, setShowLoading] = useState(false);
   useEffect(() => {
-    const t = setTimeout(() => setShowLoading(true), 200);
-    return () => clearTimeout(t);
+    const t = setTimeout(() => {
+      setShowLoading(true);
+    }, 200);
+    return () => {
+      clearTimeout(t);
+    };
   }, []);
 
   if (!data) {
     return (
-      <div className='p-4 md:p-8 h-full overflow-y-auto'>
+      <div className='h-full overflow-y-auto p-4 md:p-8'>
         <PageHeader icon={ShieldCheckIcon} title='Permissions' />
         {error ? (
           <ErrorBanner message={error} />
         ) : (
-          showLoading && <p className='text-sm text-muted'>Loading…</p>
+          showLoading && <p className='text-muted text-sm'>Loading…</p>
         )}
       </div>
     );
@@ -236,7 +244,7 @@ export default function PermissionsPage() {
 
   // Render ----------------------------------------------------------------
   return (
-    <div className='p-4 md:p-8 h-full overflow-y-auto'>
+    <div className='h-full overflow-y-auto p-4 md:p-8'>
       <PageHeader
         icon={ShieldCheckIcon}
         title='Permissions'
@@ -246,7 +254,7 @@ export default function PermissionsPage() {
       {error && <ErrorBanner message={error} className='mb-4' />}
 
       {successMsg && (
-        <div className='mb-4 p-3 rounded-lg bg-accent/10 border border-accent/20 text-accent text-sm'>
+        <div className='bg-accent/10 border-accent/20 text-accent mb-4 rounded-lg border p-3 text-sm'>
           {successMsg}
         </div>
       )}
@@ -280,7 +288,7 @@ export default function PermissionsPage() {
       )}
 
       {/* Save */}
-      <div className='flex gap-3 pt-5 justify-end'>
+      <div className='flex justify-end gap-3 pt-5'>
         <Button variant='primary' onClick={handleSave} disabled={!hasChanges || saving}>
           {saving ? 'Saving…' : 'Save Changes'}
         </Button>
@@ -338,12 +346,18 @@ const ManagedRoleCard = memo(function ManagedRoleCard({
   togglePermission: (roleId: string, action: string) => void;
   confirmRemoveRole: (id: string) => void;
 }) {
-  const handleToggleExpand = useCallback(() => toggleExpanded(role.id), [toggleExpanded, role.id]);
+  const handleToggleExpand = useCallback(() => {
+    toggleExpanded(role.id);
+  }, [toggleExpanded, role.id]);
   const handleTogglePermission = useCallback(
-    (action: string) => togglePermission(role.id, action),
+    (action: string) => {
+      togglePermission(role.id, action);
+    },
     [togglePermission, role.id]
   );
-  const handleRemove = useCallback(() => confirmRemoveRole(role.id), [confirmRemoveRole, role.id]);
+  const handleRemove = useCallback(() => {
+    confirmRemoveRole(role.id);
+  }, [confirmRemoveRole, role.id]);
 
   return (
     <RoleCard
@@ -390,23 +404,22 @@ function RoleCard({
   );
 
   return (
-    <Card hoverable className='rounded-xl overflow-hidden'>
+    <Card hoverable className='overflow-hidden rounded-xl'>
       {/* Header row — clickable to toggle expand */}
       <button
         type='button'
-        className='flex items-center gap-3 px-5 py-3 cursor-pointer w-full'
+        className='flex w-full cursor-pointer items-center gap-3 px-5 py-3'
         onClick={onToggleExpand}
       >
-        <span className='w-3 h-3 rounded-full shrink-0' style={dotStyle} />
-        <span className='text-sm font-medium text-fg'>{role.name}</span>
+        <span className='h-3 w-3 shrink-0 rounded-full' style={dotStyle} />
+        <span className='text-fg text-sm font-medium'>{role.name}</span>
 
         {/* Category badges */}
-        <div className='flex items-center gap-4 ml-auto'>
+        <div className='ml-auto flex items-center gap-4'>
           {summaries.map((cat) => (
             <span
               key={cat.key}
-              className={`flex items-center gap-1.5 text-xs font-mono
-                ${cat.summary.granted > 0 ? 'text-accent' : 'text-muted'}`}
+              className={`flex items-center gap-1.5 font-mono text-xs ${cat.summary.granted > 0 ? 'text-accent' : 'text-muted'}`}
             >
               <span className='text-sm'>{cat.icon}</span>
               <span>
@@ -431,8 +444,8 @@ function RoleCard({
 
       {/* Expanded content */}
       {isExpanded && (
-        <div className='border-t border-border px-5 py-4'>
-          <div className='grid grid-cols-1 md:grid-cols-3 gap-5'>
+        <div className='border-border border-t px-5 py-4'>
+          <div className='grid grid-cols-1 gap-5 md:grid-cols-3'>
             {summaries.map((cat) => (
               <CategorySection
                 key={cat.key}
@@ -470,8 +483,8 @@ const CategorySection = memo(function CategorySection({
 }) {
   return (
     <div>
-      <h4 className='text-xs font-mono text-muted uppercase tracking-wider mb-2.5'>
-        <span className='text-sm mr-1.5'>{cat.icon}</span>
+      <h4 className='text-muted mb-2.5 font-mono text-xs tracking-wider uppercase'>
+        <span className='mr-1.5 text-sm'>{cat.icon}</span>
         {cat.key}
       </h4>
       <div className='space-y-2'>
@@ -503,10 +516,12 @@ const PermissionCheckbox = memo(function PermissionCheckbox({
   label: string;
   onToggle: (action: string) => void;
 }) {
-  const handleChange = useCallback(() => onToggle(action), [onToggle, action]);
+  const handleChange = useCallback(() => {
+    onToggle(action);
+  }, [onToggle, action]);
 
   return (
-    <label className='flex items-center gap-2.5 text-sm text-fg cursor-pointer group'>
+    <label className='text-fg group flex cursor-pointer items-center gap-2.5 text-sm'>
       <Checkbox checked={checked} onChange={handleChange} />
       <span className='group-hover:text-fg transition-colors'>{label}</span>
     </label>

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -26,6 +26,7 @@ import {
   getPlaylistPage,
   removeSongFromPlaylist,
   renamePlaylist,
+  reorderPlaylistSongs,
   startPlayback,
   togglePlaylistVisibility,
 } from '../api/api';
@@ -38,6 +39,7 @@ import { ContextMenu, ContextMenuTrigger } from '../components/ContextMenu';
 import EmptyState from '../components/EmptyState';
 import ListToolbar from '../components/ListToolbar';
 import NotificationToast from '../components/NotificationToast';
+import { SortableVirtualSongList } from '../components/SortableVirtualSongList';
 import { Button } from '../components/ui/Button';
 import { cooldownButtonProps } from '../components/ui/cooldownButtonProps';
 import { Skeleton } from '../components/ui/Skeleton';
@@ -355,6 +357,18 @@ export default function PlaylistDetailPage() {
   const handleCloseBulkEdit = useCallback(() => {
     setBulkEditingOpen(false);
   }, []);
+
+  // ── Reorder callback for drag-and-drop ─────────────────────────────
+  const handleReorder = useCallback(
+    async (orderedIds: string[]) => {
+      if (!playlistDetailRef.current) {
+        return;
+      }
+      await reorderPlaylistSongs(playlistDetailRef.current.id, orderedIds);
+      refetch();
+    },
+    [refetch]
+  );
 
   // ── Socket: playlist updated (rename, visibility, song count changes) ──
   useEffect(() => {
@@ -886,27 +900,52 @@ export default function PlaylistDetailPage() {
               exit='exit'
               transition={viewTransition}
             >
-              <VirtualSongList
-                items={songItems}
-                isAdminView={isAdminView}
-                playlists={[]}
-                isLoading={isLoading}
-                isFetching={isFetching}
-                isError={isError}
-                hasMore={hasMore}
-                hasLoaded={!isLoading}
-                playingId={playingSongId}
-                onRetry={retry}
-                onFetchMore={fetchNextPage}
-                onDelete={selectionMode ? undefined : handleSongDelete}
-                onPlay={handlePlayFromSong}
-                onAddToQueue={handleAddToQueue}
-                selectionMode={selectionMode}
-                isSelected={bulk.isSelected}
-                onToggleSelect={bulk.toggle}
-                emptyTitle='No Songs'
-                emptyMessage='Add songs to this playlist'
-              />
+              {sort === 'position' && !isSmart && (isAdminView || isOwner) ? (
+                <SortableVirtualSongList
+                  items={songItems}
+                  isAdminView={isAdminView}
+                  playlists={[]}
+                  isLoading={isLoading}
+                  isFetching={isFetching}
+                  isError={isError}
+                  hasMore={hasMore}
+                  hasLoaded={!isLoading}
+                  playingId={playingSongId}
+                  onRetry={retry}
+                  onFetchMore={fetchNextPage}
+                  onDelete={selectionMode ? undefined : handleSongDelete}
+                  onPlay={handlePlayFromSong}
+                  onAddToQueue={handleAddToQueue}
+                  onReorder={handleReorder}
+                  selectionMode={selectionMode}
+                  isSelected={bulk.isSelected}
+                  onToggleSelect={bulk.toggle}
+                  emptyTitle='No Songs'
+                  emptyMessage='Add songs to this playlist'
+                />
+              ) : (
+                <VirtualSongList
+                  items={songItems}
+                  isAdminView={isAdminView}
+                  playlists={[]}
+                  isLoading={isLoading}
+                  isFetching={isFetching}
+                  isError={isError}
+                  hasMore={hasMore}
+                  hasLoaded={!isLoading}
+                  playingId={playingSongId}
+                  onRetry={retry}
+                  onFetchMore={fetchNextPage}
+                  onDelete={selectionMode ? undefined : handleSongDelete}
+                  onPlay={handlePlayFromSong}
+                  onAddToQueue={handleAddToQueue}
+                  selectionMode={selectionMode}
+                  isSelected={bulk.isSelected}
+                  onToggleSelect={bulk.toggle}
+                  emptyTitle='No Songs'
+                  emptyMessage='Add songs to this playlist'
+                />
+              )}
             </m.div>
           ) : (
             <m.div

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -972,6 +972,8 @@ export default function PlaylistDetailPage() {
                 onDelete={selectionMode ? undefined : handleSongDelete}
                 onPlay={handlePlayFromSong}
                 onAddToQueue={handleAddToQueue}
+                sortable={sort === 'position' && !isSmart && (isAdminView || isOwner)}
+                onReorder={handleReorder}
                 selectionMode={selectionMode}
                 isSelected={bulk.isSelected}
                 onToggleSelect={bulk.toggle}

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -281,8 +281,12 @@ export default function PlaylistDetailPage() {
 
   const pageStyle = useMemo(() => ({ paddingBottom: 0 }), []);
   const handleGoBack = useCallback(() => navigate('/playlists'), [navigate]);
-  const handleToggleMenu = useCallback(() => setMenuOpen((v) => !v), []);
-  const handleCloseMenu = useCallback(() => setMenuOpen(false), []);
+  const handleToggleMenu = useCallback(() => {
+    setMenuOpen((v) => !v);
+  }, []);
+  const handleCloseMenu = useCallback(() => {
+    setMenuOpen(false);
+  }, []);
   const handleSortChange = useCallback((field: string, newOrder: string) => {
     setSort(field);
     setOrder(newOrder);
@@ -291,18 +295,15 @@ export default function PlaylistDetailPage() {
     const t = tag.toLowerCase();
     setFilterTags((prev) => (prev.includes(t) ? prev : [...prev, t]));
   }, []);
-  const handleRemoveTag = useCallback(
-    (tag: string) => setFilterTags((prev) => prev.filter((t) => t !== tag)),
-    []
-  );
-  const handleAddSource = useCallback(
-    (s: string) => setFilterSources((prev) => (prev.includes(s) ? prev : [...prev, s])),
-    []
-  );
-  const handleRemoveSource = useCallback(
-    (s: string) => setFilterSources((prev) => prev.filter((x) => x !== s)),
-    []
-  );
+  const handleRemoveTag = useCallback((tag: string) => {
+    setFilterTags((prev) => prev.filter((t) => t !== tag));
+  }, []);
+  const handleAddSource = useCallback((s: string) => {
+    setFilterSources((prev) => (prev.includes(s) ? prev : [...prev, s]));
+  }, []);
+  const handleRemoveSource = useCallback((s: string) => {
+    setFilterSources((prev) => prev.filter((x) => x !== s));
+  }, []);
   const handleToggleSelectionMode = useCallback(() => {
     if (selectionMode) {
       bulk.clearAll();
@@ -322,23 +323,38 @@ export default function PlaylistDetailPage() {
     },
     [songs]
   );
-  const handleCloseAddSongs = useCallback(() => setShowAddSongs(false), []);
+  const handleCloseAddSongs = useCallback(() => {
+    setShowAddSongs(false);
+  }, []);
   const handleAddSongsAdded = useCallback(() => {
     refetch();
     setShowAddSongs(false);
   }, [refetch]);
-  const handleCancelBulkRemove = useCallback(() => setBulkRemoveConfirm(false), []);
-  const handleCancelRemove = useCallback(() => setRemoveId(null), []);
-  const handleCancelDeletePlaylist = useCallback(() => setDeleteConfirm(false), []);
-  const handleCancelMakeSmart = useCallback(() => setTagSmartConfirm(null), []);
-  const handleBulkTag = useCallback(() => setBulkEditingOpen(true), []);
-  const handleSelectAll = useCallback(
-    () => bulk.selectAll(songs.map((ps) => ps.songId)),
-    [bulk, songs]
-  );
-  const handleEmptyAdd = useCallback(() => setShowAddSongs(true), []);
+  const handleCancelBulkRemove = useCallback(() => {
+    setBulkRemoveConfirm(false);
+  }, []);
+  const handleCancelRemove = useCallback(() => {
+    setRemoveId(null);
+  }, []);
+  const handleCancelDeletePlaylist = useCallback(() => {
+    setDeleteConfirm(false);
+  }, []);
+  const handleCancelMakeSmart = useCallback(() => {
+    setTagSmartConfirm(null);
+  }, []);
+  const handleBulkTag = useCallback(() => {
+    setBulkEditingOpen(true);
+  }, []);
+  const handleSelectAll = useCallback(() => {
+    bulk.selectAll(songs.map((ps) => ps.songId));
+  }, [bulk, songs]);
+  const handleEmptyAdd = useCallback(() => {
+    setShowAddSongs(true);
+  }, []);
 
-  const handleCloseBulkEdit = useCallback(() => setBulkEditingOpen(false), []);
+  const handleCloseBulkEdit = useCallback(() => {
+    setBulkEditingOpen(false);
+  }, []);
 
   // ── Socket: playlist updated (rename, visibility, song count changes) ──
   useEffect(() => {
@@ -445,8 +461,8 @@ export default function PlaylistDetailPage() {
         removeItem(junctionId);
       }
       notify(`Removed ${allIds.length} song${allIds.length !== 1 ? 's' : ''}`, 'success');
-    } catch (err: unknown) {
-      notify(apiErrorMessage(err, 'Failed to remove songs.'), 'error', 5000);
+    } catch (error: unknown) {
+      notify(apiErrorMessage(error, 'Failed to remove songs.'), 'error', 5000);
     } finally {
       setBulkRemoving(false);
       bulk.clearAll();
@@ -468,8 +484,8 @@ export default function PlaylistDetailPage() {
         }
         notify(`Updated ${allIds.length} song${allIds.length !== 1 ? 's' : ''}`, 'success');
         setBulkEditingOpen(false);
-      } catch (err: unknown) {
-        notify(apiErrorMessage(err, 'Failed to update songs.'), 'error', 5000);
+      } catch (error: unknown) {
+        notify(apiErrorMessage(error, 'Failed to update songs.'), 'error', 5000);
       } finally {
         setBulkEditingApplying(false);
         bulk.clearAll();
@@ -504,8 +520,8 @@ export default function PlaylistDetailPage() {
       );
       refetch();
       notify(updated.isPrivate ? 'Playlist set to private' : 'Playlist set to public', 'success');
-    } catch (err: unknown) {
-      notify(apiErrorMessage(err, 'Could not toggle visibility.'), 'error', 5000);
+    } catch (error: unknown) {
+      notify(apiErrorMessage(error, 'Could not toggle visibility.'), 'error', 5000);
     }
   };
 
@@ -527,11 +543,11 @@ export default function PlaylistDetailPage() {
           loop: queueState.loopMode,
           startFromSongId: songId,
         });
-      } catch (err: unknown) {
+      } catch (error: unknown) {
         if (throwErrors) {
-          throw err;
+          throw error;
         }
-        notifyUnlessRateLimit(err, 'Could not start playback.', notify);
+        notifyUnlessRateLimit(error, 'Could not start playback.', notify);
       } finally {
         setPlayingSongId(null);
       }
@@ -548,8 +564,8 @@ export default function PlaylistDetailPage() {
       await updatePlaylistTag(pd.id, null);
       refetch();
       notify('Playlist converted to regular playlist', 'success');
-    } catch (err: unknown) {
-      notify(apiErrorMessage(err, 'Could not convert playlist.'), 'error', 5000);
+    } catch (error: unknown) {
+      notify(apiErrorMessage(error, 'Could not convert playlist.'), 'error', 5000);
     }
   }, [refetch, notify]);
 
@@ -563,8 +579,8 @@ export default function PlaylistDetailPage() {
         await updatePlaylistTag(pd.id, tagNameLower);
         refetch();
         notify('Playlist tag updated', 'success');
-      } catch (err: unknown) {
-        notify(apiErrorMessage(err, 'Could not update playlist tag.'), 'error', 5000);
+      } catch (error: unknown) {
+        notify(apiErrorMessage(error, 'Could not update playlist tag.'), 'error', 5000);
       }
     },
     [refetch, notify]
@@ -581,8 +597,8 @@ export default function PlaylistDetailPage() {
         await updatePlaylistTag(pd.id, tagNameLower);
         refetch();
         notify('Playlist now tracking tag', 'success');
-      } catch (err: unknown) {
-        notify(apiErrorMessage(err, 'Could not update playlist tag.'), 'error', 5000);
+      } catch (error: unknown) {
+        notify(apiErrorMessage(error, 'Could not update playlist tag.'), 'error', 5000);
       }
     },
     [refetch, notify]
@@ -606,8 +622,8 @@ export default function PlaylistDetailPage() {
         loop: queueState.loopMode,
       });
       notify(`Added "${pd.name}" to queue`, 'success');
-    } catch (err: unknown) {
-      notify(apiErrorMessage(err, 'Could not add to queue.'), 'error', 5000);
+    } catch (error: unknown) {
+      notify(apiErrorMessage(error, 'Could not add to queue.'), 'error', 5000);
     }
   }, [queueState.loopMode, notify]);
 
@@ -633,9 +649,13 @@ export default function PlaylistDetailPage() {
             editSubmenu: {
               title: 'Rename',
               value: renameValue,
-              onChange: (val: string) => setRenameValue(val),
+              onChange: (val: string) => {
+                setRenameValue(val);
+              },
               onSave: handleRenameSave,
-              onCancel: () => setRenameValue(''),
+              onCancel: () => {
+                setRenameValue('');
+              },
               saving: renameSaving,
               placeholder: 'Playlist name',
             },
@@ -675,7 +695,9 @@ export default function PlaylistDetailPage() {
                   id: 'add-songs',
                   label: 'Add Songs',
                   icon: <PlayCircleIcon size={14} weight='duotone' />,
-                  onClick: () => setShowAddSongs(true),
+                  onClick: () => {
+                    setShowAddSongs(true);
+                  },
                 } as MenuItem,
                 {
                   id: 'make-smart',
@@ -684,7 +706,9 @@ export default function PlaylistDetailPage() {
                   submenu: {
                     title: 'Track Tag',
                     items: tagSubmenuItems,
-                    onSelect: (tagId: string) => setTagSmartConfirm(tagId),
+                    onSelect: (tagId: string) => {
+                      setTagSmartConfirm(tagId);
+                    },
                     emptyMessage: 'No tags available',
                   },
                 } as MenuItem,
@@ -694,7 +718,9 @@ export default function PlaylistDetailPage() {
             label: 'Delete',
             icon: <BombIcon size={14} weight='duotone' />,
             danger: true,
-            onClick: () => setDeleteConfirm(true),
+            onClick: () => {
+              setDeleteConfirm(true);
+            },
           } as MenuItem,
         ]
       : []),
@@ -708,28 +734,28 @@ export default function PlaylistDetailPage() {
   }
 
   return (
-    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full' style={pageStyle}>
+    <div className='flex h-full min-h-0 flex-col p-4 md:p-8' style={pageStyle}>
       {/* Back */}
       <Button
         variant='inherit'
         surface='surface'
         onClick={handleGoBack}
-        className='flex items-center gap-1.5 font-mono text-xs mb-4 md:mb-6 min-h-11 md:min-h-0'
+        className='mb-4 flex min-h-11 items-center gap-1.5 font-mono text-xs md:mb-6 md:min-h-0'
       >
-        <CaretLeftIcon size={16} weight='duotone' className='md:w-3.5 md:h-3.5' />
+        <CaretLeftIcon size={16} weight='duotone' className='md:h-3.5 md:w-3.5' />
         playlists
       </Button>
 
       {/* Header */}
-      <div className='flex flex-col sm:flex-row sm:items-start justify-between mb-6 md:mb-8 gap-4'>
-        <div className='flex-1 min-w-0'>
-          <div className='flex items-center gap-2 flex-wrap'>
-            <h1 className='font-display text-3xl md:text-4xl text-fg tracking-wider'>
+      <div className='mb-6 flex flex-col justify-between gap-4 sm:flex-row sm:items-start md:mb-8'>
+        <div className='min-w-0 flex-1'>
+          <div className='flex flex-wrap items-center gap-2'>
+            <h1 className='font-display text-fg text-3xl tracking-wider md:text-4xl'>
               {playlistDetail.name}
             </h1>
             {playlistDetail.isPrivate && (
               <span className='text-muted text-sm' title='Private playlist'>
-                <GhostIcon size={14} weight='duotone' className='inline mr-1' />
+                <GhostIcon size={14} weight='duotone' className='mr-1 inline' />
                 private
               </span>
             )}
@@ -740,7 +766,7 @@ export default function PlaylistDetailPage() {
                 const colors = getTagColorClasses(displayName, tag?.color);
                 return (
                   <span
-                    className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium ${colors.bg} ${colors.text}`}
+                    className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium ${colors.bg} ${colors.text}`}
                     title={`Auto-tracking all songs tagged "${displayName}"`}
                   >
                     <TagIcon size={12} weight='duotone' />
@@ -749,7 +775,7 @@ export default function PlaylistDetailPage() {
                 );
               })()}
           </div>
-          <p className='font-mono text-xs text-muted mt-2'>
+          <p className='text-muted mt-2 font-mono text-xs'>
             {songItems.length} {songItems.length === 1 ? 'track' : 'tracks'}
             {playlistDetail.tagNameLower ? (
               <span className='text-accent'> • auto-tracked</span>
@@ -764,7 +790,7 @@ export default function PlaylistDetailPage() {
           </p>
         </div>
 
-        <div className='flex gap-2 shrink-0 items-center'>
+        <div className='flex shrink-0 items-center gap-2'>
           <Button
             variant='secondary'
             className='rounded-full!'
@@ -780,7 +806,7 @@ export default function PlaylistDetailPage() {
           </Button>
           <Button
             variant='primary'
-            className='text-xs flex items-center gap-1.5'
+            className='flex items-center gap-1.5 text-xs'
             {...cooldownButtonProps(cooldown, {
               onClick: () => {
                 void handlePlayFromSong(songs[0]?.songId, 'sequential');
@@ -853,7 +879,7 @@ export default function PlaylistDetailPage() {
           {viewMode === 'list' ? (
             <m.div
               key='list'
-              className='flex-1 min-h-0 flex flex-col'
+              className='flex min-h-0 flex-1 flex-col'
               variants={pageVariants}
               initial='initial'
               animate='animate'
@@ -885,7 +911,7 @@ export default function PlaylistDetailPage() {
           ) : (
             <m.div
               key='grid'
-              className='flex-1 min-h-0 flex flex-col'
+              className='flex min-h-0 flex-1 flex-col'
               variants={pageVariants}
               initial='initial'
               animate='animate'
@@ -1028,13 +1054,13 @@ export default function PlaylistDetailPage() {
 function DetailSkeleton() {
   return (
     <div className='p-8'>
-      <Skeleton className='h-3 w-20 mb-6 rounded' />
-      <Skeleton className='h-12 w-64 mb-2 rounded' />
-      <Skeleton className='h-3 w-24 mb-8 rounded' />
+      <Skeleton className='mb-6 h-3 w-20 rounded' />
+      <Skeleton className='mb-2 h-12 w-64 rounded' />
+      <Skeleton className='mb-8 h-3 w-24 rounded' />
       {Array.from({ length: 5 }).map((_, i) => (
         <div key={`skeleton-${i}`} className='flex items-center gap-4 py-3'>
-          <Skeleton className='w-6 h-3 rounded' />
-          <Skeleton className='w-10 h-7 rounded' />
+          <Skeleton className='h-3 w-6 rounded' />
+          <Skeleton className='h-7 w-10 rounded' />
           <Skeleton className='h-3 flex-1 rounded' />
           <Skeleton className='h-3 w-12 rounded' />
         </div>

--- a/packages/web/src/pages/PlaylistsPage.tsx
+++ b/packages/web/src/pages/PlaylistsPage.tsx
@@ -72,8 +72,8 @@ export default function PlaylistsPage() {
 
   const handleRowClick = useCallback(
     (e: React.MouseEvent) => {
-      const row = e.currentTarget.closest('[data-playlist-id]');
-      const playlistId = row?.getAttribute('data-playlist-id');
+      const row = e.currentTarget.closest<HTMLElement>('[data-playlist-id]');
+      const playlistId = row?.dataset.playlistId;
       if (playlistId) {
         void navigate(`/playlists/${playlistId}`);
       }
@@ -83,11 +83,15 @@ export default function PlaylistsPage() {
 
   const pageStyle = useMemo(() => ({ paddingBottom: 0 }), []);
 
-  const handleShowCreate = useCallback(() => setShowCreate(true), []);
-  const handleHideCreate = useCallback(() => setShowCreate(false), []);
+  const handleShowCreate = useCallback(() => {
+    setShowCreate(true);
+  }, []);
+  const handleHideCreate = useCallback(() => {
+    setShowCreate(false);
+  }, []);
 
   return (
-    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full' style={pageStyle}>
+    <div className='flex h-full min-h-0 flex-col p-4 md:p-8' style={pageStyle}>
       <PageHeader
         icon={PlaylistIcon}
         title='Playlists'
@@ -169,12 +173,12 @@ function CreatePlaylistModal({ onClose }: { onClose: () => void }) {
 
   return (
     <Backdrop onClose={onClose}>
-      <SpringUp className='p-5 md:p-6 w-full max-w-sm mx-4 glass-modal'>
+      <SpringUp className='glass-modal mx-4 w-full max-w-sm p-5 md:p-6'>
         <form action={formAction}>
-          <h2 className='font-display text-2xl md:text-3xl text-fg tracking-wider mb-1'>
+          <h2 className='font-display text-fg mb-1 text-2xl tracking-wider md:text-3xl'>
             New Playlist
           </h2>
-          <p className='font-mono text-xs text-muted mb-4 md:mb-6'>choose a name</p>
+          <p className='text-muted mb-4 font-mono text-xs md:mb-6'>choose a name</p>
           <input
             name='name'
             className='input mb-3'
@@ -185,7 +189,7 @@ function CreatePlaylistModal({ onClose }: { onClose: () => void }) {
             required
           />
           <div className='mb-3'>
-            <p className='font-mono text-xs text-muted mb-1.5'>track a tag (optional)</p>
+            <p className='text-muted mb-1.5 font-mono text-xs'>track a tag (optional)</p>
             <select
               name='tagNameLower'
               className='input w-full'
@@ -200,8 +204,8 @@ function CreatePlaylistModal({ onClose }: { onClose: () => void }) {
               ))}
             </select>
           </div>
-          {state?.error && <p className='font-mono text-xs text-danger mb-3'>{state.error}</p>}
-          <div className='flex gap-2 justify-end'>
+          {state?.error && <p className='text-danger mb-3 font-mono text-xs'>{state.error}</p>}
+          <div className='flex justify-end gap-2'>
             <Button variant='inherit' type='button' onClick={onClose} surface='surface'>
               Cancel
             </Button>

--- a/packages/web/src/pages/RequestsPage.tsx
+++ b/packages/web/src/pages/RequestsPage.tsx
@@ -63,8 +63,8 @@ export default function RequestsPage() {
       try {
         await approveRequest(id);
         removeItem(id);
-      } catch (err: unknown) {
-        setActionError(err instanceof Error ? err.message : 'Failed to approve.');
+      } catch (error: unknown) {
+        setActionError(error instanceof Error ? error.message : 'Failed to approve.');
       }
     },
     [removeItem]
@@ -76,8 +76,8 @@ export default function RequestsPage() {
       try {
         await denyRequest(id);
         removeItem(id);
-      } catch (err: unknown) {
-        setActionError(err instanceof Error ? err.message : 'Failed to deny.');
+      } catch (error: unknown) {
+        setActionError(error instanceof Error ? error.message : 'Failed to deny.');
       }
     },
     [removeItem]
@@ -89,8 +89,8 @@ export default function RequestsPage() {
       try {
         await cancelRequest(id);
         removeItem(id);
-      } catch (err: unknown) {
-        setActionError(err instanceof Error ? err.message : 'Failed to cancel.');
+      } catch (error: unknown) {
+        setActionError(error instanceof Error ? error.message : 'Failed to cancel.');
       }
     },
     [removeItem]
@@ -127,8 +127,12 @@ export default function RequestsPage() {
 
   const pageStyle = useMemo(() => ({ paddingBottom: 0 }), []);
 
-  const handleShowAddModal = useCallback(() => setShowAddModal(true), []);
-  const handleHideAddModal = useCallback(() => setShowAddModal(false), []);
+  const handleShowAddModal = useCallback(() => {
+    setShowAddModal(true);
+  }, []);
+  const handleHideAddModal = useCallback(() => {
+    setShowAddModal(false);
+  }, []);
 
   const handleSelectPendingTab = useCallback(() => {
     setTab('pending');
@@ -148,7 +152,7 @@ export default function RequestsPage() {
   }, [reset]);
 
   return (
-    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full' style={pageStyle}>
+    <div className='flex h-full min-h-0 flex-col p-4 md:p-8' style={pageStyle}>
       <PageHeader
         icon={TrayIcon}
         title='Requests'
@@ -166,12 +170,12 @@ export default function RequestsPage() {
       {/* Tabs + filter — hidden until the initial tab is resolved */}
       {resolved && (
         <>
-          <div className='flex items-center gap-3 mb-4 md:mb-6'>
-            <div className='flex gap-1 bg-elevated rounded-lg p-1'>
+          <div className='mb-4 flex items-center gap-3 md:mb-6'>
+            <div className='bg-elevated flex gap-1 rounded-lg p-1'>
               <button
                 type='button'
                 onClick={handleSelectPendingTab}
-                className={`px-3 py-1.5 rounded-md text-sm font-body transition-colors cursor-pointer ${
+                className={`font-body cursor-pointer rounded-md px-3 py-1.5 text-sm transition-colors ${
                   tab === 'pending' ? 'bg-accent text-elevated' : 'text-muted hover:text-fg'
                 }`}
               >
@@ -180,7 +184,7 @@ export default function RequestsPage() {
               <button
                 type='button'
                 onClick={handleSelectHistoryTab}
-                className={`px-3 py-1.5 rounded-md text-sm font-body transition-colors cursor-pointer ${
+                className={`font-body cursor-pointer rounded-md px-3 py-1.5 text-sm transition-colors ${
                   tab === 'closed' ? 'bg-accent text-elevated' : 'text-muted hover:text-fg'
                 }`}
               >
@@ -189,9 +193,9 @@ export default function RequestsPage() {
             </div>
 
             {tab === 'pending' && (
-              <label className='flex items-center gap-2 cursor-pointer ml-auto'>
+              <label className='ml-auto flex cursor-pointer items-center gap-2'>
                 <Checkbox checked={mineOnly} onChange={setMineOnly} />
-                <span className='font-mono text-xs text-muted'>Only show my requests</span>
+                <span className='text-muted font-mono text-xs'>Only show my requests</span>
               </label>
             )}
           </div>

--- a/packages/web/src/pages/SetupWizard.tsx
+++ b/packages/web/src/pages/SetupWizard.tsx
@@ -59,7 +59,7 @@ function RoleColorDot({ color }: { color: number | null }) {
     () => ({ backgroundColor: getRoleBgColor(color) }),
     [color]
   );
-  return <span className='w-3 h-3 rounded-full shrink-0' style={style} />;
+  return <span className='h-3 w-3 shrink-0 rounded-full' style={style} />;
 }
 
 function SourceCheckbox({
@@ -71,7 +71,9 @@ function SourceCheckbox({
   checked: boolean;
   onToggle: (key: string) => void;
 }) {
-  const handleChange = useCallback(() => onToggle(sourceKey), [sourceKey, onToggle]);
+  const handleChange = useCallback(() => {
+    onToggle(sourceKey);
+  }, [sourceKey, onToggle]);
   return <Checkbox checked={checked} onChange={handleChange} />;
 }
 
@@ -84,7 +86,9 @@ function RoleCheckbox({
   checked: boolean;
   onToggle: (id: string) => void;
 }) {
-  const handleChange = useCallback(() => onToggle(roleId), [roleId, onToggle]);
+  const handleChange = useCallback(() => {
+    onToggle(roleId);
+  }, [roleId, onToggle]);
   return <Checkbox checked={checked} onChange={handleChange} />;
 }
 
@@ -147,7 +151,7 @@ export default function SetupWizard() {
   // Auto-refresh guild list when on the guild step and no guilds are found.
   useEffect(() => {
     if (step !== 'guild' || guilds.length > 0) {
-      return undefined;
+      return;
     }
 
     let cancelled = false;
@@ -244,8 +248,8 @@ export default function SetupWizard() {
       // then redirect to /login for a fresh OAuth flow.
       await logout();
       window.location.href = '/login';
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : 'Failed to save configuration.');
+    } catch (error: unknown) {
+      setError(error instanceof Error ? error.message : 'Failed to save configuration.');
       setSaving(false);
       setStep('confirm');
     }
@@ -306,15 +310,13 @@ export default function SetupWizard() {
     setStep('timeout');
   }, []);
 
-  const handleTimeoutChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => setTimeoutMinutes(Number(e.target.value)),
-    []
-  );
+  const handleTimeoutChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setTimeoutMinutes(Number(e.target.value));
+  }, []);
 
-  const handlePublicUrlChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => setPublicUrl(e.target.value),
-    []
-  );
+  const handlePublicUrlChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setPublicUrl(e.target.value);
+  }, []);
 
   const timeoutRangeStyle = useMemo(
     () =>
@@ -333,21 +335,21 @@ export default function SetupWizard() {
 
   if (loading) {
     return (
-      <div className='h-full flex items-center justify-center bg-elevated'>
+      <div className='bg-elevated flex h-full items-center justify-center'>
         <Spinner size='lg' />
       </div>
     );
   }
 
   return (
-    <div className='min-h-full bg-surface flex items-center justify-center p-4'>
+    <div className='bg-surface flex min-h-full items-center justify-center p-4'>
       <div className='w-full max-w-lg'>
         {/* Progress dots */}
-        <div className='flex justify-center gap-2 mb-8'>
+        <div className='mb-8 flex justify-center gap-2'>
           {STEP_ORDER.slice(1).map((s, i) => (
             <div
               key={s}
-              className={`w-2 h-2 rounded-full transition-colors ${
+              className={`h-2 w-2 rounded-full transition-colors ${
                 i < stepIndex - 1
                   ? 'bg-accent'
                   : i === stepIndex - 1
@@ -363,17 +365,17 @@ export default function SetupWizard() {
         {/* Step content */}
         <div className='glass-modal p-6 md:p-8'>
           {step === 'welcome' && (
-            <div className='text-center space-y-6'>
+            <div className='space-y-6 text-center'>
               <div className='flex justify-center'>
-                <div className='w-16 h-16 rounded-full bg-accent/10 border border-accent/30 flex items-center justify-center'>
+                <div className='bg-accent/10 border-accent/30 flex h-16 w-16 items-center justify-center rounded-full border'>
                   <ShieldCheckIcon size={32} weight='duotone' className='text-accent' />
                 </div>
               </div>
               <div>
-                <h1 className='font-display text-2xl text-fg tracking-wider mb-2'>
+                <h1 className='font-display text-fg mb-2 text-2xl tracking-wider'>
                   Welcome to Alfira
                 </h1>
-                <p className='text-sm text-muted leading-relaxed'>
+                <p className='text-muted text-sm leading-relaxed'>
                   Let&apos;s get your music bot configured. You&apos;ll pick your server, choose
                   admin roles, and set a few preferences.
                 </p>
@@ -386,24 +388,24 @@ export default function SetupWizard() {
 
           {step === 'guild' && (
             <div className='space-y-5'>
-              <h2 className='font-display text-xl text-fg'>Choose a Server</h2>
-              <p className='text-sm text-muted'>
+              <h2 className='font-display text-fg text-xl'>Choose a Server</h2>
+              <p className='text-muted text-sm'>
                 Select the Discord server Alfira will operate in.
               </p>
               {guilds.length === 0 ? (
-                <div className='p-4 rounded-lg bg-warning/10 text-warning text-sm space-y-3'>
+                <div className='bg-warning/10 text-warning space-y-3 rounded-lg p-4 text-sm'>
                   <p>No servers found. Invite the bot to a Discord server first.</p>
                   {clientId && (
                     <a
                       href={`https://discord.com/oauth2/authorize?client_id=${clientId}&permissions=3148800&scope=bot+applications.commands`}
                       target='_blank'
                       rel='noopener noreferrer'
-                      className='inline-block px-4 py-2 rounded-lg bg-accent text-elevated text-sm font-body hover:opacity-90 transition-opacity'
+                      className='bg-accent text-elevated font-body inline-block rounded-lg px-4 py-2 text-sm transition-opacity hover:opacity-90'
                     >
                       Invite Alfira to a Server
                     </a>
                   )}
-                  <p className='text-xs text-warning/70'>Checking for servers every few seconds…</p>
+                  <p className='text-warning/70 text-xs'>Checking for servers every few seconds…</p>
                   {refreshingGuilds && <Spinner size='md' />}
                 </div>
               ) : (
@@ -411,7 +413,7 @@ export default function SetupWizard() {
                   {guilds.map((g) => (
                     <label
                       key={g.id}
-                      className={`flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+                      className={`flex cursor-pointer items-center gap-3 rounded-lg border p-3 transition-colors ${
                         selectedGuildId === g.id
                           ? 'border-accent bg-accent/5'
                           : 'border-border hover:border-muted'
@@ -426,7 +428,7 @@ export default function SetupWizard() {
                         data-guild={g.id}
                         className='accent-accent'
                       />
-                      <span className='text-sm text-fg'>{g.name}</span>
+                      <span className='text-fg text-sm'>{g.name}</span>
                     </label>
                   ))}
                 </div>
@@ -436,7 +438,7 @@ export default function SetupWizard() {
                   type='button'
                   onClick={handleGoToStep}
                   data-step='welcome'
-                  className='flex items-center gap-1 text-sm text-muted hover:text-fg transition-colors cursor-pointer'
+                  className='text-muted hover:text-fg flex cursor-pointer items-center gap-1 text-sm transition-colors'
                 >
                   <CaretLeftIcon size={14} />
                   Back
@@ -457,9 +459,9 @@ export default function SetupWizard() {
             <div className='space-y-5'>
               <div className='flex items-center gap-3'>
                 <MusicNotesIcon size={24} weight='duotone' className='text-accent' />
-                <h2 className='font-display text-xl text-fg'>Music Sources</h2>
+                <h2 className='font-display text-fg text-xl'>Music Sources</h2>
               </div>
-              <p className='text-sm text-muted'>
+              <p className='text-muted text-sm'>
                 Choose which music platforms Alfira can play from. At least one source must be
                 enabled.
               </p>
@@ -468,7 +470,7 @@ export default function SetupWizard() {
                   <>
                     <label
                       key={source.key}
-                      className={`flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+                      className={`flex cursor-pointer items-center gap-3 rounded-lg border p-3 transition-colors ${
                         selectedSourceKeys.has(source.key)
                           ? 'border-accent bg-accent/5'
                           : 'border-border hover:border-muted'
@@ -480,25 +482,25 @@ export default function SetupWizard() {
                         onToggle={toggleSource}
                       />
                       <SourceIcon sourceKey={source.key} className='shrink-0' />
-                      <span className='text-sm text-fg'>{source.displayName}</span>
+                      <span className='text-fg text-sm'>{source.displayName}</span>
                       {source.helpText && (
-                        <span className='relative group'>
+                        <span className='group relative'>
                           <QuestionIcon
                             size={14}
                             weight='duotone'
                             className='text-muted cursor-help'
                           />
-                          <span className='glass-tooltip absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-56 p-2'>
+                          <span className='glass-tooltip absolute bottom-full left-1/2 mb-2 w-56 -translate-x-1/2 p-2'>
                             {source.helpText}
                           </span>
                         </span>
                       )}
                       {selectedSourceKeys.size === 1 && selectedSourceKeys.has(source.key) && (
-                        <span className='text-xs text-muted ml-auto'>(must keep at least one)</span>
+                        <span className='text-muted ml-auto text-xs'>(must keep at least one)</span>
                       )}
                     </label>
                     {source.requiresCredentials && selectedSourceKeys.has(source.key) && (
-                      <p className='text-xs text-warning ml-9'>
+                      <p className='text-warning ml-9 text-xs'>
                         This source requires credentials to be configured via environment variables
                         before it can play music.
                       </p>
@@ -507,14 +509,14 @@ export default function SetupWizard() {
                 ))}
               </div>
               {selectedSourceKeys.size === 0 && (
-                <p className='text-xs text-danger'>Please enable at least one music source.</p>
+                <p className='text-danger text-xs'>Please enable at least one music source.</p>
               )}
               <div className='flex justify-between pt-2'>
                 <button
                   type='button'
                   onClick={handleGoToStep}
                   data-step='guild'
-                  className='flex items-center gap-1 text-sm text-muted hover:text-fg transition-colors cursor-pointer'
+                  className='text-muted hover:text-fg flex cursor-pointer items-center gap-1 text-sm transition-colors'
                 >
                   <CaretLeftIcon size={14} />
                   Back
@@ -532,20 +534,20 @@ export default function SetupWizard() {
 
           {step === 'roles' && (
             <div className='space-y-5'>
-              <h2 className='font-display text-xl text-fg'>Admin Roles</h2>
-              <p className='text-sm text-muted'>
+              <h2 className='font-display text-fg text-xl'>Admin Roles</h2>
+              <p className='text-muted text-sm'>
                 Select which roles can manage Alfira (add songs, control playback, etc.).
               </p>
               {roles.length === 0 ? (
-                <div className='p-4 rounded-lg bg-warning/10 text-warning text-sm'>
+                <div className='bg-warning/10 text-warning rounded-lg p-4 text-sm'>
                   No roles found in this server. Create roles in Discord first.
                 </div>
               ) : (
-                <div className='space-y-2 max-h-64 overflow-y-auto'>
+                <div className='max-h-64 space-y-2 overflow-y-auto'>
                   {roles.map((r) => (
                     <label
                       key={r.id}
-                      className={`flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+                      className={`flex cursor-pointer items-center gap-3 rounded-lg border p-3 transition-colors ${
                         selectedRoleIds.has(r.id)
                           ? 'border-accent bg-accent/5'
                           : 'border-border hover:border-muted'
@@ -557,7 +559,7 @@ export default function SetupWizard() {
                         onToggle={toggleRole}
                       />
                       <RoleColorDot color={r.color} />
-                      <span className='text-sm text-fg'>{r.name}</span>
+                      <span className='text-fg text-sm'>{r.name}</span>
                     </label>
                   ))}
                 </div>
@@ -567,7 +569,7 @@ export default function SetupWizard() {
                   type='button'
                   onClick={handleGoToStep}
                   data-step='sources'
-                  className='flex items-center gap-1 text-sm text-muted hover:text-fg transition-colors cursor-pointer'
+                  className='text-muted hover:text-fg flex cursor-pointer items-center gap-1 text-sm transition-colors'
                 >
                   <CaretLeftIcon size={14} />
                   Back
@@ -587,20 +589,20 @@ export default function SetupWizard() {
             <div className='space-y-5'>
               <div className='flex items-center gap-3'>
                 <MegaphoneIcon size={24} weight='duotone' className='text-accent' />
-                <h2 className='font-display text-xl text-fg'>Notification Channel</h2>
+                <h2 className='font-display text-fg text-xl'>Notification Channel</h2>
               </div>
-              <p className='text-sm text-muted'>
+              <p className='text-muted text-sm'>
                 Alfira can post a message when it leaves a voice channel due to inactivity. Choose a
                 text channel, or skip this step.
               </p>
               {channels.length === 0 ? (
-                <p className='text-sm text-muted'>No text channels found.</p>
+                <p className='text-muted text-sm'>No text channels found.</p>
               ) : (
-                <div className='space-y-2 max-h-64 overflow-y-auto'>
+                <div className='max-h-64 space-y-2 overflow-y-auto'>
                   {channels.map((c) => (
                     <label
                       key={c.id}
-                      className={`flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+                      className={`flex cursor-pointer items-center gap-3 rounded-lg border p-3 transition-colors ${
                         selectedChannelId === c.id
                           ? 'border-accent bg-accent/5'
                           : 'border-border hover:border-muted'
@@ -615,7 +617,7 @@ export default function SetupWizard() {
                         data-channel={c.id}
                         className='accent-accent'
                       />
-                      <span className='text-sm text-fg'># {c.name}</span>
+                      <span className='text-fg text-sm'># {c.name}</span>
                     </label>
                   ))}
                 </div>
@@ -625,7 +627,7 @@ export default function SetupWizard() {
                   type='button'
                   onClick={handleGoToStep}
                   data-step='roles'
-                  className='flex items-center gap-1 text-sm text-muted hover:text-fg transition-colors cursor-pointer'
+                  className='text-muted hover:text-fg flex cursor-pointer items-center gap-1 text-sm transition-colors'
                 >
                   <CaretLeftIcon size={14} />
                   Back
@@ -646,9 +648,9 @@ export default function SetupWizard() {
             <div className='space-y-5'>
               <div className='flex items-center gap-3'>
                 <TimerIcon size={24} weight='duotone' className='text-accent' />
-                <h2 className='font-display text-xl text-fg'>Idle Timeout</h2>
+                <h2 className='font-display text-fg text-xl'>Idle Timeout</h2>
               </div>
-              <p className='text-sm text-muted'>
+              <p className='text-muted text-sm'>
                 How many minutes before Alfira automatically leaves when nobody is listening?
               </p>
               <div className='flex items-center gap-4'>
@@ -658,10 +660,10 @@ export default function SetupWizard() {
                   max={120}
                   value={timeoutMinutes}
                   onChange={handleTimeoutChange}
-                  className='flex-1 range-input range-input-h'
+                  className='range-input range-input-h flex-1'
                   style={timeoutRangeStyle}
                 />
-                <span className='font-mono text-lg text-fg w-20 text-right whitespace-nowrap'>
+                <span className='text-fg w-20 text-right font-mono text-lg whitespace-nowrap'>
                   {timeoutMinutes} min
                 </span>
               </div>
@@ -670,7 +672,7 @@ export default function SetupWizard() {
                   type='button'
                   onClick={handleGoToStep}
                   data-step='channel'
-                  className='flex items-center gap-1 text-sm text-muted hover:text-fg transition-colors cursor-pointer'
+                  className='text-muted hover:text-fg flex cursor-pointer items-center gap-1 text-sm transition-colors'
                 >
                   <CaretLeftIcon size={14} />
                   Back
@@ -686,9 +688,9 @@ export default function SetupWizard() {
             <div className='space-y-5'>
               <div className='flex items-center gap-3'>
                 <GlobeIcon size={24} weight='duotone' className='text-accent' />
-                <h2 className='font-display text-xl text-fg'>Public URL</h2>
+                <h2 className='font-display text-fg text-xl'>Public URL</h2>
               </div>
-              <p className='text-sm text-muted'>
+              <p className='text-muted text-sm'>
                 Optional — the URL your users will use to access Alfira (e.g.,
                 https://music.yourserver.com). This can be changed later in settings.
               </p>
@@ -704,7 +706,7 @@ export default function SetupWizard() {
                   type='button'
                   onClick={handleGoToStep}
                   data-step='timeout'
-                  className='flex items-center gap-1 text-sm text-muted hover:text-fg transition-colors cursor-pointer'
+                  className='text-muted hover:text-fg flex cursor-pointer items-center gap-1 text-sm transition-colors'
                 >
                   <CaretLeftIcon size={14} />
                   Back
@@ -718,12 +720,12 @@ export default function SetupWizard() {
 
           {step === 'confirm' && (
             <div className='space-y-5'>
-              <h2 className='font-display text-xl text-fg text-center'>Ready to Go</h2>
-              <p className='text-sm text-muted text-center'>
+              <h2 className='font-display text-fg text-center text-xl'>Ready to Go</h2>
+              <p className='text-muted text-center text-sm'>
                 Review your settings below, then finish setup.
               </p>
 
-              <div className='space-y-3 bg-base rounded-lg p-4'>
+              <div className='bg-base space-y-3 rounded-lg p-4'>
                 <div className='flex justify-between text-sm'>
                   <span className='text-muted'>Server</span>
                   <span className='text-fg'>
@@ -771,7 +773,7 @@ export default function SetupWizard() {
                   type='button'
                   onClick={handleGoToStep}
                   data-step='publicUrl'
-                  className='flex items-center gap-1 text-sm text-muted hover:text-fg transition-colors cursor-pointer'
+                  className='text-muted hover:text-fg flex cursor-pointer items-center gap-1 text-sm transition-colors'
                 >
                   <CaretLeftIcon size={14} />
                   Back

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -54,7 +54,9 @@ export default function SongsPage() {
   const [playingId, setPlayingId] = useState<string | null>(null);
   const { handleAddToQueue, notification } = useAddToQueue();
   const { notify } = useNotification();
-  const handleSetDeleteId = useCallback((id: string | null) => setDeleteId(id), []);
+  const handleSetDeleteId = useCallback((id: string | null) => {
+    setDeleteId(id);
+  }, []);
 
   // Bulk selection
   const bulk = useBulkSelection();
@@ -153,7 +155,6 @@ export default function SongsPage() {
   // ── Comparator for re-sorting after real-time mutations ──────────────
   const songCompareFn = useMemo(() => {
     const dir = order === 'asc' ? 1 : -1;
-    // eslint-disable-next-line typescript/consistent-return
     return (a: Song, b: Song): number => {
       switch (sort) {
         case 'title': {
@@ -280,8 +281,8 @@ export default function SongsPage() {
         removeItem(id);
       }
       notify(`Deleted ${allIds.length} song${allIds.length !== 1 ? 's' : ''}`, 'success');
-    } catch (err: unknown) {
-      notify(apiErrorMessage(err, 'Failed to delete songs.'), 'error', 5000);
+    } catch (error: unknown) {
+      notify(apiErrorMessage(error, 'Failed to delete songs.'), 'error', 5000);
     } finally {
       setBulkDeleting(false);
       bulk.clearAll();
@@ -303,8 +304,8 @@ export default function SongsPage() {
         }
         notify(`Updated ${allIds.length} song${allIds.length !== 1 ? 's' : ''}`, 'success');
         setBulkEditingOpen(false);
-      } catch (err: unknown) {
-        notify(apiErrorMessage(err, 'Failed to update songs.'), 'error', 5000);
+      } catch (error: unknown) {
+        notify(apiErrorMessage(error, 'Failed to update songs.'), 'error', 5000);
       } finally {
         setBulkEditingApplying(false);
         bulk.clearAll();
@@ -325,9 +326,9 @@ export default function SongsPage() {
           startFromSongId: songId,
         });
         notify('Started playback', 'success');
-      } catch (err: unknown) {
+      } catch (error: unknown) {
         notifyUnlessRateLimit(
-          err,
+          error,
           'Could not start playback. Is the bot in a voice channel?',
           notify
         );
@@ -341,7 +342,9 @@ export default function SongsPage() {
   const pageStyle = useMemo(() => ({ paddingBottom: 0 }), []);
 
   const handleSearchChange = useCallback(
-    (v: string) => updateParam('search', v || null),
+    (v: string) => {
+      updateParam('search', v || null);
+    },
     [updateParam]
   );
 
@@ -380,7 +383,9 @@ export default function SongsPage() {
   );
 
   const handleRemoveTag = useCallback(
-    (tag: string) => updateParam('tags', filterTags.filter((t) => t !== tag).join(',') || null),
+    (tag: string) => {
+      updateParam('tags', filterTags.filter((t) => t !== tag).join(',') || null);
+    },
     [filterTags, updateParam]
   );
 
@@ -395,7 +400,9 @@ export default function SongsPage() {
   );
 
   const handleRemoveSource = useCallback(
-    (s: string) => updateParam('source', filterSources.filter((x) => x !== s).join(',') || null),
+    (s: string) => {
+      updateParam('source', filterSources.filter((x) => x !== s).join(',') || null);
+    },
     [filterSources, updateParam]
   );
 
@@ -417,26 +424,36 @@ export default function SongsPage() {
     }
   }, [deleteId, handleDelete]);
 
-  const handleCancelDelete = useCallback(() => setDeleteId(null), []);
+  const handleCancelDelete = useCallback(() => {
+    setDeleteId(null);
+  }, []);
 
-  const handleCancelBulkDelete = useCallback(() => setBulkDeleteConfirm(false), []);
+  const handleCancelBulkDelete = useCallback(() => {
+    setBulkDeleteConfirm(false);
+  }, []);
 
-  const handleBulkTag = useCallback(() => setBulkEditingOpen(true), []);
+  const handleBulkTag = useCallback(() => {
+    setBulkEditingOpen(true);
+  }, []);
 
-  const handleSelectAll = useCallback(() => bulk.selectAll(items.map((s) => s.id)), [bulk, items]);
+  const handleSelectAll = useCallback(() => {
+    bulk.selectAll(items.map((s) => s.id));
+  }, [bulk, items]);
 
-  const handleCloseBulkEdit = useCallback(() => setBulkEditingOpen(false), []);
+  const handleCloseBulkEdit = useCallback(() => {
+    setBulkEditingOpen(false);
+  }, []);
 
   return (
-    <div className='p-4 md:p-8 flex flex-col min-h-0 h-full' style={pageStyle}>
+    <div className='flex h-full min-h-0 flex-col p-4 md:p-8' style={pageStyle}>
       <PageHeader
         icon={MusicNotesIcon}
         title='Songs'
         subtitle={`Music library${hasLoaded ? ` • ${total} track${total !== 1 ? 's' : ''}` : ''}`}
       >
-        <span className='relative group'>
+        <span className='group relative'>
           <QuestionIcon size={20} weight='duotone' className='text-muted cursor-help' />
-          <span className='glass-tooltip absolute right-0 top-full mt-2 w-64 p-3 leading-relaxed'>
+          <span className='glass-tooltip absolute top-full right-0 mt-2 w-64 p-3 leading-relaxed'>
             Songs are added through the <span className='text-accent'>Requests</span> page. Submit a
             URL there — admins review and approve it, or it&rsquo;s added instantly if you have
             permission.
@@ -472,7 +489,7 @@ export default function SongsPage() {
         {viewMode === 'list' ? (
           <m.div
             key='list'
-            className='flex-1 min-h-0 flex flex-col'
+            className='flex min-h-0 flex-1 flex-col'
             variants={pageVariants}
             initial='initial'
             animate='animate'
@@ -512,7 +529,7 @@ export default function SongsPage() {
         ) : (
           <m.div
             key='grid'
-            className='flex-1 min-h-0 flex flex-col'
+            className='flex min-h-0 flex-1 flex-col'
             variants={pageVariants}
             initial='initial'
             animate='animate'
@@ -632,7 +649,7 @@ function DeleteConfirmDialog({
         <>
           Remove <span className='text-fg font-semibold'>"{song.nickname ?? song.title}"</span> from
           the library?{' '}
-          <span className='font-mono text-xs text-danger/70'>
+          <span className='text-danger/70 font-mono text-xs'>
             this will remove it from all playlists too.
           </span>
         </>

--- a/packages/web/src/pages/TagsPage.tsx
+++ b/packages/web/src/pages/TagsPage.tsx
@@ -34,8 +34,12 @@ export default function TagsPage() {
 
   const [showTagsLoading, setShowTagsLoading] = useState(false);
   useEffect(() => {
-    const t = setTimeout(() => setShowTagsLoading(true), 200);
-    return () => clearTimeout(t);
+    const t = setTimeout(() => {
+      setShowTagsLoading(true);
+    }, 200);
+    return () => {
+      clearTimeout(t);
+    };
   }, []);
 
   useEffect(() => {
@@ -158,24 +162,28 @@ export default function TagsPage() {
     [editingName, saveName, selected]
   );
 
-  const handleShowDelete = useCallback(() => setShowDeleteConfirm(true), []);
-  const handleCancelDelete = useCallback(() => setShowDeleteConfirm(false), []);
+  const handleShowDelete = useCallback(() => {
+    setShowDeleteConfirm(true);
+  }, []);
+  const handleCancelDelete = useCallback(() => {
+    setShowDeleteConfirm(false);
+  }, []);
 
   return (
-    <div className='p-4 md:p-8 h-full overflow-y-auto'>
+    <div className='h-full overflow-y-auto p-4 md:p-8'>
       <PageHeader
         icon={TagIcon}
         title='Tags'
         subtitle={`Manage tags & colors${loadingTags ? '' : ` • ${allTags.length} tag${allTags.length !== 1 ? 's' : ''}`}`}
       />
 
-      <div className='flex gap-4 flex-1 min-h-0'>
+      <div className='flex min-h-0 flex-1 gap-4'>
         {/* Left pane: tag list */}
-        <div className='flex-1 flex flex-col min-w-0 bg-elevated clay-resting rounded-lg overflow-hidden'>
+        <div className='bg-elevated clay-resting flex min-w-0 flex-1 flex-col overflow-hidden rounded-lg'>
           <div className='px-3 pt-3 pb-2'>
             <div className='relative'>
               <MagnifyingGlassIcon
-                className='absolute left-3 top-1/2 -translate-y-1/2 text-faint w-3.5 h-3.5'
+                className='text-faint absolute top-1/2 left-3 h-3.5 w-3.5 -translate-y-1/2'
                 weight='duotone'
               />
               <input
@@ -183,7 +191,7 @@ export default function TagsPage() {
                 value={search}
                 onChange={handleSearchChange}
                 placeholder='Search tags...'
-                className='input text-sm pl-9'
+                className='input pl-9 text-sm'
               />
             </div>
           </div>
@@ -191,7 +199,7 @@ export default function TagsPage() {
           <div className='flex-1 overflow-y-auto'>
             {loadingTags ? (
               showTagsLoading ? (
-                <div className='flex items-center justify-center h-20 text-muted text-sm'>
+                <div className='text-muted flex h-20 items-center justify-center text-sm'>
                   Loading…
                 </div>
               ) : null
@@ -220,17 +228,17 @@ export default function TagsPage() {
         </div>
 
         {/* Right pane: tag detail */}
-        <div className='flex-1 flex flex-col min-w-0 bg-elevated clay-resting rounded-lg overflow-hidden'>
+        <div className='bg-elevated clay-resting flex min-w-0 flex-1 flex-col overflow-hidden rounded-lg'>
           {!selected ? (
-            <div className='flex-1 flex items-center justify-center text-muted text-sm'>
+            <div className='text-muted flex flex-1 items-center justify-center text-sm'>
               Select a tag to view and edit its details.
             </div>
           ) : (
             <>
               {/* Header */}
-              <div className='px-4 py-3 border-b border-border'>
+              <div className='border-border border-b px-4 py-3'>
                 <div className='flex items-center gap-2'>
-                  <p className='text-xs font-medium text-fg uppercase tracking-wider shrink-0'>
+                  <p className='text-fg shrink-0 text-xs font-medium tracking-wider uppercase'>
                     Tag Name
                   </p>
                   <input
@@ -239,14 +247,14 @@ export default function TagsPage() {
                     onChange={handleNameChange}
                     onBlur={handleNameBlur}
                     onKeyDown={handleNameKeyDown}
-                    className='input text-sm flex-1'
+                    className='input flex-1 text-sm'
                   />
                   <Button
                     variant='danger'
                     size='icon'
                     onClick={handleShowDelete}
                     title={`Delete "${selected.canonicalName}"`}
-                    className='shrink-0 -mr-1'
+                    className='-mr-1 shrink-0'
                   >
                     <TrashIcon size={16} weight='duotone' />
                   </Button>
@@ -254,8 +262,8 @@ export default function TagsPage() {
               </div>
 
               {/* Color picker */}
-              <div className='px-4 py-3 border-b border-border space-y-2'>
-                <p className='text-xs font-medium text-fg uppercase tracking-wider'>Color</p>
+              <div className='border-border space-y-2 border-b px-4 py-3'>
+                <p className='text-fg text-xs font-medium tracking-wider uppercase'>Color</p>
                 <div className='flex gap-2'>
                   {TAG_COLOR_NAMES.map((colorName) => {
                     const colorClasses =
@@ -277,13 +285,13 @@ export default function TagsPage() {
 
               {/* Song list */}
               <div className='flex-1 overflow-y-auto px-4 py-3'>
-                <p className='text-xs font-medium text-fg uppercase tracking-wider mb-3'>
+                <p className='text-fg mb-3 text-xs font-medium tracking-wider uppercase'>
                   {loadingSongs
                     ? 'Loading…'
                     : `${tagSongs.length} song${tagSongs.length !== 1 ? 's' : ''}`}
                 </p>
                 {tagSongs.length === 0 && !loadingSongs ? (
-                  <p className='text-sm text-muted text-center py-8'>No songs with this tag yet.</p>
+                  <p className='text-muted py-8 text-center text-sm'>No songs with this tag yet.</p>
                 ) : (
                   <div className='space-y-1'>
                     {tagSongs.map((song) => (
@@ -325,18 +333,20 @@ const TagListItem = memo(function TagListItem({
   onSelect: (tag: TagItem) => void;
 }) {
   const colors = getTagColorClasses(tag.canonicalName, tag.color);
-  const handleClick = useCallback(() => onSelect(tag), [onSelect, tag]);
+  const handleClick = useCallback(() => {
+    onSelect(tag);
+  }, [onSelect, tag]);
 
   return (
     <button
       type='button'
       onClick={handleClick}
-      className={`w-full flex items-center gap-2 px-3 py-2 text-left text-sm rounded transition-colors cursor-pointer ${
+      className={`flex w-full cursor-pointer items-center gap-2 rounded px-3 py-2 text-left text-sm transition-colors ${
         isActive ? 'bg-accent/25 text-accent-foreground' : 'hover:bg-accent/10 text-fg'
       }`}
     >
       <span
-        className={`inline-flex items-center px-1.5 py-0.5 rounded text-[13px] font-medium whitespace-nowrap ${colors.bg} ${colors.text}`}
+        className={`inline-flex items-center rounded px-1.5 py-0.5 text-[13px] font-medium whitespace-nowrap ${colors.bg} ${colors.text}`}
       >
         {tag.canonicalName}
       </span>
@@ -355,21 +365,23 @@ const ColorButton = memo(function ColorButton({
   isSelected: boolean;
   onPick: (color: string) => void;
 }) {
-  const handleClick = useCallback(() => onPick(colorName), [onPick, colorName]);
+  const handleClick = useCallback(() => {
+    onPick(colorName);
+  }, [onPick, colorName]);
 
   return (
     <button
       type='button'
       onClick={handleClick}
       title={colorName}
-      className={`w-8 h-8 rounded-full flex items-center justify-center transition-all cursor-pointer border border-border/40 ${
+      className={`border-border/40 flex h-8 w-8 cursor-pointer items-center justify-center rounded-full border transition-all ${
         isSelected
-          ? 'opacity-100 ring-2 ring-offset-1 ring-offset-surface ring-fg'
+          ? 'ring-offset-surface ring-fg opacity-100 ring-2 ring-offset-1'
           : 'opacity-80 hover:opacity-100'
       } ${colorClasses.bg} ${colorClasses.text}`}
     >
       {isSelected ? (
-        <svg className='w-3.5 h-3.5' fill='currentColor' viewBox='0 0 12 12' aria-hidden='true'>
+        <svg className='h-3.5 w-3.5' fill='currentColor' viewBox='0 0 12 12' aria-hidden='true'>
           <path d='M10.28 2.28L4.5 8.06l-2.78-2.79a.5.5 0 0 0-.71.71l3.15 3.15a.5.5 0 0 0 .71 0l6.36-6.36a.5.5 0 0 0 0-.71.5.5 0 0 0-.71 0z' />
         </svg>
       ) : null}
@@ -385,27 +397,29 @@ const TagSongItem = memo(function TagSongItem({
   onRemove: (song: Song) => void;
 }) {
   const allTags = song.tags ?? [];
-  const handleRemove = useCallback(() => onRemove(song), [onRemove, song]);
+  const handleRemove = useCallback(() => {
+    onRemove(song);
+  }, [onRemove, song]);
 
   return (
-    <div className='flex items-center gap-3 py-2 px-2 rounded-lg hover:bg-surface/80 transition-colors group'>
-      <div className='w-12 h-12 rounded border border-border shrink-0 overflow-hidden bg-base'>
+    <div className='hover:bg-surface/80 group flex items-center gap-3 rounded-lg px-2 py-2 transition-colors'>
+      <div className='border-border bg-base h-12 w-12 shrink-0 overflow-hidden rounded border'>
         {(song.artwork ?? song.thumbnailUrl) ? (
-          <ArtworkImage src={song.artwork ?? song.thumbnailUrl} alt='' className='w-full h-full' />
+          <ArtworkImage src={song.artwork ?? song.thumbnailUrl} alt='' className='h-full w-full' />
         ) : (
-          <div className='w-full h-full flex items-center justify-center text-faint text-[10px]' />
+          <div className='text-faint flex h-full w-full items-center justify-center text-[10px]' />
         )}
       </div>
-      <div className='flex-1 min-w-0'>
-        <p className='font-body text-sm text-fg truncate leading-snug'>
+      <div className='min-w-0 flex-1'>
+        <p className='font-body text-fg truncate text-sm leading-snug'>
           {song.nickname ?? song.title}
         </p>
-        <div className='flex items-center gap-2 flex-wrap'>
+        <div className='flex flex-wrap items-center gap-2'>
           {song.artist && (
-            <span className='font-mono text-[11px] text-muted truncate'>{song.artist}</span>
+            <span className='text-muted truncate font-mono text-[11px]'>{song.artist}</span>
           )}
           {song.album && (
-            <span className='font-mono text-[11px] text-faint truncate'>{song.album}</span>
+            <span className='text-faint truncate font-mono text-[11px]'>{song.album}</span>
           )}
         </div>
         {allTags.length > 0 && <TagTicker tags={allTags} />}
@@ -416,9 +430,9 @@ const TagSongItem = memo(function TagSongItem({
         surface='base'
         onClick={handleRemove}
         title='Remove from this tag'
-        className='shrink-0 opacity-0 group-hover:opacity-100 transition-opacity'
+        className='shrink-0 opacity-0 transition-opacity group-hover:opacity-100'
       >
-        <svg className='w-3.5 h-3.5' fill='none' viewBox='0 0 16 16' aria-hidden='true'>
+        <svg className='h-3.5 w-3.5' fill='none' viewBox='0 0 16 16' aria-hidden='true'>
           <path
             d='M4 4l8 8M12 4l-8 8'
             stroke='currentColor'

--- a/scripts/setup-nodelink.sh
+++ b/scripts/setup-nodelink.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# One-time setup: clone NodeLink at the pinned commit and build it locally.
+#
+# This is only needed for local development with `bun dev` (non-Docker).
+# Docker builds handle NodeLink internally in the Dockerfile.
+#
+# Usage:
+#   bun setup:nodelink
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+NODELINK_DIR="$PROJECT_ROOT/.nodelink"
+NODELINK_REPO="https://github.com/PerformanC/NodeLink.git"
+NODELINK_COMMIT="e524ed7f38c01e0fc8f031134c86ee87e0bc7ffa"
+
+echo "→ Cloning NodeLink (commit ${NODELINK_COMMIT:0:7})..."
+if [ -d "$NODELINK_DIR" ]; then
+  echo "  .nodelink/ already exists — skipping clone."
+else
+  git init "$NODELINK_DIR"
+  cd "$NODELINK_DIR"
+  git remote add origin "$NODELINK_REPO"
+  git fetch --depth 1 origin "$NODELINK_COMMIT"
+  git checkout FETCH_HEAD
+fi
+
+cd "$NODELINK_DIR"
+
+echo "→ Installing dependencies..."
+bun install
+
+echo "→ Building NodeLink..."
+bun run build
+
+# Copy our custom NodeLink config into the cloned repo
+echo "→ Copying NodeLink config..."
+cp "$PROJECT_ROOT/nodelink-config/config.js" "$NODELINK_DIR/config.js"
+
+echo "✓ NodeLink is ready at .nodelink/"
+echo "  You can now run: bun dev"


### PR DESCRIPTION
## Release v0.4.0

### Added

- **Drag-and-drop reorder across the app** — Songs can now be reordered via drag-and-drop in playlist detail views (#737), playlist grid view (#746), and the queue panel (#745).
- **Fast local dev workflow** — `bun dev` now provides a single-command local development experience: check → web build → server with `--watch` for auto-restart on changes (#742).
- **Unit test suite** — Added a comprehensive unit test suite (120 tests across 9 files) with CI integration (#741).

### Changed

- **AddSongsModal virtualization** — The add-songs modal now uses VirtualList for efficient rendering of large song libraries (#736).
- **Type safety improvements** — Unsafe type assertions replaced with valibot schemas across the server, and the `no-unsafe-type-assertion` lint rule enabled to prevent regression (#732).
- **Linting tightened** — oxlint rules strengthened and all violations fixed; added oxfmt `sortPackageJson` for consistent package.json ordering (#733, #734).

### Fixed

- **Volume boost of 0** — Volume boost of 0 is now correctly handled (previously treated as falsy/absent), and display names are preserved on song updates (#735).

### Docs

- Added oxc badge to README (#744).
- Clarified networking requirements and polished development choices documentation (#743).
- Added development choices document and philosophy section (#740).

## Commits

- 2cfc08c feat(web): add drag-and-drop reorder to playlist grid view (#746)
- 0abb983 feat(web): add drag-and-drop reorder to queue panel (#745)
- 5b69514 docs: add oxc badge to readme (#744)
- 5f4258a docs: clarify networking requirements and polish development choices (#743)
- 724b1f3 feat(dev): add fast local dev workflow with hot reload (#742)
- d934fa6 test(server): add unit test suite and CI integration (#741)
- 0bdddcd docs(docs): add development choices document and philosophy section (#740)
- 8814068 feat(web): add drag-and-drop playlist song reorder (#737)
- 7409a96 refactor(web): use VirtualList in AddSongsModal (#736)
- bc8f181 fix(server): handle volume boost 0 and preserve display names on update (#735)
- be21d31 chore: tighten oxlint rules and add oxfmt sortPackageJson (#734)
- fa60c07 chore(lint): tighten oxlint rules and fix violations (#733)
- 1d3ab39 refactor(server): enable no-unsafe-type-assertion lint rule (#732)
- bb417ea refactor(server): replace unsafe type assertions with valibot schemas