### PR TITLE
docs: sync contributing and project docs with current tooling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,13 +20,22 @@ See [AGENTS.md](../AGENTS.md) for the full git workflow and commit conventions.
 
 ## Development Workflow
 
-The main dev command is `bun run dev`, which builds the server dist/ locally and then starts all services with Docker.
+Two dev modes are available:
 
-| What Changed             | Action                                                                                  |
-| ------------------------ | --------------------------------------------------------------------------------------- |
-| Any of the above         | `bun run dev` — rebuilds server dist/ and restarts Docker                               |
-| `packages/web/src/**`    | Run `bun run web:build` locally to rebuild the UI, then `docker compose restart alfira` |
-| `packages/server/src/**` | `docker compose restart alfira` (source is live-mounted)                                |
+| Command          | What it does                                                                                    |
+| ---------------- | ----------------------------------------------------------------------------------------------- |
+| `bun dev`        | Lint + format check + tests → build web → start server with `--watch` (auto-restart on changes) |
+| `bun dev:docker` | Full Docker integration test: lint + tests → build both packages → `docker compose up --build`  |
+
+`bun dev` is the fast path for day-to-day work — the server runs directly on your machine and watches for changes. `bun dev:docker` mirrors the production deployment and is good for a final integration check before submitting.
+
+During a `bun dev` session, if you change web source files you'll need to rebuild the UI separately:
+
+```bash
+bun run web:build
+```
+
+Server source changes are picked up automatically by `--watch`.
 
 ## Database Migrations
 
@@ -48,22 +57,65 @@ docker compose up --build
 
 ---
 
-## Code Quality
+## Testing
 
