### PR TITLE
perf(server,web): batch audio filter settings into single endpoint

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -17,6 +17,7 @@ import { handleChannelMix } from './routes/channelMix';
 import { handleCompressor } from './routes/compressor';
 import { handleDistortion } from './routes/distortion';
 import { handleEqualizer } from './routes/equalizer';
+import { handleFilters } from './routes/filters';
 import { handleGeneralSettings } from './routes/generalSettings';
 import { handleKaraoke } from './routes/karaoke';
 import { handleLowPass } from './routes/lowPass';
@@ -228,6 +229,8 @@ function startServer(): void {
       '/api/settings/distortion/*': apiRoute(handleDistortion),
       '/api/settings/equalizer': apiRoute(handleEqualizer),
       '/api/settings/equalizer/*': apiRoute(handleEqualizer),
+      '/api/settings/filters': apiRoute(handleFilters),
+      '/api/settings/filters/*': apiRoute(handleFilters),
       '/api/settings/karaoke': apiRoute(handleKaraoke),
       '/api/settings/karaoke/*': apiRoute(handleKaraoke),
       '/api/settings/lowpass': apiRoute(handleLowPass),

--- a/packages/server/src/routes/filters.ts
+++ b/packages/server/src/routes/filters.ts
@@ -1,0 +1,135 @@
+import { eq } from 'drizzle-orm';
+
+import { type RouteContext } from '../lib/context';
+import { EQ_BAND_COLUMNS, eqBandsFromRow } from '../lib/eqBands';
+import { json } from '../lib/json';
+import { checkGuards } from '../lib/routeGuards';
+import { routeTable } from '../lib/routeTable';
+import { db, tables } from '../shared/db';
+
+function handleFiltersGet(
+  ctx: RouteContext,
+  _request: Request,
+  _params: Record<string, string>
+): Response {
+  const guards = checkGuards(ctx, { admin: true, permission: 'audio.manage' });
+  if (guards instanceof Response) {
+    return guards;
+  }
+
+  const row = db
+    .select({
+      ...EQ_BAND_COLUMNS,
+      eqEnabled: tables.guildSettings.eqEnabled,
+      compressorEnabled: tables.guildSettings.compressorEnabled,
+      compressorThreshold: tables.guildSettings.compressorThreshold,
+      compressorRatio: tables.guildSettings.compressorRatio,
+      compressorAttack: tables.guildSettings.compressorAttack,
+      compressorRelease: tables.guildSettings.compressorRelease,
+      compressorGain: tables.guildSettings.compressorGain,
+      karaokeEnabled: tables.guildSettings.karaokeEnabled,
+      karaokeLevel: tables.guildSettings.karaokeLevel,
+      karaokeMonoLevel: tables.guildSettings.karaokeMonoLevel,
+      karaokeFilterBand: tables.guildSettings.karaokeFilterBand,
+      karaokeFilterWidth: tables.guildSettings.karaokeFilterWidth,
+      timescaleEnabled: tables.guildSettings.timescaleEnabled,
+      timescaleSpeed: tables.guildSettings.timescaleSpeed,
+      timescalePitch: tables.guildSettings.timescalePitch,
+      timescaleRate: tables.guildSettings.timescaleRate,
+      tremoloEnabled: tables.guildSettings.tremoloEnabled,
+      tremoloFrequency: tables.guildSettings.tremoloFrequency,
+      tremoloDepth: tables.guildSettings.tremoloDepth,
+      vibratoEnabled: tables.guildSettings.vibratoEnabled,
+      vibratoFrequency: tables.guildSettings.vibratoFrequency,
+      vibratoDepth: tables.guildSettings.vibratoDepth,
+      rotationEnabled: tables.guildSettings.rotationEnabled,
+      rotationHz: tables.guildSettings.rotationHz,
+      distortionEnabled: tables.guildSettings.distortionEnabled,
+      distortionSinOffset: tables.guildSettings.distortionSinOffset,
+      distortionSinScale: tables.guildSettings.distortionSinScale,
+      distortionCosOffset: tables.guildSettings.distortionCosOffset,
+      distortionCosScale: tables.guildSettings.distortionCosScale,
+      distortionTanOffset: tables.guildSettings.distortionTanOffset,
+      distortionTanScale: tables.guildSettings.distortionTanScale,
+      distortionOffset: tables.guildSettings.distortionOffset,
+      distortionScale: tables.guildSettings.distortionScale,
+      channelMixEnabled: tables.guildSettings.channelMixEnabled,
+      channelMixLeftToLeft: tables.guildSettings.channelMixLeftToLeft,
+      channelMixLeftToRight: tables.guildSettings.channelMixLeftToRight,
+      channelMixRightToLeft: tables.guildSettings.channelMixRightToLeft,
+      channelMixRightToRight: tables.guildSettings.channelMixRightToRight,
+      lowPassEnabled: tables.guildSettings.lowPassEnabled,
+      lowPassSmoothing: tables.guildSettings.lowPassSmoothing,
+    })
+    .from(tables.guildSettings)
+    .where(eq(tables.guildSettings.id, 1))
+    .get();
+
+  return json({
+    compressor: {
+      enabled: row?.compressorEnabled ?? false,
+      threshold: row?.compressorThreshold ?? -6,
+      ratio: row?.compressorRatio ?? 4,
+      attack: row?.compressorAttack ?? 5,
+      release: row?.compressorRelease ?? 50,
+      gain: row?.compressorGain ?? 3,
+    },
+    equalizer: {
+      bands: eqBandsFromRow(row),
+      enabled: row?.eqEnabled ?? true,
+    },
+    karaoke: {
+      enabled: row?.karaokeEnabled ?? false,
+      level: row?.karaokeLevel ?? 1,
+      monoLevel: row?.karaokeMonoLevel ?? 1,
+      filterBand: row?.karaokeFilterBand ?? 220,
+      filterWidth: row?.karaokeFilterWidth ?? 100,
+    },
+    timescale: {
+      enabled: row?.timescaleEnabled ?? false,
+      speed: row?.timescaleSpeed ?? 1,
+      pitch: row?.timescalePitch ?? 1,
+      rate: row?.timescaleRate ?? 1,
+    },
+    tremolo: {
+      enabled: row?.tremoloEnabled ?? false,
+      frequency: row?.tremoloFrequency ?? 2,
+      depth: row?.tremoloDepth ?? 0.5,
+    },
+    vibrato: {
+      enabled: row?.vibratoEnabled ?? false,
+      frequency: row?.vibratoFrequency ?? 2,
+      depth: row?.vibratoDepth ?? 0.5,
+    },
+    rotation: {
+      enabled: row?.rotationEnabled ?? false,
+      rotationHz: row?.rotationHz ?? 0,
+    },
+    distortion: {
+      enabled: row?.distortionEnabled ?? false,
+      sinOffset: row?.distortionSinOffset ?? 0,
+      sinScale: row?.distortionSinScale ?? 1,
+      cosOffset: row?.distortionCosOffset ?? 0,
+      cosScale: row?.distortionCosScale ?? 1,
+      tanOffset: row?.distortionTanOffset ?? 0,
+      tanScale: row?.distortionTanScale ?? 1,
+      offset: row?.distortionOffset ?? 0,
+      scale: row?.distortionScale ?? 1,
+    },
+    channelMix: {
+      enabled: row?.channelMixEnabled ?? false,
+      leftToLeft: row?.channelMixLeftToLeft ?? 1,
+      leftToRight: row?.channelMixLeftToRight ?? 0,
+      rightToLeft: row?.channelMixRightToLeft ?? 0,
+      rightToRight: row?.channelMixRightToRight ?? 1,
+    },
+    lowPass: {
+      enabled: row?.lowPassEnabled ?? false,
+      smoothing: row?.lowPassSmoothing ?? 20,
+    },
+  });
+}
+
+export const handleFilters = routeTable('/api/settings/filters', {
+  routes: [['GET', '/', handleFiltersGet]],
+});

--- a/packages/web/src/components/settings/ChannelMixSection.tsx
+++ b/packages/web/src/components/settings/ChannelMixSection.tsx
@@ -1,7 +1,7 @@
 import type React from 'react';
 
 import { ArrowCounterClockwiseIcon, FloppyDiskIcon } from '@phosphor-icons/react';
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useAdminView } from '../../context/AdminViewContext';
 import { usePermissions } from '../../context/PermissionsContext';
