### PR TITLE
chore: clean up knip config for v6 monorepo support

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,19 +1,12 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
-  "ignore": [
-    ".pi/**",
-    "packages/server/dist/**",
-    "packages/web/dist/**",
-    "packages/web/public/**",
-    ".nodelink/**",
-    "nodelink-config/**",
-    "scripts/**"
-  ],
-  "entry": [
-    "packages/server/src/index.ts",
-    "packages/server/src/utils/unregisterCommands.ts",
-    "packages/web/src/main.tsx",
-    "packages/web/src/server.ts"
-  ],
-  "ignoreDependencies": ["@alfira/server", "@alfira/web"]
+  "ignore": [".pi/**", "nodelink-config/**", "packages/web/public/**"],
+  "workspaces": {
+    "packages/server": {
+      "entry": ["src/utils/unregisterCommands.ts"]
+    },
+    "packages/web": {
+      "entry": ["src/main.tsx"]
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Clean up the Knip configuration to follow v6 best practices for Bun monorepos.

## Changes

- Move entry files from root-level `entry` to per-workspace `workspaces` config
- Remove redundant `ignore` entries for auto-ignored paths (`dist/`, gitignored dirs)
- Remove `ignoreDependencies` — Knip 6 resolves `workspace:*` protocols natively
- Drop auto-detected entry files (`src/index.ts`, `src/server.ts`) from explicit config
- Zero configuration hints on `bunx knip`