### PR TITLE
fix(web): prevent horizontal scrollbar on virtual list scroll

### DIFF
--- a/packages/web/src/components/SongCard.tsx
+++ b/packages/web/src/components/SongCard.tsx
@@ -1,6 +1,8 @@
 import { type Playlist, type Song } from '@alfira/server/shared';
 import { DiscIcon, MicrophoneStageIcon, MusicNoteIcon, UserIcon } from '@phosphor-icons/react';
-import React, { useCallback, useMemo, useState } from 'react';
+import { AnimatePresence } from 'motion/react';
+import * as m from 'motion/react-m';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 
 import { usePermissions } from '../context/PermissionsContext';
 import { useSongEdit } from '../context/SongEditContext';
@@ -129,6 +131,12 @@ function SongCardInner({
   }, []);
 
   const handleToggleSelect = useCallback(() => onToggleSelect?.(), [onToggleSelect]);
+
+  // Stable motion props for the edit panel expand/collapse animation.
+  const editPanelInitial = useMemo(() => ({ height: 0, opacity: 0 }), []);
+  const editPanelAnimate = useMemo(() => ({ height: 'auto' as const, opacity: 1 }), []);
+  const editPanelExit = useMemo(() => ({ height: 0, opacity: 0 }), []);
+  const editPanelTransition = useRef({ duration: 0.2, ease: 'easeOut' as const });
 
   // ── Grid variant ──────────────────────────────────────────────────────
 
@@ -265,9 +273,19 @@ function SongCardInner({
         </div>
 
         {/* Inline edit panel */}
-        <div className={`expand-panel ${isOpen ? 'expanded' : ''}`}>
-          <SongEditPanel song={song} isOpen={isOpen} onClose={handleEditClose} />
-        </div>
+        <AnimatePresence>
+          {isOpen && (
+            <m.div
+              initial={editPanelInitial}
+              animate={editPanelAnimate}
+              exit={editPanelExit}
+              transition={editPanelTransition.current}
+              className='overflow-hidden'
+            >
+              <SongEditPanel song={song} isOpen={isOpen} onClose={handleEditClose} />
+            </m.div>
+          )}
+        </AnimatePresence>
       </Card>
     );
   }
@@ -379,9 +397,19 @@ function SongCardInner({
       </div>
 
       {/* Inline edit panel */}
-      <div className={`expand-panel ${isOpen ? 'expanded' : ''}`}>
-        <SongEditPanel song={song} isOpen={isOpen} onClose={handleEditClose} />
-      </div>
+      <AnimatePresence>
+        {isOpen && (
+          <m.div
+            initial={editPanelInitial}
+            animate={editPanelAnimate}
+            exit={editPanelExit}
+            transition={editPanelTransition.current}
+            className='overflow-hidden'
+          >
+            <SongEditPanel song={song} isOpen={isOpen} onClose={handleEditClose} />
+          </m.div>
+        )}
+      </AnimatePresence>
     </Card>
   );
 }

--- a/packages/web/src/components/SongEditPanel.tsx
+++ b/packages/web/src/components/SongEditPanel.tsx
@@ -14,23 +14,7 @@ interface SongEditPanelProps {
 }
 
 export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelProps) {
-  const [closing, setClosing] = useState(false);
-  const closingRef = useRef(false);
   const { tagColorMap } = useTagColors();
-
-  useLayoutEffect(() => {
-    if (isOpen) {
-      closingRef.current = false;
-      setClosing(false);
-    } else if (!closingRef.current) {
-      closingRef.current = true;
-      setClosing(true);
-      setTimeout(() => {
-        closingRef.current = false;
-        setClosing(false);
-      }, 300);
-    }
-  }, [isOpen]);
 
   const songExtended = song as Song & {
     artist?: string | null;
@@ -245,11 +229,6 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
     e.stopPropagation();
   }, []);
 