@@ -74,7 +74,11 @@ interface ChannelMixValues {
   rightToRight: number;
 }
 
-export default function ChannelMixSection() {
+interface ChannelMixSectionProps {
+  initialValues?: ChannelMixValues;
+}
+
+export default function ChannelMixSection({ initialValues }: ChannelMixSectionProps) {
   const { isAdminView } = useAdminView();
   const { hasPermission } = usePermissions();
 
@@ -83,8 +87,23 @@ export default function ChannelMixSection() {
   const [savedValues, setSavedValues] = useState<ChannelMixValues>(DEFAULTS);
   const [saving, setSaving] = useState(false);
   const [loaded, setLoaded] = useState(false);
+  const didInitRef = useRef(false);
 
   useEffect(() => {
+    if (!canManage) {
+      setLoaded(true);
+      return;
+    }
+    if (initialValues && !didInitRef.current) {
+      setValues(initialValues);
+      setSavedValues(initialValues);
+      setLoaded(true);
+      didInitRef.current = true;
+      return;
+    }
+    if (initialValues) {
+      return;
+    }
     async function load() {
       try {
         const res = await fetch('/api/settings/channelmix');
@@ -99,12 +118,8 @@ export default function ChannelMixSection() {
         setLoaded(true);
       }
     }
-    if (canManage) {
-      void load();
-    } else {
-      setLoaded(true);
-    }
-  }, [canManage]);
+    void load();
+  }, [canManage, initialValues]);
 
   const hasChanges = JSON.stringify(values) !== JSON.stringify(savedValues);
 

--- a/packages/web/src/components/settings/CompressorSection.tsx
+++ b/packages/web/src/components/settings/CompressorSection.tsx
@@ -1,7 +1,7 @@
 import type React from 'react';
 
 import { ArrowCounterClockwiseIcon, FloppyDiskIcon } from '@phosphor-icons/react';
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useAdminView } from '../../context/AdminViewContext';
 import { usePermissions } from '../../context/PermissionsContext';
@@ -80,7 +80,11 @@ interface CompressorValues {
   gain: number;
 }
 
-export default function CompressorSection() {
+interface CompressorSectionProps {
+  initialValues?: CompressorValues;
+}
+
+export default function CompressorSection({ initialValues }: CompressorSectionProps) {
   const { isAdminView } = useAdminView();
   const { hasPermission } = usePermissions();
 
@@ -89,8 +93,23 @@ export default function CompressorSection() {
   const [savedValues, setSavedValues] = useState<CompressorValues>(DEFAULTS);
   const [saving, setSaving] = useState(false);
   const [loaded, setLoaded] = useState(false);
+  const didInitRef = useRef(false);
 
   useEffect(() => {
+    if (!canManage) {
+      setLoaded(true);
+      return;
+    }
+    if (initialValues && !didInitRef.current) {
+      setValues(initialValues);
+      setSavedValues(initialValues);
+      setLoaded(true);
+      didInitRef.current = true;
+      return;
+    }
+    if (initialValues) {
+      return;
+    }
     async function load() {
       try {
         const res = await fetch('/api/settings/compressor');
@@ -105,12 +124,8 @@ export default function CompressorSection() {
         setLoaded(true);
       }
     }
-    if (canManage) {
-      void load();
-    } else {
-      setLoaded(true);
-    }
-  }, [canManage]);
+    void load();
+  }, [canManage, initialValues]);
 
   const hasChanges = JSON.stringify(values) !== JSON.stringify(savedValues);
 

--- a/packages/web/src/components/settings/DistortionSection.tsx
+++ b/packages/web/src/components/settings/DistortionSection.tsx
@@ -1,7 +1,7 @@
 import type React from 'react';
 
 import { ArrowCounterClockwiseIcon, FloppyDiskIcon } from '@phosphor-icons/react';
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useAdminView } from '../../context/AdminViewContext';
 import { usePermissions } from '../../context/PermissionsContext';
@@ -86,7 +86,11 @@ interface DistortionValues {
   scale: number;
 }
 
-export default function DistortionSection() {
+interface DistortionSectionProps {
+  initialValues?: DistortionValues;
+}
+
+export default function DistortionSection({ initialValues }: DistortionSectionProps) {
   const { isAdminView } = useAdminView();
   const { hasPermission } = usePermissions();
 
@@ -95,8 +99,23 @@ export default function DistortionSection() {
   const [savedValues, setSavedValues] = useState<DistortionValues>(DEFAULTS);
   const [saving, setSaving] = useState(false);
   const [loaded, setLoaded] = useState(false);
+  const didInitRef = useRef(false);
 
   useEffect(() => {
+    if (!canManage) {
+      setLoaded(true);
+      return;
+    }
+    if (initialValues && !didInitRef.current) {
+      setValues(initialValues);
+      setSavedValues(initialValues);
+      setLoaded(true);
+      didInitRef.current = true;
+      return;
+    }
+    if (initialValues) {
+      return;
+    }
     async function load() {
       try {
         const res = await fetch('/api/settings/distortion');
@@ -111,12 +130,8 @@ export default function DistortionSection() {
         setLoaded(true);
       }
     }
-    if (canManage) {
-      void load();
-    } else {
-      setLoaded(true);
-    }
-  }, [canManage]);
+    void load();
+  }, [canManage, initialValues]);
 
   const hasChanges = JSON.stringify(values) !== JSON.stringify(savedValues);
 

--- a/packages/web/src/components/settings/EqualizerSection.tsx
+++ b/packages/web/src/components/settings/EqualizerSection.tsx
@@ -1,7 +1,7 @@
 import type React from 'react';
 
 import { ArrowCounterClockwiseIcon, FloppyDiskIcon } from '@phosphor-icons/react';
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useAdminView } from '../../context/AdminViewContext';
 import { usePermissions } from '../../context/PermissionsContext';
@@ -86,7 +86,11 @@ const EqBandSlider = memo(function EqBandSlider({
   );
 });
 
-export default function EqualizerSection() {
+interface EqualizerSectionProps {
+  initialValues?: { bands: number[]; enabled: boolean };
+}
+
+export default function EqualizerSection({ initialValues }: EqualizerSectionProps) {
   const { isAdminView } = useAdminView();
   const { hasPermission } = usePermissions();
 
@@ -97,8 +101,25 @@ export default function EqualizerSection() {
   const [savedEnabled, setSavedEnabled] = useState(true);
   const [saving, setSaving] = useState(false);
   const [loaded, setLoaded] = useState(false);
+  const didInitRef = useRef(false);
 
   useEffect(() => {
+    if (!canManage) {
+      setLoaded(true);
+      return;
+    }
+    if (initialValues && !didInitRef.current) {
+      setBands(initialValues.bands);
+      setSavedBands(initialValues.bands);
+      setEqEnabled(initialValues.enabled);
+      setSavedEnabled(initialValues.enabled);
+      setLoaded(true);
+      didInitRef.current = true;
+      return;
+    }
+    if (initialValues) {
+      return;
+    }
     async function load() {
       try {
         const res = await fetch('/api/settings/equalizer');
@@ -116,12 +137,8 @@ export default function EqualizerSection() {
         setLoaded(true);
       }
     }
-    if (canManage) {
-      void load();
-    } else {
-      setLoaded(true);
-    }
-  }, [canManage]);
+    void load();
+  }, [canManage, initialValues]);
 
   // When off, save sends flat bands; when on, save sends real bands
   const effectiveBands = eqEnabled ? bands : DEFAULT_BANDS;

--- a/packages/web/src/components/settings/KaraokeSection.tsx
+++ b/packages/web/src/components/settings/KaraokeSection.tsx
@@ -1,7 +1,7 @@
 import type React from 'react';
 
 import { ArrowCounterClockwiseIcon, FloppyDiskIcon } from '@phosphor-icons/react';
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useAdminView } from '../../context/AdminViewContext';
 import { usePermissions } from '../../context/PermissionsContext';
@@ -76,7 +76,11 @@ interface KaraokeValues {
   filterWidth: number;
 }
 
-export default function KaraokeSection() {
+interface KaraokeSectionProps {
+  initialValues?: KaraokeValues;
+}
+
+export default function KaraokeSection({ initialValues }: KaraokeSectionProps) {
   const { isAdminView } = useAdminView();
   const { hasPermission } = usePermissions();
 
@@ -85,8 +89,23 @@ export default function KaraokeSection() {
   const [savedValues, setSavedValues] = useState<KaraokeValues>(DEFAULTS);
   const [saving, setSaving] = useState(false);
   const [loaded, setLoaded] = useState(false);
+  const didInitRef = useRef(false);
 
   useEffect(() => {
+    if (!canManage) {
+      setLoaded(true);
+      return;
+    }
+    if (initialValues && !didInitRef.current) {
+      setValues(initialValues);
+      setSavedValues(initialValues);
+      setLoaded(true);
+      didInitRef.current = true;
+      return;
+    }
+    if (initialValues) {
+      return;
+    }
     async function load() {
       try {
         const res = await fetch('/api/settings/karaoke');
@@ -101,12 +120,8 @@ export default function KaraokeSection() {
         setLoaded(true);
       }
     }
-    if (canManage) {
-      void load();
-    } else {
-      setLoaded(true);
-    }
-  }, [canManage]);
+    void load();
+  }, [canManage, initialValues]);
 
   const hasChanges = JSON.stringify(values) !== JSON.stringify(savedValues);
 

--- a/packages/web/src/components/settings/LowPassSection.tsx
+++ b/packages/web/src/components/settings/LowPassSection.tsx
@@ -1,7 +1,7 @@
 import type React from 'react';
 
 import { ArrowCounterClockwiseIcon, FloppyDiskIcon } from '@phosphor-icons/react';
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useAdminView } from '../../context/AdminViewContext';
 import { usePermissions } from '../../context/PermissionsContext';
@@ -62,7 +62,11 @@ interface LowPassValues {
   smoothing: number;
 }
 
-export default function LowPassSection() {
+interface LowPassSectionProps {
+  initialValues?: LowPassValues;
+}
+
+export default function LowPassSection({ initialValues }: LowPassSectionProps) {
   const { isAdminView } = useAdminView();
   const { hasPermission } = usePermissions();
 
@@ -71,8 +75,23 @@ export default function LowPassSection() {
   const [savedValues, setSavedValues] = useState<LowPassValues>(DEFAULTS);
   const [saving, setSaving] = useState(false);
   const [loaded, setLoaded] = useState(false);
+  const didInitRef = useRef(false);
 
   useEffect(() => {
+    if (!canManage) {
+      setLoaded(true);
+      return;
+    }
+    if (initialValues && !didInitRef.current) {
+      setValues(initialValues);
+      setSavedValues(initialValues);
+      setLoaded(true);
+      didInitRef.current = true;
+      return;
+    }
+    if (initialValues) {
+      return;
+    }
     async function load() {
       try {
         const res = await fetch('/api/settings/lowpass');
@@ -87,12 +106,8 @@ export default function LowPassSection() {
         setLoaded(true);
       }
     }
-    if (canManage) {
-      void load();
-    } else {
-      setLoaded(true);
-    }
-  }, [canManage]);
+    void load();
+  }, [canManage, initialValues]);
 
   const hasChanges = JSON.stringify(values) !== JSON.stringify(savedValues);
 

--- a/packages/web/src/components/settings/RotationSection.tsx
+++ b/packages/web/src/components/settings/RotationSection.tsx
@@ -1,7 +1,7 @@
 import type React from 'react';
 
 import { ArrowCounterClockwiseIcon, FloppyDiskIcon } from '@phosphor-icons/react';
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useAdminView } from '../../context/AdminViewContext';
 import { usePermissions } from '../../context/PermissionsContext';
@@ -64,7 +64,11 @@ interface RotationValues {
   rotationHz: number;
 }
 
-export default function RotationSection() {
+interface RotationSectionProps {
+  initialValues?: RotationValues;
+}
+
+export default function RotationSection({ initialValues }: RotationSectionProps) {
   const { isAdminView } = useAdminView();
   const { hasPermission } = usePermissions();
 
@@ -73,8 +77,23 @@ export default function RotationSection() {
   const [savedValues, setSavedValues] = useState<RotationValues>(DEFAULTS);
   const [saving, setSaving] = useState(false);
   const [loaded, setLoaded] = useState(false);
+  const didInitRef = useRef(false);
 
   useEffect(() => {
+    if (!canManage) {
+      setLoaded(true);
+      return;
+    }
+    if (initialValues && !didInitRef.current) {
+      setValues(initialValues);
+      setSavedValues(initialValues);
+      setLoaded(true);
+      didInitRef.current = true;
+      return;
+    }
+    if (initialValues) {
+      return;
+    }
     async function load() {
       try {
         const res = await fetch('/api/settings/rotation');
@@ -89,12 +108,8 @@ export default function RotationSection() {
         setLoaded(true);
       }
     }
-    if (canManage) {
-      void load();
-    } else {
-      setLoaded(true);
-    }
-  }, [canManage]);
+    void load();
+  }, [canManage, initialValues]);
 
   const hasChanges = JSON.stringify(values) !== JSON.stringify(savedValues);
 

--- a/packages/web/src/components/settings/TimescaleSection.tsx
+++ b/packages/web/src/components/settings/TimescaleSection.tsx
@@ -1,7 +1,7 @@
 import type React from 'react';
 
 import { ArrowCounterClockwiseIcon, FloppyDiskIcon } from '@phosphor-icons/react';
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useAdminView } from '../../context/AdminViewContext';
 import { usePermissions } from '../../context/PermissionsContext';
@@ -69,7 +69,11 @@ interface TimescaleValues {
   rate: number;
 }
 
-export default function TimescaleSection() {
+interface TimescaleSectionProps {
+  initialValues?: TimescaleValues;
+}
+
+export default function TimescaleSection({ initialValues }: TimescaleSectionProps) {
   const { isAdminView } = useAdminView();
   const { hasPermission } = usePermissions();
 
@@ -78,8 +82,23 @@ export default function TimescaleSection() {
   const [savedValues, setSavedValues] = useState<TimescaleValues>(DEFAULTS);
   const [saving, setSaving] = useState(false);
   const [loaded, setLoaded] = useState(false);
+  const didInitRef = useRef(false);
 
   useEffect(() => {
+    if (!canManage) {
+      setLoaded(true);
+      return;
+    }
+    if (initialValues && !didInitRef.current) {
+      setValues(initialValues);
+      setSavedValues(initialValues);
+      setLoaded(true);
+      didInitRef.current = true;
+      return;
+    }
+    if (initialValues) {
+      return;
+    }
     async function load() {
       try {
         const res = await fetch('/api/settings/timescale');
@@ -94,12 +113,8 @@ export default function TimescaleSection() {
         setLoaded(true);
       }
     }
-    if (canManage) {
-      void load();
-    } else {
-      setLoaded(true);
-    }
-  }, [canManage]);
+    void load();
+  }, [canManage, initialValues]);
 
   const hasChanges = JSON.stringify(values) !== JSON.stringify(savedValues);
 

--- a/packages/web/src/components/settings/TremoloSection.tsx
+++ b/packages/web/src/components/settings/TremoloSection.tsx
@@ -1,7 +1,7 @@
 import type React from 'react';
 
 import { ArrowCounterClockwiseIcon, FloppyDiskIcon } from '@phosphor-icons/react';
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useAdminView } from '../../context/AdminViewContext';
 import { usePermissions } from '../../context/PermissionsContext';
@@ -66,7 +66,11 @@ interface TremoloValues {
   depth: number;
 }
 
-export default function TremoloSection() {
+interface TremoloSectionProps {
+  initialValues?: TremoloValues;
+}
+
+export default function TremoloSection({ initialValues }: TremoloSectionProps) {
   const { isAdminView } = useAdminView();
   const { hasPermission } = usePermissions();
 
@@ -75,8 +79,23 @@ export default function TremoloSection() {
   const [savedValues, setSavedValues] = useState<TremoloValues>(DEFAULTS);
   const [saving, setSaving] = useState(false);
   const [loaded, setLoaded] = useState(false);
+  const didInitRef = useRef(false);
 
   useEffect(() => {
+    if (!canManage) {
+      setLoaded(true);
+      return;
+    }
+    if (initialValues && !didInitRef.current) {
+      setValues(initialValues);
+      setSavedValues(initialValues);
+      setLoaded(true);
+      didInitRef.current = true;
+      return;
+    }
+    if (initialValues) {
+      return;
+    }
     async function load() {
       try {
         const res = await fetch('/api/settings/tremolo');
@@ -91,12 +110,8 @@ export default function TremoloSection() {
         setLoaded(true);
       }
     }
-    if (canManage) {
-      void load();
-    } else {
-      setLoaded(true);
-    }
-  }, [canManage]);
+    void load();
+  }, [canManage, initialValues]);
 
   const hasChanges = JSON.stringify(values) !== JSON.stringify(savedValues);
 

--- a/packages/web/src/components/settings/VibratoSection.tsx
+++ b/packages/web/src/components/settings/VibratoSection.tsx
@@ -1,7 +1,7 @@
 import type React from 'react';
 
 import { ArrowCounterClockwiseIcon, FloppyDiskIcon } from '@phosphor-icons/react';
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useAdminView } from '../../context/AdminViewContext';
 import { usePermissions } from '../../context/PermissionsContext';
@@ -66,7 +66,11 @@ interface VibratoValues {
   depth: number;
 }
 
-export default function VibratoSection() {
+interface VibratoSectionProps {
+  initialValues?: VibratoValues;
+}
+
+export default function VibratoSection({ initialValues }: VibratoSectionProps) {
   const { isAdminView } = useAdminView();
   const { hasPermission } = usePermissions();
 
@@ -75,8 +79,23 @@ export default function VibratoSection() {
   const [savedValues, setSavedValues] = useState<VibratoValues>(DEFAULTS);
   const [saving, setSaving] = useState(false);
   const [loaded, setLoaded] = useState(false);
+  const didInitRef = useRef(false);
 
   useEffect(() => {
+    if (!canManage) {
+      setLoaded(true);
+      return;
+    }
+    if (initialValues && !didInitRef.current) {
+      setValues(initialValues);
+      setSavedValues(initialValues);
+      setLoaded(true);
+      didInitRef.current = true;
+      return;
+    }
+    if (initialValues) {
+      return;
+    }
     async function load() {
       try {
         const res = await fetch('/api/settings/vibrato');
@@ -91,12 +110,8 @@ export default function VibratoSection() {
         setLoaded(true);
       }
     }
-    if (canManage) {
-      void load();
-    } else {
-      setLoaded(true);
-    }
-  }, [canManage]);
+    void load();
+  }, [canManage, initialValues]);
 
   const hasChanges = JSON.stringify(values) !== JSON.stringify(savedValues);
 

--- a/packages/web/src/pages/AudioPage.tsx
+++ b/packages/web/src/pages/AudioPage.tsx
@@ -10,6 +10,8 @@ import {
   WaveSineIcon,
   WavesIcon,
 } from '@phosphor-icons/react';
+import { type Icon } from '@phosphor-icons/react';
+import { useEffect, useState } from 'react';
 
 import ChannelMixSection from '../components/settings/ChannelMixSection';
 import CompressorSection from '../components/settings/CompressorSection';
@@ -22,27 +24,110 @@ import TimescaleSection from '../components/settings/TimescaleSection';
 import TremoloSection from '../components/settings/TremoloSection';
 import VibratoSection from '../components/settings/VibratoSection';
 import { PageHeader } from '../components/ui/PageHeader';
+import { Spinner } from '../components/ui/Spinner';
 import { useAdminView } from '../context/AdminViewContext';
 import { usePermissions } from '../context/PermissionsContext';
 
-const FILTER_CARDS = [
-  { icon: SlidersHorizontalIcon, label: 'Equalizer', component: EqualizerSection, wide: true },
-  { icon: ArrowsDownUpIcon, label: 'Compressor', component: CompressorSection, wide: true },
-  { icon: MicrophoneStageIcon, label: 'Karaoke', component: KaraokeSection, wide: true },
-  { icon: GaugeIcon, label: 'Timescale', component: TimescaleSection },
-  { icon: WaveSineIcon, label: 'Tremolo', component: TremoloSection },
-  { icon: WavesIcon, label: 'Vibrato', component: VibratoSection },
-  { icon: CirclesFourIcon, label: 'Rotation', component: RotationSection },
-  { icon: GuitarIcon, label: 'Distortion', component: DistortionSection, wide: true },
-  { icon: ChartBarIcon, label: 'Channel Mix', component: ChannelMixSection, wide: true },
-  { icon: BarricadeIcon, label: 'Low Pass', component: LowPassSection },
-];
+interface FiltersData {
+  compressor: {
+    enabled: boolean;
+    threshold: number;
+    ratio: number;
+    attack: number;
+    release: number;
+    gain: number;
+  };
+  equalizer: { bands: number[]; enabled: boolean };
+  karaoke: {
+    enabled: boolean;
+    level: number;
+    monoLevel: number;
+    filterBand: number;
+    filterWidth: number;
+  };
+  timescale: { enabled: boolean; speed: number; pitch: number; rate: number };
+  tremolo: { enabled: boolean; frequency: number; depth: number };
+  vibrato: { enabled: boolean; frequency: number; depth: number };
+  rotation: { enabled: boolean; rotationHz: number };
+  distortion: {
+    enabled: boolean;
+    sinOffset: number;
+    sinScale: number;
+    cosOffset: number;
+    cosScale: number;
+    tanOffset: number;
+    tanScale: number;
+    offset: number;
+    scale: number;
+  };
+  channelMix: {
+    enabled: boolean;
+    leftToLeft: number;
+    leftToRight: number;
+    rightToLeft: number;
+    rightToRight: number;
+  };
+  lowPass: { enabled: boolean; smoothing: number };
+}
+
+interface FilterCardDef {
+  icon: Icon;
+  label: string;
+  wide?: boolean;
+}
+
+function FilterCard({
+  icon: IconEl,
+  label,
+  wide,
+  children,
+}: FilterCardDef & { children: React.ReactNode }) {
+  return (
+    <section className={wide ? 'xl:col-span-2' : ''}>
+      <h2 className='text-muted mb-3 flex items-center gap-2 font-mono text-xs tracking-wider uppercase'>
+        <IconEl size={14} weight='duotone' />
+        {label}
+      </h2>
+      <div className='bg-elevated clay-resting rounded-lg p-5'>{children}</div>
+    </section>
+  );
+}
 
 export default function AudioPage() {
   const { isAdminView } = useAdminView();
   const { hasPermission } = usePermissions();
 
   const canManage = isAdminView || hasPermission('audio.manage');
+  const [filters, setFilters] = useState<FiltersData | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!canManage) {
+      setLoaded(true);
+      return;
+    }
+    async function load() {
+      try {
+        const res = await fetch('/api/settings/filters');
+        if (res.ok) {
+          setFilters((await res.json()) as FiltersData);
+        }
+      } catch {
+        // silently fail — sections will fall back to individual fetches
+      } finally {
+        setLoaded(true);
+      }
+    }
+    void load();
+  }, [canManage]);
+
+  if (!loaded) {
+    return (
+      <div className='flex h-full items-center justify-center p-4 md:p-8'>
+        <Spinner />
+      </div>
+    );
+  }
 
   return (
     <div className='h-full overflow-y-auto p-4 md:p-8'>
@@ -62,17 +147,36 @@ export default function AudioPage() {
         </div>
       ) : (
         <div className='grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3'>
-          {FILTER_CARDS.map(({ icon: Icon, label, component: Section, wide }) => (
-            <section key={label} className={wide ? 'xl:col-span-2' : ''}>
-              <h2 className='text-muted mb-3 flex items-center gap-2 font-mono text-xs tracking-wider uppercase'>
-                <Icon size={14} weight='duotone' />
-                {label}
-              </h2>
-              <div className='bg-elevated clay-resting rounded-lg p-5'>
-                <Section />
-              </div>
-            </section>
-          ))}
+          <FilterCard icon={SlidersHorizontalIcon} label='Equalizer' wide>
+            <EqualizerSection initialValues={filters?.equalizer} />
+          </FilterCard>
+          <FilterCard icon={ArrowsDownUpIcon} label='Compressor' wide>
+            <CompressorSection initialValues={filters?.compressor} />
+          </FilterCard>
+          <FilterCard icon={MicrophoneStageIcon} label='Karaoke' wide>
+            <KaraokeSection initialValues={filters?.karaoke} />
+          </FilterCard>
+          <FilterCard icon={GaugeIcon} label='Timescale'>
+            <TimescaleSection initialValues={filters?.timescale} />
+          </FilterCard>
+          <FilterCard icon={WaveSineIcon} label='Tremolo'>
+            <TremoloSection initialValues={filters?.tremolo} />
+          </FilterCard>
+          <FilterCard icon={WavesIcon} label='Vibrato'>
+            <VibratoSection initialValues={filters?.vibrato} />
+          </FilterCard>
+          <FilterCard icon={CirclesFourIcon} label='Rotation'>
+            <RotationSection initialValues={filters?.rotation} />
+          </FilterCard>
+          <FilterCard icon={GuitarIcon} label='Distortion' wide>
+            <DistortionSection initialValues={filters?.distortion} />
+          </FilterCard>
+          <FilterCard icon={ChartBarIcon} label='Channel Mix' wide>
+            <ChannelMixSection initialValues={filters?.channelMix} />
+          </FilterCard>
+          <FilterCard icon={BarricadeIcon} label='Low Pass'>
+            <LowPassSection initialValues={filters?.lowPass} />
+          </FilterCard>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

Replaces 10 parallel API requests on the Audio page with a single batched `GET /api/settings/filters` endpoint. Eliminates visible card pop-in and reduces network overhead.

## Changes

- **New route** `GET /api/settings/filters` — returns all 10 audio filter settings (compressor, equalizer, karaoke, timescale, tremolo, vibrato, rotation, distortion, channel mix, low pass) in one response
- **AudioPage** fetches once from the batch endpoint, shows a single spinner while loading, then passes data as `initialValues` props to each section
- **10 section components** gain an optional `initialValues` prop — when provided, they skip their individual fetch and use the passed data directly, backed by an existing fallback fetch when used standalone