### PR TITLE
chore: add import/no-unassigned-import lint rule

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -208,6 +208,8 @@ export default defineConfig({
     'import/no-self-import': 'error',
     // Merge duplicate imports from the same module
     'import/no-duplicates': 'warn',
+    // Side-effect-only imports (import 'foo') create implicit, hidden dependencies
+    'import/no-unassigned-import': ['warn', { allow: ['**/*.css'] }],
 
     // -----------------------------------------------------------------------
     // equality — 'smart' allows == null / != null (idiomatic nullish checks)


### PR DESCRIPTION
## Summary

Add the `import/no-unassigned-import` rule to prevent side-effect-only imports from creeping into the codebase.

## Changes

- Enable `import/no-unassigned-import` at `'warn'` level with `allow: ['**/*.css']` for future CSS imports