### PR TITLE
fix(web): fix album art flash and stale grid on admin view toggle

### DIFF
--- a/packages/web/src/components/VirtualSongGrid.tsx
+++ b/packages/web/src/components/VirtualSongGrid.tsx
@@ -44,6 +44,8 @@ interface GridSongItem {
   isPlaying: boolean;
   selectionMode: boolean;
   isSelected: boolean;
+  /** Included so masonic re-renders cards when admin view toggles. */
+  isAdminView: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -162,6 +164,11 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
   // lets masonic detect changes and update cards in-place (same itemKey =
   // no unmount/remount flash). The GridCard render component stays
   // memoized with empty deps so its identity is stable across re-renders.
+  // isAdminView is included in GridSongItem so masonic re-renders cards
+  // when the admin/user view toggles. The gridItems array reference must
+  // change for masonic to detect the update (keys alone don't trigger
+  // re-renders). Card no longer changes element type when hoverable flips,
+  // so this re-render won't cause artwork flashes.
   const gridItems: GridSongItem[] = useMemo(
     () =>
       items.map((song) => ({
@@ -169,8 +176,9 @@ export const VirtualSongGrid = memo(function VirtualSongGrid({
         isPlaying: playingId === song.id,
         selectionMode,
         isSelected: isSelected?.(song.id) ?? false,
+        isAdminView,
       })),
-    [items, playingId, selectionMode, isSelected]
+    [items, playingId, selectionMode, isSelected, isAdminView]
   );
 
   // ── Grid card renderer (stable component identity via refs) ─────────

--- a/packages/web/src/components/ui/Card.tsx
+++ b/packages/web/src/components/ui/Card.tsx
@@ -19,14 +19,15 @@ export const Card = memo(function Card({
 }: CardProps) {
   const baseClass = `bg-elevated overflow-hidden ${className}`;
 
-  const card = hoverable ? (
-    <ClayPressable depth='medium' className={baseClass} {...rest}>
+  const card = (
+    <ClayPressable
+      depth='medium'
+      disabled={!hoverable}
+      className={hoverable ? baseClass : `clay-resting ${baseClass}`}
+      {...rest}
+    >
       {children}
     </ClayPressable>
-  ) : (
-    <div className={`clay-resting ${baseClass}`} {...rest}>
-      {children}
-    </div>
   );
 
   if (animate) {

--- a/packages/web/src/components/ui/ClayPressable.tsx
+++ b/packages/web/src/components/ui/ClayPressable.tsx
@@ -209,9 +209,11 @@ export function ClayPressable({
     [disabled, preset.hoverY]
   );
 
+  const transition = useMemo(() => (disabled ? undefined : claySpring), [disabled]);
+
   const mergedStyle = useMemo(
-    () => Object.assign({}, outerStyle, clayStyle(clayState, mode)),
-    [outerStyle, clayState, mode]
+    () => (disabled ? outerStyle : Object.assign({}, outerStyle, clayStyle(clayState, mode))),
+    [disabled, outerStyle, clayState, mode]
   );
 
   // ── Render ────────────────────────────────────────────────────────────
@@ -225,14 +227,14 @@ export function ClayPressable({
       className={className}
       style={mergedStyle}
       whileHover={whileHover}
-      transition={claySpring}
-      onHoverStart={handleHoverStart}
-      onHoverEnd={handleHoverEnd}
-      onTapStart={handleTapStart}
-      onTap={handleTapEnd}
-      onTapCancel={handleTapEnd}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
+      transition={transition}
+      onHoverStart={disabled ? undefined : handleHoverStart}
+      onHoverEnd={disabled ? undefined : handleHoverEnd}
+      onTapStart={disabled ? undefined : handleTapStart}
+      onTap={disabled ? undefined : handleTapEnd}
+      onTapCancel={disabled ? undefined : handleTapEnd}
+      onMouseEnter={disabled ? undefined : handleMouseEnter}
+      onMouseLeave={disabled ? undefined : handleMouseLeave}
       {...rest}
     >
       {children}


### PR DESCRIPTION
## Summary

Fixes two related bugs when toggling between admin and user view modes in the song library.

## Changes

- **Card.tsx** — Always renders `ClayPressable` instead of switching between `ClayPressable` and plain `div` based on `hoverable`. Changing element types caused React to unmount/remount the subtree, resetting `ArtworkImage`'s loaded state and causing a spinner flash.
- **ClayPressable.tsx** — When `disabled`, skips clay-specific inline styles (box-shadow, background) and motion event handlers so the `clay-resting` CSS class controls the shadow. This preserves the identical visual while keeping the element type stable.
- **VirtualSongGrid.tsx** — Includes `isAdminView` in `GridSongItem` and `gridItems` useMemo deps so masonic detects the admin view toggle and re-renders cards in-place (same keys = no remount). Previously, `isAdminView` was only in a ref, so masonic never knew it changed and cards stayed stale.