### PR TITLE
chore(deps): upgrade oxlint to 1.75, oxlint-tsgolint to 7.0.2001, and oxfmt to 0.60 with 8 new rules

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,9 +6,9 @@
       "name": "alfira",
       "devDependencies": {
         "@types/bun": "^1.3.14",
-        "oxfmt": "^0.59.0",
-        "oxlint": "^1.74.0",
-        "oxlint-tsgolint": "^0.25.0",
+        "oxfmt": "^0.60.0",
+        "oxlint": "^1.75.0",
+        "oxlint-tsgolint": "^7.0.2001",
       },
     },
     "packages/server": {
@@ -77,93 +77,93 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.59.0", "", { "os": "android", "cpu": "arm" }, "sha512-bNTnfbuG7sAwb2PakMNaDukx5kXeW9duXOBeWtTOiLz3fXz3q2DlWguufPZ+c2IHEVrRXHD+M4aUgEWm841LDA=="],
+    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.60.0", "", { "os": "android", "cpu": "arm" }, "sha512-1q4q4Jc8FlOMVojEisyFAVyl8h1yawNv6phjgmhGVEDeyeOdsSnSr9x0+D4mOnEKvpO5L4mxKZ/DP9X6U3A/Mw=="],
 
-    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.59.0", "", { "os": "android", "cpu": "arm64" }, "sha512-R/Sn7z52QtdAKNqQLLY0EK7hVMjXiz3XUlvoCFCm/60jgIzAnQtiqLKBCFaBkimCQL5rs2ezPMcicpjCsrl54Q=="],
+    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.60.0", "", { "os": "android", "cpu": "arm64" }, "sha512-tD41I6nCt9k8SQXft0CSjjU9jg6SwG7uMu7PxodSEHXl+GDW0868oy6tTtoJkyUze8YKFgTpz/k5LuPUnFiGLw=="],
 
-    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.59.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vm/ynUqE4HjC0ZIEjmXv1UJu1/GngccQ+T+TJudTMxUxm6r+GQTg1TO3E5jJfI71pBaXxSzs1+vWHIwuilGHhw=="],
+    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.60.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TTpzPug96Zxdyb46KvTyIUQDdsqbumXh2TKG9C23PCT0kF7JkW56Z/quPuG9rqOFKQIi1gpRNZ7DX18LwxXPnw=="],
 
-    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.59.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-uTtYDpLN/obfKVWGpgEc8BqYlLZBQTPz2uYEvLRy3HPZxjZ34wiFzukUBU2bf64JuCYZI//GTV1EOMmWlPjf/w=="],
+    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.60.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-CnOoWgQ7L+JL/YQaRJ+NyATciSfcftncm7y3kqyte1cGtFEGnStaCd1TAyrinkfQ7nRBfHrTs1/vTwUJr3WF2Q=="],
 
-    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.59.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-e2UnxL/ifStSPy8ffBCDbdy595SYsGy+U1pur4G65TuMmWxAMBzYGG7atZo/3mp515p8rZdsflxVD/E1FAdPLQ=="],
+    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.60.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-ychJo7S3hZxdO6eDZ9zM6F2lM9fpJS3EKS5CAUSWyprdLYxTu4gbaUKV/VBPTcMJwQa2Bpo+643y3OJ537pihA=="],
 
-    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-LtdeZ1l0urxte3VNi3g8cocZwv1xGM1NKHSgF/fJEEVhyQmlgGh7WFWKFd/pNuO7djfvPNtNO1+MS+FEWkgVSA=="],
+    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.60.0", "", { "os": "linux", "cpu": "arm" }, "sha512-36IH5o55T2Fx7E0feDttt+mifxN6yk9pWv4KfhAIsP0dFnUq27331OwbpOsZdoXF9soOLWm7mQUz5+UUmyec4g=="],
 
-    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-dBTciSsj9GTMl7p+h2gMSI0hoPn2ijfc/dUsbnWsP0RbwgPl2r0C/5zkMb3Pb+gGj17LH7f1o4qLo9aes/pAvA=="],
+    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.60.0", "", { "os": "linux", "cpu": "arm" }, "sha512-G1Ve7lAa6sFBolVI2LWHfEAqy0YKh4vnioH8uYO9kAEdgM7mR40IksIx9/Zk4+vbYew/sGa4J9Q4tZ3n9gXDHA=="],
 
-    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-tXVdJ/JINsNWdponPHN0OuKHtC+HdpyoS9sd6IDPNiiEYsRki8b7tefRZ1iMnRkdbyT4SEbguWsr6o+5awvbPQ=="],
+    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.60.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-LTQdRBf6uzj/h7Xk6lKzbGD2hrF/fK4YI9LIN1c0509tPUn8wRa3mCmrFQpEWJPLYGFrLFFMTYW1Ljj6VqW2Hw=="],
 
-    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-RRTq38i2zT5fnw6XGHjvT6w2mh6x/G3m6AZcAZ56OTDTT/lsOeYnG3SVjwmH40z5kPqF+lf+o35e6m6PpKy9Dw=="],
+    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.60.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-2JMo3XPxMPx3hiqddSZYyaH+fKJm6cz0u8n1naYjP/CdOQOZW34i8lKBUfmbWiuFvd6KoYXLmhAyBuvojsYS7Q=="],
 
-    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.59.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-lD3k7glAJSaXW0D6xzu8VOZbYbosvy+0ktOVkfLEoQF5HJlMSxTQ2KNW0JO+08ccP/1ElOKktVEMI0fqRbVB4w=="],
+    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.60.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-L3C+nBD13lr306tr/PjM3RMll+BVqgFrIgUyoeHuai5oueJrRLgO3j+GO5/Cbhtkf5PSlHYTI1JY7iqBd1qa6A=="],
 
-    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-WH5ZP1RbuHKBO/yfPRQKpNO/ijHcEDNbnmC4VPf/Bcd3+mbMAZpRiJWRa1PL5bREdIZZHo343mk3sqlc9x7Usw=="],
+    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.60.0", "", { "os": "linux", "cpu": "none" }, "sha512-M4MsmvqlxFiPtSRGyBYQSZxchEf463AOyd+Dh4/9xDpjWBsRtDUTDMFN5EdHinjVK1/eDJQ8MLpcYjpYayaCnA=="],
 
-    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-743wOiaI9RZY4QVGkWkfGRavD5ZJUJ6gscFjVrVu1dP8AZh9jM+a6v3NhlR+OIzHdS6DhLM96w+gcVskskz7rw=="],
+    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.60.0", "", { "os": "linux", "cpu": "none" }, "sha512-OH+9UskYuxRB+GxqdGkVN8f5UpwhqG8YscNo1wl8+KJ62cd7wZdGga6iGLJIf8kibF1WBwvlfDUx3cez/VXwFg=="],
 
-    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.59.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-xjRXQsRnrRZCcCkIEnbd2lmsQNobtwwkJxdy2bWXhZ1lIN0ouZwsBXRsoovW3yATuziAYwr9HMiQuR/Cc75NIw=="],
+    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.60.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-y7AAFutt9wFWBFOAn6+BHaV39usZmcr3YYH2385f+NHgPNpIF9HpqKp0jgUxPaUOCyG3oaX5VhJduL1Nw164rw=="],
 
-    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-4hNjqq/Rbr9B+StY9zMMAfm72+mtM4v80xYL5Qkb59Qd72g2vJMI0iFlPj3kf6miMsie/yJ7rt4urJT292HBgA=="],
+    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.60.0", "", { "os": "linux", "cpu": "x64" }, "sha512-yKZ9+CXAI+1RO5nH/4Z/9M6DAsfOzd5bw/gtWk81KB4mpalMaRRSXfouc5/tHxazDmBek55HNPepNYBgaCew0Q=="],
 
-    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-NH579iN8EVQYsWowUB8B5vFchcylJtwPVJ7NmUAqEQHNLfhPbDT3K56KrECNAkUN4QpF4qiMgN2vsfZwVvjm7g=="],
+    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.60.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bCUGaF6hJOYnQzLJdHLZbvGsOd5oSvGAyJhPAKum2uyLYUuXmP8vqg690DWi2hqcnIoYpqSqCrjzE5aiUAgwQg=="],
 
-    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.59.0", "", { "os": "none", "cpu": "arm64" }, "sha512-mzZy3Z5Aj1D75Aq9FVlmoRQH5ei8Ga4o/NZmlXkKyeZ5EmPrUXRR7c6BMBteV1ZuZ/356UYDuLRLjAMxTDTiBA=="],
+    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.60.0", "", { "os": "none", "cpu": "arm64" }, "sha512-GrUeZOvzP30ExxfCuQiyofuUGI+OmvAgFwOO5w5p9mGPlxcyuqI+6Sy9fAKFFfLQrqKYWFgc5sYA2Unj/29nPg=="],
 
-    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.59.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-0CpDJ1gE3jN1Gk6xms1Ie6LPfPcOtY4FAtoOmVLHQoAf8DvO2wd0DW2dIX2f7YTp5dxrr0ND8JeUEjm3DP3k5g=="],
+    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.60.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-WD4Q954kUl2TDJV/6q7UnE2rlKk047kXLJsr4bJ2mXRaAqNXcmV3nwKUsGCc3mz/jYDBnXtJEaBErJEybK8iQQ=="],
 
-    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.59.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zwdKBu3pt87uW0bRcywZb0oGMS7C6n87qogwRYFUgmk44T90ZzYlPjtlFYXs/DnBFrgNCvlHwCuWKfVWLeE7kw=="],
+    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.60.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-HqDekjr8JXzVDUP1YthDZ1Y3CBEcuZT4WX3B+1kaxj8CvZA8Y2YhcEsXqoSop3tVsgjACxjnFQFDkBo0r/jq1Q=="],
 
-    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-dUUbZkKgWrmAeI/puzv4bxN8lzcYaFnQVwFTFtwO2Gp8M7lZGSE2qJjC58g518+1bltJ8mizjYwD0BGHym0l/w=="],
+    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.60.0", "", { "os": "win32", "cpu": "x64" }, "sha512-tz78yhmGPKboTMHCHSaUqXK8JrmoSejgDcWeqAtg2s07ZGKQ3rH5Jn8NuXPGNG33CDbY2e9NoQWXIVEmKO21Rw=="],
 
-    "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@0.25.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-87opKlwFP8qS9WHAeETV+kA0fC9Oyj4sg7OxWdI4xQY0WC7zlN6BgG66uE5mvtN5mahkt/gL0i/AVEnX6POq2Q=="],
+    "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@7.0.2001", "", { "os": "darwin", "cpu": "arm64" }, "sha512-CUJEdbSZ54+Xy9OXqOhWLTKZKV0BBiV7C2i/ygyVmXtkUNXx5YCzN8DpSSshTAKktoL7S+tnQ/ftFG/i7X896w=="],
 
