### PR TITLE
chore(web): fix union type truthiness in web components

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -598,22 +598,6 @@ export default defineConfig({
       },
     },
 
-    // Web components: union types with inconsistent truthiness (e.g. string | number)
-    // or any-typed conditionals. These need individual type narrowing — deferred.
-    {
-      files: [
-        'packages/web/src/hooks/useProgressBar.ts',
-        'packages/web/src/components/ContextMenu/MenuItemButton.tsx',
-        'packages/web/src/components/ContextMenu/SubmenuPanel.tsx',
-        'packages/web/src/components/ContextMenu.tsx',
-        'packages/web/src/components/ui/PageHeader.tsx',
-        'packages/web/src/components/VirtualList.tsx',
-      ],
-      rules: {
-        '@typescript-eslint/strict-boolean-expressions': 'off',
-      },
-    },
-
     // Logger: console is the implementation, not a mistake
     {
       files: ['packages/server/src/shared/logger.ts'],

--- a/packages/web/src/components/ContextMenu.tsx
+++ b/packages/web/src/components/ContextMenu.tsx
@@ -444,7 +444,7 @@ function InfoRow({ item }: { item: MenuItem }) {
       role='presentation'
       className='text-muted flex items-center gap-2 px-3 py-1.5 font-mono text-xs'
     >
-      {item.icon && <span className='shrink-0'>{item.icon}</span>}
+      {item.icon != null && <span className='shrink-0'>{item.icon}</span>}
       <span className='truncate'>{item.info?.label}</span>
     </div>
   );

--- a/packages/web/src/components/ContextMenu/MenuItemButton.tsx
+++ b/packages/web/src/components/ContextMenu/MenuItemButton.tsx
@@ -17,6 +17,8 @@ interface MenuItemButtonProps {
 }
 
 export function MenuItemButton({ item, onClick }: MenuItemButtonProps) {
+  const hasSubmenu = item.submenu != null || item.editSubmenu != null;
+
   return (
     <button
       type='button'
@@ -26,9 +28,9 @@ export function MenuItemButton({ item, onClick }: MenuItemButtonProps) {
       onClick={onClick}
       className={`flex w-full items-center gap-2 px-3 py-1.5 text-left font-mono text-xs transition-colors duration-100 disabled:cursor-not-allowed disabled:opacity-50 ${item.danger ? 'text-danger hover:bg-danger/10' : 'text-fg hover:bg-muted/20'} `}
     >
-      {item.icon && <span className='shrink-0'>{item.icon}</span>}
+      {item.icon != null && <span className='shrink-0'>{item.icon}</span>}
       <span className='flex-1 truncate'>{item.label}</span>
-      {(item.submenu ?? item.editSubmenu) && (
+      {hasSubmenu && (
         <CaretRightIcon size={12} weight='duotone' className='ml-auto shrink-0 opacity-50' />
       )}
     </button>

--- a/packages/web/src/components/ContextMenu/SubmenuPanel.tsx
+++ b/packages/web/src/components/ContextMenu/SubmenuPanel.tsx
@@ -29,7 +29,7 @@ const SubmenuItem = memo(function SubmenuItem({ item, onSelect }: SubmenuItemPro
       onClick={handleClick}
       className='text-fg hover:bg-border/50 flex w-full items-center gap-2 px-3 py-1.5 text-left font-mono text-xs transition-colors duration-100 disabled:opacity-50'
     >
-      {item.icon && <span className='shrink-0'>{item.icon}</span>}
+      {item.icon != null && <span className='shrink-0'>{item.icon}</span>}
       <span className='truncate'>{item.label}</span>
     </button>
   );

--- a/packages/web/src/components/VirtualList.tsx
+++ b/packages/web/src/components/VirtualList.tsx
@@ -217,7 +217,7 @@ function VirtualListInner<T>({
                 );
               }
 
-              if (!item) {
+              if (item === undefined) {
                 return null;
               }
 

--- a/packages/web/src/components/ui/PageHeader.tsx
+++ b/packages/web/src/components/ui/PageHeader.tsx
@@ -15,12 +15,12 @@ export function PageHeader({ icon: Icon, title, subtitle, children }: PageHeader
     </h1>
   );
 
-  if (children) {
+  if (children != null) {
     return (
       <div className='mb-6 flex shrink-0 flex-col justify-between gap-3 sm:flex-row sm:items-center md:mb-8'>
         <div>
           {heading}
-          {subtitle && <p className='text-muted mt-2 font-mono text-xs'>{subtitle}</p>}
+          {subtitle != null && <p className='text-muted mt-2 font-mono text-xs'>{subtitle}</p>}
         </div>
         {children}
       </div>
@@ -30,7 +30,7 @@ export function PageHeader({ icon: Icon, title, subtitle, children }: PageHeader
   return (
     <div className='mb-6 shrink-0 md:mb-8'>
       {heading}
-      {subtitle && <p className='text-muted mt-2 font-mono text-xs'>{subtitle}</p>}
+      {subtitle != null && <p className='text-muted mt-2 font-mono text-xs'>{subtitle}</p>}
     </div>
   );
 }

--- a/packages/web/src/hooks/useProgressBar.ts
+++ b/packages/web/src/hooks/useProgressBar.ts
@@ -118,7 +118,7 @@ export function useProgressBar(
       if (rafIdRef.current) {
         cancelAnimationFrame(rafIdRef.current);
       }
-      if (intervalIdRef.current) {
+      if (intervalIdRef.current !== 0) {
         clearInterval(intervalIdRef.current);
       }
       rafIdRef.current = 0;
@@ -158,7 +158,7 @@ export function useProgressBar(
     if (rafIdRef.current) {
       cancelAnimationFrame(rafIdRef.current);
     }
-    if (intervalIdRef.current) {
+    if (intervalIdRef.current !== 0) {
       clearInterval(intervalIdRef.current);
     }
 
@@ -236,7 +236,7 @@ export function useProgressBar(
       if (rafIdRef.current) {
         cancelAnimationFrame(rafIdRef.current);
       }
-      if (intervalIdRef.current) {
+      if (intervalIdRef.current !== 0) {
         clearInterval(intervalIdRef.current);
       }
       rafIdRef.current = 0;


### PR DESCRIPTION
## Summary

Fixes `@typescript-eslint/strict-boolean-expressions` violations in six web components that were previously suppressed via oxlint override, then removes the override block.

Closes #756

## Changes

- **`useProgressBar.ts`** — `intervalIdRef` (`Timer | 0`): `if (intervalIdRef.current)` → `if (intervalIdRef.current !== 0)` in all three locations
- **`MenuItemButton.tsx`** — `item.icon` (`ReactNode | undefined`): `&&` → `!= null`; submenu check extracted to boolean variable to narrow union type
- **`SubmenuPanel.tsx`** — `item.icon` (`ReactNode | undefined`): `&&` → `!= null`
- **`ContextMenu.tsx`** — `item.icon` in InfoRow (`ReactNode | undefined`): `&&` → `!= null`
- **`PageHeader.tsx`** — `subtitle` (`string | ReactNode | undefined`) and `children` (`ReactNode | undefined`): `&&` → `!= null`
- **`VirtualList.tsx`** — `if (!item)` on generic `T` → `if (item === undefined)` (defensive guard for `noUncheckedIndexedAccess`)
- **`oxlint.config.ts`** — Removed the 16-line override block that suppressed these violations