### PR TITLE
refactor(server): extract shared song field validation and playback filter building

### DIFF
--- a/packages/server/src/GuildPlayer.ts
+++ b/packages/server/src/GuildPlayer.ts
@@ -1,7 +1,12 @@
 import { eq } from 'drizzle-orm';
 
-import { buildCompressorFilter } from './lib/applyNodeLinkFilter';
-import { buildEqualizerFilter, EQ_BAND_COLUMNS, eqBandsFromRow } from './lib/eqBands';
+import { buildCompressorFilter, type CompressorFilterParams } from './lib/applyNodeLinkFilter';
+import {
+  buildEqualizerFilter,
+  EQ_BAND_COLUMNS,
+  eqBandsFromRow,
+  type EqSettingsRow,
+} from './lib/eqBands';
 import { connectToVoice, getClient } from './lib/gatewayState';
 import { lavalink, type TrackEndReason } from './lib/lavalink';
 import { emitPlayerUpdate } from './lib/socket';
@@ -43,6 +48,40 @@ export class GuildPlayer {
   // gapless TrackEndEvent can transition without a cold-start load.
   // Disable if a future NodeLink update regresses the gapless pipeline.
   private static readonly ENABLE_GAPLESS_PRELOAD = true;
+
+  /**
+   * Merge compressor and equalizer filters into a NodeLink PATCH payload.
+   * Extracted from playSong() so the gapless and cold-start paths share
+   * the same filter-building logic.
+   */
+  private applyPlaybackFilters(
+    patch: Record<string, unknown>,
+    settings: (CompressorFilterParams & { enabled: boolean } & EqSettingsRow) | undefined
+  ): void {
+    if (settings?.enabled) {
+      try {
+        const compressorFilter = buildCompressorFilter(settings);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        patch.filters = { ...(patch.filters as Record<string, unknown>), ...compressorFilter };
+      } catch (error) {
+        logger.error({ error, guildId: this.guildId }, 'Failed to build compressor filter');
+      }
+    }
+
+    const eqBands = eqBandsFromRow(settings);
+    if (eqBands.some((b) => b !== 50)) {
+      try {
+        const equalizerFilter = buildEqualizerFilter(eqBands);
+        patch.filters = {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+          ...(patch.filters as Record<string, unknown>),
+          equalizer: equalizerFilter,
+        };
+      } catch (error) {
+        logger.error({ error, guildId: this.guildId }, 'Failed to build equalizer filter');
+      }
+    }
+  }
 
   // Called when the voice session is torn down so the manager Map can
   // remove this GuildPlayer (see manager.ts).
@@ -840,29 +879,7 @@ export class GuildPlayer {
         volume: 100 + (next.volumeBoost ?? 0),
       };
 
-      if (settings?.enabled) {
-        try {
-          const compressorFilter = buildCompressorFilter(settings);
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-          patch.filters = { ...(patch.filters as Record<string, unknown>), ...compressorFilter };
-        } catch (error) {
-          logger.error({ error, guildId: this.guildId }, 'Failed to build compressor filter');
-        }
-      }
-
-      const eqBands = eqBandsFromRow(settings);
-      if (eqBands.some((b) => b !== 50)) {
-        try {
-          const equalizerFilter = buildEqualizerFilter(eqBands);
-          patch.filters = {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-            ...(patch.filters as Record<string, unknown>),
-            equalizer: equalizerFilter,
-          };
-        } catch (error) {
-          logger.error({ error, guildId: this.guildId }, 'Failed to build equalizer filter');
-        }
-      }
+      this.applyPlaybackFilters(patch, settings);
 
       const t1 = Date.now();
       await updateNodeLinkPlayer(this.guildId, sessionId, patch);
@@ -944,29 +961,7 @@ export class GuildPlayer {
       volume,
     };
 
-    if (settings?.enabled) {
-      try {
-        const compressorFilter = buildCompressorFilter(settings);
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-        patch.filters = { ...(patch.filters as Record<string, unknown>), ...compressorFilter };
-      } catch (error) {
-        logger.error({ error, guildId: this.guildId }, 'Failed to build compressor filter');
-      }
-    }
-
-    const eqBands = eqBandsFromRow(settings);
-    if (eqBands.some((b) => b !== 50)) {
-      try {
-        const equalizerFilter = buildEqualizerFilter(eqBands);
-        patch.filters = {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-          ...(patch.filters as Record<string, unknown>),
-          equalizer: equalizerFilter,
-        };
-      } catch (error) {
-        logger.error({ error, guildId: this.guildId }, 'Failed to build equalizer filter');
-      }
-    }
+    this.applyPlaybackFilters(patch, settings);
 
     await updateNodeLinkPlayer(this.guildId, sessionId, patch);
     const tCold3 = Date.now();

--- a/packages/server/src/lib/eqBands.ts
+++ b/packages/server/src/lib/eqBands.ts
@@ -40,7 +40,7 @@ const BAND_KEYS = [
 
 type EqBandKey = (typeof BAND_KEYS)[number];
 
-interface EqSettingsRow {
+export interface EqSettingsRow {
   eqBand0: number;
   eqBand1: number;
   eqBand2: number;

--- a/packages/server/src/lib/songFieldValidation.ts
+++ b/packages/server/src/lib/songFieldValidation.ts
@@ -1,0 +1,108 @@
+import { canonicalizeTags } from './tagCanonicalization';
+import {
+  validateArtworkUrl,
+  validateNickname,
+  validateOptionalString,
+  validateTags,
+  validateVolumeBoost,
+} from './validation';
+
+// ---------------------------------------------------------------------------
+// Shared song field validation
+//
+// Used by POST /api/songs/bulk-edit and PATCH /api/songs/:id to avoid
+// duplicating ~50 lines of per-field validation logic.  Accepts a body
+// with optional song metadata fields and an optional clearFields array
+// (for bulk-edit null-outs).  Tags go through canonicalizeTags to ensure
+// consistent casing.  Returns either the built `data` record plus
+// `processedTags`/`processedVolumeBoost` for post-update work, or an
+// error Response.
+// ---------------------------------------------------------------------------
+
+export interface SongFieldInput {
+  nickname?: unknown;
+  artist?: unknown;
+  album?: unknown;
+  artwork?: unknown;
+  tags?: unknown;
+  volumeBoost?: unknown;
+}
+
+export interface SongFieldOutput {
+  data: Record<string, unknown>;
+  processedTags?: string[];
+  processedVolumeBoost?: number | null | undefined;
+}
+
+export async function validateAndBuildSongFields(
+  body: SongFieldInput,
+  clearFields: string[] = []
+): Promise<SongFieldOutput | Response> {
+  const data: Record<string, unknown> = {};
+  let processedTags: string[] | undefined;
+  let processedVolumeBoost: number | null | undefined;
+
+  // Nickname
+  if (body.nickname !== undefined) {
+    const result = validateNickname(body.nickname);
+    if (!result.ok) {
+      return result.response;
+    }
+    data.nickname = result.value;
+  } else if (clearFields.includes('nickname')) {
+    data.nickname = null;
+  }
+
+  // Artist
+  if (body.artist !== undefined) {
+    data.artist = validateOptionalString(body.artist);
+  } else if (clearFields.includes('artist')) {
+    data.artist = null;
+  }
+
+  // Album
+  if (body.album !== undefined) {
+    data.album = validateOptionalString(body.album);
+  } else if (clearFields.includes('album')) {
+    data.album = null;
+  }
+
+  // Artwork
+  if (body.artwork !== undefined) {
+    const artworkResult = validateArtworkUrl(body.artwork);
+    if (!artworkResult.ok) {
+      return artworkResult.response;
+    }
+    data.artwork = artworkResult.value;
+  } else if (clearFields.includes('artwork')) {
+    data.artwork = null;
+  }
+
+  // Tags
+  if (body.tags !== undefined) {
+    const tagsResult = validateTags(body.tags);
+    if (!tagsResult.ok) {
+      return tagsResult.response;
+    }
+    processedTags = await canonicalizeTags(tagsResult.value);
+    data.tags = processedTags;
+  } else if (clearFields.includes('tags')) {
+    data.tags = [];
+    processedTags = [];
+  }
+
+  // Volume boost
+  if (body.volumeBoost !== undefined) {
+    const volumeResult = validateVolumeBoost(body.volumeBoost);
+    if (!volumeResult.ok) {
+      return volumeResult.response;
+    }
+    processedVolumeBoost = volumeResult.value;
+    data.volumeBoost = processedVolumeBoost;
+  } else if (clearFields.includes('volumeBoost')) {
+    data.volumeBoost = null;
+    processedVolumeBoost = null;
+  }
+
+  return { data, processedTags, processedVolumeBoost };
+}

--- a/packages/server/src/routes/songs.ts
+++ b/packages/server/src/routes/songs.ts
@@ -16,15 +16,10 @@ import {
 } from '../lib/search';
 import { formatSong } from '../lib/serialization';
 import { emitSongDeleted, emitSongUpdated } from '../lib/socket';
+import { validateAndBuildSongFields } from '../lib/songFieldValidation';
 import { reSyncPlaylistsForTags } from '../lib/syncPlaylistToTag';
 import { canonicalizeTags } from '../lib/tagCanonicalization';
-import {
-  validateArtworkUrl,
-  validateNickname,
-  validateOptionalString,
-  validateTags,
-  validateVolumeBoost,
-} from '../lib/validation';
+import { validateTags } from '../lib/validation';
 import { db, tables } from '../shared/db';
 import { getPlayer } from '../startDiscord';
 
@@ -33,6 +28,51 @@ const { song: songTable } = tables;
 const BulkDeleteSchema = v.object({
   ids: v.pipe(v.array(v.string()), v.minLength(1), v.maxLength(5000)),
 });
+
+// ---------------------------------------------------------------------------
+// Shared helper — update the live GuildPlayer cache after a song edit so
+// the UI reflects metadata changes immediately (currentSong, priorityQueue,
+// regular queue).  Also pushes a live volume boost change to NodeLink when
+// the edited song is currently playing.
+// ---------------------------------------------------------------------------
+function notifyPlayerOfMetadataChange(
+  songIds: string[],
+  data: Record<string, unknown>,
+  processedVolumeBoost: number | null | undefined
+): void {
+  const player = getPlayer(getGuildId());
+  if (!player) {
+    return;
+  }
+
+  if (processedVolumeBoost !== undefined) {
+    const currentSong = player.getCurrentSong();
+    if (currentSong && songIds.includes(currentSong.id)) {
+      player.updateVolumeBoost(processedVolumeBoost ?? 0);
+    }
+  }
+
+  const fields: Record<string, unknown> = {};
+  if ('nickname' in data) {
+    fields.nickname = data.nickname;
+  }
+  if ('artist' in data) {
+    fields.artist = data.artist;
+  }
+  if ('album' in data) {
+    fields.album = data.album;
+  }
+  if ('artwork' in data) {
+    fields.artwork = data.artwork;
+  }
+  if ('tags' in data) {
+    fields.tags = data.tags;
+  }
+  if ('volumeBoost' in data) {
+    fields.volumeBoost = data.volumeBoost;
+  }
+  player.updateSongMetadata(songIds, fields);
+}
 
 // ---------------------------------------------------------------------------
 // POST /api/songs/bulk-delete — delete multiple songs at once.
@@ -182,69 +222,11 @@ async function handleBulkEdit(ctx: RouteContext, request: Request): Promise<Resp
   const { ids, clearFields = [] } = parsed.output;
   const body = parsed.output;
 
-  const data: Record<string, unknown> = {};
-
-  // Nickname
-  if (body.nickname !== undefined) {
-    const result = validateNickname(body.nickname);
-    if (!result.ok) {
-      return result.response;
-    }
-    data.nickname = result.value;
-  } else if (clearFields.includes('nickname')) {
-    data.nickname = null;
+  const fieldResult = await validateAndBuildSongFields(body, clearFields);
+  if (fieldResult instanceof Response) {
+    return fieldResult;
   }
-
-  // Artist
-  if (body.artist !== undefined) {
-    data.artist = validateOptionalString(body.artist);
-  } else if (clearFields.includes('artist')) {
-    data.artist = null;
-  }
-
-  // Album
-  if (body.album !== undefined) {
-    data.album = validateOptionalString(body.album);
-  } else if (clearFields.includes('album')) {
-    data.album = null;
-  }
-
-  // Artwork
-  if (body.artwork !== undefined) {
-    const artworkResult = validateArtworkUrl(body.artwork);
-    if (!artworkResult.ok) {
-      return artworkResult.response;
-    }
-    data.artwork = artworkResult.value;
-  } else if (clearFields.includes('artwork')) {
-    data.artwork = null;
-  }
-
-  // Tags
-  let processedTags: string[] | undefined;
-  if (body.tags !== undefined) {
-    const tagsResult = validateTags(body.tags);
-    if (!tagsResult.ok) {
-      return tagsResult.response;
-    }
-    processedTags = await canonicalizeTags(tagsResult.value);
-    data.tags = processedTags;
-  } else if (clearFields.includes('tags')) {
-    data.tags = [];
-  }
-
-  // Volume boost
-  let processedVolumeBoost: number | null | undefined;
-  if (body.volumeBoost !== undefined) {
-    const volumeResult = validateVolumeBoost(body.volumeBoost);
-    if (!volumeResult.ok) {
-      return volumeResult.response;
-    }
-    processedVolumeBoost = volumeResult.value;
-    data.volumeBoost = processedVolumeBoost;
-  } else if (clearFields.includes('volumeBoost')) {
-    data.volumeBoost = null;
-  }
+  const { data, processedTags, processedVolumeBoost } = fieldResult;
 
   if (Object.keys(data).length === 0) {
     return json({ error: 'No fields to update.' }, 400);
@@ -271,37 +253,7 @@ async function handleBulkEdit(ctx: RouteContext, request: Request): Promise<Resp
 
   // Update the player cache for any of the edited songs that are currently
   // in the queue / now playing.
-  const bulkPlayer = getPlayer(getGuildId());
-  if (bulkPlayer) {
-    // Use !== undefined so we handle explicit null (clear boost → 0)
-    // as well as explicit 0.
-    if (processedVolumeBoost !== undefined) {
-      const currentSong = bulkPlayer.getCurrentSong();
-      if (currentSong && ids.includes(currentSong.id)) {
-        bulkPlayer.updateVolumeBoost(processedVolumeBoost ?? 0);
-      }
-    }
-    const bulkFields: Record<string, unknown> = {};
-    if ('nickname' in data) {
-      bulkFields.nickname = data.nickname;
-    }
-    if ('artist' in data) {
-      bulkFields.artist = data.artist;
-    }
-    if ('album' in data) {
-      bulkFields.album = data.album;
-    }
-    if ('artwork' in data) {
-      bulkFields.artwork = data.artwork;
-    }
-    if ('tags' in data) {
-      bulkFields.tags = data.tags;
-    }
-    if ('volumeBoost' in data) {
-      bulkFields.volumeBoost = data.volumeBoost;
-    }
-    bulkPlayer.updateSongMetadata(ids, bulkFields);
-  }
+  notifyPlayerOfMetadataChange(ids, data, processedVolumeBoost);
 
   return json({ updated: ids.length });
 }
@@ -454,60 +406,14 @@ async function handlePatchSong(
     return json({ error: 'Song not found.' }, 404);
   }
 
-  const data: Record<string, unknown> = {};
-
-  // Nickname
-  if (body.nickname !== undefined) {
-    const result = validateNickname(body.nickname);
-    if (!result.ok) {
-      return result.response;
-    }
-    data.nickname = result.value;
-  }
-
-  // Artist
-  if (body.artist !== undefined) {
-    data.artist = validateOptionalString(body.artist);
-  }
-
-  // Album
-  if (body.album !== undefined) {
-    data.album = validateOptionalString(body.album);
-  }
-
-  // Artwork
-  if (body.artwork !== undefined) {
-    const artworkResult = validateArtworkUrl(body.artwork);
-    if (!artworkResult.ok) {
-      return artworkResult.response;
-    }
-    data.artwork = artworkResult.value;
-  }
-
-  // Tags
   // Track old tags for smart playlist re-sync
   const oldTagsLower = new Set((existing.tags ?? []).map((t: string) => t.toLowerCase()));
-  let processedTags: string[] | undefined;
 
-  if (body.tags !== undefined) {
-    const tagsResult = validateTags(body.tags);
-    if (!tagsResult.ok) {
-      return tagsResult.response;
-    }
-    processedTags = await canonicalizeTags(tagsResult.value);
-    data.tags = processedTags;
+  const fieldResult = await validateAndBuildSongFields(body);
+  if (fieldResult instanceof Response) {
+    return fieldResult;
   }
-
-  // Volume boost
-  let processedVolumeBoost: number | null | undefined;
-  if (body.volumeBoost !== undefined) {
-    const volumeResult = validateVolumeBoost(body.volumeBoost);
-    if (!volumeResult.ok) {
-      return volumeResult.response;
-    }
-    processedVolumeBoost = volumeResult.value;
-    data.volumeBoost = processedVolumeBoost;
-  }
+  const { data, processedTags, processedVolumeBoost } = fieldResult;
 
   const [updatedSong] = await db
     .update(songTable)
@@ -534,41 +440,7 @@ async function handlePatchSong(
 
   // Update the song in the GuildPlayer's cache (currentSong, priorityQueue,
   // regular queue) so the UI reflects metadata changes immediately.
-  const player = getPlayer(getGuildId());
-  if (player) {
-    // Volume boost also needs live audio update.
-    // Use !== undefined so we handle explicit null (clear boost → 0)
-    // as well as explicit 0.
-    if (processedVolumeBoost !== undefined) {
-      const currentSong = player.getCurrentSong();
-      if (currentSong?.id === id) {
-        player.updateVolumeBoost(processedVolumeBoost ?? 0);
-      }
-    }
-
-    // Build fields object with only the keys that are actually in data —
-    // undefined values still create keys, which would clear fields in merge.
-    const fields: Record<string, unknown> = {};
-    if ('nickname' in data) {
-      fields.nickname = data.nickname;
-    }
-    if ('artist' in data) {
-      fields.artist = data.artist;
-    }
-    if ('album' in data) {
-      fields.album = data.album;
-    }
-    if ('artwork' in data) {
-      fields.artwork = data.artwork;
-    }
-    if ('tags' in data) {
-      fields.tags = data.tags;
-    }
-    if ('volumeBoost' in data) {
-      fields.volumeBoost = data.volumeBoost;
-    }
-    player.updateSongMetadata(id, fields);
-  }
+  notifyPlayerOfMetadataChange([id], data, processedVolumeBoost);
 
   return json(formatSong(updatedSong));
 }


### PR DESCRIPTION
## Summary

Deduplicates three areas of repeated code in the server package. No behavioral changes — pure mechanical extraction.

## Changes

- **New `lib/songFieldValidation.ts`** — shared `validateAndBuildSongFields()` used by both `handleBulkEdit` and `handlePatchSong`. All 6 song metadata field validators (nickname, artist, album, artwork, tags, volumeBoost) plus `clearFields` support in one place.
- **`GuildPlayer.ts`** — extracted `applyPlaybackFilters()` private method from the duplicated compressor+EQ filter building blocks in the gapless and cold-start paths of `playSong()`.
- **`routes/songs.ts`** — extracted `notifyPlayerOfMetadataChange()` helper to deduplicate the player cache update logic shared by both edit handlers.
- **`lib/eqBands.ts`** — exported `EqSettingsRow` interface (was private, needed for type-safe method signature).

**Net: -25 lines of code** (209 added, 234 removed)