### PR TITLE
chore(server): remove dead null checks and strict-boolean-expressions overrides

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -653,21 +653,6 @@ export default defineConfig({
       },
     },
 
-    // GuildPlayer + Drizzle query results: defensive null checks on types
-    // that the type system says are non-nullable. The checks exist as runtime
-    // safety. strict-boolean-expressions flags these as dead checks on
-    // always-truthy objects.
-    {
-      files: [
-        'packages/server/src/GuildPlayer.ts',
-        'packages/server/src/lib/migrateExistingTags.ts',
-        'packages/server/src/routes/tags.ts',
-      ],
-      rules: {
-        '@typescript-eslint/strict-boolean-expressions': 'off',
-      },
-    },
-
     // Route handler files: "always falsy/truthy" checks on Drizzle query results
     // are defensive guards. The type system says the value can't be null, but
     // these checks exist as runtime safety. Suppress no-unnecessary-condition
@@ -679,15 +664,12 @@ export default defineConfig({
         'packages/server/src/routes/player.ts',
         'packages/server/src/routes/playlists.ts',
         'packages/server/src/routes/songs.ts',
-        'packages/server/src/routes/tags.ts',
         'packages/server/src/routes/requests.ts',
-        'packages/server/src/lib/migrateExistingTags.ts',
         'packages/server/src/lib/ensureTagsMigrated.ts',
         'packages/server/src/lib/playlistAccess.ts',
         'packages/server/src/lib/syncPlaylistToTag.ts',
         'packages/server/src/lib/search.ts',
         'packages/server/src/utils/nodelink.ts',
-        'packages/server/src/GuildPlayer.ts',
         'packages/server/src/routes/equalizer.ts',
         'packages/server/src/index.ts',
         // Web files with known false positives for this pedantic rule:

--- a/packages/server/src/GuildPlayer.ts
+++ b/packages/server/src/GuildPlayer.ts
@@ -759,10 +759,7 @@ export class GuildPlayer {
       // NodeLink auto-started it.
       this.gaplessTransition = false;
 
-      this.currentSong = prioritySong;
-      if (this.currentSong) {
-        this.currentSong = { ...this.currentSong, isSeekable: true };
-      }
+      this.currentSong = { ...prioritySong, isSeekable: true };
       this.paused = false;
       await this.playSong(prioritySong);
       return;
@@ -795,10 +792,7 @@ export class GuildPlayer {
       return;
     }
 
-    this.currentSong = next;
-    if (this.currentSong) {
-      this.currentSong = { ...this.currentSong, isSeekable: true };
-    }
+    this.currentSong = { ...next, isSeekable: true };
     this.queue.advance();
 
     await this.playSong(next);
@@ -884,6 +878,7 @@ export class GuildPlayer {
 
       // Fire gapless preload before broadcast so NodeLink has maximum
       // time to fetch + decode the next track.
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- feature flag; flip to false if NodeLink gapless regresses
       if (GuildPlayer.ENABLE_GAPLESS_PRELOAD) {
         this.preloadNextTrack(sessionId);
       }
@@ -983,6 +978,7 @@ export class GuildPlayer {
 
     // Fire gapless preload as soon as the track starts — don't wait for
     // broadcast so NodeLink has maximum time to fetch + decode.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- feature flag; flip to false if NodeLink gapless regresses
     if (GuildPlayer.ENABLE_GAPLESS_PRELOAD) {
       this.preloadNextTrack(sessionId);
     }

--- a/packages/server/src/lib/migrateExistingTags.ts
+++ b/packages/server/src/lib/migrateExistingTags.ts
@@ -35,10 +35,6 @@ export async function runTagMigration(): Promise<{ normalized: number; errors: n
   let errors = 0;
 
   for (const song of songs) {
-    if (!song.tags || !Array.isArray(song.tags) || song.tags.length === 0) {
-      continue;
-    }
-
     try {
       const canonicalTags = await canonicalizeTags(song.tags.map(normalizeTag));
 

--- a/packages/server/src/routes/tags.ts
+++ b/packages/server/src/routes/tags.ts
@@ -173,10 +173,8 @@ async function handleDeleteTag(
     .all();
 
   for (const song of songsWithTag) {
-    if (song.tags && Array.isArray(song.tags)) {
-      const updatedTags = song.tags.filter((t) => t.toLowerCase() !== nameLower);
-      db.update(songTable).set({ tags: updatedTags }).where(eq(songTable.id, song.id)).returning();
-    }
+    const updatedTags = song.tags.filter((t) => t.toLowerCase() !== nameLower);
+    db.update(songTable).set({ tags: updatedTags }).where(eq(songTable.id, song.id)).returning();
   }
 
   // Convert any smart playlists tracking this tag to regular playlists


### PR DESCRIPTION
## Summary

Removes dead defensive null checks on Drizzle query results whose types are already non-nullable. These checks were flagged by `strict-boolean-expressions` and suppressed via oxlint overrides. Aligning the code with the type system eliminates three oxlint overrides.

## Changes

- **GuildPlayer.ts** — Removed dead `if (this.currentSong)` guards after assignments from non-null `QueuedSong` values. Added inline suppressions on intentional `ENABLE_GAPLESS_PRELOAD` feature-flag checks.
- **migrateExistingTags.ts** — Removed dead `if (!song.tags || !Array.isArray(song.tags) || song.tags.length === 0)` guard; the schema guarantees `string[]` and the query filters out nulls and empties.
- **tags.ts** — Removed dead `if (song.tags && Array.isArray(song.tags))` guard on the tag-deletion path.
- **oxlint.config.ts** — Removed the `strict-boolean-expressions` override block for these three files, and removed them from the `no-unnecessary-condition` override.

Closes #755