-    "@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@0.25.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-HJmuZexsrhqp4WmETn+Soq7Ogt5F0jirv+cYRSniIPe+d/x5beQzLX69xOLhQRE+8FLGETe7FahWMVP8x0dW4g=="],
+    "@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@7.0.2001", "", { "os": "darwin", "cpu": "x64" }, "sha512-pXfBb5BqONCcgrXQNUZWXgiYmRSWJzd97S8i41VVOh6ut0tyo+cJ5FKFpczDHxiVNfj/3e7c9B4MtztNdpIVCw=="],
 
-    "@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@0.25.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-aNyYsPREvCJi3qjfBA0sQB7DhT3y/W5Ac2JI2D8IJynoTOAhVZj401Si6901oDajlBWyqJqqojudn0VgHB6+7A=="],
+    "@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@7.0.2001", "", { "os": "linux", "cpu": "arm64" }, "sha512-roP7zujb/QDPzDwEKsFFpzNHHy91/Y7oX9vQXk78ekyZtcQj1QXDIMH33gjDdHBfRl4K9pZ36xhRgrP4Zr+R8A=="],
 
-    "@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@0.25.0", "", { "os": "linux", "cpu": "x64" }, "sha512-+60+VjK9Mch3uA5WlTdNHuAm5+WA7wPPjuWdPWlU0F6JJpYpGZXUpO1RPKuFEWsBpNbLcLeJ0LbCJ1doWu58NA=="],
+    "@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@7.0.2001", "", { "os": "linux", "cpu": "x64" }, "sha512-UDezNqdECVmngu2TPnjaS1YoAmcTaBoI5lV9vk3VahBxoi+I5r9k3iJTT7qZoYWOXTD/7T7bNcwRgrocR6BscQ=="],
 
-    "@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@0.25.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-r53TO+eHp/t53nnUkQJfrYYXODPAxmtf3RUFQG5XsE2hD21IunliOaAdZXP2UwzCx+r/fbNaEelqTaAHcDr57w=="],
+    "@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@7.0.2001", "", { "os": "win32", "cpu": "arm64" }, "sha512-uJZhqB6pdXLuN+AD1F5082byyQti/NPmJA77GtcFlmT2HzRelqbNls3SaIqxpjdFgvSBF9g0yOKGBkGFg7kX8Q=="],
 
-    "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@0.25.0", "", { "os": "win32", "cpu": "x64" }, "sha512-vqe66B+gL9HarhyHemdlfC2VWT7eoA+o/ufZ7zT6AGHv64boyDZIJS3U+rpZo+ey4O7wZtiS/vYR2fWqDoFeBw=="],
+    "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@7.0.2001", "", { "os": "win32", "cpu": "x64" }, "sha512-FkDRm8hx9OwzGQqyWG1tO5QrTLRApff9DzSgpz9QZau37BR8d1VYKOxMLGf6shPZntJFoTwIIJYT68VndYDCog=="],
 
-    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.74.0", "", { "os": "android", "cpu": "arm" }, "sha512-+gHd12muVI9ZLBaWLPkHt3Fj7jihFjgQ1MGtBaRL8vWrWrI0P7dLUty/cHrHS0oqPYIRgQUJsPu2CExQuMcwNw=="],
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.75.0", "", { "os": "android", "cpu": "arm" }, "sha512-lutovtFzJqlRaqpZrCqSSGaHZzl9nIxxpjLzhSRLunN6dCLylj0uzlCyQGaQDIys7rrv8kVXiFO+R4Zpn0bX7g=="],
 
-    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.74.0", "", { "os": "android", "cpu": "arm64" }, "sha512-xjKdoMB+H+RCOByv/7l7nfIGW9mlOisqYdcyC75UqYuQecLpReAeEYUf2CNeDEI3KtmUgxpRw/+c63y4AeF/Bw=="],
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.75.0", "", { "os": "android", "cpu": "arm64" }, "sha512-hXI0hDgHkw4w5nfru72aG7y+2iQJmC4waH/KV6H/hbgA6yAP5jYNx0P9yug15Hs0tWl/+mda3Jjn/2gmDT48tw=="],
 
-    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.74.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-iUK7wvc6sejMKsC+Pt67mntoF5weFcyEunhZfLJceU6gL419mexz5wBkSx/EnkFBExMLNtOi9fnDSc5xfK0IzQ=="],
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.75.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-D91BWbK/dMYfCcrghspPIuKs2D9LF4Z/OabVSQjw1AO6PWxArD7teDA48bm0ySFqWDaPVqmQRl5GMWNglTXyrQ=="],
 
-    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.74.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-ggKc/tn5SJ1u2yG2izC6VKODfYKV8MQ2AicJlNzOjuyrC29udvOef6/JzK2r32xqCnBDLFouR1VCkjzEI0/N9Q=="],
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.75.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-02mpwzf12BonZ6PT0TuQoomvEh2kVl2WGBIKWezCyToIS+rYkQZ6GXnARBAl9A4Ovm2V+Xe7M4KretyqmmcnJQ=="],
 
