### PR TITLE
ci: add dependabot bun lockfile auto-update and group codeql actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
       semver-major-days: 30
       semver-minor-days: 14
       semver-patch-days: 3
+    groups:
+      deps:
+        patterns:
+          - '*'
   - package-ecosystem: 'docker'
     directory: '/'
     target-branch: 'dev'
@@ -27,3 +31,7 @@ updates:
     ignore:
       - dependency-name: 'actions/setup-node'
         versions: ['6.x']
+    groups:
+      codeql:
+        patterns:
+          - 'github/codeql-action/*'

--- a/.github/workflows/dependabot-bun-lock.yml
+++ b/.github/workflows/dependabot-bun-lock.yml
@@ -1,0 +1,31 @@
+name: Dependabot — Update Bun Lockfile
+
+on:
+  pull_request:
+    paths:
+      - 'package.json'
+      - 'packages/*/package.json'
+
+permissions:
+  contents: write
+
+jobs:
+  update-lockfile:
+    name: Regenerate bun.lock
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.head_ref }}
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Regenerate lockfile
+        run: bun install
+
+      - name: Commit updated bun.lock
+        uses: stefanzweifel/git-auto-commit-action@e348103e9026cc0eee72ae06630dbe30c8bf7a79 # v5
+        with:
+          commit_message: 'chore: update bun.lock'
+          file_pattern: bun.lock


### PR DESCRIPTION
## Summary

Fixes Dependabot PRs consistently failing CI for two reasons:

### 1. Bun lockfile mismatch
Dependabot bumps versions in `package.json` but doesn't run `bun install` to update `bun.lock`. CI fails on `bun install --frozen-lockfile`.

**Fix**: New workflow `.github/workflows/dependabot-bun-lock.yml` — triggers on Dependabot PRs that touch any `package.json`, checks out the branch, runs `bun install`, and commits the updated `bun.lock`.

### 2. Split CodeQL action PRs
Dependabot treats `github/codeql-action/init` and `github/codeql-action/analyze` as separate dependencies, creating two PRs. Since the CodeQL workflow uses both in the same job, version mismatch breaks the analysis step.

**Fix**: Added `groups.codeql` to the github-actions ecosystem in `dependabot.yml` to batch all `github/codeql-action/*` updates into a single PR.

### Bonus
Also grouped all npm dependencies into a single PR (`groups.deps`) to reduce PR noise.