### PR TITLE
fix(web): fix playlist order sort inconsistency

### DIFF
--- a/packages/web/src/components/ListToolbar.tsx
+++ b/packages/web/src/components/ListToolbar.tsx
@@ -65,6 +65,9 @@ export interface ListToolbarProps {
   // ── View mode toggle ──
   viewMode?: 'list' | 'grid';
   onViewModeChange?: (mode: 'list' | 'grid') => void;
+
+  /** Sort fields where the asc/desc toggle is hidden (e.g. canonical order fields). */
+  noOrderToggleFields?: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -92,6 +95,7 @@ export default function ListToolbar({
   onToggleSelectionMode,
   viewMode,
   onViewModeChange,
+  noOrderToggleFields,
 }: ListToolbarProps) {
   // ── Search (local mirror + debounce) ─────────────────────────────
   const [searchInput, setSearchInput] = useState(searchValue);
@@ -163,8 +167,10 @@ export default function ListToolbar({
   const handleSortOptionClick = useCallback(
     (field: string) => {
       if (field === sort) {
-        // Toggle order
-        onSortChange(field, order === 'asc' ? 'desc' : 'asc');
+        // Toggle order (unless this field locks its order, e.g. canonical position)
+        if (!noOrderToggleFields?.includes(field)) {
+          onSortChange(field, order === 'asc' ? 'desc' : 'asc');
+        }
       } else {
         // New field — determine default order: text fields → asc, numeric/date → desc
         const newOrder = textSortFields.includes(field) ? 'asc' : 'desc';
@@ -172,7 +178,7 @@ export default function ListToolbar({
       }
       setSortOpen(false);
     },
-    [sort, order, textSortFields, onSortChange]
+    [sort, order, textSortFields, onSortChange, noOrderToggleFields]
   );
 
   // Direction arrow: text fields show ↓ when ascending (A→Z = down),
@@ -256,6 +262,7 @@ export default function ListToolbar({
                     isActive={isActive}
                     showDownArrow={showDownArrow}
                     order={order}
+                    hideOrderToggle={noOrderToggleFields?.includes(opt.value) ?? false}
                     onClick={handleSortOptionClick}
                   />
                 );
@@ -319,12 +326,14 @@ const SortOptionItem = memo(function SortOptionItem({
   isActive,
   showDownArrow,
   order,
+  hideOrderToggle,
   onClick,
 }: {
   opt: SortOption;
   isActive: boolean;
   showDownArrow: boolean;
   order: 'asc' | 'desc';
+  hideOrderToggle?: boolean;
   onClick: (value: string) => void;
 }) {
   const handleClick = useCallback(() => {
@@ -347,7 +356,7 @@ const SortOptionItem = memo(function SortOptionItem({
       onClick={handleClick}
     >
       <span>{opt.label}</span>
-      {isActive && (
+      {isActive && !hideOrderToggle && (
         <button
           type='button'
           className='cursor-pointer rounded p-0.5 transition-colors hover:bg-black/10 dark:hover:bg-white/10'

--- a/packages/web/src/hooks/usePaginatedData.ts
+++ b/packages/web/src/hooks/usePaginatedData.ts
@@ -123,7 +123,10 @@ export function usePaginatedData<T, A extends unknown[], M = undefined>({
         hasEverLoadedRef.current = true;
 
         if (isInitial) {
-          setItems(result.items);
+          const sorted = compareFnRef.current
+            ? [...result.items].sort(compareFnRef.current)
+            : result.items;
+          setItems(sorted);
           setHasMore(result.hasMore);
           if (result.total !== undefined) {
             setTotal(result.total);
@@ -133,7 +136,13 @@ export function usePaginatedData<T, A extends unknown[], M = undefined>({
           }
           pageRef.current = 1;
         } else {
-          setItems((prev) => [...prev, ...result.items]);
+          setItems((prev) => {
+            const next = [...prev, ...result.items];
+            if (compareFnRef.current) {
+              next.sort(compareFnRef.current);
+            }
+            return next;
+          });
           setHasMore(result.hasMore);
           pageRef.current = page;
         }
@@ -231,7 +240,10 @@ export function usePaginatedData<T, A extends unknown[], M = undefined>({
         if (!isMountedRef.current) {
           return;
         }
-        setItems(result.items);
+        const sorted = compareFnRef.current
+          ? [...result.items].sort(compareFnRef.current)
+          : result.items;
+        setItems(sorted);
         setHasMore(result.hasMore);
         if (result.total !== undefined) {
           setTotal(result.total);

--- a/packages/web/src/pages/PlaylistDetailPage.tsx
+++ b/packages/web/src/pages/PlaylistDetailPage.tsx
@@ -211,8 +211,8 @@ export default function PlaylistDetailPage() {
             dir * (new Date(a.song.createdAt).getTime() - new Date(b.song.createdAt).getTime())
           );
         default:
-          // position — lower position first for asc, higher first for desc
-          return dir * (a.position - b.position);
+          // position — always ascending (canonical playlist order)
+          return a.position - b.position;
       }
     };
   }, [sort, order]);
@@ -856,6 +856,7 @@ export default function PlaylistDetailPage() {
         onSortChange={handleSortChange}
         defaultSort='position'
         textSortFields={['title', 'artist', 'album']}
+        noOrderToggleFields={['position']}
         filterTags={filterTags}
         filterSources={filterSources}
         onAddTag={handleAddTag}


### PR DESCRIPTION
## Summary

Fix the "Playlist Order" sort so it stays consistent across page loads, drag-and-drop reorders, and song edits — rather than flipping randomly due to a mismatch between the API response order and the client-side sort comparator.

## Changes

- **usePaginatedData**: Apply `compareFn` on initial load, pagination, and refetch (was only on `updateItem`/`prepend`), so sort order is consistent regardless of how data arrives
- **PlaylistDetailPage**: Treat position as canonical playlist order (always ascending) rather than a sortable field — the asc/desc toggle is a no-op for position since playlist order is user-defined
- **ListToolbar**: Add `noOrderToggleFields` prop to hide the order toggle arrow in the sort dropdown for canonical-order fields like position