### PR TITLE
chore(ci): simplify lefthook pre-commit hooks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,11 +2,8 @@ pre-commit:
   parallel: true
   commands:
     lint:
-      glob: '*.{ts,tsx}'
-      run: bun run lint {staged_files}
+      run: bun run lint
     format:
-      glob: '*.{ts,tsx,js,jsx,json,md,css}'
-      run: bun run format:check {staged_files}
+      run: bun run format:check
     test:
-      glob: '*.{ts,tsx}'
       run: bun test


### PR DESCRIPTION
## Summary

Remove misleading `glob` patterns and `{staged_files}` placeholders from the lefthook pre-commit config. The npm scripts (`bun run lint`, `bun run format:check`) hardcode `.` for full-project checks, so the file-level filtering had no effect — commands always ran on the entire project regardless of what changed.

## Changes

- Drop `glob` and `{staged_files}` from all three pre-commit commands
- Commands now honestly reflect what they do: always run the full check