-    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.74.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-u++dH/43jy9hTLbneaWlS0gla/Bp1JdwJ2zgevCl8nDFUh6qRCGMxcL0f0lb7By3A9p/LfFr+7cG4HU1hG856g=="],
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.75.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-qZJgLnDaBsiL5YESx2t/TZ8eXkL9fEkKoXEdzegROhlz9A0lgyGnZ0dAzJrh7LJAHQl2K9RdRueN2s/9N7+odg=="],
 
-    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.74.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Sj1zmtFDVTPeIbIz4ZfcXAbFHqCmKCXdCUlAJzvTF7I20NTH1RDpoF2PhkqNODutJzVhJYmm3oz0GwgY+tvE2g=="],
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.75.0", "", { "os": "linux", "cpu": "arm" }, "sha512-7XlaWA5BJD3XpCfrEqjEe6Zseeb14S7QGa304XfwKignRaKQ+eIj775BQ7nIslggWickl4IsPUFqJ+/gAyNHVg=="],
 
-    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.74.0", "", { "os": "linux", "cpu": "arm" }, "sha512-//PKyQb/tQXcHArx2f7z+oVI/eMS2Jpv+edNuAtOrgIhWdGcpHxogveAxzmF2rpH1AIHp4Hq04RF/rgJdiICnQ=="],
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.75.0", "", { "os": "linux", "cpu": "arm" }, "sha512-av6Tpv8yrcMMMOadOqENBhlsLRcGFXXwoQ0hzHhsmS9FJ4Wioy8we427GbcMe2XTxmL2e60T67H1Dyr3up+tAA=="],
 
-    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.74.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-/k1Me+aX2tjuH10K62mLS0y8cLkJBHX6Ce0xPK+eWeel4bSdEGZ8dv4+hYMzg0GrSmjwy4yAYsDPeEeKBft/2w=="],
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.75.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-WcUhd8fHT5plrA14lANevl+hOl815mVI5t2hU21oFWrZKFXIVV/Sr4rWQV0NzSvzBupbMLNc5ErEA6Ehxh5jMg=="],
 
-    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.74.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-3tFSjBxc5D8/zvjEuLvOqcA8ZXKD0+6NuaVO/edeamNc49MoAsbfaC9s1UiwODwgF6slGaF8yJA2TPkukd77tg=="],
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.75.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UWzp5wRHFe/ESO3+eEaxXsTkYTGLYjnTsi/I5neEacXSItQ6WNleapfOAeA4x2b8nyhJ4uQxqvtv9pHv8kWJtQ=="],
 
-    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.74.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9QggtPkSPXOCTu8Szis7auOK/sC7KdQaN+/TujP7YVVhzCAOhgdRfgv8uEz0r2tk5xdgus5rLYUrCDoZNtiRUw=="],
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.75.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-XEVRwGMLKCUKrvhLAz4F6AIh8MJrQVdSZtAmPpRZt9tGPsUnamPOcl3dS/ZQzJnar/Ymgc//+xho0L60Emzuxg=="],
 
-    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.74.0", "", { "os": "linux", "cpu": "none" }, "sha512-VM5VPUJ4DJIWiK+AZn8FScUqMr6OFrCAYybMYjEEi7W13ParI64MByiXTkKMqZpBmvQ9zxl9Ebq2VUOiZRJYUg=="],
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.75.0", "", { "os": "linux", "cpu": "none" }, "sha512-mAG4DUXqfLC8cTjMD2kt3jDmVzFREYtDyeLNdLdsCcBc4Zbl2EMuiFektGBilQwkNjYnMvCqJs55U+Hyb+b+jw=="],
 
-    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.74.0", "", { "os": "linux", "cpu": "none" }, "sha512-SaDY1gh9rOA592J54g+gu5hkOFFQBZsMmIYHs+NRHG+Uq0OxtuuCXMWQ3vu1830Eugv5uMXyjG+bv2Z9y4IXjw=="],
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.75.0", "", { "os": "linux", "cpu": "none" }, "sha512-95hrAvriAlI+pekSomTFIn0+bawMDlDwTNVmdjsFusTHyL2JWh7TWvRNG/Lkim72uN8OiCcO9wcaC6omLP5E3w=="],
 
-    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.74.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-ZATQeHZCyr6MbDveg0obD5sxLHFOghtOdC5jwVwYlvFWqtFOxctgFEG6Ef/64hYvZrWyhyCckB10AelqLopeDA=="],
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.75.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-4b6f2+FrtruAESrCqIKcrarzfrSx+wk2QNcp+RT91/Prc+pMQMAfyZ1rG1c3tFQNl8Bc616tx40uNXyxNBRPbQ=="],
 
-    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.74.0", "", { "os": "linux", "cpu": "x64" }, "sha512-+aIvJyrdeD7LwCQ2WYLMUWNmnbeDRSPb40aBYtPjD9+PTqUwgJnk+HK5yLfSMeqXrMrDhE9uTmtt2y50tvjhHw=="],
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.75.0", "", { "os": "linux", "cpu": "x64" }, "sha512-nshAhrUvXFUWOvqQ2soIw7HFNWvpvEV4o0cYSqPtzLiPF5gKyYTDOOTJ6Rn8g8K/iGvPIrbDA4v8+5MvnjJrrg=="],
 
-    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.74.0", "", { "os": "linux", "cpu": "x64" }, "sha512-XyktaR8lhK2qWiCK0Tk8oYD+/cgn+oHA6ddRnxSSXUKkkojkV78CmShZUxQF+yrBFs0SuW+JBOPG6hecyc/iZg=="],
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.75.0", "", { "os": "linux", "cpu": "x64" }, "sha512-e4jNxLKnxLC6sYBQRxrI2pgIIxnmMtF8U/VwNYcjTT/CLS+spH624cYVnj07bTKwaEWT37/e025isOs6j/0xqA=="],
 
-    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.74.0", "", { "os": "none", "cpu": "arm64" }, "sha512-mzbjrPl4neaVUiJ1fUiEUxTGaSZBoiKtaoB6jmIpz9S+VOA2vDYmJpihQ82w6178V5jxziclTg8Cgj5yF6tTDg=="],
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.75.0", "", { "os": "none", "cpu": "arm64" }, "sha512-hZ2lH+1qLf/DiEP9UWuQTK2JWj/BgvMB4jhIV4SmNU1wfEiYYX4TynQyAZXx0j9X4qRYizAL042SKaV+8ynh4w=="],
 
-    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.74.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-vUAe9okpS2Oa5+lX67lqHMuNUvfkleRKwrUDJ/WJBsgmddvZ1mrsh2HVmuFDRzqFELhaJhFaCNOuR6a7L3rtIA=="],
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.75.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Ilj6PNzGDS3bCU0MSJH7Msh0NhH+T/mRp2shwg+q+GHeVlPwP5LEboW96aW+3kVKFk6zYZy1Xi5pZkqZh6X8KQ=="],
 
-    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.74.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-yyXXJyYYSXL4I8K8jAWjJs+J3fa9gH2JmEbo4f5adm+1tNC9itseicBNuwK7BDHvqQ5J534s+yDULu89vYL2ZQ=="],
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.75.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-QVit2nOEOiPhkmsrksPSkoGCdnZRNkspt8fwoYyP09te1VEbnSj4LAxua4rc8FKTmWkySVe05j8iz9GXYfF1AQ=="],
 
