### PR TITLE
fix(server): prevent duplicate lavalink connection on re-identify

### DIFF
--- a/packages/server/src/lib/lavalink.ts
+++ b/packages/server/src/lib/lavalink.ts
@@ -120,6 +120,13 @@ class LavalinkSocket extends EventEmitter<LavalinkEvents> {
   // -----------------------------------------------------------------------
 
   connect(url: string, auth: string, userId?: string): Promise<void> {
+    // Close any existing connection before creating a new one.
+    // The Lavalink client auto-reconnects via scheduleReconnect() on close,
+    // so external callers should only call connect() once. This guard
+    // prevents duplicate WebSocket connections if connect() is called
+    // while a connection is already active.
+    this.disconnect();
+
     this.url = url;
     this.auth = auth;
     this._userId = userId ?? null;

--- a/packages/server/src/startDiscord.ts
+++ b/packages/server/src/startDiscord.ts
@@ -130,13 +130,23 @@ function handleVoiceServerUpdate(data: unknown): void {
   setPendingConnectionDetails(d.guild_id, d.token, d.endpoint);
 }
 
+// Tracks whether the initial Lavalink connection has been established.
+// Prevents duplicate connections when the Discord gateway re-identifies
+// (e.g. after a failed resume on op 7 reconnect).
+let lavalinkConnected = false;
+
 function handleReady(data: unknown): void {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
   const ready = data as { user: { id: string; username: string } };
   setBotUserId(ready.user.id);
   logger.info(`Bot logged in as ${ready.user.username}`);
 
-  // Now that we have the bot's Discord user ID, connect to NodeLink.
+  // Connect to NodeLink on the first READY only. The Lavalink client
+  // handles its own reconnection internally via scheduleReconnect().
+  if (lavalinkConnected) {
+    return;
+  }
+
   const nodelinkParsed = new URL(NODELINK_URL);
   const wsProtocol = nodelinkParsed.protocol === 'https:' ? 'wss:' : 'ws:';
   const wsUrl = `${wsProtocol}//${nodelinkParsed.hostname}:${nodelinkParsed.port || 2333}/v4/websocket`;
@@ -144,6 +154,7 @@ function handleReady(data: unknown): void {
   void (async () => {
     try {
       await lavalink.connect(wsUrl, NODELINK_AUTH, ready.user.id);
+      lavalinkConnected = true;
       logger.info('Lavalink WebSocket connected');
     } catch (error) {
       logger.error({ error }, 'Lavalink WebSocket connection failed — audio will be unavailable');


### PR DESCRIPTION
## Summary

Prevents the Lavalink client from creating duplicate WebSocket connections when the Discord gateway does a full re-identify (e.g. after a failed session resume on op 7 reconnect).

## Changes

- **startDiscord.ts**: Guard `handleReady` with a `lavalinkConnected` flag so `lavalink.connect()` only runs on the first Discord READY event. The Lavalink client handles its own reconnection internally via `scheduleReconnect()`.
- **lib/lavalink.ts**: Add `this.disconnect()` at the top of `connect()` as defense-in-depth, ensuring any future duplicate calls don't leak the old WebSocket.