### PR TITLE
fix(server): allow settings page to load roles and channels after setup

### DIFF
--- a/packages/server/src/routes/setup.elysia.ts
+++ b/packages/server/src/routes/setup.elysia.ts
@@ -253,7 +253,7 @@ export const setupPlugin = new Elysia({ prefix: '/setup', name: 'setup' })
       return { roles };
     },
     {
-      isSetupAdmin: true,
+      isAuth: true,
       detail: { security: [{ cookieAuth: [] }] },
       query: t.Object({ guildId: t.String() }),
       response: { 200: t.Object({ roles: t.Array(SetupRoleSchema) }) },
@@ -273,7 +273,7 @@ export const setupPlugin = new Elysia({ prefix: '/setup', name: 'setup' })
       }
     },
     {
-      isSetupAdmin: true,
+      isAuth: true,
       detail: { security: [{ cookieAuth: [] }] },
       query: t.Object({ guildId: t.String() }),
       response: { 200: t.Object({ channels: t.Array(SetupChannelSchema) }) },


### PR DESCRIPTION
## Summary

The general settings page (`AdminSection`) calls `/api/setup/roles` and `/api/setup/channels` to populate the role and channel pickers. These endpoints used the `isSetupAdmin` guard, which only passes when `user.isSetupAdmin` is in the JWT — a flag that is only set during the initial setup flow. After setup is complete, admin users would get 403 when loading the settings page.

## Changes

- Changed the guard on `/api/setup/roles` and `/api/setup/channels` from `isSetupAdmin` to `isAuth`. These are read-only metadata endpoints needed by both the setup wizard and the general settings admin section. The frontend already gates the settings page behind `ProtectedRoute`.
- Setup-only endpoints (`/setup/guilds`, `/setup/complete`) retain `isSetupAdmin`.