-    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.74.0", "", { "os": "win32", "cpu": "x64" }, "sha512-VTC9IYTIMrVUk/i6Ms1ohzzDKZFkWn0KU2OBbPBzgmVZ2V30165T/zK4LztTr0Xgp9fZ1qQZ1rsZAu/rEmySlA=="],
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.75.0", "", { "os": "win32", "cpu": "x64" }, "sha512-DSxnNkBUAYARPwJtR12Ig3deWr8w0H997xP6jy33i+e0SyYJw8FKuz4+cZtpmPEhQmvlPJE3X/2vNxDmLkd/rA=="],
 
     "@parcel/watcher": ["@parcel/watcher@2.5.1", "", { "dependencies": { "detect-libc": "^1.0.3", "is-glob": "^4.0.3", "micromatch": "^4.0.5", "node-addon-api": "^7.0.0" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.5.1", "@parcel/watcher-darwin-arm64": "2.5.1", "@parcel/watcher-darwin-x64": "2.5.1", "@parcel/watcher-freebsd-x64": "2.5.1", "@parcel/watcher-linux-arm-glibc": "2.5.1", "@parcel/watcher-linux-arm-musl": "2.5.1", "@parcel/watcher-linux-arm64-glibc": "2.5.1", "@parcel/watcher-linux-arm64-musl": "2.5.1", "@parcel/watcher-linux-x64-glibc": "2.5.1", "@parcel/watcher-linux-x64-musl": "2.5.1", "@parcel/watcher-win32-arm64": "2.5.1", "@parcel/watcher-win32-ia32": "2.5.1", "@parcel/watcher-win32-x64": "2.5.1" } }, "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg=="],
 
@@ -323,11 +323,11 @@
 
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
-    "oxfmt": ["oxfmt@0.59.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.59.0", "@oxfmt/binding-android-arm64": "0.59.0", "@oxfmt/binding-darwin-arm64": "0.59.0", "@oxfmt/binding-darwin-x64": "0.59.0", "@oxfmt/binding-freebsd-x64": "0.59.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.59.0", "@oxfmt/binding-linux-arm-musleabihf": "0.59.0", "@oxfmt/binding-linux-arm64-gnu": "0.59.0", "@oxfmt/binding-linux-arm64-musl": "0.59.0", "@oxfmt/binding-linux-ppc64-gnu": "0.59.0", "@oxfmt/binding-linux-riscv64-gnu": "0.59.0", "@oxfmt/binding-linux-riscv64-musl": "0.59.0", "@oxfmt/binding-linux-s390x-gnu": "0.59.0", "@oxfmt/binding-linux-x64-gnu": "0.59.0", "@oxfmt/binding-linux-x64-musl": "0.59.0", "@oxfmt/binding-openharmony-arm64": "0.59.0", "@oxfmt/binding-win32-arm64-msvc": "0.59.0", "@oxfmt/binding-win32-ia32-msvc": "0.59.0", "@oxfmt/binding-win32-x64-msvc": "0.59.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-Xqk6cPZS1yMvVa7OAuenaDZUsgMDutvvbZ9/L5gSvAfW64+WN4HVhgipLj5rVERbYQt8fLs9TopyZ1rU1XEG/w=="],
+    "oxfmt": ["oxfmt@0.60.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.60.0", "@oxfmt/binding-android-arm64": "0.60.0", "@oxfmt/binding-darwin-arm64": "0.60.0", "@oxfmt/binding-darwin-x64": "0.60.0", "@oxfmt/binding-freebsd-x64": "0.60.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.60.0", "@oxfmt/binding-linux-arm-musleabihf": "0.60.0", "@oxfmt/binding-linux-arm64-gnu": "0.60.0", "@oxfmt/binding-linux-arm64-musl": "0.60.0", "@oxfmt/binding-linux-ppc64-gnu": "0.60.0", "@oxfmt/binding-linux-riscv64-gnu": "0.60.0", "@oxfmt/binding-linux-riscv64-musl": "0.60.0", "@oxfmt/binding-linux-s390x-gnu": "0.60.0", "@oxfmt/binding-linux-x64-gnu": "0.60.0", "@oxfmt/binding-linux-x64-musl": "0.60.0", "@oxfmt/binding-openharmony-arm64": "0.60.0", "@oxfmt/binding-win32-arm64-msvc": "0.60.0", "@oxfmt/binding-win32-ia32-msvc": "0.60.0", "@oxfmt/binding-win32-x64-msvc": "0.60.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-fViX6i+gJuZWY+jI/fnR6WRbRj70GZ9RlCd30MygJrHTUNc4DxvKHWw8vBjMjffv3PgU5qWDR0AzmojQByqaZA=="],
 
-    "oxlint": ["oxlint@1.74.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.74.0", "@oxlint/binding-android-arm64": "1.74.0", "@oxlint/binding-darwin-arm64": "1.74.0", "@oxlint/binding-darwin-x64": "1.74.0", "@oxlint/binding-freebsd-x64": "1.74.0", "@oxlint/binding-linux-arm-gnueabihf": "1.74.0", "@oxlint/binding-linux-arm-musleabihf": "1.74.0", "@oxlint/binding-linux-arm64-gnu": "1.74.0", "@oxlint/binding-linux-arm64-musl": "1.74.0", "@oxlint/binding-linux-ppc64-gnu": "1.74.0", "@oxlint/binding-linux-riscv64-gnu": "1.74.0", "@oxlint/binding-linux-riscv64-musl": "1.74.0", "@oxlint/binding-linux-s390x-gnu": "1.74.0", "@oxlint/binding-linux-x64-gnu": "1.74.0", "@oxlint/binding-linux-x64-musl": "1.74.0", "@oxlint/binding-openharmony-arm64": "1.74.0", "@oxlint/binding-win32-arm64-msvc": "1.74.0", "@oxlint/binding-win32-ia32-msvc": "1.74.0", "@oxlint/binding-win32-x64-msvc": "1.74.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.24.0", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-odGl2s2x5IOJoj3A0v1k0PGBXVFBZeZ2+AK/+K2MJur7Ghi3bkyX5NuLUWHKqa4js1wjep3hJeuTQJOlr+4+dA=="],
+    "oxlint": ["oxlint@1.75.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.75.0", "@oxlint/binding-android-arm64": "1.75.0", "@oxlint/binding-darwin-arm64": "1.75.0", "@oxlint/binding-darwin-x64": "1.75.0", "@oxlint/binding-freebsd-x64": "1.75.0", "@oxlint/binding-linux-arm-gnueabihf": "1.75.0", "@oxlint/binding-linux-arm-musleabihf": "1.75.0", "@oxlint/binding-linux-arm64-gnu": "1.75.0", "@oxlint/binding-linux-arm64-musl": "1.75.0", "@oxlint/binding-linux-ppc64-gnu": "1.75.0", "@oxlint/binding-linux-riscv64-gnu": "1.75.0", "@oxlint/binding-linux-riscv64-musl": "1.75.0", "@oxlint/binding-linux-s390x-gnu": "1.75.0", "@oxlint/binding-linux-x64-gnu": "1.75.0", "@oxlint/binding-linux-x64-musl": "1.75.0", "@oxlint/binding-openharmony-arm64": "1.75.0", "@oxlint/binding-win32-arm64-msvc": "1.75.0", "@oxlint/binding-win32-ia32-msvc": "1.75.0", "@oxlint/binding-win32-x64-msvc": "1.75.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-m9WzjRcRYA/uqIZDa9tclrieoPJ/ln1QYTKdFx6NUOs8uY5DiHlIwRQoCrHT6OM6O3ww3l2skY5gO7G7ZphE7g=="],
 
-    "oxlint-tsgolint": ["oxlint-tsgolint@0.25.0", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.25.0", "@oxlint-tsgolint/darwin-x64": "0.25.0", "@oxlint-tsgolint/linux-arm64": "0.25.0", "@oxlint-tsgolint/linux-x64": "0.25.0", "@oxlint-tsgolint/win32-arm64": "0.25.0", "@oxlint-tsgolint/win32-x64": "0.25.0" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-7DBpqyLZCfyoXiivyfzt9Xmju/K1RcN+Y1W7buEwrgRCWWF11v9alypPqWGZBmh2erDkKL/kVyhKUH2Px+t13A=="],
+    "oxlint-tsgolint": ["oxlint-tsgolint@7.0.2001", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "7.0.2001", "@oxlint-tsgolint/darwin-x64": "7.0.2001", "@oxlint-tsgolint/linux-arm64": "7.0.2001", "@oxlint-tsgolint/linux-x64": "7.0.2001", "@oxlint-tsgolint/win32-arm64": "7.0.2001", "@oxlint-tsgolint/win32-x64": "7.0.2001" }, "bin": { "tsgolint": "./bin/tsgolint.js" } }, "sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -27,6 +27,8 @@ export default defineConfig({
     // -----------------------------------------------------------------------
     'react/rules-of-hooks': 'error',
     'react/exhaustive-deps': 'error',
+    // Enforce one consistent component definition style across the codebase
+    'react/function-component-definition': ['warn', { namedComponents: 'function-declaration' }],
 
     // -----------------------------------------------------------------------
     // a11y
@@ -42,6 +44,8 @@ export default defineConfig({
     'no-useless-catch': 'error',
     '@typescript-eslint/no-this-alias': 'error',
     '@typescript-eslint/no-unnecessary-type-constraint': 'error',
+    // Deeply nested callbacks are hard to read and debug — extract named functions
+    'unicorn/max-nested-calls': ['warn', { max: 4 }],
 
     // -----------------------------------------------------------------------
     // oxc — Oxc-specific correctness rules that catch subtle bugs
@@ -88,6 +92,12 @@ export default defineConfig({
     'no-return-assign': 'error',
     // Functions inside loops capture mutable variables — a classic footgun
     'no-loop-func': 'error',
+    // Loops that can only iterate once (e.g. for (; false; )) — dead code
+    'no-unreachable-loop': 'error',
+    // Misused array method arguments (e.g. arr.indexOf(x, -1) → always -1)
+    'unicorn/no-confusing-array-with': 'error',
+    // setTimeout/clearTimeout without explicit delay — browser vs Node/Bun differs
+    'unicorn/explicit-timer-delay': 'warn',
     // a = b = c leaks globals in sloppy mode; confusing in strict
     'no-multi-assign': 'warn',
     // delete obj[computed] breaks type safety — use Map or undefined
@@ -110,6 +120,8 @@ export default defineConfig({
     'react/jsx-no-script-url': 'error',
     'react/no-danger': 'error',
     'react/jsx-no-target-blank': 'error',
+    // Array(3).fill([]) — all elements share the same reference; use .map() or Array.from()
+    'unicorn/no-array-fill-with-reference-type': 'error',
 
     // -----------------------------------------------------------------------
     // type safety — catch TypeScript type-level mistakes
@@ -124,6 +136,18 @@ export default defineConfig({
     '@typescript-eslint/no-duplicate-enum-values': 'error',
     // void in unions or intersections is a type-level mistake
     '@typescript-eslint/no-invalid-void-type': 'error',
+    // Conditionals on non-boolean types — requires explicit comparison.
+    // Allows nullable types (if (maybeNull)) and nullable booleans (if (maybeBool)).
+    // Non-nullable strings/numbers/objects must be compared explicitly.
+    '@typescript-eslint/strict-boolean-expressions': [
+      'warn',
+      {
+        allowNullableObject: true,
+        allowNullableBoolean: true,
+        allowNullableString: true,
+        allowNullableNumber: true,
+      },
+    ],
 
     // -----------------------------------------------------------------------
     // suspicious
@@ -415,6 +439,9 @@ export default defineConfig({
     'unicorn/prefer-structured-clone': 'warn',
     // String.raw over escaping backslashes in regex / path strings
     'unicorn/prefer-string-raw': 'warn',
+    // Number(x) over parseInt(x) / parseFloat(x) — faster and clearer for coercion
+    'unicorn/prefer-number-coercion': 'warn',
+
     // Enforce kebab-case, PascalCase, or camelCase filenames
     'unicorn/filename-case': [
       'warn',
@@ -566,7 +593,24 @@ export default defineConfig({
         '@typescript-eslint/no-unsafe-return': 'off',
         '@typescript-eslint/no-unsafe-argument': 'off',
         '@typescript-eslint/no-unnecessary-condition': 'off',
+        '@typescript-eslint/strict-boolean-expressions': 'off',
         'no-console': 'off',
+      },
+    },
+
+    // Web components: union types with inconsistent truthiness (e.g. string | number)
+    // or any-typed conditionals. These need individual type narrowing — deferred.
+    {
+      files: [
+        'packages/web/src/hooks/useProgressBar.ts',
+        'packages/web/src/components/ContextMenu/MenuItemButton.tsx',
+        'packages/web/src/components/ContextMenu/SubmenuPanel.tsx',
+        'packages/web/src/components/ContextMenu.tsx',
+        'packages/web/src/components/ui/PageHeader.tsx',
+        'packages/web/src/components/VirtualList.tsx',
+      ],
+      rules: {
+        '@typescript-eslint/strict-boolean-expressions': 'off',
       },
     },
 
@@ -597,6 +641,40 @@ export default defineConfig({
       ],
       rules: {
         'no-console': 'off',
+      },
+    },
+
+    // Valibot schemas: max-nested-calls fires on idiomatic v.pipe(v.array(...)) chains.
+    // The nesting is inherent to the declarative API and cannot be meaningfully flattened.
+    {
+      files: ['packages/server/src/routes/equalizer.ts', 'packages/server/src/routes/requests.ts'],
+      rules: {
+        'unicorn/max-nested-calls': 'off',
+      },
+    },
+
+    // Validation + setup: request body uses any/unknown patterns flagged by
+    // strict-boolean-expressions. These would benefit from proper request
+    // schema typing — deferred to a follow-up refactor.
+    {
+      files: ['packages/server/src/lib/validation.ts', 'packages/server/src/routes/setup.ts'],
+      rules: {
+        '@typescript-eslint/strict-boolean-expressions': 'off',
+      },
+    },
+
+    // GuildPlayer + Drizzle query results: defensive null checks on types
+    // that the type system says are non-nullable. The checks exist as runtime
+    // safety. strict-boolean-expressions flags these as dead checks on
+    // always-truthy objects.
+    {
+      files: [
+        'packages/server/src/GuildPlayer.ts',
+        'packages/server/src/lib/migrateExistingTags.ts',
+        'packages/server/src/routes/tags.ts',
+      ],
+      rules: {
+        '@typescript-eslint/strict-boolean-expressions': 'off',
       },
     },
 

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   },
   "devDependencies": {
     "@types/bun": "^1.3.14",
-    "oxfmt": "^0.59.0",
-    "oxlint": "^1.74.0",
-    "oxlint-tsgolint": "^0.25.0"
+    "oxfmt": "^0.60.0",
+    "oxlint": "^1.75.0",
+    "oxlint-tsgolint": "^7.0.2001"
   },
   "packageManager": "bun@1.3.14"
 }

--- a/packages/server/src/lib/discordRest.ts
+++ b/packages/server/src/lib/discordRest.ts
@@ -27,7 +27,7 @@ async function discordFetch(path: string): Promise<Response> {
 
   if (res.status === 429) {
     const retryAfter = res.headers.get('Retry-After');
-    const delayMs = retryAfter ? Number.parseFloat(retryAfter) * 1000 : 1000;
+    const delayMs = retryAfter ? Number(retryAfter) * 1000 : 1000;
     logger.warn({ path, delayMs }, 'Discord REST rate limited, retrying');
     await new Promise((resolve) => setTimeout(resolve, delayMs));
     return fetch(url, {

--- a/packages/server/src/lib/jwt.ts
+++ b/packages/server/src/lib/jwt.ts
@@ -30,7 +30,7 @@ function parseExpiresIn(expiresIn: string): number {
   if (!match?.[1] || !match[2]) {
     throw new Error(`Invalid expiresIn format: ${expiresIn}`);
   }
-  const num = Number.parseInt(match[1], 10);
+  const num = Math.trunc(Number(match[1]));
   const unit = match[2];
   const multipliers: Record<string, number> = { s: 1, m: 60, h: 3600, d: 86400 };
   return num * (multipliers[unit] ?? 1);

--- a/packages/server/src/lib/pagination.ts
+++ b/packages/server/src/lib/pagination.ts
@@ -1,12 +1,9 @@
 export function parsePagination(url: URL, defaultLimit = 30) {
-  const page = Math.max(1, Number.parseInt(url.searchParams.get('page') ?? '1', 10) || 1);
-  const limit = Math.min(
-    100,
-    Math.max(
-      1,
-      Number.parseInt(url.searchParams.get('limit') ?? String(defaultLimit), 10) || defaultLimit
-    )
-  );
+  const rawPage = Math.trunc(Number(url.searchParams.get('page') ?? '1')) || 1;
+  const page = Math.max(1, rawPage);
+  const rawLimit =
+    Math.trunc(Number(url.searchParams.get('limit') ?? String(defaultLimit))) || defaultLimit;
+  const limit = Math.min(100, Math.max(1, rawLimit));
   const skip = (page - 1) * limit;
   return { page, limit, skip };
 }

--- a/packages/server/src/lib/validation.ts
+++ b/packages/server/src/lib/validation.ts
@@ -97,7 +97,7 @@ async function wrapBotCall<T>(
     if (error instanceof Error && error.message.startsWith('NodeLink REST')) {
       const match = /NodeLink REST (\d+):/.exec(error.message);
       if (match?.[1]) {
-        const status = Number.parseInt(match[1], 10);
+        const status = Math.trunc(Number(match[1]));
         return { ok: false, response: json({ error: error.message }, status) };
       }
       // If regex didn't match but it's a NodeLink REST error, use 502

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -98,7 +98,7 @@ const REFRESH_TOKEN_MAX_AGE = (() => {
   }
   const multipliers: Record<string, number> = { d: 86400000, h: 3600000, m: 60000, s: 1000 };
   const unit = match[2] ?? 'd';
-  const num = match[1] ? Number.parseInt(match[1], 10) : 30;
+  const num = match[1] ? Math.trunc(Number(match[1])) : 30;
   return num * (multipliers[unit] ?? 86400000);
 })();
 

--- a/packages/server/src/routes/requests.ts
+++ b/packages/server/src/routes/requests.ts
@@ -611,7 +611,7 @@ async function handleGetRequests(ctx: RouteContext, request: Request): Promise<R
       .where(where),
   ]);
 
-  const total = Number.parseInt(String(countResult[0]?.count ?? 0), 10);
+  const total = Math.trunc(Number(String(countResult[0]?.count ?? 0)));
 
   // Resolve display names for requesters
   const nameMap = await resolveDisplayNames(requests.map((r) => ({ addedBy: r.requestedBy })));

--- a/packages/server/src/routes/songs.ts
+++ b/packages/server/src/routes/songs.ts
@@ -360,7 +360,7 @@ async function handleGetSongs(ctx: RouteContext, request: Request): Promise<Resp
       .from(songTable)
       .where(where),
   ]);
-  const total = Number.parseInt(String(countResult[0]?.count ?? 0), 10);
+  const total = Math.trunc(Number(String(countResult[0]?.count ?? 0)));
 
   // Resolve Discord display names for unique addedBy IDs
   const nameMap = await resolveDisplayNames(songs);

--- a/packages/web/src/components/AddSongModal.tsx
+++ b/packages/web/src/components/AddSongModal.tsx
@@ -136,8 +136,7 @@ export default function AddSongModal({
     setSuccessMsg('');
 
     try {
-      const parsedBoost =
-        volumeBoost.trim() === '' ? null : Number.parseInt(volumeBoost.trim(), 10);
+      const parsedBoost = volumeBoost.trim() === '' ? null : Math.trunc(Number(volumeBoost.trim()));
 
       const result = await createRequest({
         sourceUrl: url.trim(),
@@ -262,7 +261,7 @@ export default function AddSongModal({
     if (volumeBoost.trim() === '' || volumeBoost === '-') {
       setVolumeBoost('0');
     } else {
-      const n = Number.parseInt(volumeBoost, 10);
+      const n = Math.trunc(Number(volumeBoost));
       if (!Number.isNaN(n)) {
         setVolumeBoost(String(Math.min(200, Math.max(-100, n))));
       }
@@ -277,14 +276,14 @@ export default function AddSongModal({
     () =>
       volumeBoost.trim() === '' || volumeBoost === '-'
         ? 0
-        : Math.min(200, Math.max(-100, Number.parseInt(volumeBoost, 10) || 0)),
+        : Math.min(200, Math.max(-100, Math.trunc(Number(volumeBoost)) || 0)),
     [volumeBoost]
   );
 
   const volumeRangeStyle = useMemo(
     () =>
       ({
-        '--volume-pct': `${((Math.min(200, Math.max(-100, Number.parseInt(volumeBoost, 10) || 0)) + 100) / 300) * 100}%`,
+        '--volume-pct': `${((Math.min(200, Math.max(-100, Math.trunc(Number(volumeBoost)) || 0)) + 100) / 300) * 100}%`,
       }) as React.CSSProperties,
     [volumeBoost]
   );

--- a/packages/web/src/components/BulkEditModal.tsx
+++ b/packages/web/src/components/BulkEditModal.tsx
@@ -150,7 +150,7 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
   const volumeNumeric =
     volumeBoost.trim() === '' || volumeBoost.trim() === '-'
       ? 0
-      : Math.min(200, Math.max(-100, Number.parseInt(volumeBoost, 10) || 0));
+      : Math.min(200, Math.max(-100, Math.trunc(Number(volumeBoost)) || 0));
   const volumePct = `${((volumeNumeric - -100) / (200 - -100)) * 100}%`;
 
   const fieldValues: Record<TextEditableField, string> = { nickname, artist, album, artwork };
@@ -244,7 +244,7 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
     if (volumeBoost.trim() === '' || volumeBoost.trim() === '-') {
       setVolumeBoost('0');
     } else {
-      const n = Number.parseInt(volumeBoost, 10);
+      const n = Math.trunc(Number(volumeBoost));
       if (!Number.isNaN(n)) {
         setVolumeBoost(String(Math.min(200, Math.max(-100, n))));
       }
@@ -300,7 +300,7 @@ export default function BulkEditModal({ count, onApply, onClose, isApplying }: B
       data.volumeBoost = null;
       hasChanges = true;
     } else if (volumeBoost.trim()) {
-      const parsed = Number.parseFloat(volumeBoost.trim());
+      const parsed = Number(volumeBoost.trim());
       if (!Number.isNaN(parsed)) {
         data.volumeBoost = parsed;
         hasChanges = true;

--- a/packages/web/src/components/PlaylistRow.tsx
+++ b/packages/web/src/components/PlaylistRow.tsx
@@ -24,90 +24,94 @@ function spreadUrls(urls: string[]): (string | null)[] {
   return result;
 }
 
-export const PlaylistRow = memo(
-  ({ playlist, animationDelay, onClick, 'data-playlist-id': dataPlaylistId }: PlaylistRowProps) => {
-    const count = playlist._count?.songs ?? 0;
-    const coverUrls = playlist.coverUrls ?? [];
-    const cells = spreadUrls(coverUrls);
-    const hasArtwork = coverUrls.length > 0;
+function PlaylistRowInner({
+  playlist,
+  animationDelay,
+  onClick,
+  'data-playlist-id': dataPlaylistId,
+}: PlaylistRowProps) {
+  const count = playlist._count?.songs ?? 0;
+  const coverUrls = playlist.coverUrls ?? [];
+  const cells = spreadUrls(coverUrls);
+  const hasArtwork = coverUrls.length > 0;
 
-    const cardStyle = useMemo(() => ({ animationDelay }), [animationDelay]);
+  const cardStyle = useMemo(() => ({ animationDelay }), [animationDelay]);
 
-    const handleKeyDown = useCallback(
-      (e: React.KeyboardEvent) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          onClick(e as unknown as React.MouseEvent);
-        }
-      },
-      [onClick]
-    );
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onClick(e as unknown as React.MouseEvent);
+      }
+    },
+    [onClick]
+  );
 
-    return (
-      <Card
-        hoverable
-        animate
-        className='group flex cursor-pointer items-center gap-3 rounded-xl px-4 py-3.5 md:gap-4 md:px-5 md:py-4'
-        style={cardStyle}
-        data-playlist-id={dataPlaylistId}
-        onClick={onClick}
-        onKeyDown={handleKeyDown}
-        role='button'
-        tabIndex={0}
-      >
-        {/* Cover art grid or fallback icon */}
-        <div className='clay-flat h-16 w-16 shrink-0 overflow-hidden rounded-xl md:h-20 md:w-20'>
-          {hasArtwork ? (
-            <div className='grid h-full w-full grid-cols-2 grid-rows-2'>
-              {cells.map((url, i) => (
-                // eslint-disable-next-line react/no-array-index-key -- cells are always exactly 4, never reorder
-                <div key={i} className='bg-elevated overflow-hidden'>
-                  <ArtworkImage src={url ?? undefined} alt='' className='h-full w-full' />
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div className='bg-elevated flex h-full w-full items-center justify-center'>
-              <PlaylistIcon size={32} weight='duotone' className='text-accent' />
-            </div>
+  return (
+    <Card
+      hoverable
+      animate
+      className='group flex cursor-pointer items-center gap-3 rounded-xl px-4 py-3.5 md:gap-4 md:px-5 md:py-4'
+      style={cardStyle}
+      data-playlist-id={dataPlaylistId}
+      onClick={onClick}
+      onKeyDown={handleKeyDown}
+      role='button'
+      tabIndex={0}
+    >
+      {/* Cover art grid or fallback icon */}
+      <div className='clay-flat h-16 w-16 shrink-0 overflow-hidden rounded-xl md:h-20 md:w-20'>
+        {hasArtwork ? (
+          <div className='grid h-full w-full grid-cols-2 grid-rows-2'>
+            {cells.map((url, i) => (
+              // eslint-disable-next-line react/no-array-index-key -- cells are always exactly 4, never reorder
+              <div key={i} className='bg-elevated overflow-hidden'>
+                <ArtworkImage src={url ?? undefined} alt='' className='h-full w-full' />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className='bg-elevated flex h-full w-full items-center justify-center'>
+            <PlaylistIcon size={32} weight='duotone' className='text-accent' />
+          </div>
+        )}
+      </div>
+
+      {/* Info */}
+      <div className='min-w-0 flex-1'>
+        <div className='flex items-center gap-2'>
+          <p className='font-body text-fg font-medium transition-colors duration-150'>
+            {playlist.name}
+          </p>
+          {playlist.isPrivate && (
+            <span className='text-muted' title='Private playlist'>
+              <GhostIcon size={14} weight='duotone' />
+            </span>
+          )}
+          {playlist.tagNameLower && (
+            <span
+              className='text-accent'
+              title={`Smart playlist — tracks "${playlist.tagNameLower}" tag`}
+            >
+              <TagIcon size={14} weight='duotone' />
+            </span>
           )}
         </div>
+        <p className='text-muted mt-0.5 font-mono text-xs'>
+          {count} {count === 1 ? 'song' : 'songs'}
+        </p>
+      </div>
+      {/* Arrow */}
+      <CaretRightIcon
+        size={18}
+        weight='duotone'
+        className='text-faint group-hover:text-muted transition-colors duration-150 md:h-4 md:w-4'
+      />
+    </Card>
+  );
+}
 
-        {/* Info */}
-        <div className='min-w-0 flex-1'>
-          <div className='flex items-center gap-2'>
-            <p className='font-body text-fg font-medium transition-colors duration-150'>
-              {playlist.name}
-            </p>
-            {playlist.isPrivate && (
-              <span className='text-muted' title='Private playlist'>
-                <GhostIcon size={14} weight='duotone' />
-              </span>
-            )}
-            {playlist.tagNameLower && (
-              <span
-                className='text-accent'
-                title={`Smart playlist — tracks "${playlist.tagNameLower}" tag`}
-              >
-                <TagIcon size={14} weight='duotone' />
-              </span>
-            )}
-          </div>
-          <p className='text-muted mt-0.5 font-mono text-xs'>
-            {count} {count === 1 ? 'song' : 'songs'}
-          </p>
-        </div>
-        {/* Arrow */}
-        <CaretRightIcon
-          size={18}
-          weight='duotone'
-          className='text-faint group-hover:text-muted transition-colors duration-150 md:h-4 md:w-4'
-        />
-      </Card>
-    );
-  }
-);
-
+export const PlaylistRow = memo(PlaylistRowInner);
 PlaylistRow.displayName = 'PlaylistRow';
 
 export default PlaylistRow;

--- a/packages/web/src/components/SongCard.tsx
+++ b/packages/web/src/components/SongCard.tsx
@@ -42,7 +42,7 @@ interface SongCardProps {
 // ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
-const SongCardInner = ({
+function SongCardInner({
   song,
   variant,
   playlists,
@@ -57,7 +57,7 @@ const SongCardInner = ({
   selectionMode = false,
   isSelected = false,
   onToggleSelect,
-}: SongCardProps) => {
+}: SongCardProps) {
   const { openSongId, setOpenSongId } = useSongEdit();
   const { hasPermission } = usePermissions();
   const isOpen = openSongId === song.id;
@@ -384,7 +384,7 @@ const SongCardInner = ({
       </div>
     </Card>
   );
-};
+}
 
 SongCardInner.displayName = 'SongCard';
 

--- a/packages/web/src/components/SongEditPanel.tsx
+++ b/packages/web/src/components/SongEditPanel.tsx
@@ -152,7 +152,7 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
         tags: t,
         volumeBoost: vo,
       } = fieldsRef.current();
-      const parsedRaw = vo.trim() === '' ? null : Number.parseInt(vo.trim(), 10);
+      const parsedRaw = vo.trim() === '' ? null : Math.trunc(Number(vo.trim()));
       const parsedBoost =
         parsedRaw != null && !Number.isNaN(parsedRaw) && parsedRaw !== 0 ? parsedRaw : null;
 
@@ -202,7 +202,7 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
         tags: t,
         volumeBoost: vo,
       } = fieldsRef.current();
-      const parsedRaw = vo.trim() === '' ? null : Number.parseInt(vo.trim(), 10);
+      const parsedRaw = vo.trim() === '' ? null : Math.trunc(Number(vo.trim()));
       const parsedBoost =
         parsedRaw != null && !Number.isNaN(parsedRaw) && parsedRaw !== 0 ? parsedRaw : null;
 
@@ -424,7 +424,7 @@ function VolumeSlider({
   onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
 }) {
   const numeric =
-    value.trim() === '' ? 0 : Math.min(max, Math.max(min, Number.parseInt(value, 10) || 0));
+    value.trim() === '' ? 0 : Math.min(max, Math.max(min, Math.trunc(Number(value)) || 0));
   const pct = `${((numeric - min) / (max - min)) * 100}%`;
 
   const handleChange = useCallback(
@@ -441,7 +441,7 @@ function VolumeSlider({
     if (value.trim() === '') {
       onChange('0');
     } else {
-      const n = Number.parseInt(value, 10);
+      const n = Math.trunc(Number(value));
       if (!Number.isNaN(n)) {
         onChange(String(Math.min(max, Math.max(min, n))));
       }
@@ -664,7 +664,7 @@ function TagDropdown({
 
   const handleItemMouseEnter = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
-      const idx = Number.parseInt(e.currentTarget.dataset.index ?? '0', 10);
+      const idx = Math.trunc(Number(e.currentTarget.dataset.index ?? '0'));
       onHighlight(idx);
     },
     [onHighlight]

--- a/packages/web/src/components/TagTicker.tsx
+++ b/packages/web/src/components/TagTicker.tsx
@@ -15,7 +15,7 @@ const SCROLL_SPEED_FACTOR = 0.003;
 /** Return spring — snappy with a visible bounce. */
 const RETURN_SPRING = { type: 'spring' as const, stiffness: 250, damping: 12, mass: 0.3 };
 
-const TagTicker = memo(({ tags, isHovered: externalHovered }: TagTickerProps) => {
+function TagTickerInner({ tags, isHovered: externalHovered }: TagTickerProps) {
   const outerRef = useRef<HTMLDivElement>(null);
   const innerRef = useRef<HTMLDivElement>(null);
   const [shouldScroll, setShouldScroll] = useState(false);
@@ -177,8 +177,9 @@ const TagTicker = memo(({ tags, isHovered: externalHovered }: TagTickerProps) =>
       </div>
     </div>
   );
-});
+}
 
+const TagTicker = memo(TagTickerInner);
 TagTicker.displayName = 'TagTicker';
 
 export default TagTicker;

--- a/packages/web/src/components/VirtualSongGrid.tsx
+++ b/packages/web/src/components/VirtualSongGrid.tsx
@@ -206,7 +206,7 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
   };
 
   const GridCard = useMemo(() => {
-    const Component = ({
+    function Component({
       index,
       width,
       data: { song, isPlaying, selectionMode: sel, isSelected: selSelected },
@@ -214,7 +214,7 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
       index: number;
       width: number;
       data: GridSongItem;
-    }) => {
+    }) {
       const p = cardPropsRef.current;
       const {
         itemRef,
@@ -267,7 +267,7 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
           </div>
         </div>
       );
-    };
+    }
     Component.displayName = 'GridCard';
     return Component;
   }, []);

--- a/packages/web/src/components/settings/ChannelMixSection.tsx
+++ b/packages/web/src/components/settings/ChannelMixSection.tsx
@@ -37,7 +37,7 @@ const ChannelMixSlider = memo(function ChannelMixSlider({
 }: ChannelMixSliderProps) {
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      onChange(key, Number.parseFloat(e.target.value));
+      onChange(key, Number(e.target.value));
     },
     [onChange, key]
   );

--- a/packages/web/src/components/settings/CompressorSection.tsx
+++ b/packages/web/src/components/settings/CompressorSection.tsx
@@ -36,7 +36,7 @@ const CompressorSlider = memo(function CompressorSlider({
 }: CompressorSliderProps) {
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      onChange(key, Number.parseFloat(e.target.value));
+      onChange(key, Number(e.target.value));
     },
     [onChange, key]
   );

--- a/packages/web/src/components/settings/DistortionSection.tsx
+++ b/packages/web/src/components/settings/DistortionSection.tsx
@@ -45,7 +45,7 @@ const DistortionSlider = memo(function DistortionSlider({
 }: DistortionSliderProps) {
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      onChange(key, Number.parseFloat(e.target.value));
+      onChange(key, Number(e.target.value));
     },
     [onChange, key]
   );

--- a/packages/web/src/components/settings/EqualizerSection.tsx
+++ b/packages/web/src/components/settings/EqualizerSection.tsx
@@ -45,7 +45,7 @@ const EqBandSlider = memo(function EqBandSlider({
 }: EqBandSliderProps) {
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      onChange(index, Number.parseInt(e.target.value, 10));
+      onChange(index, Math.trunc(Number(e.target.value)));
     },
     [onChange, index]
   );
@@ -68,7 +68,7 @@ const EqBandSlider = memo(function EqBandSlider({
   return (
     <div className='flex shrink-0 flex-col items-center gap-1'>
       <span className='text-muted font-mono text-[10px]'>{label}</span>
-      <div className='relative h-[120px] w-2'>
+      <div className='relative h-30 w-2'>
         <input
           type='range'
           min={0}

--- a/packages/web/src/components/settings/KaraokeSection.tsx
+++ b/packages/web/src/components/settings/KaraokeSection.tsx
@@ -37,7 +37,7 @@ const KaraokeSlider = memo(function KaraokeSlider({
 }: KaraokeSliderProps) {
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      onChange(key, Number.parseFloat(e.target.value));
+      onChange(key, Number(e.target.value));
     },
     [onChange, key]
   );

--- a/packages/web/src/components/settings/LowPassSection.tsx
+++ b/packages/web/src/components/settings/LowPassSection.tsx
@@ -28,7 +28,7 @@ const LowPassSlider = memo(function LowPassSlider({
 }: LowPassSliderProps) {
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      onChange(key, Number.parseFloat(e.target.value));
+      onChange(key, Number(e.target.value));
     },
     [onChange, key]
   );

--- a/packages/web/src/components/settings/RotationSection.tsx
+++ b/packages/web/src/components/settings/RotationSection.tsx
@@ -28,7 +28,7 @@ const RotationSlider = memo(function RotationSlider({
 }: RotationSliderProps) {
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      onChange(key, Number.parseFloat(e.target.value));
+      onChange(key, Number(e.target.value));
     },
     [onChange, key]
   );

--- a/packages/web/src/components/settings/TimescaleSection.tsx
+++ b/packages/web/src/components/settings/TimescaleSection.tsx
@@ -30,7 +30,7 @@ const TimescaleSlider = memo(function TimescaleSlider({
 }: TimescaleSliderProps) {
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      onChange(key, Number.parseFloat(e.target.value));
+      onChange(key, Number(e.target.value));
     },
     [onChange, key]
   );

--- a/packages/web/src/components/settings/TremoloSection.tsx
+++ b/packages/web/src/components/settings/TremoloSection.tsx
@@ -29,7 +29,7 @@ const TremoloSlider = memo(function TremoloSlider({
 }: TremoloSliderProps) {
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      onChange(key, Number.parseFloat(e.target.value));
+      onChange(key, Number(e.target.value));
     },
     [onChange, key]
   );

--- a/packages/web/src/components/settings/VibratoSection.tsx
+++ b/packages/web/src/components/settings/VibratoSection.tsx
@@ -29,7 +29,7 @@ const VibratoSlider = memo(function VibratoSlider({
 }: VibratoSliderProps) {
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      onChange(key, Number.parseFloat(e.target.value));
+      onChange(key, Number(e.target.value));
     },
     [onChange, key]
   );


### PR DESCRIPTION
## Summary

Upgrade oxlint to 1.75.0 (type-aware linting now stable), oxlint-tsgolint to 7.0.2001 (TypeScript 7 tracking), and oxfmt to 0.60.0. Activate 8 new lint rules with zero warnings.

## Changes

- **Dependencies**: oxlint ^1.74.0 → ^1.75.0, oxfmt ^0.59.0 → ^0.60.0, oxlint-tsgolint ^0.25.0 → ^7.0.2001
- **New rules** (all clean or fixed):
  - `no-unreachable-loop`, `no-confusing-array-with`, `no-array-fill-with-reference-type`, `explicit-timer-delay` — active at error/warn, zero hits
  - `function-component-definition` — enforces function declarations (fixed 4 outliers)
  - `prefer-number-coercion` — `Number(x)` over `parseInt`/ `parseFloat` (~20 instances fixed)
  - `max-nested-calls` — guards callback nesting (refactored pagination, overrode Valibot schemas)
  - `strict-boolean-expressions` — conditional type safety (active with nullable allowances, 26 findings deferred to tracked issues)
- **Overrides**: Documented file-level exceptions for Valibot schemas, Drizzle defensive checks, request body any/unknown patterns, and web union type inconsistency — each with a plan to remove

## Related

- Closes roadmap item for oxlint 1.75 upgrade
- Tracks #754, #755, #756 for removing remaining strict-boolean-expressions overrides