### PR TITLE
fix(docker): improve data directory permission handling

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -154,7 +154,7 @@ nano .env  # or micro, zed, code, vim, etc.
 #    The container runs as UID 1001 (non-root). This directory
 #    holds your SQLite database — back it up regularly.
 mkdir -p data
-chmod 755 data
+sudo chown -R 1001:1001 data
 
 # 4. Start the stack — web UI at http://localhost:3001
 docker compose up -d

--- a/packages/server/src/shared/db/index.ts
+++ b/packages/server/src/shared/db/index.ts
@@ -4,6 +4,7 @@ import { drizzle } from 'drizzle-orm/bun-sqlite';
 import { mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 
+import { logger } from '../logger';
 import * as schema from './schema';
 
 // ---------------------------------------------------------------------------
@@ -18,7 +19,28 @@ const DATABASE_URL = process.env.DATABASE_URL ?? 'data/alfira.db';
 // Ensure the parent directory exists (e.g., data/ for local dev).
 mkdirSync(dirname(DATABASE_URL), { recursive: true });
 
-const sqliteDb = new Database(DATABASE_URL, { create: true, strict: true });
+function openDatabase(path: string): Database {
+  try {
+    return new Database(path, { create: true, strict: true });
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'SQLITE_CANTOPEN') {
+      const dir = dirname(path);
+      const msg = [
+        `Cannot open database at "${path}".`,
+        `The directory "${dir}" is not writable by the current user (UID ${process.getuid?.() ?? 'unknown'}).`,
+        ``,
+        `If you are running in Docker with a bind mount, the host directory`,
+        `is likely owned by a different UID. Fix it with:`,
+        `  sudo chown -R 1001:1001 "${dir}"`,
+      ].join('\n');
+      logger.fatal(msg);
+      process.exit(1);
+    }
+    throw error;
+  }
+}
+
+const sqliteDb = openDatabase(DATABASE_URL);
 sqliteDb.run('PRAGMA journal_mode=WAL;');
 sqliteDb.run('PRAGMA foreign_keys=ON;');
 export const db = drizzle(sqliteDb, { schema });


### PR DESCRIPTION
## Summary

Fixes #796 — the `SQLITE_CANTOPEN` crash on Docker production startup caused by a UID mismatch between the host bind mount and the container's `nodejs` user.

## Root cause

The production Docker image runs as UID 1001, but the bind mount `./data:/data` inherits the host directory's ownership (typically UID 1000). The docs instructed `chmod 755` which doesn't grant write to UID 1001. Result: `SQLITE_CANTOPEN` with no helpful guidance.

## Changes

- **`docs/installation.md`** — Fix the permission command from `chmod 755 data` (doesn't work for the typical case) to `sudo chown -R 1001:1001 data`
- **`packages/server/src/shared/db/index.ts`** — Wrap `new Database()` in an `openDatabase()` helper that catches `SQLITE_CANTOPEN` and logs a clear, actionable error message (with the affected path and the exact fix command) before exiting