-The project uses [oxlint](https://oxc.rs/) and [oxfmt](https://oxc.rs/) for linting and formatting.
+The project uses [Bun's built-in test runner](https://bun.sh/docs/cli/test). Tests live alongside source files as `*.test.ts`.
 
 ```bash
-# Lint + format check with auto-fix (recommended before committing)
-bun run check
+# Run all tests
+bun test
 
-# Lint only, with auto-fix
-bun run lint:fix
-
-# Format only, with auto-fix
-bun run format
+# Run tests for a specific package
+bun test --filter @alfira/server
+bun test --filter @alfira/web
 ```
 
-CI runs `bun run lint` and `bun run build` for both packages — your code must pass before merging.
+## Code Quality
+
+The project uses [oxlint](https://oxc.rs/) and [oxfmt](https://oxc.rs/) for linting and formatting, plus Bun's test runner. The universal pre-commit gate is:
+
+```bash
+# Lint (type-aware) + format check + tests — run this before every commit
+bun run check
+```
+
+Individual commands are also available:
+
+```bash
+# Typecheck only
+bun run typecheck
+
+# Lint with auto-fix
+bun run lint:fix
+
+# Format with auto-fix
+bun run format
+
+# Tests only
+bun test
+```
+
+CI runs `bun run check` plus Trivy vulnerability scanning, then builds both packages. Your code must pass `bun run check` locally before pushing — any failure in CI means you skipped the pre-commit check.
+
+### Git Hooks (lefthook)
+
+The project uses [lefthook](https://github.com/evilmartians/lefthook) to run checks automatically on commit. Install the hooks once:
+
+```bash
+bunx lefthook install
+```
+
+After that, every `git commit` will run lint, format check, and tests in parallel on staged files. If anything fails, the commit is blocked — same checks as CI, but before you push.
+
+### Dead Code Detection (knip)
+
+[knip](https://knip.dev/) finds unused files, dependencies, and exports. Run it periodically to keep the codebase lean:
+
+```bash
+bunx knip
+```
+
+It's preconfigured in `knip.json` and won't flag intentional exports (entry points, scripts, etc.).
 
 ## Editor Tooling
 

--- a/docs/development-choices.md
+++ b/docs/development-choices.md
@@ -25,7 +25,7 @@ The catch is that Bun is younger and more experimental — it's not the safe, bo
 
 ## TypeScript, Linting & Formatting: The Oxc "Supertool"
 
-Alfira uses the **[Oxc](https://oxc.rs/) toolchain** (`oxlint` + `oxfmt`) for all three code quality concerns: **linting, typechecking, and formatting**. There is no `typescript` dev dependency and no `tsconfig.json`.
+Alfira uses the **[Oxc](https://oxc.rs/) toolchain** (`oxlint` + `oxfmt`) for all three code quality concerns: **linting, typechecking, and formatting**. There is no `typescript` dev dependency — typechecking is handled entirely by oxlint's tsgo engine.
 
 This is a deliberate bet on a newer toolchain that does more with less:
 
@@ -34,8 +34,9 @@ This is a deliberate bet on a newer toolchain that does more with less:
 `oxlint` handles both traditional lint rules (~120 enabled) **and** full type-aware checking via **tsgo** — the Go-based TypeScript compiler that just landed as the native engine in TypeScript 7. This means Alfira gets TypeScript 7-level type inference and checking without depending on the `typescript` npm package at all.
 
 ```bash
-bun run check    # lint + full typecheck + format check (runs in CI)
+bun run check    # lint + full typecheck + format check + tests (runs in CI)
 bun run typecheck # lint + typecheck only
+bun test          # run all tests
 ```
 
 The `--deny-warnings` flag means every rule — even `warn`-level — fails the build. There is no "fix it later" category.
@@ -54,6 +55,15 @@ Zero-config, runs as `oxfmt --write .`. Shares the same Rust-based parser and AS
 - **Speed.** Biome is fast. Oxc is a little faster. When the tools are otherwise close, the edge goes to the faster one.
 
 The `oxlint.config.ts` is the most detailed config file in the project (300+ lines) — a reflection of how seriously type safety and correctness are taken here. Every rule has a reason, and every file-specific override has a comment explaining why.
+
+### Additional QA tooling
+
+Two more tools round out the quality pipeline:
+
+- **[knip](https://knip.dev/)** finds unused files, dependencies, and exports. Run `bunx knip` periodically — it catches dead code that the linter can't see (unused exports, orphaned files, stale dependencies).
+- **[lefthook](https://github.com/evilmartians/lefthook)** runs lint, format check, and tests automatically on `git commit`. Install once with `bunx lefthook install` and every commit gets the same checks as CI — no more "works on my machine but fails in CI" surprises.
+
+Together with `oxlint --deny-warnings`, these create a ratchet: the bar never goes down, and violations are caught as early as possible (on save → on commit → in CI).
 
 ---
 

--- a/docs/oxlint-setup.md
+++ b/docs/oxlint-setup.md
@@ -8,7 +8,7 @@ This document describes the oxlint and oxfmt configuration for the Alfira projec
 
 Together they provide:
 
-- **Linting**: 660+ rules across eslint, typescript, react, jsx-a11y, unicorn, import, and more
+- **Linting**: 700+ rules across eslint, typescript, react, jsx-a11y, unicorn, import, and more
 - **Formatting**: Prettier-compatible code formatting with near-identical options
 
 ## Installation
@@ -38,7 +38,10 @@ bun run format
 # Check formatting without making changes
 bun run format:check
 
-# Combined: lint + format check
+# Lint with type-aware checking only
+bun run typecheck
+
+# Combined: lint + format check + tests
 bun run check
 ```
 
@@ -54,11 +57,11 @@ See the [oxlint editor setup](https://oxc.rs/docs/guide/usage/linter/editors.htm
 
 ## CI Integration
 
-oxlint is integrated into the GitHub Actions workflow (`.github/workflows/ci.yml`):
+CI runs `bun run check` (`.github/workflows/ci.yml`), which includes lint, format check, and tests — plus Trivy vulnerability scanning and full builds of both packages.
 
 ```yaml
-- name: Lint (oxlint)
-  run: bun run lint
+- name: Lint, typecheck, and format check
+  run: bun run check
 ```
 
 ## Common Workflows

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -69,14 +69,23 @@ package via the `@alfira/server/shared` export.
 
 Top-level scripts:
 
-| Script              | Description                                             |
-| ------------------- | ------------------------------------------------------- |
-| `bun run dev`       | Build server dist/, then start all services with Docker |
-| `bun run web:build` | Build the web UI (used by Docker)                       |
+| Script              | Description                                                              |
+| ------------------- | ------------------------------------------------------------------------ |
+| `bun dev`           | Lint + format check + tests → build web → start server with `--watch`    |
+| `bun dev:docker`    | Full Docker integration test (lint + tests → build → docker compose up)  |
+| `bun run web:build` | Build the web UI                                                         |
+| `bun run check`     | Lint (type-aware) + format check + tests — the universal pre-commit gate |
+| `bun run typecheck` | Lint with type-aware checking only                                       |
+| `bun run lint:fix`  | Lint with auto-fix                                                       |
+| `bun run format`    | Format with auto-fix                                                     |
+| `bun test`          | Run all tests                                                            |
 
-| `bun run check` | Lint (oxlint) and check format (oxfmt) |
-| `bun run lint:fix` | Lint with auto-fix |
-| `bun run format` | Format with auto-fix |
+Additional QA tools:
+
+| Tool     | Command                 | Purpose                                   |
+| -------- | ----------------------- | ----------------------------------------- |
+| knip     | `bunx knip`             | Find unused files, dependencies, exports  |
+| lefthook | `bunx lefthook install` | Run lint + format check + tests on commit |
 
 ## Shared Package Exports
 
@@ -105,9 +114,9 @@ Top-level scripts:
 
 Four GitHub Actions workflows run on the repository:
 
-| Workflow             | Trigger                                               | Purpose                                                           |
-| -------------------- | ----------------------------------------------------- | ----------------------------------------------------------------- |
-| **ci.yml**           | All PRs, pushes to `main` and `dev`                   | Lint with oxlint + build all packages + Trivy vuln scan           |
-| **codeql.yml**       | All PRs, pushes to `main` and `dev`, weekly schedule  | CodeQL security analysis                                          |
-| **docker-build.yml** | All PRs, pushes to `main` and `dev` (ignores `docs/`) | Build Docker images; publish to GHCR on `main`                    |
-| **release.yml**      | Pushes of `v*` tags                                   | Build multi-arch Docker image, push to GHCR, draft GitHub release |
+| Workflow             | Trigger                                               | Purpose                                                                              |
+| -------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **ci.yml**           | All PRs, pushes to `main` and `dev`                   | `bun run check` (lint + format check + tests) + build all packages + Trivy vuln scan |
+| **codeql.yml**       | All PRs, pushes to `main` and `dev`, weekly schedule  | CodeQL security analysis                                                             |
+| **docker-build.yml** | All PRs, pushes to `main` and `dev` (ignores `docs/`) | Build Docker images; publish to GHCR on `main`                                       |
+| **release.yml**      | Pushes of `v*` tags                                   | Build multi-arch Docker image, push to GHCR, draft GitHub release                    |


### PR DESCRIPTION
## Summary

Updates CONTRIBUTING.md, docs/tech-stack.md, docs/development-choices.md, and docs/oxlint-setup.md to reflect the current state of the project tooling and workflow.

## Changes

- **CONTRIBUTING.md**: Fix dev workflow (bun dev vs bun dev:docker), document knip and lefthook, add testing section, make bun run check the centerpiece, fix CI description
- **docs/tech-stack.md**: Fix dev script descriptions, add missing scripts (dev:docker, typecheck, test), add knip/lefthook table, fix CI description, add PWA mention
- **docs/development-choices.md**: Remove incorrect "no tsconfig.json" claim, update bun run check to include tests, add QA tooling subsection (knip + lefthook)
- **docs/oxlint-setup.md**: Update rule count, add typecheck script, fix bun run check description to include tests, fix CI reference (lint → check)