### PR TITLE
chore(deps): migrate from react-router-dom to react-router v8

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
     },
     "packages/server": {
       "name": "@alfira/server",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "drizzle-valibot": "^0.4.2",
         "valibot": "^1.4.2",
@@ -24,7 +24,7 @@
     },
     "packages/web": {
       "name": "@alfira/web",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@alfira/server": "workspace:*",
         "@atlaskit/pragmatic-drag-and-drop": "^2.0.1",
@@ -36,7 +36,7 @@
         "motion": "^12.42.2",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "react-router-dom": "7.18.1",
+        "react-router": "8.3.0",
       },
       "devDependencies": {
         "@tailwindcss/cli": "4.3.3",
@@ -257,7 +257,7 @@
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
-    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+    "cookie-es": ["cookie-es@3.1.1", "", {}, "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
@@ -341,13 +341,9 @@
 
     "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
 
-    "react-router": ["react-router@7.18.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg=="],
-
-    "react-router-dom": ["react-router-dom@7.18.1", "", { "dependencies": { "react-router": "7.18.1" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg=="],
+    "react-router": ["react-router@8.3.0", "", { "dependencies": { "cookie-es": "^3.1.1" }, "peerDependencies": { "react": ">=19.2.7", "react-dom": ">=19.2.7" }, "optionalPeers": ["react-dom"] }, "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
-
-    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -19,7 +19,7 @@
     "motion": "^12.42.2",
     "react": "19.2.7",
     "react-dom": "19.2.7",
-    "react-router-dom": "7.18.1"
+    "react-router": "8.3.0"
   },
   "devDependencies": {
     "@tailwindcss/cli": "4.3.3",

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 
 import Layout from './components/Layout';
 import ProtectedRoute from './components/ProtectedRoute';

--- a/packages/web/src/components/AnimatedOutlet.tsx
+++ b/packages/web/src/components/AnimatedOutlet.tsx
@@ -1,11 +1,11 @@
 import { AnimatePresence } from 'motion/react';
 import * as m from 'motion/react-m';
-import { useLocation, useOutlet } from 'react-router-dom';
+import { useLocation, useOutlet } from 'react-router';
 
 import { pageVariants, viewTransition } from '../lib/motion';
 
 /**
- * Drop-in replacement for react-router-dom's <Outlet /> that animates page
+ * Drop-in replacement for react-router's <Outlet /> that animates page
  * transitions using motion's AnimatePresence.
  *
  * Each route change triggers a quick crossfade + vertical slide. The exiting

--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -2,7 +2,7 @@ import { CaretLeftIcon, CraneTowerIcon, GuitarIcon, LinkBreakIcon } from '@phosp
 import { useAnimationControls } from 'motion/react';
 import * as m from 'motion/react-m';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { NavLink, useNavigate } from 'react-router-dom';
+import { NavLink, useNavigate } from 'react-router';
 
 import { ADMIN_NAV_ITEMS, NAV_ITEMS } from '../constants';
 import { useAdminView } from '../context/AdminViewContext';

--- a/packages/web/src/components/MobileNav.tsx
+++ b/packages/web/src/components/MobileNav.tsx
@@ -6,7 +6,7 @@ import {
   XCircleIcon,
 } from '@phosphor-icons/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { NavLink, useNavigate } from 'react-router-dom';
+import { NavLink, useNavigate } from 'react-router';
 
 import { ADMIN_NAV_ITEMS, NAV_ITEMS } from '../constants';
 import { useAdminView } from '../context/AdminViewContext';

--- a/packages/web/src/components/ProtectedRoute.tsx
+++ b/packages/web/src/components/ProtectedRoute.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 
-import { Navigate, useLocation } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router';
 
 import { useAuth } from '../context/AuthContext';
 import { Spinner } from './ui/Spinner';

--- a/packages/web/src/components/SettingsMenu.tsx
+++ b/packages/web/src/components/SettingsMenu.tsx
@@ -1,6 +1,6 @@
 import { WrenchIcon } from '@phosphor-icons/react';
 import { useCallback, useMemo } from 'react';
-import { NavLink } from 'react-router-dom';
+import { NavLink } from 'react-router';
 
 interface SettingsMenuProps {
   collapsed?: boolean;

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,5 +1,5 @@
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 
 import App from './App';
 

--- a/packages/web/src/pages/LoginPage.tsx
+++ b/packages/web/src/pages/LoginPage.tsx
@@ -1,6 +1,6 @@
 import { DiscordLogoIcon } from '@phosphor-icons/react';
 import { useEffect, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { SpringUp } from '../components/ui/SpringUp';
 import { useAuth } from '../context/AuthContext';

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -17,7 +17,7 @@ import {
 import { AnimatePresence } from 'motion/react';
 import * as m from 'motion/react-m';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import {
   bulkEditSongs,

--- a/packages/web/src/pages/PlaylistsPage.tsx
+++ b/packages/web/src/pages/PlaylistsPage.tsx
@@ -2,7 +2,7 @@ import { type Playlist, type TagItem } from '@alfira/server/shared';
 import { fetchTags } from '@alfira/server/shared/api';
 import { PlaylistIcon } from '@phosphor-icons/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { getPlaylistsPage } from '../api/api';
 import { Backdrop } from '../components/Backdrop';

--- a/packages/web/src/pages/SetupWizard.tsx
+++ b/packages/web/src/pages/SetupWizard.tsx
@@ -9,7 +9,7 @@ import {
   TimerIcon,
 } from '@phosphor-icons/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Navigate, useNavigate } from 'react-router-dom';
+import { Navigate, useNavigate } from 'react-router';
 
 import {
   completeSetup,

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -4,7 +4,7 @@ import { MusicNotesIcon, QuestionIcon } from '@phosphor-icons/react';
 import { AnimatePresence } from 'motion/react';
 import * as m from 'motion/react-m';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import {
   bulkDeleteSongs,


### PR DESCRIPTION
## Summary

Replace the deprecated `react-router-dom` package with `react-router` v8.3.0. React Router v8 removed the `react-router-dom` re-export package — all APIs now come from `react-router`.

## Changes

- Replace `react-router-dom@7.18.1` with `react-router@8.3.0` in `packages/web/package.json`
- Update all 12 import statements from `react-router-dom` to `react-router`
- Fix a comment in `AnimatedOutlet.tsx` referencing the old package name