-  const panelStyle = useMemo(
-    () => (closing ? ({ pointerEvents: 'none' } as const) : undefined),
-    [closing]
-  );
-
   const handleFocusTagInput = useCallback(() => {
     tagInputRef.current?.focus();
     if (!fetchedTags) {
@@ -294,17 +273,8 @@ export default function SongEditPanel({ song, isOpen, onClose }: SongEditPanelPr
     setHighlightedIndex(-1);
   }, []);
 
-  if (!isOpen && !closing) {
-    return null;
-  }
-
   return (
-    <div
-      className='expand-panel-content'
-      data-closing={closing ? 'true' : undefined}
-      style={panelStyle}
-      onClick={handlePanelClick}
-    >
+    <div onClick={handlePanelClick}>
       <div className='border-border border-t px-3 pt-4 pb-4 md:px-4'>
         <div className='flex flex-col gap-3'>
           <Field

--- a/packages/web/src/components/SortableVirtualSongList.tsx
+++ b/packages/web/src/components/SortableVirtualSongList.tsx
@@ -188,7 +188,7 @@ export const SortableVirtualSongList = memo(function SortableVirtualSongList({
     } else {
       const timeout = setTimeout(() => {
         setEffectiveOpenId(null);
-      }, 300);
+      }, 200);
       return () => {
         clearTimeout(timeout);
       };

--- a/packages/web/src/components/VirtualList.tsx
+++ b/packages/web/src/components/VirtualList.tsx
@@ -237,7 +237,7 @@ function VirtualListInner<T>({
                     transform: `translateY(${virtualRow.start}px)`,
                   }}
                 >
-                  <m.div layout initial='initial' animate='animate' variants={listItemVariants}>
+                  <m.div initial='initial' animate='animate' variants={listItemVariants}>
                     {renderItem(item, virtualRow.index)}
                   </m.div>
                   {spacer}

--- a/packages/web/src/components/VirtualSongList.tsx
+++ b/packages/web/src/components/VirtualSongList.tsx
@@ -159,10 +159,10 @@ export const VirtualSongList = memo(function VirtualSongList({
       setEffectiveOpenId(openSongId);
       return;
     } else {
-      // Collapse: wait for the CSS transition to finish before releasing space.
+      // Collapse: wait for the exit animation to finish before releasing space.
       const timeout = setTimeout(() => {
         setEffectiveOpenId(null);
-      }, 300);
+      }, 200);
       return () => {
         clearTimeout(timeout);
       };

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1265,28 +1265,6 @@
   box-shadow: var(--clay-shadow-player);
 }
 
-.expand-panel {
-  max-height: 0px;
-  overflow: hidden;
-  transition: max-height 0.3s ease;
-}
-.expand-panel.expanded {
-  max-height: 600px;
-}
-.expand-panel .expand-panel-content {
-  transition:
-    opacity 0.25s ease,
-    visibility 0s linear 0s;
-  visibility: visible;
-}
-.expand-panel .expand-panel-content[data-closing='true'] {
-  opacity: 0;
-  visibility: hidden;
-  transition:
-    opacity 0.25s ease,
-    visibility 0s linear 0.25s;
-}
-
 /* Volume range input — fill track using accent color up to thumb position */
 .volume-range-input {
   appearance: none;

--- a/packages/web/src/lib/motion.ts
+++ b/packages/web/src/lib/motion.ts
@@ -24,13 +24,13 @@ export { LazyMotion, domAnimation };
 
 /**
  * List item enter variants.
- * Slides in from the right with a spring settle — subtle per-item animation on scroll.
+ * Slides up with a spring settle — subtle per-item animation on scroll.
  */
 export const listItemVariants: Variants = {
-  initial: { opacity: 0, x: 24 },
+  initial: { opacity: 0, y: 12 },
   animate: {
     opacity: 1,
-    x: 0,
+    y: 0,
     transition: { type: 'spring', stiffness: 400, damping: 38 },
   },
   exit: { opacity: 0 },


### PR DESCRIPTION
## Summary

Fixes a regression where a horizontal scrollbar appeared at the bottom of virtual lists (Songs, Playlists, Playlist Details) when scrolling.

## Root cause

Two interacting issues:

1. The `layout` prop on framer-motion's `m.div` in VirtualList caused layout snapshots during mount, making the `x: 24` initial variant extend content 24px beyond the right edge.
2. The `listItemVariants` animation used `x: 24 → x: 0` (horizontal slide from right), which inherently pushes past the container boundary.

## Changes

- **VirtualList.tsx** — Remove `layout` prop from `m.div` wrapping each item
- **motion.ts** — Change `listItemVariants` from `x: 24` to `y: 12` (vertical slide-up, no horizontal overflow)
- **SongCard.tsx** — Replace CSS `expand-panel` (max-height transition) with `AnimatePresence` + `m.div` (height+fade, 200ms) for both grid and list variants
- **SongEditPanel.tsx** — Remove `closing` state machine, `data-closing` attribute, orphaned CSS class, and early-return guard (AnimatePresence handles exit)
- **VirtualSongList.tsx / SortableVirtualSongList.tsx** — Collapse delay: 300ms → 200ms to match new exit animation timing
- **index.css** — Remove 4 dead `.expand-panel` CSS rules