### PR TITLE
fix(web): add crossorigin to font preload links

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -24,10 +24,29 @@
       href="/fonts/chiron-go-round-tc-400-latin.woff2"
       as="font"
       type="font/woff2"
+      crossorigin="anonymous"
     />
-    <link rel="preload" href="/fonts/jetbrains-mono-400-latin.woff2" as="font" type="font/woff2" />
-    <link rel="preload" href="/fonts/cherry-bomb-one-400-latin.woff2" as="font" type="font/woff2" />
-    <link rel="preload" href="/fonts/jetbrains-mono-500-latin.woff2" as="font" type="font/woff2" />
+    <link
+      rel="preload"
+      href="/fonts/jetbrains-mono-400-latin.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin="anonymous"
+    />
+    <link
+      rel="preload"
+      href="/fonts/cherry-bomb-one-400-latin.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin="anonymous"
+    />
+    <link
+      rel="preload"
+      href="/fonts/jetbrains-mono-500-latin.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin="anonymous"
+    />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
The `<link rel="preload" as="font">` tags in `index.html` were missing `crossorigin="anonymous"`. Fonts loaded via `@font-face` in CSS are always fetched as CORS requests with `crossorigin="anonymous"` in modern browsers. The preload used the default non-CORS credentials mode, so the browser discarded the preloaded fonts and re-downloaded them — producing 4 console warnings and rendering the preloading ineffective.

**Fix:** Added `crossorigin="anonymous"` to all four font preload links in `packages/web/index.html`.