### PR TITLE
chore(lint): tighten lint config and fix new violations

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -50,6 +50,8 @@ export default defineConfig({
     // -----------------------------------------------------------------------
     // oxc — Oxc-specific correctness rules that catch subtle bugs
     // -----------------------------------------------------------------------
+    // overly broad disable comments (e.g. eslint-disable without specific rules)
+    'unicorn/no-abusive-eslint-disable': 'warn',
     // Math.min(Math.max(x, min), max) — wrong clamping direction
     'oxc/bad-min-max-func': 'error',
     // a < b < c evaluates as (a < b) < c — a boolean-number comparison
@@ -75,6 +77,12 @@ export default defineConfig({
     'no-unsafe-finally': 'error',
     'no-unsafe-optional-chaining': 'error',
     'no-unused-labels': 'error',
+    // new Promise(r => r(5)) — return value of executor is silently ignored
+    'no-promise-executor-return': 'error',
+    // 9007199254740993 — integer exceeds IEEE 754 safe range; value silently changes
+    'no-loss-of-precision': 'error',
+    // while (node) { ... } where node never changes — infinite loop or dead code
+    'no-unmodified-loop-condition': 'error',
     '@typescript-eslint/no-unused-vars': 'warn',
     'use-isnan': 'error',
     'for-direction': 'error',
@@ -126,6 +134,8 @@ export default defineConfig({
     // -----------------------------------------------------------------------
     // type safety — catch TypeScript type-level mistakes
     // -----------------------------------------------------------------------
+    // private foo: string → private readonly foo: string — immutability intent
+    '@typescript-eslint/prefer-readonly': 'warn',
     // {} means "any non-nullish value", not "empty object" — use Record<string, never>
     '@typescript-eslint/no-empty-object-type': 'error',
     // Function type is unsafe — use (...args: unknown[]) => unknown
@@ -221,6 +231,8 @@ export default defineConfig({
     // -----------------------------------------------------------------------
     // promises
     // -----------------------------------------------------------------------
+    // for (const x of xs) { await f(x); } — serial where parallel was intended
+    'no-await-in-loop': 'warn',
     'promise/prefer-await-to-then': 'error',
     'promise/valid-params': 'error',
     'promise/catch-or-return': 'error',
@@ -444,6 +456,8 @@ export default defineConfig({
     'unicorn/prefer-string-raw': 'warn',
     // Number(x) over parseInt(x) / parseFloat(x) — faster and clearer for coercion
     'unicorn/prefer-number-coercion': 'warn',
+    // arr.filter(Boolean) over arr.filter(x => !!x) — cleaner, zero-cost
+    'unicorn/prefer-native-coercion-functions': 'warn',
 
     // Enforce kebab-case, PascalCase, or camelCase filenames
     'unicorn/filename-case': [
@@ -790,6 +804,33 @@ export default defineConfig({
       files: ['packages/server/src/index.ts'],
       rules: {
         '@typescript-eslint/consistent-return': 'off',
+      },
+    },
+
+    // Sequential await-in-loop is intentional for these files:
+    // - Discord API calls must respect rate limits
+    // - Playback operations are inherently serial
+    // - Route registration order matters
+    // - Tag sync / migration writes to DB and needs consistency
+    // - Voice connection state machine steps must be serial
+    // - Retry loops with backoff are serial by design
+    // - Chunked bulk operations throttle server load
+    // - DB transactions are serial by SQLite design
+    {
+      files: [
+        'packages/server/src/utils/unregisterCommands.ts',
+        'packages/server/src/lib/routeTable.ts',
+        'packages/server/src/GuildPlayer.ts',
+        'packages/server/src/lib/syncPlaylistToTag.ts',
+        'packages/server/src/lib/voice.ts',
+        'packages/web/src/api/client.ts',
+        'packages/server/src/routes/auth.ts',
+        'packages/web/src/pages/PlaylistDetailPage.tsx',
+        'packages/server/src/lib/tagCanonicalization.ts',
+        'packages/server/src/lib/migrateExistingTags.ts',
+      ],
+      rules: {
+        'no-await-in-loop': 'off',
       },
     },
   ],

--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
     "web:build": "bun run --filter @alfira/web build",
     "discord:unregister-commands": "bun run packages/server/src/utils/unregisterCommands.ts",
     "setup:nodelink": "bash scripts/setup-nodelink.sh",
-    "lint": "oxlint .",
-    "lint:fix": "oxlint --fix .",
+    "lint": "oxlint --deny-warnings .",
+    "lint:fix": "oxlint --fix --deny-warnings .",
     "format": "oxfmt --write .",
     "format:check": "oxfmt --check .",
-    "check": "oxlint --type-aware --type-check --deny-warnings . && oxfmt --check . && bun test",
-    "typecheck": "oxlint --type-aware --type-check --deny-warnings .",
+    "check": "oxlint --deny-warnings . && oxfmt --check . && bun test",
+    "typecheck": "oxlint --deny-warnings .",
     "test": "bun test"
   },
   "devDependencies": {

--- a/packages/server/src/GuildPlayer.ts
+++ b/packages/server/src/GuildPlayer.ts
@@ -19,7 +19,7 @@ import {
 export class GuildPlayer {
   private static readonly MAX_CONSECUTIVE_FAILURES = 3;
 
-  private queue = new PlaybackCursor<QueuedSong>();
+  private readonly queue = new PlaybackCursor<QueuedSong>();
   private priorityQueue: QueuedSong[] = [];
   private currentSong: QueuedSong | null = null;
   private loopMode: LoopMode = 'off';
@@ -928,7 +928,9 @@ export class GuildPlayer {
         return;
       }
       await connectToVoice(this.guildId, this.voiceId);
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      await new Promise((resolve) => {
+        setTimeout(resolve, 500);
+      });
     }
     const tCold2 = Date.now();
 
@@ -1038,7 +1040,9 @@ export class GuildPlayer {
       } catch (error) {
         lastError = error;
         if (attempt < RETRY_ATTEMPTS - 1) {
-          await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+          await new Promise((resolve) => {
+            setTimeout(resolve, RETRY_DELAY_MS);
+          });
         }
       }
     }

--- a/packages/server/src/lib/discordGateway.ts
+++ b/packages/server/src/lib/discordGateway.ts
@@ -56,9 +56,9 @@ interface VoiceStateData {
 
 export class DiscordGateway {
   private ws: WebSocket | null = null;
-  private token: string;
-  private intents: number;
-  private handlers: DispatchHandler[] = [];
+  private readonly token: string;
+  private readonly intents: number;
+  private readonly handlers: DispatchHandler[] = [];
 
   // Session state for resume.
   private sessionId: string | null = null;
@@ -81,7 +81,7 @@ export class DiscordGateway {
 
   // Voice state tracking (for voice.ts lookups).
   // Map of userId -> channelId.
-  private voiceStates = new Map<string, string>();
+  private readonly voiceStates = new Map<string, string>();
 
   constructor(token: string, intents: number) {
     this.token = token;

--- a/packages/server/src/lib/discordRest.ts
+++ b/packages/server/src/lib/discordRest.ts
@@ -29,7 +29,9 @@ async function discordFetch(path: string): Promise<Response> {
     const retryAfter = res.headers.get('Retry-After');
     const delayMs = retryAfter ? Number(retryAfter) * 1000 : 1000;
     logger.warn({ path, delayMs }, 'Discord REST rate limited, retrying');
-    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    await new Promise((resolve) => {
+      setTimeout(resolve, delayMs);
+    });
     return fetch(url, {
       headers: { Authorization: `Bot ${botToken()}` },
     });
@@ -46,9 +48,9 @@ async function discordFetch(path: string): Promise<Response> {
 
 class ConcurrencyLimiter {
   private running = 0;
-  private queue: (() => void)[] = [];
+  private readonly queue: (() => void)[] = [];
 
-  constructor(private max: number) {}
+  constructor(private readonly max: number) {}
 
   acquire(): Promise<void> {
     if (this.running < this.max) {

--- a/packages/server/src/lib/jwt.test.ts
+++ b/packages/server/src/lib/jwt.test.ts
@@ -207,7 +207,9 @@ describe('verify', () => {
     // Sign with a very short expiration and wait for it to expire.
     // exp = iat + 1, so we need floor(now) > iat + 1 — wait 2 full seconds.
     const token = sign({ sub: 'user-1' }, SECRET, { expiresIn: '1s' });
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 2000);
+    });
     expect(verify(token, SECRET)).toBeNull();
   });
 

--- a/packages/server/src/lib/tagCanonicalization.ts
+++ b/packages/server/src/lib/tagCanonicalization.ts
@@ -1,4 +1,6 @@
-import { db, eq, tables } from '../shared/db';
+import { inArray } from 'drizzle-orm';
+
+import { db, tables } from '../shared/db';
 
 const { tag: tagTable } = tables;
 
@@ -34,15 +36,19 @@ export async function canonicalizeTags(rawTags: string[]): Promise<string[]> {
   const canonicalNames: string[] = [];
   const missingTags: string[] = [];
 
-  for (const [nameLower, originalSpelling] of seen) {
-    const existing = await db
-      .select({ canonicalName: tagTable.canonicalName })
-      .from(tagTable)
-      .where(eq(tagTable.nameLower, nameLower))
-      .limit(1);
+  // Batch-check all tags in one query instead of N sequential lookups
+  const nameLowers = [...seen.keys()];
+  const existingRows = await db
+    .select({ nameLower: tagTable.nameLower, canonicalName: tagTable.canonicalName })
+    .from(tagTable)
+    .where(inArray(tagTable.nameLower, nameLowers));
 
-    if (existing.length > 0) {
-      canonicalNames.push(existing[0]?.canonicalName ?? '');
+  const existingMap = new Map(existingRows.map((r) => [r.nameLower, r.canonicalName]));
+
+  for (const [nameLower, originalSpelling] of seen) {
+    const canonicalName = existingMap.get(nameLower);
+    if (canonicalName !== undefined) {
+      canonicalNames.push(canonicalName);
     } else {
       missingTags.push(originalSpelling);
     }

--- a/packages/server/src/lib/voice.ts
+++ b/packages/server/src/lib/voice.ts
@@ -71,7 +71,9 @@ export async function resolveOrAutoJoinPlayer(
     await connectToVoice(guildId, voiceChannelId);
     // Give NodeLink time to fully establish the voice connection
     // before we start sending track data.
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 500);
+    });
 
     return { ok: true, player: createPlayer(guildId, voiceChannelId) };
   } catch (error) {

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -527,7 +527,9 @@ async function withRetry<T>(fn: () => Promise<T>, attempts = 3, baseDelayMs = 50
     } catch (error) {
       lastErr = error;
       if (i < attempts - 1) {
-        await new Promise((resolve) => setTimeout(resolve, baseDelayMs * 2 ** i));
+        await new Promise((resolve) => {
+          setTimeout(resolve, baseDelayMs * 2 ** i);
+        });
       }
     }
   }

--- a/packages/server/src/routes/songs.ts
+++ b/packages/server/src/routes/songs.ts
@@ -115,13 +115,15 @@ async function handleBulkTag(ctx: RouteContext, request: Request): Promise<Respo
     await db.update(songTable).set({ tags: newTags }).where(inArray(songTable.id, ids));
     updatedIds.push(...ids);
   } else {
-    // Merge: add new tags to each song's existing tags
-    for (const song of existingSongs) {
-      const existingTags = song.tags ?? [];
-      const merged = [...new Set([...existingTags, ...newTags])];
-      await db.update(songTable).set({ tags: merged }).where(eq(songTable.id, song.id));
-      updatedIds.push(song.id);
-    }
+    // Merge: add new tags to each song's existing tags — run updates in parallel
+    await Promise.all(
+      existingSongs.map(async (song) => {
+        const existingTags = song.tags ?? [];
+        const merged = [...new Set([...existingTags, ...newTags])];
+        await db.update(songTable).set({ tags: merged }).where(eq(songTable.id, song.id));
+        updatedIds.push(song.id);
+      })
+    );
   }
 
   // Re-fetch updated songs and emit events

--- a/packages/server/src/routes/tags.ts
+++ b/packages/server/src/routes/tags.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from 'drizzle-orm';
+import { eq, inArray, sql } from 'drizzle-orm';
 import * as v from 'valibot';
 
 import { type RouteContext } from '../lib/context';
@@ -184,21 +184,28 @@ async function handleDeleteTag(
     .where(eq(playlistTable.tagNameLower, nameLower))
     .all();
 
-  for (const pl of smartPlaylists) {
-    await db.update(playlistTable).set({ tagNameLower: null }).where(eq(playlistTable.id, pl.id));
+  // Update all smart playlists to remove the tag reference, then re-fetch and emit
+  await Promise.all(
+    smartPlaylists.map((pl) =>
+      db.update(playlistTable).set({ tagNameLower: null }).where(eq(playlistTable.id, pl.id))
+    )
+  );
 
-    // Emit update for each affected playlist
-    const [updatedPl] = await db
-      .select()
-      .from(playlistTable)
-      .where(eq(playlistTable.id, pl.id))
-      .limit(1);
-    if (updatedPl) {
-      emitPlaylistUpdated({
-        ...updatedPl,
-        createdAt: updatedPl.createdAt.toISOString(),
-      });
-    }
+  const updatedPlaylists = await db
+    .select()
+    .from(playlistTable)
+    .where(
+      inArray(
+        playlistTable.id,
+        smartPlaylists.map((pl) => pl.id)
+      )
+    );
+
+  for (const updatedPl of updatedPlaylists) {
+    emitPlaylistUpdated({
+      ...updatedPl,
+      createdAt: updatedPl.createdAt.toISOString(),
+    });
   }
 
   await db.delete(tagTable).where(eq(tagTable.nameLower, nameLower));

--- a/packages/server/src/utils/unregisterCommands.ts
+++ b/packages/server/src/utils/unregisterCommands.ts
@@ -14,7 +14,9 @@ import { logger } from '../shared/logger';
 
 /** Delay helper for rate limit pacing. */
 function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
 }
 
 /** Delete a command with retry on rate limit (429). */

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -132,7 +132,9 @@ export async function trySilentRefresh(): Promise<boolean> {
   let result = await refreshToken();
   for (let attempt = 0; attempt < 2 && !result.ok && result.retryable; attempt++) {
     console.warn(`[auth] trySilentRefresh: retry ${attempt + 1}/2 after retryable failure`);
-    await new Promise((resolve) => setTimeout(resolve, 1500));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1500);
+    });
     result = await refreshToken();
   }
 

--- a/packages/web/src/pages/SongsPage.tsx
+++ b/packages/web/src/pages/SongsPage.tsx
@@ -274,9 +274,11 @@ export default function SongsPage() {
     try {
       const allIds = [...bulk.selectedIds];
       const chunkSize = 500;
+      // oxlint-disable no-await-in-loop
       for (let i = 0; i < allIds.length; i += chunkSize) {
         await bulkDeleteSongs(allIds.slice(i, i + chunkSize));
       }
+      // oxlint-enable no-await-in-loop
       for (const id of allIds) {
         removeItem(id);
       }
@@ -299,9 +301,11 @@ export default function SongsPage() {
       try {
         const allIds = [...bulk.selectedIds];
         const chunkSize = 500;
+        // oxlint-disable no-await-in-loop
         for (let i = 0; i < allIds.length; i += chunkSize) {
           await bulkEditSongs(allIds.slice(i, i + chunkSize), data);
         }
+        // oxlint-enable no-await-in-loop
         notify(`Updated ${allIds.length} song${allIds.length !== 1 ? 's' : ''}`, 'success');
         setBulkEditingOpen(false);
       } catch (error: unknown) {


### PR DESCRIPTION
## Summary

Adds 7 new oxlint rules and fixes all resulting violations. Removes redundant CLI flags, adds `--deny-warnings` to standalone lint scripts for consistency.

## Changes

### New rules added
- `no-promise-executor-return` (error) — implicit return in Promise executor
- `no-loss-of-precision` (error) — numbers exceeding IEEE 754 safe range
- `no-unmodified-loop-condition` (error) — infinite loop / dead code detector
- `@typescript-eslint/prefer-readonly` (warn) — immutability intent on class members
- `unicorn/no-abusive-eslint-disable` (warn) — overly broad disable comments
- `unicorn/prefer-native-coercion-functions` (warn) — cleaner coercion patterns
- `no-await-in-loop` (warn) — serial where parallel was intended

### Script fixes
- Removed redundant `--type-aware --type-check` from `check` and `typecheck` scripts (config already has `options.typeAware: true` and `options.typeCheck: true`)
- Added `--deny-warnings` to `lint` and `lint:fix` for consistency with `check`

### Violation fixes
- Added `readonly` to `DiscordGateway`, `GuildPlayer`, and `ConcurrencyLimiter` members
- Fixed Promise executor implicit returns in 6 files
- Parallelized tag existence lookups in `tagCanonicalization.ts` (N queries → 1 batch query)
- Parallelized batch tag updates in `songs.ts` and `tags.ts`
- Suppressed intentional sequential loops (Discord rate limits, chunked bulk ops, retry with backoff, playback state machine, DB transactions)